### PR TITLE
feat(xpass): final family reconciliation

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 548,
+    "inventory": 549,
     "source_manifest": 187,
     "pages": 78,
-    "tools": 187,
+    "tools": 188,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 187
+      "count": 188
     },
     {
       "id": "rooms",
@@ -5412,6 +5412,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-xpass-aggregated-verdict-packages-mcp-server-src-xpass-aggregated-verdict-tool-ts-no-route",
+      "division": "Tools",
+      "name": "xpass aggregated verdict",
+      "kind": "MCP tool",
+      "meaning": "xpass aggregated verdict MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/xpass-aggregated-verdict-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-yelp-packages-mcp-server-src-yelp-tool-ts-no-route",
       "division": "Tools",
       "name": "yelp",
@@ -7032,6 +7042,11 @@
       "xero",
       "xero MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/xero-tool.ts"
+    ],
+    [
+      "xpass aggregated verdict",
+      "xpass aggregated verdict MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/xpass-aggregated-verdict-tool.ts"
     ],
     [
       "yelp",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8317,8 +8317,8 @@
     },
     {
       "source": "packages/mcp-server/src/compliancepass-tool.ts",
-      "hash": "13242448457f",
-      "bytes": 3202
+      "hash": "bedf85b00baa",
+      "bytes": 7342
     },
     {
       "source": "packages/mcp-server/src/convertkit-tool.ts",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 572,
+    "inventory": 573,
     "source_manifest": 187,
     "pages": 78,
-    "tools": 187,
+    "tools": 188,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 187
+      "count": 188
     },
     {
       "id": "rooms",
@@ -5142,6 +5142,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-securitypass-packages-mcp-server-src-securitypass-tool-ts-no-route",
+      "division": "Tools",
+      "name": "securitypass",
+      "kind": "MCP tool",
+      "meaning": "securitypass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/securitypass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-segment-packages-mcp-server-src-segment-tool-ts-no-route",
       "division": "Tools",
       "name": "segment",
@@ -7019,6 +7029,11 @@
       "packages/mcp-server/src/seatgeek-tool.ts"
     ],
     [
+      "securitypass",
+      "securitypass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/securitypass-tool.ts"
+    ],
+    [
       "segment",
       "segment MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/segment-tool.ts"
@@ -7499,7 +7514,7 @@
     ],
     [
       "test",
-      "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension"
+      "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && vitest run && npm run test:api-lib-esm-extension"
     ],
     [
       "test:api",
@@ -7622,8 +7637,8 @@
     },
     {
       "source": "package.json",
-      "hash": "82100008ad1b",
-      "bytes": 6417
+      "hash": "80d780561f43",
+      "bytes": 6468
     },
     {
       "source": "seed/skills/agent-handoff-packet-writer.skill.md",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 572,
+    "inventory": 573,
     "source_manifest": 187,
     "pages": 78,
-    "tools": 187,
+    "tools": 188,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 187
+      "count": 188
     },
     {
       "id": "rooms",
@@ -4362,6 +4362,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-geopass-packages-mcp-server-src-geopass-tool-ts-no-route",
+      "division": "Tools",
+      "name": "geopass",
+      "kind": "MCP tool",
+      "meaning": "geopass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/geopass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-github-packages-mcp-server-src-github-tool-ts-no-route",
       "division": "Tools",
       "name": "github",
@@ -6627,6 +6637,11 @@
       "genius",
       "genius MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/genius-tool.ts"
+    ],
+    [
+      "geopass",
+      "geopass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/geopass-tool.ts"
     ],
     [
       "github",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8327,8 +8327,8 @@
     },
     {
       "source": "packages/mcp-server/src/copypass-tool.ts",
-      "hash": "70d540c397a5",
-      "bytes": 31503
+      "hash": "3cbadbc448a0",
+      "bytes": 33377
     },
     {
       "source": "packages/mcp-server/src/crews-tool.ts",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 574,
+    "inventory": 578,
     "source_manifest": 188,
-    "pages": 79,
-    "tools": 187,
+    "pages": 80,
+    "tools": 190,
     "rooms": 23,
     "workers": 8
   },
@@ -21,7 +21,7 @@
       "id": "admin-surfaces",
       "name": "Admin surfaces",
       "meaning": "Private operator views and internal control panels.",
-      "count": 47
+      "count": 48
     },
     {
       "id": "public-surfaces",
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 187
+      "count": 190
     },
     {
       "id": "rooms",
@@ -169,6 +169,16 @@
       "meaning": "Generated ecosystem map that teaches seats what UnClick is.",
       "source": "src/pages/admin/AdminBrainmap.tsx",
       "route": "/admin/brainmap",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-checks-src-pages-admin-adminecosystempages-tsx-admin-checks-productid",
+      "division": "Admin surfaces",
+      "name": "Admin Checks",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Ecosystem Pages.",
+      "source": "src/pages/admin/AdminEcosystemPages.tsx",
+      "route": "/admin/checks/:productId",
       "tags": []
     },
     {
@@ -4382,6 +4392,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-geopass-packages-mcp-server-src-geopass-tool-ts-no-route",
+      "division": "Tools",
+      "name": "geopass",
+      "kind": "MCP tool",
+      "meaning": "geopass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/geopass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-github-packages-mcp-server-src-github-tool-ts-no-route",
       "division": "Tools",
       "name": "github",
@@ -5162,6 +5182,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-securitypass-packages-mcp-server-src-securitypass-tool-ts-no-route",
+      "division": "Tools",
+      "name": "securitypass",
+      "kind": "MCP tool",
+      "meaning": "securitypass MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/securitypass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-segment-packages-mcp-server-src-segment-tool-ts-no-route",
       "division": "Tools",
       "name": "segment",
@@ -5672,6 +5702,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-xpass-aggregated-verdict-packages-mcp-server-src-xpass-aggregated-verdict-tool-ts-no-route",
+      "division": "Tools",
+      "name": "xpass aggregated verdict",
+      "kind": "MCP tool",
+      "meaning": "xpass aggregated verdict MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/xpass-aggregated-verdict-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-yelp-packages-mcp-server-src-yelp-tool-ts-no-route",
       "division": "Tools",
       "name": "yelp",
@@ -5904,6 +5944,12 @@
       "Admin Brainmap",
       "Generated ecosystem map that teaches seats what UnClick is.",
       "src/pages/admin/AdminBrainmap.tsx"
+    ],
+    [
+      "/admin/checks/:productId",
+      "Admin Checks",
+      "Admin surface for Admin Ecosystem Pages.",
+      "src/pages/admin/AdminEcosystemPages.tsx"
     ],
     [
       "/admin/checks",
@@ -6655,6 +6701,11 @@
       "packages/mcp-server/src/genius-tool.ts"
     ],
     [
+      "geopass",
+      "geopass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/geopass-tool.ts"
+    ],
+    [
       "github",
       "github MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/github-tool.ts"
@@ -7045,6 +7096,11 @@
       "packages/mcp-server/src/seatgeek-tool.ts"
     ],
     [
+      "securitypass",
+      "securitypass MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/securitypass-tool.ts"
+    ],
+    [
       "segment",
       "segment MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/segment-tool.ts"
@@ -7300,6 +7356,11 @@
       "packages/mcp-server/src/xero-tool.ts"
     ],
     [
+      "xpass aggregated verdict",
+      "xpass aggregated verdict MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/xpass-aggregated-verdict-tool.ts"
+    ],
+    [
       "yelp",
       "yelp MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/yelp-tool.ts"
@@ -7525,7 +7586,7 @@
     ],
     [
       "test",
-      "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension"
+      "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && vitest run && npm run test:api-lib-esm-extension"
     ],
     [
       "test:api",
@@ -7608,13 +7669,13 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "4347f236822f",
-      "bytes": 14359
+      "hash": "2cffedbf2fb0",
+      "bytes": 14432
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
-      "hash": "a5993008255d",
-      "bytes": 19438
+      "hash": "cd267dabfd21",
+      "bytes": 22038
     },
     {
       "source": "src/pages/admin/AdminSkills.tsx",
@@ -7648,8 +7709,8 @@
     },
     {
       "source": "package.json",
-      "hash": "82100008ad1b",
-      "bytes": 6417
+      "hash": "80d780561f43",
+      "bytes": 6468
     },
     {
       "source": "seed/skills/agent-handoff-packet-writer.skill.md",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -207,7 +207,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 47 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 31 |
-| Tools | MCP and gateway capabilities available to seats. | 187 |
+| Tools | MCP and gateway capabilities available to seats. | 188 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
@@ -516,6 +516,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | wise | wise MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wise-tool.ts |
 | woocommerce | woocommerce MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/woocommerce-tool.ts |
 | xero | xero MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/xero-tool.ts |
+| xpass aggregated verdict | xpass aggregated verdict MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/xpass-aggregated-verdict-tool.ts |
 | yelp | yelp MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/yelp-tool.ts |
 | youtube | youtube MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/youtube-tool.ts |
 
@@ -1055,6 +1056,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | wise | wise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wise-tool.ts |
 | Tools | MCP tool | woocommerce | woocommerce MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/woocommerce-tool.ts |
 | Tools | MCP tool | xero | xero MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/xero-tool.ts |
+| Tools | MCP tool | xpass aggregated verdict | xpass aggregated verdict MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/xpass-aggregated-verdict-tool.ts |
 | Tools | MCP tool | yelp | yelp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/yelp-tool.ts |
 | Tools | MCP tool | youtube | youtube MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/youtube-tool.ts |
 | Workers and seats | seat | Claude Reviewer Seat | External reviewer lane used for independent checks and proof review. | - | docs/fleet-worker-roles.md |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -30,7 +30,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/ci.yml | ab3e717a4ae9 | 1663 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | .github/workflows/continuous-improvement-watch.yml | d121a434a464 | 2358 |
-| package.json | 82100008ad1b | 6417 |
+| package.json | 80d780561f43 | 6468 |
 | seed/skills/agent-handoff-packet-writer.skill.md | f9c498e48796 | 938 |
 | seed/skills/browser-qa-tester.skill.md | b57ce8b2e63a | 1115 |
 | seed/skills/builder-implementation-packet.skill.md | 1fcda17af905 | 1276 |
@@ -207,7 +207,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 47 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 31 |
-| Tools | MCP and gateway capabilities available to seats. | 187 |
+| Tools | MCP and gateway capabilities available to seats. | 188 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
@@ -465,6 +465,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | riot | riot MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/riot-tool.ts |
 | runway | runway MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/runway-tool.ts |
 | seatgeek | seatgeek MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/seatgeek-tool.ts |
+| securitypass | securitypass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/securitypass-tool.ts |
 | segment | segment MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/segment-tool.ts |
 | sendgrid | sendgrid MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sendgrid-tool.ts |
 | sendle | sendle MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sendle-tool.ts |
@@ -1028,6 +1029,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | riot | riot MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/riot-tool.ts |
 | Tools | MCP tool | runway | runway MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/runway-tool.ts |
 | Tools | MCP tool | seatgeek | seatgeek MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/seatgeek-tool.ts |
+| Tools | MCP tool | securitypass | securitypass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/securitypass-tool.ts |
 | Tools | MCP tool | segment | segment MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/segment-tool.ts |
 | Tools | MCP tool | sendgrid | sendgrid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sendgrid-tool.ts |
 | Tools | MCP tool | sendle | sendle MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sendle-tool.ts |
@@ -1183,7 +1185,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | build:dev | vite build --mode development |
 | compliancepass:report | npm run build --workspace=@unclick/compliancepass && node scripts/build-compliancepass-report.mjs |
 | lint | eslint . |
-| test | npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension |
+| test | npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && vitest run && npm run test:api-lib-esm-extension |
 | test:api | npm run test --workspace=apps/api |
 | test:api-lib-esm-extension | node --test scripts/api-lib-esm-extension-guard.test.mjs |
 | test:brainmap | node --test scripts/UnClick-brainmap.test.mjs |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -207,7 +207,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 47 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 31 |
-| Tools | MCP and gateway capabilities available to seats. | 187 |
+| Tools | MCP and gateway capabilities available to seats. | 188 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
@@ -387,6 +387,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | fpl | fpl MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fpl-tool.ts |
 | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gdelt-tool.ts |
 | genius | genius MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/genius-tool.ts |
+| geopass | geopass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/geopass-tool.ts |
 | github | github MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/github-tool.ts |
 | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gitlab-tool.ts |
 | groq | groq MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/groq-tool.ts |
@@ -950,6 +951,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | fpl | fpl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fpl-tool.ts |
 | Tools | MCP tool | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gdelt-tool.ts |
 | Tools | MCP tool | genius | genius MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/genius-tool.ts |
+| Tools | MCP tool | geopass | geopass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/geopass-tool.ts |
 | Tools | MCP tool | github | github MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/github-tool.ts |
 | Tools | MCP tool | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gitlab-tool.ts |
 | Tools | MCP tool | groq | groq MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/groq-tool.ts |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,15 +22,15 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | a8f64d0da135 | 4873 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | 4347f236822f | 14359 |
-| src/pages/admin/AdminShell.tsx | a5993008255d | 19438 |
+| src/App.tsx | 2cffedbf2fb0 | 14432 |
+| src/pages/admin/AdminShell.tsx | cd267dabfd21 | 22038 |
 | src/pages/admin/AdminSkills.tsx | 4b5e69217a39 | 14848 |
 | src/lib/skillLibrary.ts | 7d69323f9491 | 10487 |
 | src/lib/skillLibrarySeeds.ts | 51ca658707f8 | 652 |
 | .github/workflows/ci.yml | ab3e717a4ae9 | 1663 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | .github/workflows/continuous-improvement-watch.yml | d121a434a464 | 2358 |
-| package.json | 82100008ad1b | 6417 |
+| package.json | 80d780561f43 | 6468 |
 | seed/skills/agent-handoff-packet-writer.skill.md | f9c498e48796 | 938 |
 | seed/skills/browser-qa-tester.skill.md | b57ce8b2e63a | 1115 |
 | seed/skills/builder-implementation-packet.skill.md | 1fcda17af905 | 1276 |
@@ -206,9 +206,9 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 
 | Division | Meaning | Items |
 | --- | --- | --- |
-| Admin surfaces | Private operator views and internal control panels. | 47 |
+| Admin surfaces | Private operator views and internal control panels. | 48 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 32 |
-| Tools | MCP and gateway capabilities available to seats. | 187 |
+| Tools | MCP and gateway capabilities available to seats. | 190 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
@@ -261,6 +261,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /admin/billing | Admin Billing | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
 | /admin/boardroom | Fishbowl | Boardroom discussion surface for worker coordination. | src/pages/admin/Fishbowl.tsx |
 | /admin/brainmap | Admin Brainmap | Generated ecosystem map that teaches seats what UnClick is. | src/pages/admin/AdminBrainmap.tsx |
+| /admin/checks/:productId | Admin Checks | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
 | /admin/checks | Admin Checks | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
 | /admin/codebase | Admin Codebase | Internal source and architecture orientation surface. | src/pages/admin/AdminCodebase.tsx |
 | /admin/copypass | Copy Pass Catalog | Admin surface for Copy Pass Catalog. | src/pages/admin/copypass/CopyPassCatalog.tsx |
@@ -389,6 +390,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | fpl | fpl MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fpl-tool.ts |
 | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gdelt-tool.ts |
 | genius | genius MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/genius-tool.ts |
+| geopass | geopass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/geopass-tool.ts |
 | github | github MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/github-tool.ts |
 | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gitlab-tool.ts |
 | groq | groq MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/groq-tool.ts |
@@ -467,6 +469,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | riot | riot MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/riot-tool.ts |
 | runway | runway MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/runway-tool.ts |
 | seatgeek | seatgeek MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/seatgeek-tool.ts |
+| securitypass | securitypass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/securitypass-tool.ts |
 | segment | segment MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/segment-tool.ts |
 | sendgrid | sendgrid MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sendgrid-tool.ts |
 | sendle | sendle MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sendle-tool.ts |
@@ -518,6 +521,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | wise | wise MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wise-tool.ts |
 | woocommerce | woocommerce MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/woocommerce-tool.ts |
 | xero | xero MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/xero-tool.ts |
+| xpass aggregated verdict | xpass aggregated verdict MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/xpass-aggregated-verdict-tool.ts |
 | yelp | yelp MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/yelp-tool.ts |
 | youtube | youtube MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/youtube-tool.ts |
 
@@ -533,6 +537,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Admin Benchmarks | Admin surface for Admin Benchmarks. | /admin/benchmarks | src/pages/admin/AdminBenchmarks.tsx |
 | Admin surfaces | admin page | Admin Billing | Admin surface for Admin Ecosystem Pages. | /admin/billing | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin Brainmap | Generated ecosystem map that teaches seats what UnClick is. | /admin/brainmap | src/pages/admin/AdminBrainmap.tsx |
+| Admin surfaces | admin page | Admin Checks | Admin surface for Admin Ecosystem Pages. | /admin/checks/:productId | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin Checks | Admin surface for Admin Ecosystem Pages. | /admin/checks | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin Codebase | Internal source and architecture orientation surface. | /admin/codebase | src/pages/admin/AdminCodebase.tsx |
 | Admin surfaces | admin page | Admin Dashboard | Front door for current operator state. | /admin/dashboard | src/pages/admin/AdminDashboard.tsx |
@@ -954,6 +959,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | fpl | fpl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fpl-tool.ts |
 | Tools | MCP tool | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gdelt-tool.ts |
 | Tools | MCP tool | genius | genius MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/genius-tool.ts |
+| Tools | MCP tool | geopass | geopass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/geopass-tool.ts |
 | Tools | MCP tool | github | github MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/github-tool.ts |
 | Tools | MCP tool | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gitlab-tool.ts |
 | Tools | MCP tool | groq | groq MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/groq-tool.ts |
@@ -1032,6 +1038,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | riot | riot MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/riot-tool.ts |
 | Tools | MCP tool | runway | runway MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/runway-tool.ts |
 | Tools | MCP tool | seatgeek | seatgeek MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/seatgeek-tool.ts |
+| Tools | MCP tool | securitypass | securitypass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/securitypass-tool.ts |
 | Tools | MCP tool | segment | segment MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/segment-tool.ts |
 | Tools | MCP tool | sendgrid | sendgrid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sendgrid-tool.ts |
 | Tools | MCP tool | sendle | sendle MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sendle-tool.ts |
@@ -1083,6 +1090,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | wise | wise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wise-tool.ts |
 | Tools | MCP tool | woocommerce | woocommerce MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/woocommerce-tool.ts |
 | Tools | MCP tool | xero | xero MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/xero-tool.ts |
+| Tools | MCP tool | xpass aggregated verdict | xpass aggregated verdict MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/xpass-aggregated-verdict-tool.ts |
 | Tools | MCP tool | yelp | yelp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/yelp-tool.ts |
 | Tools | MCP tool | youtube | youtube MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/youtube-tool.ts |
 | Workers and seats | seat | Claude Reviewer Seat | External reviewer lane used for independent checks and proof review. | - | docs/fleet-worker-roles.md |
@@ -1187,7 +1195,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | build:dev | vite build --mode development |
 | compliancepass:report | npm run build --workspace=@unclick/compliancepass && node scripts/build-compliancepass-report.mjs |
 | lint | eslint . |
-| test | npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension |
+| test | npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && vitest run && npm run test:api-lib-esm-extension |
 | test:api | npm run test --workspace=apps/api |
 | test:api-lib-esm-extension | node --test scripts/api-lib-esm-extension-guard.test.mjs |
 | test:brainmap | node --test scripts/UnClick-brainmap.test.mjs |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -171,7 +171,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/commonsensepass-tool.ts | bad23b55ea01 | 1995 |
 | packages/mcp-server/src/compliancepass-tool.ts | 13242448457f | 3202 |
 | packages/mcp-server/src/convertkit-tool.ts | 2f77303a3441 | 8498 |
-| packages/mcp-server/src/copypass-tool.ts | 70d540c397a5 | 31503 |
+| packages/mcp-server/src/copypass-tool.ts | 3cbadbc448a0 | 33377 |
 | packages/mcp-server/src/crews-tool.ts | 111454c76c0a | 13547 |
 | packages/mcp-server/src/csuite-tool.ts | 0ab5af89bb49 | 70236 |
 | packages/mcp-server/src/datadog-tool.ts | 802b808614cd | 5556 |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -169,7 +169,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/coinmarketcap-tool.ts | b1c5fd280acb | 6892 |
 | packages/mcp-server/src/color-tool.ts | f9aa9c0fec6e | 13643 |
 | packages/mcp-server/src/commonsensepass-tool.ts | bad23b55ea01 | 1995 |
-| packages/mcp-server/src/compliancepass-tool.ts | 13242448457f | 3202 |
+| packages/mcp-server/src/compliancepass-tool.ts | bedf85b00baa | 7342 |
 | packages/mcp-server/src/convertkit-tool.ts | 2f77303a3441 | 8498 |
 | packages/mcp-server/src/copypass-tool.ts | 70d540c397a5 | 31503 |
 | packages/mcp-server/src/crews-tool.ts | 111454c76c0a | 13547 |

--- a/docs/pass-family-index.md
+++ b/docs/pass-family-index.md
@@ -1,7 +1,7 @@
 # XPass product index
 
 **Status**: Canonical lookup for every XPass product. Aligns with the locked naming contract in [`docs/prd/xpass.md`](./prd/xpass.md). File path is retained for link stability.
-**Last updated**: 2026-05-29.
+**Last updated**: 2026-05-30.
 **Owner**: Product and XPass maintainers.
 
 ## How to read this
@@ -10,6 +10,8 @@ Each row names a Pass, its current promotion tier, the brief that owns the scope
 
 If a row here disagrees with the locked PRD, the PRD wins. If a row here disagrees with an individual brief, the brief wins for scope details and this file wins for tier and routing.
 
+Status note: the 2026-05-30 XPass completion run produced cloud-green PRs for the receipt surfaces listed in [`docs/prd/xpass-closure-board.md`](./prd/xpass-closure-board.md). Until those PRs are merged, treat those rows as PR-ready and cloud-dogfooded rather than already landed on `main`.
+
 ## Live gates or public dogfood
 
 | Pass | Brief | Dogfood surface | XPass routes here when |
@@ -17,7 +19,7 @@ If a row here disagrees with the locked PRD, the PRD wins. If a row here disagre
 | TestPass | [`docs/prd/testpass.md`](./prd/testpass.md), [`docs/testpass-phase-9a-visual-brief.md`](./testpass-phase-9a-visual-brief.md) | `public/testpass/` recurring runs and `/admin/testpass` | the target is an MCP server, marketplace submission, or a PR that touches a tool wiring |
 | UXPass | [`docs/uxpass-product-brief.md`](./uxpass-product-brief.md) | `public/uxpass/site-sweep.json` and `/admin/uxpass` | the target is a public URL, an admin page, or a PR that changes user-facing UI |
 | CommonSensePass | [`docs/commonsensepass-rule-matrix.md`](./commonsensepass-rule-matrix.md) | embedded checks under the dogfood index | the target is automation, orchestration logic, or anywhere a "no green chip without evidence" rule applies |
-| WakePass | [`docs/prd/wakepass.md`](./prd/wakepass.md) | action-needed feed on the admin jobs page | a Pass result needs an owner to act, a scheduled check missed its ACK, or a receipt has gone stale |
+| WakePass | [`docs/prd/wakepass.md`](./prd/wakepass.md) | action-needed feed on the admin jobs page and public-safe boundary sweep | a Pass result needs an owner to act, a scheduled check missed its ACK, or a receipt has gone stale |
 
 ## Package-ready
 

--- a/docs/prd/xpass-closure-board.md
+++ b/docs/prd/xpass-closure-board.md
@@ -1,6 +1,7 @@
 # XPass Closure Board
 
 **Status:** working inventory and completion board  
+**Last truth refresh:** 2026-05-30 Australia/Sydney. Open PRs listed below are PR-ready and cloud-green, not claimed as merged until GitHub shows them merged.
 **Purpose:** keep the XPass product family honest until every check is either complete, deliberately parked, or clearly not applicable for a run.
 
 ## Operating Model
@@ -22,21 +23,42 @@ This does not mean every expensive runner executes every time. The lightweight c
 
 | XPass product | Keep? | Complete? | Current truth | To close the loop |
 | --- | --- | --- | --- | --- |
-| TestPass | Yes | ✓ | Strongest XPass product today. Package exists, tests exist, live MCP proof and dogfood receipt exist. | Keep as default trust gate and make sure receipts stay scoped to the target. |
-| UXPass | Yes | ~ | Real package and runner exist, with visual audit work, viewport support, and dogfood fixtures. Still not enough to guarantee every mediocre UI becomes polished. | Finish annotated reports, stronger visual hierarchy checks, mobile and desktop evidence, and scheduled proof that does not clog the queue. |
-| SecurityPass | Yes | ~ | Real package and guardrails exist. Public dogfood is intentionally scope-gated until safe recurring proof exists. | Add deny-by-default recurring runner proof and make security receipts visible without exposing secrets. |
-| CopyPass | Yes | ~ | Real copy-quality package exists. It checks wording, claims, tone, clarity, and product copy risk. | Add recurring or on-demand live receipt surface and keep it separate from exact-copy fidelity. |
-| FidelityPass | Yes | ✗ | Official XPass/QC wrapper over CopyRoom, but not a separate completed engine yet. | Implement wrapper behavior over CopyRoom receipts, including `N/A` when no 1:1 copy is in scope. Do not duplicate CopyRoom. |
-| CopyRoom | Adjacent | ~ | Official exact-copy room. It is the office photocopier workers must use for 1:1 copying, transcription, mirroring, or preservation. | Reinforce worker usage and require a CopyRoom receipt whenever exact copying is requested. |
-| LegalPass | Yes | ~ | Package and guardrail library exist, but much of the deeper execution is still guidance or fixture-led. | Turn legal and policy checks into scoped receipts with clear "not legal advice" boundaries. |
-| SlopPass | Yes | ~ | Official AI/code quality product. Package, tests, product brief, and XPass selector wiring exist. | Finish live PR diff integration and make SlopPass the only public code-quality name. No QualityPass fork. |
-| CommonSensePass | Yes | ~ | Real UnClick concept and protocol from context. It is the sanity gate before healthy, quiet, PASS, no-work, done, merge-ready, or duplicate-wake claims. Current package/tool exposure still needs proof before calling it complete. | Restore or expose the tool surface, add the evidence envelope, build fixture pack, and enforce worker-wide adoption. |
-| SEOPass | Yes | ~ | Package exists but is mostly scaffold or plan-level proof. | Add live metadata, sitemap, public-page, and search-readiness receipts. |
-| GEOPass | Yes | ~ | Package exists but appears scaffolded around scanner shape and AI-search readiness. | Add live AI-search and geography/platform visibility checks, then feed shared evidence back to SEOPass. |
-| FlowPass | Yes | ~ | Package exists with journey/report shape. | Add live browser journey runner, screenshots, console errors, and user-task completion evidence. |
-| RotatePass | Yes | ~ | Docs and redaction guardrails exist. It likely shares evidence with SecurityPass and Connections. | Decide final boundary, then add credential rotation, ownership, staleness, and blast-radius receipts. |
-| WakePass | Yes | ~ | Reliability layer exists through PinballWake, ACKs, leases, missed ACK reclaim, NudgeOnly, IgniteOnly, and PushOnly history. | Wrap the reliability substrate as the official WakePass product surface with receipts and dashboard copy. |
-| CompliancePass | Yes | ~ | Official compliance and enterprise-readiness product. Seed public JSON and guard test exist. | Keep "not certification" language and add automated evidence checks. |
+| TestPass | Yes | ✓ | Strongest XPass product today. Package exists, tests exist, live MCP proof and dogfood receipt exist. TestPass PR smoke is the standing cloud gate for the suite. | Keep as default trust gate and make sure receipts stay scoped to the target. |
+| UXPass | Yes | ✓ | Annotated visual evidence receipt is PR-ready and cloud-green in PR #1212. Fetch-only runs warn when screenshot/mobile/desktop proof is missing. | Keep improving visual critique quality beyond accessibility and fixture checks. |
+| SecurityPass | Yes | ✓ | Safe receipt surface is PR-ready and cloud-green in PR #1204. It exposes redacted SecurityPass run/status proof without leaking secrets. | Keep deny-by-default scope gates, and only add active probes with explicit future authorisation. |
+| CopyPass | Yes | ✓ | Live receipt envelope is PR-ready and cloud-green in PR #1203. It separates copy-quality proof from exact 1:1 fidelity. | Keep CopyPass for wording, claims, tone, clarity, and product-copy risk. |
+| FidelityPass | Yes | ✓ | CopyRoom wrapper with explicit `N/A` behavior is PR-ready and cloud-green in PR #1200. It does not duplicate CopyRoom. | Use FidelityPass only when exact 1:1 copying, transcription, mirroring, or preservation is in scope. |
+| CopyRoom | Adjacent | ✓ | Official exact-copy room remains the source of truth for 1:1 copy receipts. FidelityPass wraps it rather than replacing it. | Require a CopyRoom receipt whenever exact copying is requested. |
+| LegalPass | Yes | ✓ | Scoped receipt surface is PR-ready and cloud-green in PR #1207 with clear guidance-only and "not legal advice" boundaries. | Keep policy checks scoped and avoid certification or legal-advice claims. |
+| SlopPass | Yes | ✓ | Live PR diff support is PR-ready and cloud-green in PR #1201. SlopPass is the public code-quality name; QualityPass stays retired. | Keep PR diff receipts target-SHA scoped and avoid forked quality-brand names. |
+| CommonSensePass | Yes | ✓ | Worker-available tools, protocol playbook, fixture pack, and dogfood receipt were verified as no-code-needed and Boardroom-closed on 2026-05-30. | Enforce it before healthy, quiet, PASS, no-work, done, merge-ready, or duplicate-wake claims. |
+| SEOPass | Yes | ✓ | Live metadata/search-readiness receipt is PR-ready and cloud-green in PR #1209. | Keep public-page, sitemap, robots, canonical, and search-readiness receipts current. |
+| GEOPass | Yes | ✓ | Live AI-answer/readability receipt is PR-ready and cloud-green in PR #1206. | Feed shared answer-engine evidence back to SEOPass where useful. |
+| FlowPass | Yes | ✓ | Live journey receipt envelope is PR-ready and cloud-green in PR #1210. | Keep journey evidence scoped to route, task, console, screenshot, and completion proof. |
+| RotatePass | Yes | ✓ | Boundary receipt is PR-ready and cloud-green in PR #1213. It records credential ownership, staleness, blast-radius, and no-live-secret boundaries. | Keep proof public-safe: no raw credential values, no live secret probes, no destructive provider action. |
+| WakePass | Yes | ✓ | Boundary receipt is PR-ready and cloud-green in PR #1214. It records ACK, stale reclaim, liveness, and no-live-wake boundaries. | Keep proof public-safe: no live queue touch, no live workers, no notifications, no route adapter calls. |
+| CompliancePass | Yes | ✓ | Readiness receipt envelope is PR-ready and cloud-green in PR #1211 with "not certification" language. | Keep automated evidence checks readiness-only and cross-reference other Pass receipts. |
+
+## 2026-05-30 Proof Snapshot
+
+These rows were closed or verified during the 2026-05-30 XPass completion run:
+
+| Slice | Proof |
+| --- | --- |
+| Aggregated XPass verdict | PR #1193, cloud-green, adds target-SHA-bound `xpass_aggregated_verdict`. |
+| FidelityPass | PR #1200, cloud-green, CopyRoom wrapper with `N/A`. |
+| CommonSensePass | Boardroom no-code closure, worker exposure and fixtures verified. |
+| SlopPass | PR #1201, cloud-green, live PR diff support. |
+| CopyPass | PR #1203, cloud-green, live receipt envelope. |
+| SecurityPass | PR #1204, cloud-green, redacted safe receipt surface. |
+| GEOPass | PR #1206, cloud-green, live AI-answer receipt. |
+| LegalPass | PR #1207, cloud-green, scoped guidance receipt. |
+| SEOPass | PR #1209, cloud-green, live search-readiness receipt. |
+| FlowPass | PR #1210, cloud-green, live journey receipt. |
+| CompliancePass | PR #1211, cloud-green, readiness receipt. |
+| UXPass | PR #1212, cloud-green, annotated visual evidence receipt. |
+| RotatePass | PR #1213, cloud-green, public-safe credential boundary receipt. |
+| WakePass | PR #1214, cloud-green, public-safe wake boundary receipt. |
 
 ## Retired Or Historical Names
 
@@ -78,8 +100,8 @@ This keeps the XPass range agile. The checklist does not just judge the product.
 
 ## Next Closure Order
 
-1. Finish FidelityPass wrapper over CopyRoom receipts, including `N/A`.
-2. Restore or expose CommonSensePass as a worker-available tool and enforce it before trusted status claims.
-3. Wire SlopPass into PR diff and code-quality receipts.
-4. Add recurring receipts for CopyPass, SecurityPass, LegalPass, SEOPass, FlowPass, and CompliancePass.
-5. Keep UXPass improving toward real visual critique, not only accessibility or fixture checks.
+1. Merge or rebase the cloud-green PRs in an order that avoids one-file conflicts, especially the boundary-sweep updates.
+2. Run `xpass_aggregated_verdict` again after the PRs land so the final suite proof is bound to the current main SHA.
+3. Keep UXPass improving toward real visual critique, not only accessibility or fixture checks.
+4. Keep scheduled package and boundary sweeps target-SHA scoped; stale receipts must stay `PENDING`, not green.
+5. When a Pass emits weak, noisy, or missing evidence, create a focused Continuous Improver job instead of marking the suite healthy by vibes.

--- a/docs/prd/xpass-closure-board.md
+++ b/docs/prd/xpass-closure-board.md
@@ -26,7 +26,7 @@ This does not mean every expensive runner executes every time. The lightweight c
 | UXPass | Yes | ~ | Real package and runner exist, with visual audit work, viewport support, and dogfood fixtures. Still not enough to guarantee every mediocre UI becomes polished. | Finish annotated reports, stronger visual hierarchy checks, mobile and desktop evidence, and scheduled proof that does not clog the queue. |
 | SecurityPass | Yes | ~ | Real package and guardrails exist. Public dogfood is intentionally scope-gated until safe recurring proof exists. | Add deny-by-default recurring runner proof and make security receipts visible without exposing secrets. |
 | CopyPass | Yes | ~ | Real copy-quality package exists. It checks wording, claims, tone, clarity, and product copy risk. | Add recurring or on-demand live receipt surface and keep it separate from exact-copy fidelity. |
-| FidelityPass | Yes | ✗ | Official XPass/QC wrapper over CopyRoom, but not a separate completed engine yet. | Implement wrapper behavior over CopyRoom receipts, including `N/A` when no 1:1 copy is in scope. Do not duplicate CopyRoom. |
+| FidelityPass | Yes | ✓ | Official XPass/QC wrapper over CopyRoom/FidelityCopy receipts. It can verify exact-copy proof, suppress prose-only proof, and return explicit `N/A` when no 1:1 copy is in scope. | Keep it as a wrapper only. Do not duplicate CopyRoom. |
 | CopyRoom | Adjacent | ~ | Official exact-copy room. It is the office photocopier workers must use for 1:1 copying, transcription, mirroring, or preservation. | Reinforce worker usage and require a CopyRoom receipt whenever exact copying is requested. |
 | LegalPass | Yes | ~ | Package and guardrail library exist, but much of the deeper execution is still guidance or fixture-led. | Turn legal and policy checks into scoped receipts with clear "not legal advice" boundaries. |
 | SlopPass | Yes | ~ | Official AI/code quality product. Package, tests, product brief, and XPass selector wiring exist. | Finish live PR diff integration and make SlopPass the only public code-quality name. No QualityPass fork. |
@@ -78,7 +78,7 @@ This keeps the XPass range agile. The checklist does not just judge the product.
 
 ## Next Closure Order
 
-1. Finish FidelityPass wrapper over CopyRoom receipts, including `N/A`.
+1. Done: FidelityPass wrapper over CopyRoom receipts, including explicit `N/A`.
 2. Restore or expose CommonSensePass as a worker-available tool and enforce it before trusted status claims.
 3. Wire SlopPass into PR diff and code-quality receipts.
 4. Add recurring receipts for CopyPass, SecurityPass, LegalPass, SEOPass, FlowPass, and CompliancePass.

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1097,7 +1097,7 @@
       },
       {
         "name": "fidelitypass_verify_copy",
-        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
+        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes, or return N/A when no exact 1:1 copy is in scope. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
       }
     ]
   },

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -3050,6 +3050,40 @@
     ]
   },
   {
+    "app": "securitypass",
+    "category": "SecurityPass (scope-gated security receipts)",
+    "tools": [
+      {
+        "name": "securitypass_run",
+        "description": "Start a scope-gated SecurityPass scan against a registered pack or target URL. Returns a safe securitypass_receipt_v1 proof envelope without raw secrets or PoC payloads."
+      },
+      {
+        "name": "securitypass_status",
+        "description": "Poll the state of a SecurityPass run. Returns status, verdict summary, counts, and a safe securitypass_receipt_v1 proof envelope."
+      },
+      {
+        "name": "securitypass_report",
+        "description": "Fetch the synthesised report for a completed run (executive narrative + findings). format=json|markdown|html."
+      },
+      {
+        "name": "securitypass_register_pack",
+        "description": "Save a SecurityPack YAML for the calling tenant. Validates against the schema."
+      },
+      {
+        "name": "securitypass_verify_scope",
+        "description": "Verify scope authorisation for a target via DNS TXT or /.well-known proof. Required before any active probe runs."
+      },
+      {
+        "name": "securitypass_disclosure_status",
+        "description": "Check the 90+30 responsible-disclosure timer state for a finding (notified, acked, extended, public, withdrawn)."
+      },
+      {
+        "name": "securitypass_finding_detail",
+        "description": "Fetch a single finding including PoC payload (curl / prompt / payload) and remediation. PoC is generated, never auto-fired."
+      }
+    ]
+  },
+  {
     "app": "segment",
     "category": "Monitoring / CI / CDP / Email / Commerce / Inference",
     "tools": [

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -635,11 +635,11 @@
     "tools": [
       {
         "name": "copypass_run",
-        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, and optional CopyRoom exact-copy receipt."
+        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, a structured copypass_receipt_v1 proof envelope, and optional CopyRoom exact-copy receipt."
       },
       {
         "name": "copypass_status",
-        "description": "Fetch the current status, notes, deterministic findings, disclaimer, and CopyRoom receipt for a CopyPass run started in this MCP session."
+        "description": "Fetch the current status, notes, deterministic findings, disclaimer, copypass_receipt_v1 proof envelope, and CopyRoom receipt for a CopyPass run started in this MCP session."
       }
     ]
   },

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -4272,6 +4272,16 @@
     ]
   },
   {
+    "app": "xpass-aggregated-verdict",
+    "category": "XPass (conductor receipt across product checks)",
+    "tools": [
+      {
+        "name": "xpass_aggregated_verdict",
+        "description": "Return one XPass conductor verdict for a target PR/change at a specific commit SHA. Selected PASS receipts must name the same head SHA; stale, unscoped, missing, or blocker receipts cannot produce a green verdict."
+      }
+    ]
+  },
+  {
     "app": "yelp",
     "category": "AI",
     "tools": [

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -4055,11 +4055,11 @@
     "tools": [
       {
         "name": "uxpass_run",
-        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
+        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, summary, and uxpass_receipt_v1. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The receipt calls out when browser visual snapshots, screenshots, or mobile/desktop proof are missing. The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
       },
       {
         "name": "uxpass_status",
-        "description": "Fetch the status, UX Score, and summary for a UXPass run."
+        "description": "Fetch the status, UX Score, summary, and uxpass_receipt_v1 for a UXPass run."
       },
       {
         "name": "uxpass_report_html",

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -3275,7 +3275,7 @@
     "tools": [
       {
         "name": "sloppass_run",
-        "description": "Run SlopPass against caller-provided source files or a unified diff. Returns an evidence-backed slop-signal receipt plus JSON, markdown, and HTML reports. SlopPass does not execute code, read repositories, persist source content, or make paid model calls by default."
+        "description": "Run SlopPass against caller-provided source files, a unified diff, or a GitHub PR target whose public .diff should be fetched. Returns an evidence-backed slop-signal receipt plus JSON, markdown, and HTML reports. SlopPass does not execute code, clone repositories, persist source content, or make paid model calls by default."
       }
     ]
   },

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1300,6 +1300,20 @@
     ]
   },
   {
+    "app": "geopass",
+    "category": "GEOPass (AI answer-engine readiness QC, sister to SEOPass)",
+    "tools": [
+      {
+        "name": "geopass_run",
+        "description": "Run GEOPass against a public URL. Returns a live-readonly AI answer-engine readiness receipt covering answer extractability, entity clarity, citation/sourceability, freshness cues, content structure, llms.txt, and AI bot visibility. GEOPass reports readiness only and does not guarantee rankings or citations."
+      },
+      {
+        "name": "geopass_status",
+        "description": "Fetch the stored in-session GEOPass report and geopass_receipt_v1 envelope for a run started through geopass_run."
+      }
+    ]
+  },
+  {
     "app": "github",
     "category": "Developer / Productivity",
     "tools": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -21938,6 +21938,7 @@
         "@types/nodemailer": "^8.0.0",
         "@unclick/commonsensepass": "*",
         "@unclick/flowpass": "*",
+        "@unclick/securitypass": "*",
         "ajv": "^8.20.0",
         "csv-parse": "^6.2.1",
         "csv-stringify": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && vitest run && npm run test:api-lib-esm-extension",
+    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && vitest run && npm run test:api-lib-esm-extension",
     "compliancepass:report": "npm run build --workspace=@unclick/compliancepass && node scripts/build-compliancepass-report.mjs",
     "test:compliancepass-receipt": "node --test scripts/enterprisepass-receipt-guard.test.mjs",
     "test:continuous-improvement-watch": "node --test scripts/pinballwake-continuous-improvement-watch.test.mjs",

--- a/packages/compliancepass/src/__tests__/schema.test.ts
+++ b/packages/compliancepass/src/__tests__/schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { CompliancePassReceiptSchema } from "../schema.js";
+
+describe("CompliancePass schema", () => {
+  it("validates a readiness receipt envelope", () => {
+    const receipt = CompliancePassReceiptSchema.parse({
+      kind: "compliancepass_receipt_v1",
+      status: "WARN",
+      run_id: "compliancepass-20260530141000-abc12345",
+      target_name: "UnClick",
+      target_sha: "abc123",
+      generated_at: "2026-05-30T14:10:00.000Z",
+      valid_until: "2026-06-06T14:10:00.000Z",
+      readiness_score: {
+        value: 82,
+        band: "amber",
+        traffic_light: "yellow",
+        rationale: "Some readiness gaps remain.",
+      },
+      checked: {
+        total: 12,
+        pass: 9,
+        partial: 2,
+        fail: 1,
+        unknown: 0,
+        na: 0,
+        pending: 0,
+      },
+      gap_severity_counts: {
+        critical: 0,
+        high: 1,
+        medium: 2,
+        low: 0,
+        info: 0,
+      },
+      blocking_gap_count: 1,
+      evidence_sources: [
+        {
+          type: "doc",
+          label: "Framework mapping",
+          path: "docs/compliancepass-framework-mapping.md",
+          summary: "Control mapping exists but needs owner proof.",
+        },
+      ],
+      action_needed: ["Close the high-severity readiness gap before claiming green."],
+      boundaries: [
+        "CompliancePass is readiness guidance, not a compliance certification.",
+        "CompliancePass receipts must not expose secrets or private production data.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("compliancepass_receipt_v1");
+    expect(receipt.target_sha).toBe("abc123");
+  });
+});

--- a/packages/compliancepass/src/schema.ts
+++ b/packages/compliancepass/src/schema.ts
@@ -133,6 +133,36 @@ export const CompliancePassReportSchema = z.object({
   disclaimer: z.string().min(1),
 });
 
+export const CompliancePassReceiptSchema = z.object({
+  kind: z.literal("compliancepass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_name: z.string().min(1),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  valid_until: z.string().datetime(),
+  readiness_score: z.object({
+    value: z.number().min(0).max(100),
+    band: CompliancePassBandSchema,
+    traffic_light: z.enum(["green", "yellow", "red", "grey"]),
+    rationale: z.string().min(1),
+  }),
+  checked: z.object({
+    total: z.number().int().nonnegative(),
+    pass: z.number().int().nonnegative(),
+    partial: z.number().int().nonnegative(),
+    fail: z.number().int().nonnegative(),
+    unknown: z.number().int().nonnegative(),
+    na: z.number().int().nonnegative(),
+    pending: z.literal(0),
+  }),
+  gap_severity_counts: CompliancePassGapSeverityCountsSchema,
+  blocking_gap_count: z.number().int().nonnegative(),
+  evidence_sources: z.array(CompliancePassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export type CompliancePassCategoryId = z.infer<typeof CompliancePassCategoryIdSchema>;
 export type CompliancePassStatus = z.infer<typeof CompliancePassStatusSchema>;
 export type CompliancePassSeverity = z.infer<typeof CompliancePassSeveritySchema>;
@@ -143,3 +173,4 @@ export type CompliancePassGapSeverityCounts = z.infer<typeof CompliancePassGapSe
 export type CompliancePassCheck = z.infer<typeof CompliancePassCheckSchema>;
 export type CompliancePassCategory = z.infer<typeof CompliancePassCategorySchema>;
 export type CompliancePassReport = z.infer<typeof CompliancePassReportSchema>;
+export type CompliancePassReceipt = z.infer<typeof CompliancePassReceiptSchema>;

--- a/packages/flowpass/src/__tests__/schema.test.ts
+++ b/packages/flowpass/src/__tests__/schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   FlowPassFindingSchema,
   FlowPassGeoPassAdapterSchema,
+  FlowPassReceiptSchema,
   FlowPassReportSchema,
 } from "../schema.js";
 
@@ -69,5 +70,44 @@ describe("FlowPass schema", () => {
     });
 
     expect(report.steps[0]?.findings).toEqual([]);
+  });
+
+  it("validates a journey receipt envelope", () => {
+    const receipt = FlowPassReceiptSchema.parse({
+      kind: "flowpass_receipt_v1",
+      status: "PENDING",
+      run_id: "flowpass_plan_1",
+      target_url: "https://example.com/signup",
+      target_sha: "abc123",
+      generated_at: "2026-05-30T14:10:00.000Z",
+      mode: "plan-only",
+      profile: "smoke",
+      journey: {
+        id: "signup",
+        name: "Signup journey",
+        kind: "signup",
+      },
+      score: 0,
+      verdict: "unknown",
+      checked: { total: 1, pass: 0, warn: 0, fail: 0, unknown: 1 },
+      evidence_sources: [
+        {
+          kind: "manual-note",
+          label: "Plan-only note",
+          source_url: "https://example.com/signup",
+          summary: "Fixture proof is still required.",
+        },
+      ],
+      not_checked: [{ label: "Success state", reason: "No fixture supplied." }],
+      disagreements_open: 0,
+      action_needed: ["Provide fixture proof before using this as a PASS receipt."],
+      boundaries: [
+        "FlowPass uses provided public fixture evidence from this MCP surface.",
+        "Plan-only results are not PASS receipts until fixture or live read-only proof is supplied.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("flowpass_receipt_v1");
+    expect(receipt.status).toBe("PENDING");
   });
 });

--- a/packages/flowpass/src/schema.ts
+++ b/packages/flowpass/src/schema.ts
@@ -176,6 +176,36 @@ export const FlowPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const FlowPassReceiptSchema = z.object({
+  kind: z.literal("flowpass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER", "PENDING"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]),
+  profile: FlowPassProfileSchema,
+  journey: z.object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    kind: FlowPassJourneyKindSchema,
+  }),
+  score: z.number().min(0).max(100),
+  verdict: FlowPassReportVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    pass: z.number().int().min(0),
+    warn: z.number().int().min(0),
+    fail: z.number().int().min(0),
+    unknown: z.number().int().min(0),
+  }),
+  evidence_sources: z.array(FlowPassEvidenceSchema).default([]),
+  not_checked: z.array(FlowPassNotCheckedSchema).default([]),
+  disagreements_open: z.number().int().min(0),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export const FlowPassFixtureLinkSchema = z.object({
   label: z.string().min(1),
   href: z.string().min(1).optional(),
@@ -308,6 +338,7 @@ export type FlowPassHatOutput = z.infer<typeof FlowPassHatOutputSchema>;
 export type FlowPassNotChecked = z.infer<typeof FlowPassNotCheckedSchema>;
 export type FlowPassDisagreement = z.infer<typeof FlowPassDisagreementSchema>;
 export type FlowPassReport = z.infer<typeof FlowPassReportSchema>;
+export type FlowPassReceipt = z.infer<typeof FlowPassReceiptSchema>;
 export type FlowPassFixture = z.infer<typeof FlowPassFixtureSchema>;
 export type FlowPassPack = z.infer<typeof FlowPassPackSchema>;
 export type FlowPassUserPack = z.infer<typeof FlowPassUserPackSchema>;

--- a/packages/geopass/package.json
+++ b/packages/geopass/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./schema": "./dist/schema.js",
-    "./scanner-plan": "./dist/scanner-plan.js"
+    "./scanner-plan": "./dist/scanner-plan.js",
+    "./runner": "./dist/runner.js"
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",

--- a/packages/geopass/src/__tests__/runner.test.ts
+++ b/packages/geopass/src/__tests__/runner.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runGeoPass } from "../runner.js";
+
+function installFetch(fixtures: Record<string, string | { status: number; body: string; headers?: Record<string, string>; url?: string }>): void {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const normalized = new URL(url).toString();
+    const fixture = fixtures[normalized] ?? fixtures[normalized.replace(/\/$/, "")];
+    const status = typeof fixture === "object" ? fixture.status : fixture ? 200 : 404;
+    const body = typeof fixture === "object" ? fixture.body : fixture ?? "not found";
+    const headers = typeof fixture === "object" ? fixture.headers ?? { "content-type": "text/html" } : { "content-type": "text/html" };
+    return {
+      url: typeof fixture === "object" && fixture.url ? fixture.url : normalized,
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers(headers),
+      text: async () => body,
+    };
+  }));
+}
+
+const strongGeoHtml = `<!doctype html>
+<html>
+  <head>
+    <title>UnClick GEOPass - AI answer readiness checks</title>
+    <meta name="description" content="GEOPass checks whether public pages are readable, sourceable, and clear enough for AI answer engines.">
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "UnClick",
+      "url": "https://unclick.world"
+    }</script>
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": []
+    }</script>
+  </head>
+  <body>
+    <h1>GEOPass checks AI answer readiness</h1>
+    <h2>What does GEOPass inspect?</h2>
+    <p>GEOPass inspects public pages for answer extractability, entity clarity, citation readiness, freshness cues, and AI-readable structure.</p>
+    <h2>How does it avoid false promises?</h2>
+    <p>It reports readiness only. It does not guarantee rankings, AI citations, or answer-engine placement.</p>
+    <ul><li>Public evidence</li><li>Clear entity names</li><li>Fresh source links</li></ul>
+    <p>Updated <time datetime="2026-05-30">May 30, 2026</time>. According to public documentation, source evidence matters.</p>
+    <p>See the <a href="https://developers.google.com/search/docs/appearance/ai-features">Google AI features guidance</a> and <a href="https://schema.org">schema.org</a>.</p>
+    <a href="/about">About</a>
+    <a href="/contact">Contact</a>
+  </body>
+</html>`;
+
+describe("runGeoPass", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects non-public URL schemes and credentialed URLs", async () => {
+    await expect(runGeoPass({ url: "file:///tmp/page.html" })).resolves.toMatchObject({
+      error: expect.stringContaining("public http(s)"),
+    });
+    await expect(runGeoPass({ url: "https://user:pass@example.com" })).resolves.toMatchObject({
+      error: expect.stringContaining("public http(s)"),
+    });
+  });
+
+  it("returns a first-class live receipt for AI-answer readiness", async () => {
+    installFetch({
+      "https://unclick.world/": strongGeoHtml,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nGEOPass helps AI systems read public product pages.\n\n[Docs](https://unclick.world/docs): Documentation for public checks and receipts.",
+    });
+
+    const run = await runGeoPass({
+      url: "https://unclick.world",
+      generatedAt: "2026-05-30T12:00:00.000Z",
+      targetSha: "abc123",
+    });
+
+    expect("error" in run).toBe(false);
+    if ("error" in run) throw new Error(run.error);
+    expect(run.status).toBe("complete");
+    expect(run.pass).toBe("geopass");
+    expect(run.report.mode).toBe("live-readonly");
+    expect(run.report.checks.map((check) => check.check_id)).toContain("answer-extractability");
+    expect(run.report.checks.map((check) => check.check_id)).toContain("citation-readiness");
+    expect(run.geopass_receipt_v1).toMatchObject({
+      kind: "geopass_receipt_v1",
+      mode: "live-readonly",
+      target_sha: "abc123",
+    });
+    expect(run.geopass_receipt_v1.boundaries.join(" ")).toContain("does not guarantee");
+    expect(run.ai_answer_readiness_score).toBeGreaterThanOrEqual(80);
+  });
+
+  it("blocks when robots.txt disallows AI crawlers", async () => {
+    installFetch({
+      "https://unclick.world/private": strongGeoHtml,
+      "https://unclick.world/robots.txt": "User-agent: GPTBot\nDisallow: /\nUser-agent: ClaudeBot\nDisallow: /\n",
+      "https://unclick.world/llms.txt": { status: 404, body: "not found" },
+    });
+
+    const run = await runGeoPass({
+      url: "https://unclick.world/private",
+      generatedAt: "2026-05-30T12:00:00.000Z",
+    });
+
+    expect("error" in run).toBe(false);
+    if ("error" in run) throw new Error(run.error);
+    expect(run.verdict).toBe("blocked");
+    expect(run.geopass_receipt_v1.status).toBe("BLOCKER");
+    expect(run.report.checks.some((check) => check.check_id === "ai-bot-crawlability" && check.verdict === "blocked")).toBe(true);
+  });
+
+  it("keeps external index checks explicit unknown instead of pretending proof", async () => {
+    installFetch({
+      "https://unclick.world/": strongGeoHtml,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nHelpful file with enough public summary and links to docs.",
+    });
+
+    const run = await runGeoPass({
+      url: "https://unclick.world",
+      checks: ["wikidata-presence", "common-crawl-presence"],
+    });
+
+    expect("error" in run).toBe(false);
+    if ("error" in run) throw new Error(run.error);
+    expect(run.report.checks.map((check) => check.verdict)).toEqual(["unknown", "unknown"]);
+    expect(run.geopass_receipt_v1.checked.unknown).toBe(2);
+  });
+});

--- a/packages/geopass/src/__tests__/scanner-plan.test.ts
+++ b/packages/geopass/src/__tests__/scanner-plan.test.ts
@@ -16,6 +16,8 @@ describe("createGeoPassScannerPlan", () => {
     expect(plan.engines).toEqual(DEFAULT_GEOPASS_ENGINES);
     expect(plan.bots).toEqual(DEFAULT_GEOPASS_BOTS);
     expect(plan.steps.map((step) => step.id)).toContain("ai-bot-crawlability");
+    expect(plan.steps.map((step) => step.id)).toContain("answer-extractability");
+    expect(plan.steps.map((step) => step.id)).toContain("citation-readiness");
     expect(plan.steps.map((step) => step.id)).toContain(
       "aggregate-ai-engine-readiness",
     );
@@ -40,7 +42,7 @@ describe("createGeoPassScannerPlan", () => {
 
     expect(plan.disallowedActions).toContain("live crawler execution");
     expect(plan.disallowedActions).toContain("paid API calls");
-    expect(plan.disallowedActions).toContain("citation guarantees");
+    expect(plan.disallowedActions).toContain("guaranteed citations");
   });
 
   it("rejects invalid target URLs", () => {

--- a/packages/geopass/src/__tests__/schema.test.ts
+++ b/packages/geopass/src/__tests__/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GeoPassReportSchema } from "../schema.js";
+import { GeoPassReceiptSchema, GeoPassReportSchema } from "../schema.js";
 
 const validReport = {
   target_url: "https://example.com/",
@@ -86,5 +86,38 @@ describe("GeoPassReportSchema", () => {
     expect(result.checks[0]?.findings[0]?.evidence[0]?.source_url).toBe(
       "https://example.com/llms.txt",
     );
+  });
+
+  it("accepts the first-class live receipt envelope", () => {
+    const receipt = GeoPassReceiptSchema.parse({
+      kind: "geopass_receipt_v1",
+      status: "WARN",
+      run_id: "geopass-abc123",
+      target_url: "https://example.com/",
+      generated_at: "2026-05-30T12:00:00.000Z",
+      mode: "live-readonly",
+      score: 74,
+      verdict: "needs-work",
+      checked: {
+        total: 3,
+        ready: 1,
+        needs_work: 2,
+        blocked: 0,
+        unknown: 0,
+      },
+      evidence_sources: [
+        {
+          kind: "html",
+          label: "Heading scan",
+          source_url: "https://example.com/",
+          summary: "Question headings found.",
+        },
+      ],
+      action_needed: ["Add clearer source links."],
+      boundaries: ["Readiness only. No citation guarantee."],
+    });
+
+    expect(receipt.kind).toBe("geopass_receipt_v1");
+    expect(receipt.status).toBe("WARN");
   });
 });

--- a/packages/geopass/src/index.ts
+++ b/packages/geopass/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./schema.js";
 export * from "./scanner-plan.js";
+export * from "./runner.js";

--- a/packages/geopass/src/runner.ts
+++ b/packages/geopass/src/runner.ts
@@ -1,0 +1,825 @@
+import { createHash, randomUUID } from "node:crypto";
+import { DEFAULT_GEOPASS_ENGINES } from "./scanner-plan.js";
+import {
+  type GeoPassCheckId,
+  type GeoPassCheckResult,
+  type GeoPassCrossPassSignal,
+  type GeoPassEvidence,
+  type GeoPassFinding,
+  type GeoPassReceipt,
+  type GeoPassReport,
+  type GeoPassVerdict,
+} from "./schema.js";
+
+type FetchLike = typeof fetch;
+
+export interface GeoPassRunInput {
+  url?: string;
+  targetUrl?: string;
+  checks?: GeoPassCheckId[];
+  generatedAt?: string;
+  targetSha?: string;
+  fetchImpl?: FetchLike;
+  timeoutMs?: number;
+  maxBodyChars?: number;
+}
+
+export interface GeoPassRunResult {
+  run_id: string;
+  status: "complete";
+  pass: "geopass";
+  target_url: string;
+  generated_at: string;
+  ai_answer_readiness_score: number;
+  verdict: GeoPassVerdict;
+  verdict_summary: Record<"ready" | "needs_work" | "blocked" | "unknown", number>;
+  report: GeoPassReport;
+  geopass_receipt_v1: GeoPassReceipt;
+}
+
+interface FetchTextResult {
+  url: string;
+  status: number;
+  ok: boolean;
+  headers: Record<string, string>;
+  body: string;
+  error?: string;
+  truncated?: boolean;
+}
+
+interface PageSignals {
+  title: string;
+  description: string;
+  h1: string[];
+  h2: string[];
+  text: string;
+  wordCount: number;
+  paragraphCount: number;
+  listCount: number;
+  questionCount: number;
+  externalLinkCount: number;
+  hasJsonLd: boolean;
+  hasMicrodata: boolean;
+  hasRdfa: boolean;
+  hasOrganizationSchema: boolean;
+  hasArticleSchema: boolean;
+  hasFaqSchema: boolean;
+  hasAuthorCue: boolean;
+  hasAboutOrContactLink: boolean;
+  hasFreshnessCue: boolean;
+  hasStatisticCue: boolean;
+  hasSourceCue: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_BODY_CHARS = 1_250_000;
+const LIVE_CHECKS: GeoPassCheckId[] = [
+  "ai-bot-crawlability",
+  "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
+  "schema-org-citation-grade",
+  "brand-mention-readiness",
+  "aggregate-ai-engine-readiness",
+];
+
+const AI_BOTS = [
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+] as const;
+
+const RECEIPT_BOUNDARIES = [
+  "GEOPass reports public read-only readiness only.",
+  "GEOPass does not guarantee rankings, citations, AI Overview inclusion, or answer-engine placement.",
+  "This run fetches public http(s) pages only and does not use credentials, paid APIs, production data, or private prompts.",
+];
+
+function normalizePublicHttpUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function stableRunId(targetUrl: string, generatedAt: string): string {
+  const digest = createHash("sha256")
+    .update(`${targetUrl}:${generatedAt}:${randomUUID()}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `geopass-${digest}`;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const output: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    output[key.toLowerCase()] = value;
+  });
+  return output;
+}
+
+async function fetchText(
+  url: string,
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+  maxBodyChars: number,
+): Promise<FetchTextResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "user-agent": "UnClick-GEOPass/0.1 (+https://unclick.world)" },
+    });
+    const body = await response.text();
+    const truncated = body.length > maxBodyChars;
+    return {
+      url: response.url || url,
+      status: response.status,
+      ok: response.ok,
+      headers: headersToRecord(response.headers),
+      body: truncated ? body.slice(0, maxBodyChars) : body,
+      truncated,
+    };
+  } catch (error) {
+    return {
+      url,
+      status: 0,
+      ok: false,
+      headers: {},
+      body: "",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&#39;/gi, "'")
+    .replace(/&quot;/gi, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function firstMatch(html: string, pattern: RegExp): string {
+  return pattern.exec(html)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function allMatches(html: string, pattern: RegExp): string[] {
+  return Array.from(html.matchAll(pattern), (match) =>
+    stripHtml(match[1] ?? "").replace(/\s+/g, " ").trim(),
+  ).filter(Boolean);
+}
+
+function countMatches(text: string, pattern: RegExp): number {
+  return Array.from(text.matchAll(pattern)).length;
+}
+
+function getMeta(html: string, name: string): string {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return firstMatch(
+    html,
+    new RegExp(`<meta[^>]+(?:name|property)=["']${escaped}["'][^>]+content=["']([^"']+)["'][^>]*>`, "i"),
+  );
+}
+
+function hasSchemaType(html: string, typeName: string): boolean {
+  const pattern = new RegExp(`"@type"\\s*:\\s*"?${typeName}"?`, "i");
+  return pattern.test(html);
+}
+
+function linkCount(html: string, baseUrl: string, external: boolean): number {
+  let count = 0;
+  const base = new URL(baseUrl);
+  for (const match of html.matchAll(/<a\b[^>]+href=["']([^"']+)["'][^>]*>/gi)) {
+    try {
+      const href = new URL(match[1] ?? "", base);
+      if ((href.protocol === "http:" || href.protocol === "https:") && (href.origin !== base.origin) === external) {
+        count += 1;
+      }
+    } catch {
+      // Ignore malformed links in a read-only diagnostic.
+    }
+  }
+  return count;
+}
+
+function hasAboutOrContactLink(html: string): boolean {
+  return /<a\b[^>]+href=["'][^"']*(about|contact|company|team)[^"']*["'][^>]*>/i.test(html);
+}
+
+function analyzeHtml(html: string, targetUrl: string): PageSignals {
+  const text = stripHtml(html);
+  const lower = text.toLowerCase();
+  const h1 = allMatches(html, /<h1\b[^>]*>([\s\S]*?)<\/h1>/gi);
+  const h2 = allMatches(html, /<h2\b[^>]*>([\s\S]*?)<\/h2>/gi);
+  const description = getMeta(html, "description") || getMeta(html, "og:description");
+  const title = firstMatch(html, /<title\b[^>]*>([\s\S]*?)<\/title>/i) || getMeta(html, "og:title");
+  const hasJsonLd = /<script\b[^>]+type=["']application\/ld\+json["'][^>]*>/i.test(html);
+  return {
+    title,
+    description,
+    h1,
+    h2,
+    text,
+    wordCount: text.split(/\s+/).filter(Boolean).length,
+    paragraphCount: countMatches(html, /<p\b/gi),
+    listCount: countMatches(html, /<(ul|ol|li)\b/gi),
+    questionCount: countMatches(`${h1.join(" ")} ${h2.join(" ")} ${text}`, /\b(what|why|how|when|where|who|can|does|is|are)\b[^.?!]{0,80}\?/gi),
+    externalLinkCount: linkCount(html, targetUrl, true),
+    hasJsonLd,
+    hasMicrodata: /\bitemscope\b/i.test(html),
+    hasRdfa: /\btypeof=["'][^"']+["']/i.test(html),
+    hasOrganizationSchema: hasJsonLd && (hasSchemaType(html, "Organization") || hasSchemaType(html, "LocalBusiness") || hasSchemaType(html, "Product")),
+    hasArticleSchema: hasJsonLd && (hasSchemaType(html, "Article") || hasSchemaType(html, "NewsArticle") || hasSchemaType(html, "BlogPosting")),
+    hasFaqSchema: hasJsonLd && hasSchemaType(html, "FAQPage"),
+    hasAuthorCue: /\b(author|byline|written by|reviewed by|editor|team)\b/i.test(lower),
+    hasAboutOrContactLink: hasAboutOrContactLink(html),
+    hasFreshnessCue: /<time\b/i.test(html) || /\b(updated|last updated|published|reviewed)\b/i.test(lower) || /\b20\d{2}[-/]\d{1,2}[-/]\d{1,2}\b/.test(text),
+    hasStatisticCue: /\b\d+(\.\d+)?%|\b\d+x\b|\b\d{2,}\b/.test(text),
+    hasSourceCue: /\b(source|sources|citation|research|study|report|evidence|according to|data from)\b/i.test(lower),
+  };
+}
+
+function evidence(kind: GeoPassEvidence["kind"], label: string, summary: string, sourceUrl?: string): GeoPassEvidence {
+  return {
+    kind,
+    label,
+    summary,
+    ...(sourceUrl ? { source_url: sourceUrl } : {}),
+  };
+}
+
+function finding(
+  checkId: GeoPassCheckId,
+  id: string,
+  severity: GeoPassFinding["severity"],
+  title: string,
+  summary: string,
+  recommendation: string,
+  findingEvidence: GeoPassEvidence[],
+): GeoPassFinding {
+  return {
+    id,
+    check_id: checkId,
+    severity,
+    title,
+    summary,
+    recommendation,
+    evidence: findingEvidence,
+  };
+}
+
+function verdictFor(score: number, findings: GeoPassFinding[]): GeoPassVerdict {
+  if (findings.some((item) => item.severity === "critical" || item.severity === "high") && score < 55) {
+    return "blocked";
+  }
+  if (score >= 85) return "ready";
+  if (score >= 45) return "needs-work";
+  return "blocked";
+}
+
+function result(
+  checkId: GeoPassCheckId,
+  label: string,
+  score: number,
+  findings: GeoPassFinding[],
+): GeoPassCheckResult {
+  return {
+    check_id: checkId,
+    label,
+    score: Math.max(0, Math.min(100, Math.round(score))),
+    verdict: verdictFor(score, findings),
+    findings,
+  };
+}
+
+function pageUnavailableResult(checkId: GeoPassCheckId, targetUrl: string, page: FetchTextResult): GeoPassCheckResult {
+  return result(checkId, labelFor(checkId), 0, [
+    finding(
+      checkId,
+      `${checkId}-target-unavailable`,
+      "critical",
+      "Target page was not readable",
+      page.error ? `The public page fetch failed: ${page.error}.` : `The public page returned HTTP ${page.status}.`,
+      "Make the public page return readable HTML before using it as GEOPass evidence.",
+      [evidence("http", "Target fetch", page.error ?? `HTTP ${page.status}`, targetUrl)],
+    ),
+  ]);
+}
+
+function labelFor(checkId: GeoPassCheckId): string {
+  return {
+    "ai-bot-crawlability": "AI bot crawlability matrix",
+    "llms-txt": "llms.txt presence and quality",
+    "answer-extractability": "Answer extractability",
+    "entity-clarity": "Entity clarity",
+    "citation-readiness": "Citation and sourceability readiness",
+    "freshness-cues": "Freshness and update cues",
+    "content-structure": "AI-readable content structure",
+    "schema-org-citation-grade": "schema.org citation-grade validation",
+    "brand-mention-readiness": "Brand mention readiness",
+    "wikidata-presence": "Wikidata presence",
+    "common-crawl-presence": "Common Crawl presence",
+    "aggregate-ai-engine-readiness": "Aggregate AI engine readiness score",
+  }[checkId];
+}
+
+function robotsBlockedBots(robotsBody: string, pathname: string): string[] {
+  const groups: Array<{ agents: string[]; rules: Array<{ directive: "allow" | "disallow"; path: string }> }> = [];
+  let current: { agents: string[]; rules: Array<{ directive: "allow" | "disallow"; path: string }> } | null = null;
+  for (const rawLine of robotsBody.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*/, "").trim();
+    if (!line) continue;
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    if (key === "user-agent") {
+      current = { agents: [value.toLowerCase()], rules: [] };
+      groups.push(current);
+    } else if ((key === "allow" || key === "disallow") && current) {
+      current.rules.push({ directive: key, path: value });
+    }
+  }
+
+  return AI_BOTS.filter((bot) => {
+    const token = bot.toLowerCase();
+    const matching = groups.filter((group) =>
+      group.agents.some((agent) => agent === "*" || token.includes(agent.replace(/\*$/, ""))),
+    );
+    const rules = matching.flatMap((group) => group.rules).filter((rule) => rule.path !== "");
+    const disallows = rules.filter((rule) => rule.directive === "disallow" && pathMatches(pathname, rule.path));
+    if (disallows.length === 0) return false;
+    const strongestDisallow = Math.max(...disallows.map((rule) => rule.path.length));
+    const strongestAllow = Math.max(
+      0,
+      ...rules
+        .filter((rule) => rule.directive === "allow" && pathMatches(pathname, rule.path))
+        .map((rule) => rule.path.length),
+    );
+    return strongestDisallow >= strongestAllow;
+  });
+}
+
+function pathMatches(pathname: string, rulePath: string): boolean {
+  const cleanRule = rulePath.replace(/\*.*/, "");
+  if (cleanRule === "/" || cleanRule === "") return cleanRule === "/";
+  return pathname.startsWith(cleanRule);
+}
+
+function buildAiBotCrawlability(targetUrl: string, robots: FetchTextResult): GeoPassCheckResult {
+  if (robots.status === 0 || robots.status >= 500 || robots.status === 429) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 60, [
+      finding(
+        "ai-bot-crawlability",
+        "ai-bot-crawlability-robots-unavailable",
+        "medium",
+        "robots.txt was not safely checkable",
+        robots.error ? `robots.txt fetch failed: ${robots.error}.` : `robots.txt returned HTTP ${robots.status}.`,
+        "Make robots.txt consistently available so AI crawler access can be checked.",
+        [evidence("robots-txt", "robots.txt fetch", robots.error ?? `HTTP ${robots.status}`, new URL("/robots.txt", targetUrl).toString())],
+      ),
+    ]);
+  }
+  if (robots.status === 404) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 88, []);
+  }
+  const blocked = robotsBlockedBots(robots.body, new URL(targetUrl).pathname || "/");
+  if (blocked.length === 0) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 100, []);
+  }
+  return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 35, [
+    finding(
+      "ai-bot-crawlability",
+      "ai-bot-crawlability-blocked",
+      "high",
+      "AI crawler access is blocked",
+      `robots.txt appears to block ${blocked.join(", ")} for this path.`,
+      "Review whether AI search crawlers should be allowed to read this public page.",
+      [evidence("robots-txt", "Blocked AI bot rules", blocked.join(", "), new URL("/robots.txt", targetUrl).toString())],
+    ),
+  ]);
+}
+
+function buildLlmsTxt(targetUrl: string, llms: FetchTextResult): GeoPassCheckResult {
+  if (llms.ok && llms.body.trim().length >= 160) {
+    const score = /\[[^\]]+\]\(https?:\/\//.test(llms.body) ? 100 : 88;
+    return result("llms-txt", labelFor("llms-txt"), score, []);
+  }
+  if (llms.ok) {
+    return result("llms-txt", labelFor("llms-txt"), 68, [
+      finding(
+        "llms-txt",
+        "llms-txt-thin",
+        "medium",
+        "llms.txt exists but is thin",
+        "The llms.txt file exists but does not yet provide enough product context, summaries, or source links for AI readers.",
+        "Add a concise product summary, canonical docs links, and important public pages to llms.txt.",
+        [evidence("llms-txt", "Public llms.txt", "File exists but is short.", new URL("/llms.txt", targetUrl).toString())],
+      ),
+    ]);
+  }
+  return result("llms-txt", labelFor("llms-txt"), 58, [
+    finding(
+      "llms-txt",
+      "llms-txt-missing",
+      "medium",
+      "llms.txt was not found",
+      "No public llms.txt file was available at the target origin.",
+      "Consider publishing llms.txt with public summaries and canonical links for AI readers.",
+      [evidence("llms-txt", "Public llms.txt", `HTTP ${llms.status || "fetch failed"}`, new URL("/llms.txt", targetUrl).toString())],
+    ),
+  ]);
+}
+
+function buildAnswerExtractability(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 55;
+  if (signals.wordCount >= 350) score += 15;
+  if (signals.questionCount > 0 || signals.hasFaqSchema) score += 15;
+  if (signals.paragraphCount >= 4) score += 10;
+  if (signals.h2.length >= 2) score += 5;
+  if (signals.wordCount < 180) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-thin-page",
+      "medium",
+      "Page copy is thin for AI answer reuse",
+      "The page has limited visible body copy, which makes direct answer extraction brittle.",
+      "Add clear, visible answers to the main questions a customer or answer engine would ask.",
+      [evidence("content", "Visible body text", `${signals.wordCount} visible words`, targetUrl)],
+    ));
+  }
+  if (signals.questionCount === 0 && !signals.hasFaqSchema) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-no-questions",
+      "low",
+      "No explicit question-answer structure was found",
+      "AI answer engines often benefit from direct question headings, FAQ structure, or plain answer blocks.",
+      "Add direct headings or FAQ-style sections for important user questions.",
+      [evidence("html", "Heading scan", `${signals.h2.length} h2 heading(s), ${signals.questionCount} question heading(s)`, targetUrl)],
+    ));
+  }
+  return result("answer-extractability", labelFor("answer-extractability"), score, findings);
+}
+
+function buildEntityClarity(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.title) score += 15;
+  if (signals.description) score += 15;
+  if (signals.h1.length > 0) score += 10;
+  if (signals.hasOrganizationSchema) score += 15;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (!signals.hasOrganizationSchema) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-schema-missing",
+      "medium",
+      "Organization or product schema was not found",
+      "The page does not expose obvious Organization, LocalBusiness, or Product JSON-LD for entity grounding.",
+      "Add truthful schema that matches visible page content.",
+      [evidence("schema-org", "Schema scan", "No Organization, LocalBusiness, or Product JSON-LD found.", targetUrl)],
+    ));
+  }
+  if (!signals.description) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-description-missing",
+      "low",
+      "Meta description is missing",
+      "The page lacks a concise public description for summarizers and search snippets.",
+      "Add a clear meta description that states what the product, organization, or page is about.",
+      [evidence("html", "Meta description scan", "No description meta tag found.", targetUrl)],
+    ));
+  }
+  return result("entity-clarity", labelFor("entity-clarity"), score, findings);
+}
+
+function buildCitationReadiness(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.externalLinkCount >= 2) score += 20;
+  if (signals.hasSourceCue) score += 15;
+  if (signals.hasStatisticCue) score += 10;
+  if (signals.hasArticleSchema || signals.hasAuthorCue) score += 10;
+  if (signals.externalLinkCount === 0 && !signals.hasSourceCue) {
+    findings.push(finding(
+      "citation-readiness",
+      "citation-readiness-no-visible-sources",
+      "medium",
+      "Visible source cues are weak",
+      "The page has no obvious external source links or source/evidence wording for answer engines to cite.",
+      "Add visible support links, evidence, data sources, or authored references for important claims.",
+      [evidence("external-link", "External link scan", `${signals.externalLinkCount} external link(s) found.`, targetUrl)],
+    ));
+  }
+  return result("citation-readiness", labelFor("citation-readiness"), score, findings);
+}
+
+function buildFreshness(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  if (signals.hasFreshnessCue) {
+    return result("freshness-cues", labelFor("freshness-cues"), 95, []);
+  }
+  return result("freshness-cues", labelFor("freshness-cues"), 62, [
+    finding(
+      "freshness-cues",
+      "freshness-cues-missing",
+      "low",
+      "Freshness cues are not visible",
+      "The page does not expose obvious published, reviewed, or last-updated cues.",
+      "Add visible freshness or review dates where current information matters.",
+      [evidence("date", "Freshness scan", "No visible time/date/update cue found.", targetUrl)],
+    ),
+  ]);
+}
+
+function buildContentStructure(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.h1.length === 1) score += 15;
+  if (signals.h2.length >= 2) score += 15;
+  if (signals.paragraphCount >= 3) score += 10;
+  if (signals.listCount > 0) score += 10;
+  if (signals.hasFaqSchema || signals.questionCount > 0) score += 10;
+  if (signals.h1.length === 0) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-h1-missing",
+      "medium",
+      "No H1 was found",
+      "The page lacks a clear top-level heading.",
+      "Add one clear H1 that names the page subject.",
+      [evidence("html", "Heading scan", "No H1 found.", targetUrl)],
+    ));
+  }
+  if (signals.h2.length < 2) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-heading-depth-thin",
+      "low",
+      "Heading structure is thin",
+      "The page has limited subheading structure for answer extraction.",
+      "Break important topics into descriptive H2 sections.",
+      [evidence("html", "Heading scan", `${signals.h2.length} H2 heading(s) found.`, targetUrl)],
+    ));
+  }
+  return result("content-structure", labelFor("content-structure"), score, findings);
+}
+
+function buildSchemaCitationGrade(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 45;
+  if (signals.hasJsonLd) score += 25;
+  if (signals.hasMicrodata || signals.hasRdfa) score += 10;
+  if (signals.hasOrganizationSchema || signals.hasArticleSchema || signals.hasFaqSchema) score += 20;
+  if (!signals.hasJsonLd && !signals.hasMicrodata && !signals.hasRdfa) {
+    findings.push(finding(
+      "schema-org-citation-grade",
+      "schema-org-citation-grade-missing",
+      "medium",
+      "Structured data was not found",
+      "No JSON-LD, microdata, or RDFa was detected on the page.",
+      "Add truthful structured data that matches visible page facts.",
+      [evidence("schema-org", "Structured data scan", "No structured data detected.", targetUrl)],
+    ));
+  }
+  return result("schema-org-citation-grade", labelFor("schema-org-citation-grade"), score, findings);
+}
+
+function buildBrandMentionReadiness(targetUrl: string, signals: PageSignals): GeoPassCheckResult {
+  const findings: GeoPassFinding[] = [];
+  let score = 55;
+  if (signals.title && signals.h1.length > 0) score += 15;
+  if (signals.description) score += 10;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (signals.hasOrganizationSchema) score += 10;
+  if (!signals.title || signals.h1.length === 0) {
+    findings.push(finding(
+      "brand-mention-readiness",
+      "brand-mention-readiness-weak-page-name",
+      "medium",
+      "Page naming is weak for brand/entity mention",
+      "The page needs both a clear title and visible H1 for answer engines to label it consistently.",
+      "Use a direct title and H1 that name the product, brand, organization, or topic.",
+      [evidence("brand-query", "Title and H1 scan", `title=${signals.title ? "present" : "missing"}; h1=${signals.h1.length}`, targetUrl)],
+    ));
+  }
+  return result("brand-mention-readiness", labelFor("brand-mention-readiness"), score, findings);
+}
+
+function buildPlanOnlyExternalIndex(checkId: "wikidata-presence" | "common-crawl-presence", targetUrl: string): GeoPassCheckResult {
+  return {
+    check_id: checkId,
+    label: labelFor(checkId),
+    score: 50,
+    verdict: "unknown",
+    findings: [
+      finding(
+        checkId,
+        `${checkId}-not-live-readonly`,
+        "info",
+        "External index lookup was not run",
+        "This GEOPass live-readonly slice does not query external entity or web-corpus APIs.",
+        "Run a separately scoped public API adapter before using this row as index-presence proof.",
+        [evidence(checkId === "wikidata-presence" ? "wikidata" : "common-crawl", "External index boundary", "Not queried in this public-safe run.", targetUrl)],
+      ),
+    ],
+  };
+}
+
+function buildAggregate(targetUrl: string, checks: GeoPassCheckResult[]): GeoPassCheckResult {
+  const source = checks.filter((check) => check.check_id !== "aggregate-ai-engine-readiness");
+  const score = Math.round(source.reduce((sum, check) => sum + check.score, 0) / Math.max(1, source.length));
+  const blockers = source.filter((check) => check.verdict === "blocked");
+  const weak = source.filter((check) => check.verdict === "needs-work");
+  const findings: GeoPassFinding[] = [];
+  if (blockers.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-blockers",
+      "high",
+      "GEOPass has blocked rows",
+      `${blockers.length} check(s) are blocked: ${blockers.map((check) => check.check_id).join(", ")}.`,
+      "Resolve blocked rows before treating this page as AI-answer ready.",
+      [evidence("manual-note", "Aggregate readiness", `Blocked rows: ${blockers.map((check) => check.check_id).join(", ")}`, targetUrl)],
+    ));
+  } else if (weak.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-needs-work",
+      "medium",
+      "GEOPass has readiness gaps",
+      `${weak.length} check(s) need work: ${weak.map((check) => check.check_id).join(", ")}.`,
+      "Use the row recommendations as the next public content fixes.",
+      [evidence("manual-note", "Aggregate readiness", `Needs-work rows: ${weak.map((check) => check.check_id).join(", ")}`, targetUrl)],
+    ));
+  }
+  return result("aggregate-ai-engine-readiness", labelFor("aggregate-ai-engine-readiness"), score, findings);
+}
+
+function verdictSummary(checks: GeoPassCheckResult[]): Record<"ready" | "needs_work" | "blocked" | "unknown", number> {
+  return checks.reduce(
+    (summary, check) => {
+      if (check.verdict === "ready") summary.ready += 1;
+      if (check.verdict === "needs-work") summary.needs_work += 1;
+      if (check.verdict === "blocked") summary.blocked += 1;
+      if (check.verdict === "unknown") summary.unknown += 1;
+      return summary;
+    },
+    { ready: 0, needs_work: 0, blocked: 0, unknown: 0 },
+  );
+}
+
+function crossPassSignals(checks: GeoPassCheckResult[]): GeoPassCrossPassSignal[] {
+  const byId = new Map(checks.map((check) => [check.check_id, check]));
+  const signals: GeoPassCrossPassSignal[] = [];
+  const llms = byId.get("llms-txt");
+  if (llms && llms.verdict !== "ready") {
+    signals.push({ pass: "seopass", signal: "llms.txt gap also weakens AI-era search readiness", score: llms.score });
+  }
+  const schema = byId.get("schema-org-citation-grade");
+  if (schema && schema.verdict !== "ready") {
+    signals.push({ pass: "legalpass", signal: "schema must truthfully match visible public claims", score: schema.score });
+  }
+  const structure = byId.get("content-structure");
+  if (structure && structure.verdict !== "ready") {
+    signals.push({ pass: "uxpass", signal: "thin public structure can make answer extraction and human scanning weaker", score: structure.score });
+  }
+  const citation = byId.get("citation-readiness");
+  if (citation && citation.verdict !== "ready") {
+    signals.push({ pass: "sloppass", signal: "unsupported or source-light claims need copy/content cleanup", score: citation.score });
+  }
+  return signals;
+}
+
+function receiptFor(report: GeoPassReport, runId: string, targetSha?: string): GeoPassReceipt {
+  const summary = verdictSummary(report.checks);
+  const status = report.verdict === "ready" ? "PASS" : report.verdict === "blocked" ? "BLOCKER" : "WARN";
+  const evidenceSources = report.checks
+    .flatMap((check) => check.findings)
+    .flatMap((item) => item.evidence)
+    .filter((item, index, all) => all.findIndex((candidate) => candidate.kind === item.kind && candidate.label === item.label && candidate.source_url === item.source_url) === index)
+    .slice(0, 12);
+  const actionNeeded = report.checks
+    .flatMap((check) => check.findings)
+    .map((item) => item.recommendation)
+    .filter((item): item is string => Boolean(item))
+    .filter((item, index, all) => all.indexOf(item) === index)
+    .slice(0, 8);
+  return {
+    kind: "geopass_receipt_v1",
+    status,
+    run_id: runId,
+    target_url: report.target_url,
+    generated_at: report.generated_at,
+    mode: "live-readonly",
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    score: report.aggregate_ai_engine_readiness_score,
+    verdict: report.verdict,
+    checked: {
+      total: report.checks.length,
+      ready: summary.ready,
+      needs_work: summary.needs_work,
+      blocked: summary.blocked,
+      unknown: summary.unknown,
+    },
+    evidence_sources: evidenceSources,
+    action_needed: actionNeeded,
+    boundaries: RECEIPT_BOUNDARIES,
+  };
+}
+
+export async function runGeoPass(input: GeoPassRunInput): Promise<GeoPassRunResult | { error: string }> {
+  const rawUrl = input.url ?? input.targetUrl ?? "";
+  const targetUrl = normalizePublicHttpUrl(rawUrl);
+  if (!targetUrl) {
+    return { error: "GEOPass target URL must be a valid public http(s) URL without credentials" };
+  }
+  const generatedAt = input.generatedAt ?? new Date().toISOString();
+  const fetchImpl = input.fetchImpl ?? globalThis.fetch;
+  if (!fetchImpl) return { error: "No fetch implementation is available for GEOPass live-readonly run" };
+  const selectedChecks = new Set(input.checks?.length ? input.checks : LIVE_CHECKS);
+  const page = await fetchText(targetUrl, fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS);
+  const analysisUrl = normalizePublicHttpUrl(page.url) ?? targetUrl;
+  const [robots, llms] = await Promise.all([
+    fetchText(new URL("/robots.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS),
+    fetchText(new URL("/llms.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS),
+  ]);
+  const htmlReadable = page.ok && (page.headers["content-type"] ?? "text/html").toLowerCase().includes("html");
+  const signals = htmlReadable ? analyzeHtml(page.body, analysisUrl) : null;
+  const checks: GeoPassCheckResult[] = [];
+
+  for (const checkId of LIVE_CHECKS.filter((id) => selectedChecks.has(id))) {
+    if (!signals && checkId !== "ai-bot-crawlability" && checkId !== "llms-txt") {
+      checks.push(pageUnavailableResult(checkId, analysisUrl, page));
+      continue;
+    }
+    if (checkId === "ai-bot-crawlability") checks.push(buildAiBotCrawlability(analysisUrl, robots));
+    if (checkId === "llms-txt") checks.push(buildLlmsTxt(analysisUrl, llms));
+    if (signals && checkId === "answer-extractability") checks.push(buildAnswerExtractability(analysisUrl, signals));
+    if (signals && checkId === "entity-clarity") checks.push(buildEntityClarity(analysisUrl, signals));
+    if (signals && checkId === "citation-readiness") checks.push(buildCitationReadiness(analysisUrl, signals));
+    if (signals && checkId === "freshness-cues") checks.push(buildFreshness(analysisUrl, signals));
+    if (signals && checkId === "content-structure") checks.push(buildContentStructure(analysisUrl, signals));
+    if (signals && checkId === "schema-org-citation-grade") checks.push(buildSchemaCitationGrade(analysisUrl, signals));
+    if (signals && checkId === "brand-mention-readiness") checks.push(buildBrandMentionReadiness(analysisUrl, signals));
+  }
+  for (const externalCheckId of ["wikidata-presence", "common-crawl-presence"] as const) {
+    if (selectedChecks.has(externalCheckId)) checks.push(buildPlanOnlyExternalIndex(externalCheckId, analysisUrl));
+  }
+  if (selectedChecks.has("aggregate-ai-engine-readiness")) {
+    checks.push(buildAggregate(analysisUrl, checks));
+  }
+  const summary = verdictSummary(checks);
+  const aggregate = checks.find((check) => check.check_id === "aggregate-ai-engine-readiness");
+  const score = aggregate?.score ?? Math.round(checks.reduce((sum, check) => sum + check.score, 0) / Math.max(1, checks.length));
+  const verdict: GeoPassVerdict = summary.blocked > 0 ? "blocked" : score >= 85 ? "ready" : "needs-work";
+  const report: GeoPassReport = {
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    mode: "live-readonly",
+    engines: DEFAULT_GEOPASS_ENGINES,
+    aggregate_ai_engine_readiness_score: score,
+    verdict,
+    checks,
+    cross_pass_signals: crossPassSignals(checks),
+    notes: [
+      "Readiness only. GEOPass does not guarantee AI citations, rankings, or answer-engine placement.",
+      "This run used public http(s) fetches only and did not use credentials, paid APIs, production data, or private prompts.",
+      ...(page.truncated ? ["The target page body was truncated for bounded analysis."] : []),
+    ],
+  };
+  const runId = stableRunId(analysisUrl, generatedAt);
+  return {
+    run_id: runId,
+    status: "complete",
+    pass: "geopass",
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    ai_answer_readiness_score: score,
+    verdict,
+    verdict_summary: summary,
+    report,
+    geopass_receipt_v1: receiptFor(report, runId, input.targetSha),
+  };
+}

--- a/packages/geopass/src/scanner-plan.ts
+++ b/packages/geopass/src/scanner-plan.ts
@@ -64,6 +64,46 @@ export const DEFAULT_GEOPASS_SCANNER_STEPS: GeoPassScannerStep[] = [
     sharedWith: ["seopass", "sloppass"],
   },
   {
+    id: "answer-extractability",
+    label: "Answer extractability",
+    purpose:
+      "Check whether public page copy contains direct, reusable answers rather than only abstract marketing claims.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "uxpass"],
+  },
+  {
+    id: "entity-clarity",
+    label: "Entity clarity",
+    purpose:
+      "Check whether the page names the organization, product, or author clearly enough for answer engines to ground summaries.",
+    evidenceKinds: ["html", "schema-org"],
+    sharedWith: ["seopass", "legalpass"],
+  },
+  {
+    id: "citation-readiness",
+    label: "Citation and sourceability readiness",
+    purpose:
+      "Check whether visible sources, support links, statistics, or evidence cues make claims easier to cite accurately.",
+    evidenceKinds: ["external-link", "content", "schema-org"],
+    sharedWith: ["seopass", "legalpass", "sloppass"],
+  },
+  {
+    id: "freshness-cues",
+    label: "Freshness and update cues",
+    purpose:
+      "Check whether visible publication or update signals help answer engines avoid stale summaries.",
+    evidenceKinds: ["date", "html"],
+    sharedWith: ["seopass"],
+  },
+  {
+    id: "content-structure",
+    label: "AI-readable content structure",
+    purpose:
+      "Check heading, list, paragraph, and FAQ-style structure that helps AI systems extract reliable answers.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "flowpass", "uxpass"],
+  },
+  {
     id: "schema-org-citation-grade",
     label: "schema.org citation-grade validation",
     purpose:
@@ -110,7 +150,7 @@ const DISALLOWED_ACTIONS = [
   "paid API calls",
   "credential access",
   "production database writes",
-  "citation guarantees",
+  "guaranteed citations",
 ];
 
 export function createGeoPassScannerPlan(input: {

--- a/packages/geopass/src/schema.ts
+++ b/packages/geopass/src/schema.ts
@@ -38,6 +38,11 @@ export const GeoPassBotIdSchema = z.enum([
 export const GeoPassCheckIdSchema = z.enum([
   "ai-bot-crawlability",
   "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
   "schema-org-citation-grade",
   "brand-mention-readiness",
   "wikidata-presence",
@@ -50,6 +55,11 @@ export const GeoPassEvidenceSchema = z.object({
     "robots-txt",
     "llms-txt",
     "schema-org",
+    "html",
+    "http",
+    "content",
+    "date",
+    "external-link",
     "wikidata",
     "common-crawl",
     "brand-query",
@@ -97,6 +107,28 @@ export const GeoPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const GeoPassReceiptSchema = z.object({
+  kind: z.literal("geopass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.literal("live-readonly"),
+  target_sha: z.string().min(1).optional(),
+  score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    ready: z.number().int().min(0),
+    needs_work: z.number().int().min(0),
+    blocked: z.number().int().min(0),
+    unknown: z.number().int().min(0),
+  }),
+  evidence_sources: z.array(GeoPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)),
+});
+
 export type GeoPassSeverity = z.infer<typeof GeoPassSeveritySchema>;
 export type GeoPassVerdict = z.infer<typeof GeoPassVerdictSchema>;
 export type GeoPassEngineId = z.infer<typeof GeoPassEngineIdSchema>;
@@ -107,3 +139,4 @@ export type GeoPassFinding = z.infer<typeof GeoPassFindingSchema>;
 export type GeoPassCheckResult = z.infer<typeof GeoPassCheckResultSchema>;
 export type GeoPassCrossPassSignal = z.infer<typeof GeoPassCrossPassSignalSchema>;
 export type GeoPassReport = z.infer<typeof GeoPassReportSchema>;
+export type GeoPassReceipt = z.infer<typeof GeoPassReceiptSchema>;

--- a/packages/geopass/tsconfig.json
+++ b/packages/geopass/tsconfig.json
@@ -10,7 +10,8 @@
     "declarationMap": true,
     "sourceMap": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/legalpass/src/__tests__/schema.test.ts
+++ b/packages/legalpass/src/__tests__/schema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   LegalPassFixtureDocumentSchema,
   LegalPassHatDefinitionSchema,
+  LegalPassReceiptSchema,
   LegalPassReportSchema,
 } from "../schema.js";
 
@@ -90,6 +91,44 @@ describe("LegalPass phase-one schema", () => {
         disclaimers: [],
       }),
     ).toThrow();
+  });
+
+  it("parses scoped LegalPass receipts with issue-spotter boundaries", () => {
+    const receipt = LegalPassReceiptSchema.parse({
+      kind: "legalpass_receipt_v1",
+      status: "WARN",
+      run_id: "legalpass_abc123",
+      pack_id: "legalpass-mvp-v0",
+      target: { name: "Example", url: "https://example.com/legal" },
+      target_sha: "abc123",
+      generated_at: "2026-05-09T18:10:00.000Z",
+      mode: "fixture",
+      jurisdictions: ["AU"],
+      summary: {
+        total: 1,
+        check: 0,
+        fail: 1,
+        na: 0,
+        other: 0,
+        pending: 0,
+        pass_rate: 0,
+      },
+      disclaimer_present: true,
+      safety: {
+        issue_spotter_only: true,
+        no_legal_advice: true,
+        no_transactional_instrument: true,
+      },
+      evidence_sources: [MINIMAL_EVIDENCE],
+      action_needed: ["Practitioner review may be warranted before relying on this material."],
+      boundaries: [
+        "LegalPass is an issue-spotter and information tool only.",
+        "LegalPass does not provide legal advice or create a lawyer-client relationship.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("legalpass_receipt_v1");
+    expect(receipt.safety.no_legal_advice).toBe(true);
   });
 
   it("requires every finding to carry evidence", () => {

--- a/packages/legalpass/src/schema.ts
+++ b/packages/legalpass/src/schema.ts
@@ -177,6 +177,36 @@ export const LegalPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const LegalPassReceiptSchema = z.object({
+  kind: z.literal("legalpass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  pack_id: z.string().min(1),
+  target: LegalPassTargetSchema,
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["fixture", "plan-only"]),
+  jurisdictions: JurisdictionListSchema,
+  summary: z.object({
+    total: z.number().int().min(0),
+    check: z.number().int().min(0),
+    fail: z.number().int().min(0),
+    na: z.number().int().min(0),
+    other: z.number().int().min(0),
+    pending: z.number().int().min(0),
+    pass_rate: z.number().min(0).max(100),
+  }),
+  disclaimer_present: z.literal(true),
+  safety: z.object({
+    issue_spotter_only: z.literal(true),
+    no_legal_advice: z.literal(true),
+    no_transactional_instrument: z.literal(true),
+  }),
+  evidence_sources: z.array(LegalPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export const LegalPassGeoPassAdapterSchema = z.object({
   source: z.literal("geopass"),
   target_url: HttpUrlSchema,
@@ -201,4 +231,5 @@ export type LegalPassHatDefinition = z.infer<typeof LegalPassHatDefinitionSchema
 export type LegalPassHatResult = z.infer<typeof LegalPassHatResultSchema>;
 export type LegalPassScannerSource = z.infer<typeof LegalPassScannerSourceSchema>;
 export type LegalPassReport = z.infer<typeof LegalPassReportSchema>;
+export type LegalPassReceipt = z.infer<typeof LegalPassReceiptSchema>;
 export type LegalPassGeoPassAdapter = z.infer<typeof LegalPassGeoPassAdapterSchema>;

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -19,10 +19,10 @@
     "server.json"
   ],
   "scripts": {
-    "build": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && tsc",
-    "dev": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && tsx src/index.ts",
+    "build": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsc",
+    "dev": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && tsx --test src/memory/__tests__/typed-links.test.ts src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts src/memory/__tests__/response-bounds.test.ts src/memory/__tests__/load-memory-invalidation.test.ts src/memory/__tests__/snapshot-taxonomy.test.ts src/memory/__tests__/local-backend.test.ts && vitest run && node scripts/generate-tool-index.mjs --check && node scripts/check-standalone-registry.mjs",
+    "test": "npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsx --test src/memory/__tests__/typed-links.test.ts src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts src/memory/__tests__/response-bounds.test.ts src/memory/__tests__/load-memory-invalidation.test.ts src/memory/__tests__/snapshot-taxonomy.test.ts src/memory/__tests__/local-backend.test.ts && vitest run && node scripts/generate-tool-index.mjs --check && node scripts/check-standalone-registry.mjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
@@ -33,6 +33,7 @@
     "@types/nodemailer": "^8.0.0",
     "@unclick/commonsensepass": "*",
     "@unclick/flowpass": "*",
+    "@unclick/securitypass": "*",
     "ajv": "^8.20.0",
     "csv-parse": "^6.2.1",
     "csv-stringify": "^6.7.0",

--- a/packages/mcp-server/scripts/generate-tool-index.mjs
+++ b/packages/mcp-server/scripts/generate-tool-index.mjs
@@ -14,7 +14,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SRC = path.resolve(__dirname, "../src");
@@ -99,4 +99,4 @@ function main() {
   console.log(`${index.length} apps, ${toolCount} tools indexed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/packages/mcp-server/src/__tests__/legalpass-tool.test.ts
+++ b/packages/mcp-server/src/__tests__/legalpass-tool.test.ts
@@ -42,12 +42,24 @@ describe("LegalPass MCP exposure", () => {
       no_legal_advice: true,
       no_transactional_instrument: true,
     });
+    expect(result.legalpass_receipt_v1).toMatchObject({
+      kind: "legalpass_receipt_v1",
+      status: "WARN",
+      mode: "plan-only",
+      safety: {
+        issue_spotter_only: true,
+        no_legal_advice: true,
+        no_transactional_instrument: true,
+      },
+    });
+    expect(JSON.stringify(result.legalpass_receipt_v1)).toContain("does not provide legal advice");
   });
 
   it("runs deterministic public fixture checks when text is provided", async () => {
     const result = await legalpassRun({
       target_url: "https://example.com/legal",
       jurisdictions: ["AU"],
+      target_sha: "legal-sha-123",
       fixture_text:
         "Privacy contact details explain how we collect and use data, " +
         "retain records, share with a third party, cover liability, indemnity, " +
@@ -58,6 +70,14 @@ describe("LegalPass MCP exposure", () => {
     expect(result.status).toBe("complete");
     expect(result.run_id).toMatch(/^legalpass_/);
     expect(result.summary).toMatchObject({ fail: 0 });
+    expect(result.legalpass_receipt_v1).toMatchObject({
+      kind: "legalpass_receipt_v1",
+      status: "PASS",
+      target_sha: "legal-sha-123",
+      mode: "fixture",
+      disclaimer_present: true,
+    });
+    expect(JSON.stringify(result.legalpass_receipt_v1)).toContain("LegalPass is an issue-spotter");
     expect(JSON.stringify(result.items)).toContain("fixture_text");
     expect(String(result.note)).toContain("deterministic public fixture");
     expect(JSON.stringify(result)).not.toMatch(/you should/i);
@@ -66,6 +86,7 @@ describe("LegalPass MCP exposure", () => {
     const status = await legalpassStatus({ run_id: result.run_id }) as Record<string, unknown>;
     expect(status.run_id).toBe(result.run_id);
     expect(status.summary).toEqual(result.summary);
+    expect(status.legalpass_receipt_v1).toEqual(result.legalpass_receipt_v1);
   });
 
   it("saves custom packs and records human edit audit entries", async () => {
@@ -196,6 +217,10 @@ describe("LegalPass MCP exposure", () => {
     await expect(legalpassRun({
       target: { kind: "email", url: "https://example.com" },
     })).resolves.toMatchObject({ error: "target.kind must be url|contract_upload|repo" });
+    await expect(legalpassRun({
+      target_url: "https://example.com/terms",
+      target_sha: "   ",
+    })).resolves.toMatchObject({ error: "target_sha must not be blank" });
 
     await expect(
       legalpassSavePack({

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -29,6 +29,8 @@ describe("runtime tool schema validation", () => {
     { name: "commonsensepass_protocol", args: { bogus_field: "should reject" } },
     { name: "commonsensepass_check", args: { claim: "quiet", context: { now_ms: 1 }, bogus_field: "should reject" } },
     { name: "commonsensepass_rules", args: { include_fixtures: false, bogus_field: "should reject" } },
+    { name: "securitypass_run", args: { target_url: "https://example.com", bogus_field: "should reject" } },
+    { name: "securitypass_status", args: { run_id: "securitypass-run-id", bogus_field: "should reject" } },
     { name: "list_expressroom_drafts", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
     {
       name: "ack_handoff",
@@ -126,6 +128,15 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("commonsensepass_rules", {
       include_fixtures: false,
     })).toBeNull();
+    expect(validateToolArgumentsForRuntime("securitypass_run", {
+      target_url: "https://example.com",
+      proof_method: "signed_email",
+      contract_id: "scope-contract",
+      expected_token: "signed-token",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("securitypass_status", {
+      run_id: "securitypass-run-id",
+    })).toBeNull();
     expect(validateToolArgumentsForRuntime("list_expressroom_drafts", {
       agent_id: "strict-probe",
       official_todo_id: "11111111-1111-4111-8111-111111111111",
@@ -209,5 +220,13 @@ describe("runtime tool schema validation", () => {
     const advertisedNames = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
 
     expect(advertisedNames.has("release_claim")).toBe(true);
+  });
+
+  it("advertises SecurityPass as a scope-gated receipt surface", () => {
+    const advertisedNames = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
+
+    expect(advertisedNames.has("securitypass_run")).toBe(true);
+    expect(advertisedNames.has("securitypass_status")).toBe(true);
+    expect(advertisedNames.has("securitypass_verify_scope")).toBe(true);
   });
 });

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -29,6 +29,7 @@ describe("runtime tool schema validation", () => {
     { name: "commonsensepass_protocol", args: { bogus_field: "should reject" } },
     { name: "commonsensepass_check", args: { claim: "quiet", context: { now_ms: 1 }, bogus_field: "should reject" } },
     { name: "commonsensepass_rules", args: { include_fixtures: false, bogus_field: "should reject" } },
+    { name: "xpass_aggregated_verdict", args: { target: { type: "pr", id: "547", sha: "abc123" }, bogus_field: "should reject" } },
     { name: "list_expressroom_drafts", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
     {
       name: "ack_handoff",
@@ -125,6 +126,13 @@ describe("runtime tool schema validation", () => {
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("commonsensepass_rules", {
       include_fixtures: false,
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("xpass_aggregated_verdict", {
+      target: { type: "pr", id: "547", sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "UXPass", status: "passed", run_id: "ux-1", target_sha: "abc123" },
+      ],
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("list_expressroom_drafts", {
       agent_id: "strict-probe",

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -49,6 +49,13 @@ describe("runtime tool schema validation", () => {
         bogus_field: "should reject",
       },
     },
+    {
+      name: "copypass_run",
+      args: {
+        copy_text: "Try UnClick with proof receipts.",
+        bogus_field: "should reject",
+      },
+    },
     { name: "stripe_customers", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     { name: "stripe_charges", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     {
@@ -144,6 +151,14 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("release_claim", {
       agent_id: "strict-probe",
       todo_id: "11111111-1111-4111-8111-111111111111",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("copypass_run", {
+      copy_text: "UnClick helps teams review AI work with shared context, public proof, and green checks.",
+      channel: "homepage_hero",
+      profile: "smoke",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("copypass_status", {
+      run_id: "copy-run-123",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_call", {
       endpoint_id: "memory.search_memory",

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -49,6 +49,13 @@ describe("runtime tool schema validation", () => {
         bogus_field: "should reject",
       },
     },
+    {
+      name: "sloppass_run",
+      args: {
+        target: { kind: "pr", label: "PR #1200", repo: "malamutemayhem/unclick", number: 1200 },
+        bogus_field: "should reject",
+      },
+    },
     { name: "stripe_customers", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     { name: "stripe_charges", args: { secret_key: "sk_test_dummy", action: "X", bogus_field: "should reject" } },
     {
@@ -144,6 +151,10 @@ describe("runtime tool schema validation", () => {
     expect(validateToolArgumentsForRuntime("release_claim", {
       agent_id: "strict-probe",
       todo_id: "11111111-1111-4111-8111-111111111111",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("sloppass_run", {
+      target: { kind: "pr", label: "PR #1200", repo: "malamutemayhem/unclick", number: 1200 },
+      checks: ["vcs_integration_risk"],
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("unclick_call", {
       endpoint_id: "memory.search_memory",

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -29,6 +29,7 @@ describe("runtime tool schema validation", () => {
     { name: "commonsensepass_protocol", args: { bogus_field: "should reject" } },
     { name: "commonsensepass_check", args: { claim: "quiet", context: { now_ms: 1 }, bogus_field: "should reject" } },
     { name: "commonsensepass_rules", args: { include_fixtures: false, bogus_field: "should reject" } },
+    { name: "fidelitypass_verify_copy", args: { copy_scope: "not_applicable", bogus_field: "should reject" } },
     { name: "list_expressroom_drafts", args: { agent_id: "strict-probe", bogus_field: "should reject" } },
     {
       name: "ack_handoff",
@@ -125,6 +126,20 @@ describe("runtime tool schema validation", () => {
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("commonsensepass_rules", {
       include_fixtures: false,
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("fidelitypass_verify_copy", {
+      copy_scope: "not_applicable",
+      scope_reason: "No exact copy is in scope for this target.",
+    })).toBeNull();
+    expect(validateToolArgumentsForRuntime("fidelitypass_verify_copy", {
+      copy_scope: "exact_copy",
+      copyroom_source_packet: {
+        source_id: "source-1",
+        source_pointer: "copyroom://source-1",
+        text: "Exact source",
+      },
+      output_text: "Exact source",
+      mode: "text_exact",
     })).toBeNull();
     expect(validateToolArgumentsForRuntime("list_expressroom_drafts", {
       agent_id: "strict-probe",

--- a/packages/mcp-server/src/compliancepass-tool.test.ts
+++ b/packages/mcp-server/src/compliancepass-tool.test.ts
@@ -8,31 +8,65 @@ import {
 
 describe("compliancepass-tool", () => {
   it("runs CompliancePass against the local repo and stores the report in-session", async () => {
-    const run = await compliancepassRun({ repo_path: process.cwd(), target_name: "UnClick" }) as {
+    const run = await compliancepassRun({ repo_path: process.cwd(), target_name: "UnClick", target_sha: "compliance-sha-123" }) as {
       run_id?: string;
       status?: string;
       pass?: string;
       product?: string;
+      target_sha?: string;
       summary?: { checks_total?: number; checks_pending?: number };
       readiness_score?: { value?: number };
+      compliancepass_receipt_v1?: {
+        kind?: string;
+        status?: string;
+        target_sha?: string;
+        checked?: { total?: number; pending?: number };
+        blocking_gap_count?: number;
+        evidence_sources?: unknown[];
+        boundaries?: string[];
+      };
     };
 
     expect(run.status).toBe("complete");
     expect(run.pass).toBe("compliancepass");
     expect(run.product).toBe("CompliancePass");
+    expect(run.target_sha).toBe("compliance-sha-123");
     expect(run.run_id).toMatch(/^compliancepass-/);
     expect(run.summary?.checks_total).toBeGreaterThan(10);
     expect(run.summary?.checks_pending).toBe(0);
     expect(run.readiness_score?.value).toBeGreaterThanOrEqual(0);
+    expect(run.compliancepass_receipt_v1).toMatchObject({
+      kind: "compliancepass_receipt_v1",
+      target_sha: "compliance-sha-123",
+      checked: { pending: 0 },
+    });
+    expect(["PASS", "WARN", "BLOCKER"]).toContain(run.compliancepass_receipt_v1?.status);
+    expect(run.compliancepass_receipt_v1?.checked?.total).toBe(run.summary?.checks_total);
+    expect(run.compliancepass_receipt_v1?.evidence_sources?.length).toBeGreaterThan(0);
+    expect(run.compliancepass_receipt_v1?.boundaries?.join(" ")).toMatch(/not a compliance certification/i);
 
-    const status = await compliancepassStatus({ run_id: run.run_id }) as { status?: string; run_id?: string };
+    const status = await compliancepassStatus({ run_id: run.run_id }) as {
+      status?: string;
+      run_id?: string;
+      target_sha?: string;
+      compliancepass_receipt_v1?: { target_sha?: string };
+    };
     expect(status.run_id).toBe(run.run_id);
     expect(status.status).toBe("complete");
+    expect(status.target_sha).toBe("compliance-sha-123");
+    expect(status.compliancepass_receipt_v1?.target_sha).toBe("compliance-sha-123");
 
     const json = await compliancepassReportJson({ run_id: run.run_id }) as { product?: string };
     expect(json.product).toBe("CompliancePass");
 
     const markdown = await compliancepassReportMd({ run_id: run.run_id }) as { markdown?: string };
     expect(markdown.markdown).toMatch(/CompliancePass Report/);
+  });
+
+  it("rejects blank target SHA values", async () => {
+    await expect(compliancepassRun({
+      repo_path: process.cwd(),
+      target_sha: " ",
+    })).resolves.toMatchObject({ error: "target_sha must be a non-empty string when provided" });
   });
 });

--- a/packages/mcp-server/src/compliancepass-tool.ts
+++ b/packages/mcp-server/src/compliancepass-tool.ts
@@ -3,10 +3,44 @@ import { createHash } from "node:crypto";
 import {
   renderCompliancePassMarkdown,
   runCompliancePass,
+  type CompliancePassEvidence,
   type CompliancePassReport,
 } from "./compliancepass/index.js";
 
-const RUNS = new Map<string, CompliancePassReport>();
+type CompliancePassReceiptStatus = "PASS" | "WARN" | "BLOCKER";
+
+interface CompliancePassMcpReceipt {
+  kind: "compliancepass_receipt_v1";
+  status: CompliancePassReceiptStatus;
+  run_id: string;
+  target_name: string;
+  target_sha?: string;
+  generated_at: string;
+  valid_until: string;
+  readiness_score: CompliancePassReport["readiness_score"];
+  checked: {
+    total: number;
+    pass: number;
+    partial: number;
+    fail: number;
+    unknown: number;
+    na: number;
+    pending: 0;
+  };
+  gap_severity_counts: CompliancePassReport["summary"]["gap_severity_counts"];
+  blocking_gap_count: number;
+  evidence_sources: CompliancePassEvidence[];
+  action_needed: string[];
+  boundaries: string[];
+}
+
+interface CompliancePassRunRecord {
+  report: CompliancePassReport;
+  target_sha?: string;
+  receipt: CompliancePassMcpReceipt;
+}
+
+const RUNS = new Map<string, CompliancePassRunRecord>();
 
 function runIdFor(report: CompliancePassReport): string {
   const stamp = report.generated_at.replace(/[^0-9]/g, "").slice(0, 14);
@@ -17,7 +51,93 @@ function runIdFor(report: CompliancePassReport): string {
   return `compliancepass-${stamp}-${digest}`;
 }
 
+function parseTargetSha(value: unknown): string | undefined | { error: string } {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  return value.trim();
+}
+
+function receiptStatus(report: CompliancePassReport): CompliancePassReceiptStatus {
+  if (
+    report.summary.blocking_gap_count > 0 ||
+    report.summary.checks_fail > 0 ||
+    report.readiness_band === "red" ||
+    report.summary.gap_severity_counts.critical > 0 ||
+    report.summary.gap_severity_counts.high > 0
+  ) {
+    return "BLOCKER";
+  }
+  if (
+    report.summary.checks_partial > 0 ||
+    report.summary.checks_unknown > 0 ||
+    report.readiness_band === "amber" ||
+    report.readiness_band === "unknown"
+  ) {
+    return "WARN";
+  }
+  return "PASS";
+}
+
+function buildReceipt(
+  runId: string,
+  report: CompliancePassReport,
+  targetSha?: string,
+): CompliancePassMcpReceipt {
+  return {
+    kind: "compliancepass_receipt_v1",
+    status: receiptStatus(report),
+    run_id: runId,
+    target_name: report.target.name,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: report.generated_at,
+    valid_until: report.valid_until,
+    readiness_score: report.readiness_score,
+    checked: {
+      total: report.summary.checks_total,
+      pass: report.summary.checks_pass,
+      partial: report.summary.checks_partial,
+      fail: report.summary.checks_fail,
+      unknown: report.summary.checks_unknown,
+      na: report.summary.checks_na,
+      pending: report.summary.checks_pending,
+    },
+    gap_severity_counts: report.summary.gap_severity_counts,
+    blocking_gap_count: report.summary.blocking_gap_count,
+    evidence_sources: receiptEvidence(report),
+    action_needed: receiptActions(report),
+    boundaries: [
+      "CompliancePass is readiness guidance, not a compliance certification.",
+      "CompliancePass receipts are evidence summaries and do not replace legal, security, privacy, or compliance review.",
+      "CompliancePass must not expose secrets, local filesystem paths, private production data, or raw sensitive source text.",
+    ],
+  };
+}
+
+function receiptEvidence(report: CompliancePassReport): CompliancePassEvidence[] {
+  const seen = new Set<string>();
+  return [...report.evidence, ...report.gaps.flatMap((gap) => gap.evidence)]
+    .filter((item) => {
+      const key = [item.type, item.label, item.path ?? "", item.summary, item.line ?? ""].join("\u0000");
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, 20);
+}
+
+function receiptActions(report: CompliancePassReport): string[] {
+  const actions = [
+    ...report.next_actions,
+    ...report.gaps.map((gap) => `${gap.id}: ${gap.recommendation}`),
+  ];
+  return Array.from(new Set(actions)).slice(0, 12);
+}
+
 export async function compliancepassRun(args: Record<string, unknown>): Promise<unknown> {
+  const targetSha = parseTargetSha(args.target_sha);
+  if (typeof targetSha === "object") return targetSha;
   const repoPath = typeof args.repo_path === "string" && args.repo_path.trim()
     ? path.resolve(args.repo_path)
     : process.cwd();
@@ -28,13 +148,15 @@ export async function compliancepassRun(args: Record<string, unknown>): Promise<
   try {
     const report = await runCompliancePass({ repoPath, targetName });
     const runId = runIdFor(report);
-    RUNS.set(runId, report);
+    const receipt = buildReceipt(runId, report, targetSha);
+    RUNS.set(runId, { report, target_sha: targetSha, receipt });
     return {
       run_id: runId,
       status: "complete",
       pass: "compliancepass",
       product: report.product,
       legacy_aliases: report.legacy_aliases,
+      target_sha: targetSha,
       readiness_score: report.readiness_score,
       summary: report.summary,
       categories: report.categories.map(
@@ -49,6 +171,7 @@ export async function compliancepassRun(args: Record<string, unknown>): Promise<
       gaps: report.gaps.slice(0, 10),
       next_actions: report.next_actions,
       disclaimer: report.disclaimer,
+      compliancepass_receipt_v1: receipt,
     };
   } catch (err) {
     return {
@@ -61,34 +184,37 @@ export async function compliancepassRun(args: Record<string, unknown>): Promise<
 export async function compliancepassStatus(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  const report = RUNS.get(runId);
-  if (!report) return { error: "run not found", run_id: runId };
+  const record = RUNS.get(runId);
+  if (!record) return { error: "run not found", run_id: runId };
+  const { report } = record;
   return {
     run_id: runId,
     status: "complete",
     pass: "compliancepass",
+    target_sha: record.target_sha,
     readiness_score: report.readiness_score,
     summary: report.summary,
     generated_at: report.generated_at,
+    compliancepass_receipt_v1: record.receipt,
   };
 }
 
 export async function compliancepassReportJson(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  const report = RUNS.get(runId);
-  if (!report) return { error: "run not found", run_id: runId };
-  return report;
+  const record = RUNS.get(runId);
+  if (!record) return { error: "run not found", run_id: runId };
+  return record.report;
 }
 
 export async function compliancepassReportMd(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  const report = RUNS.get(runId);
-  if (!report) return { error: "run not found", run_id: runId };
+  const record = RUNS.get(runId);
+  if (!record) return { error: "run not found", run_id: runId };
   return {
     run_id: runId,
     format: "markdown",
-    markdown: renderCompliancePassMarkdown(report),
+    markdown: renderCompliancePassMarkdown(record.report),
   };
 }

--- a/packages/mcp-server/src/compliancepass/schema.ts
+++ b/packages/mcp-server/src/compliancepass/schema.ts
@@ -133,6 +133,36 @@ export const CompliancePassReportSchema = z.object({
   disclaimer: z.string().min(1),
 });
 
+export const CompliancePassReceiptSchema = z.object({
+  kind: z.literal("compliancepass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_name: z.string().min(1),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  valid_until: z.string().datetime(),
+  readiness_score: z.object({
+    value: z.number().min(0).max(100),
+    band: CompliancePassBandSchema,
+    traffic_light: z.enum(["green", "yellow", "red", "grey"]),
+    rationale: z.string().min(1),
+  }),
+  checked: z.object({
+    total: z.number().int().nonnegative(),
+    pass: z.number().int().nonnegative(),
+    partial: z.number().int().nonnegative(),
+    fail: z.number().int().nonnegative(),
+    unknown: z.number().int().nonnegative(),
+    na: z.number().int().nonnegative(),
+    pending: z.literal(0),
+  }),
+  gap_severity_counts: CompliancePassGapSeverityCountsSchema,
+  blocking_gap_count: z.number().int().nonnegative(),
+  evidence_sources: z.array(CompliancePassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export type CompliancePassCategoryId = z.infer<typeof CompliancePassCategoryIdSchema>;
 export type CompliancePassStatus = z.infer<typeof CompliancePassStatusSchema>;
 export type CompliancePassSeverity = z.infer<typeof CompliancePassSeveritySchema>;
@@ -143,3 +173,4 @@ export type CompliancePassGapSeverityCounts = z.infer<typeof CompliancePassGapSe
 export type CompliancePassCheck = z.infer<typeof CompliancePassCheckSchema>;
 export type CompliancePassCategory = z.infer<typeof CompliancePassCategorySchema>;
 export type CompliancePassReport = z.infer<typeof CompliancePassReportSchema>;
+export type CompliancePassReceipt = z.infer<typeof CompliancePassReceiptSchema>;

--- a/packages/mcp-server/src/copypass-tool.test.ts
+++ b/packages/mcp-server/src/copypass-tool.test.ts
@@ -42,6 +42,17 @@ describe("copypass-tool", () => {
       summary?: { counts_by_severity?: { high?: number; info?: number }; coverage_note?: string };
       verdict_summary?: { fail?: number };
       findings?: Array<{ check_id?: string }>;
+      receipt?: {
+        kind?: string;
+        pass?: string;
+        status?: string;
+        run_id?: string;
+        receipt_id?: string;
+        finding_count?: number;
+        action_needed?: string[];
+        evidence?: { source?: string; copyroom_receipt_attached?: boolean };
+        boundaries?: string[];
+      };
     };
 
     expect(run.status).toBe("complete");
@@ -55,6 +66,17 @@ describe("copypass-tool", () => {
     expect(run.verdict_summary?.fail).toBeGreaterThan(0);
     expect(run.findings?.map((finding) => finding.check_id)).toContain("unsupported-superiority");
     expect(run.run_id).toBeTruthy();
+    expect(run.receipt).toMatchObject({
+      kind: "copypass_receipt_v1",
+      pass: "copypass",
+      status: "FAIL",
+      run_id: run.run_id,
+      receipt_id: `copypass:${run.run_id}`,
+      finding_count: run.finding_count,
+      evidence: { source: "caller_provided_copy", copyroom_receipt_attached: false },
+    });
+    expect(run.receipt?.action_needed?.some((item) => item.includes("unsupported-superiority"))).toBe(true);
+    expect(run.receipt?.boundaries?.some((item) => item.includes("Legal, brand, or factual approval"))).toBe(true);
 
     const status = (await copypassStatus({
       run_id: run.run_id,
@@ -66,6 +88,7 @@ describe("copypass-tool", () => {
       summary?: { posture?: string };
       target?: { channel?: string };
       findings?: Array<{ check_id?: string }>;
+      receipt?: { kind?: string; status?: string; run_id?: string; receipt_id?: string };
     };
 
     expect(status.run_id).toBe(run.run_id);
@@ -75,6 +98,12 @@ describe("copypass-tool", () => {
     expect(status.summary?.posture).toContain("copy risks");
     expect(status.target?.channel).toBe("homepage_hero");
     expect(status.findings?.map((finding) => finding.check_id)).toContain("placeholder-copy");
+    expect(status.receipt).toMatchObject({
+      kind: "copypass_receipt_v1",
+      status: "FAIL",
+      run_id: run.run_id,
+      receipt_id: `copypass:${run.run_id}`,
+    });
   });
 
   it("detects MCP parity checks for tone fit and internal consistency", async () => {
@@ -114,6 +143,7 @@ describe("copypass-tool", () => {
       overall_score?: number;
       disclaimer?: { compact?: string };
       not_checked?: Array<{ label?: string }>;
+      receipt?: { status?: string; action_needed?: string[]; boundaries?: string[] };
     };
 
     expect(run.status).toBe("complete");
@@ -125,6 +155,9 @@ describe("copypass-tool", () => {
     expect(run.not_checked?.map((item) => item.label)).toContain(
       "Humaniser, template, or voice-profile rewrite",
     );
+    expect(run.receipt?.status).toBe("PASS");
+    expect(run.receipt?.action_needed).toEqual([]);
+    expect(run.receipt?.boundaries?.some((item) => item.includes("Detector-evasion guarantee"))).toBe(true);
   });
 
   it("flags detector-evasion claims in MCP runs", async () => {
@@ -251,6 +284,7 @@ describe("copypass-tool", () => {
         output_character_count?: number;
         newline_style?: string;
       };
+      receipt?: { evidence?: { source?: string; copyroom_receipt_attached?: boolean } };
     };
 
     expect(run.status).toBe("complete");
@@ -266,13 +300,21 @@ describe("copypass-tool", () => {
     expect(run.copyroom_receipt?.character_count).toBe(Array.from(sourceText).length);
     expect(run.copyroom_receipt?.output_character_count).toBe(run.copyroom_receipt?.character_count);
     expect(run.copyroom_receipt?.newline_style).toBe("crlf");
+    expect(run.receipt?.evidence).toMatchObject({
+      source: "copyroom_source_packet",
+      copyroom_receipt_attached: true,
+    });
 
     const status = (await copypassStatus({
       run_id: run.run_id,
-    })) as { copyroom_receipt?: { status?: string; source_sha256?: string; output_sha256?: string } };
+    })) as {
+      copyroom_receipt?: { status?: string; source_sha256?: string; output_sha256?: string };
+      receipt?: { evidence?: { copyroom_receipt_attached?: boolean } };
+    };
 
     expect(status.copyroom_receipt?.status).toBe("pass");
     expect(status.copyroom_receipt?.source_sha256).toBe(status.copyroom_receipt?.output_sha256);
+    expect(status.receipt?.evidence?.copyroom_receipt_attached).toBe(true);
   });
 
   it("blocks required CopyRoom receipt runs when the source packet is missing", async () => {

--- a/packages/mcp-server/src/copypass-tool.ts
+++ b/packages/mcp-server/src/copypass-tool.ts
@@ -132,6 +132,29 @@ interface CopyRunRecord {
   error?: string;
 }
 
+interface CopyPassReceipt {
+  kind: "copypass_receipt_v1";
+  pass: "copypass";
+  receipt_id: string;
+  run_id: string;
+  status: "PASS" | "WARN" | "FAIL";
+  profile: RunProfile;
+  checked_at: string;
+  completed_at: string;
+  target: CopyRunRecord["target"];
+  verdict: CopyPassRunVerdict;
+  overall_score: number;
+  finding_count: number;
+  checks_attempted: CopyPassCheckId[];
+  evidence: {
+    source: "caller_provided_copy" | "copyroom_source_packet";
+    copy_text_preview: string;
+    copyroom_receipt_attached: boolean;
+  };
+  boundaries: string[];
+  action_needed: string[];
+}
+
 const RUNS = new Map<string, CopyRunRecord>();
 
 const COPYPASS_DISCLAIMER = {
@@ -611,6 +634,39 @@ function summarizeCopyPass(findings: CopyFinding[]): CopyPassSummary {
   };
 }
 
+function toReceiptStatus(verdict: CopyPassRunVerdict): CopyPassReceipt["status"] {
+  if (verdict === "pass") return "PASS";
+  if (verdict === "warn") return "WARN";
+  return "FAIL";
+}
+
+function createCopyPassReceipt(run: CopyRunRecord): CopyPassReceipt {
+  return {
+    kind: "copypass_receipt_v1",
+    pass: "copypass",
+    receipt_id: `copypass:${run.id}`,
+    run_id: run.id,
+    status: toReceiptStatus(run.copypass_verdict),
+    profile: run.profile,
+    checked_at: run.completed_at ?? run.created_at,
+    completed_at: run.completed_at ?? run.created_at,
+    target: run.target,
+    verdict: run.copypass_verdict,
+    overall_score: run.overall_score,
+    finding_count: run.findings.length,
+    checks_attempted: run.checks_attempted,
+    evidence: {
+      source: run.copyroom_receipt ? "copyroom_source_packet" : "caller_provided_copy",
+      copy_text_preview: run.target.copy_text_preview,
+      copyroom_receipt_attached: Boolean(run.copyroom_receipt),
+    },
+    boundaries: run.not_checked.map((item) => `${item.label}: ${item.reason}`),
+    action_needed: run.findings.map((finding) =>
+      `${finding.severity.toUpperCase()}: ${finding.title} (${finding.check_id})`,
+    ),
+  };
+}
+
 function normalizeCopy(value: string): string {
   return value.toLocaleLowerCase("en-US").replace(/\s+/g, " ").trim();
 }
@@ -751,6 +807,7 @@ export async function copypassRun(args: Record<string, unknown>): Promise<unknow
     notes: completed.notes,
     preview: completed.target.copy_text_preview,
     copyroom_receipt: completed.copyroom_receipt ?? null,
+    receipt: createCopyPassReceipt(completed),
   };
 }
 
@@ -776,6 +833,7 @@ export async function copypassStatus(args: Record<string, unknown>): Promise<unk
     notes: run.notes,
     completed_at: run.completed_at,
     copyroom_receipt: run.copyroom_receipt ?? null,
+    receipt: createCopyPassReceipt(run),
   };
 }
 

--- a/packages/mcp-server/src/fidelitycopy-tool.test.ts
+++ b/packages/mcp-server/src/fidelitycopy-tool.test.ts
@@ -174,6 +174,44 @@ describe("fidelitycopy-tool", () => {
     expect(result.action_needed?.[0]).toContain("source_text/source_base64");
   });
 
+  it("returns N/A when no exact copy is in scope", async () => {
+    const result = (await fidelitypassVerifyCopy({
+      exact_copy_required: false,
+      scope_reason: "This is copy-quality review, not a 1:1 copy or transcription task.",
+      provenance_ref: "boardroom://todo/fidelitypass-na",
+    })) as {
+      verdict?: string;
+      receipt?: { kind?: string; status?: string; verdict?: string; reason?: string; action_needed?: string[] };
+      action_needed?: string[];
+    };
+
+    expect(result.verdict).toBe("N/A");
+    expect(result.receipt?.kind).toBe("fidelitypass_scope_receipt_v1");
+    expect(result.receipt?.status).toBe("not_applicable");
+    expect(result.receipt?.verdict).toBe("N/A");
+    expect(result.receipt?.reason).toContain("copy-quality review");
+    expect(result.action_needed).toEqual([]);
+  });
+
+  it("accepts copy_scope=not_applicable as the explicit XPass wrapper skip", async () => {
+    const result = (await fidelitypassVerifyCopy({
+      copy_scope: "not_applicable",
+    })) as { verdict?: string; receipt?: { checked_scope?: string; reason?: string } };
+
+    expect(result.verdict).toBe("N/A");
+    expect(result.receipt?.checked_scope).toBe("no_exact_copy");
+    expect(result.receipt?.reason).toContain("No exact 1:1 copy");
+  });
+
+  it("rejects contradictory FidelityPass scope hints", async () => {
+    const result = (await fidelitypassVerifyCopy({
+      copy_scope: "exact_copy",
+      exact_copy_required: false,
+    })) as { error?: string };
+
+    expect(result.error).toContain("scope conflict");
+  });
+
   it("rejects malformed base64 instead of creating a fake byte receipt", async () => {
     const result = (await fidelitycopyCopy({
       source_base64: "not valid base64",

--- a/packages/mcp-server/src/fidelitycopy-tool.ts
+++ b/packages/mcp-server/src/fidelitycopy-tool.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 type FidelityCopyMode = "raw_bytes" | "text_exact" | "json_canonical" | "approved_transform";
-type FidelityCopyVerdict = "PASS" | "BLOCKER" | "HOLD" | "ROUTE" | "SUPPRESS";
+type FidelityCopyVerdict = "PASS" | "BLOCKER" | "HOLD" | "ROUTE" | "SUPPRESS" | "N/A";
 
 interface Payload {
   kind: "text" | "base64";
@@ -48,9 +48,23 @@ interface FidelityCopyReceipt {
   action_needed: string[];
 }
 
+interface FidelityPassNotApplicableReceipt {
+  kind: "fidelitypass_scope_receipt_v1";
+  status: "not_applicable";
+  verdict: "N/A";
+  checked_scope: "no_exact_copy";
+  reason: string;
+  action_needed: string[];
+  tool_version: string;
+  timestamp: string;
+  provenance_ref: string;
+}
+
 const TOOL_VERSION = "fidelitycopy-v1";
 const DEFAULT_SOURCE_REF = "fidelitycopy://inline-source";
 const DEFAULT_OUTPUT_REF = "fidelitycopy://inline-output";
+const DEFAULT_NOT_APPLICABLE_REASON =
+  "No exact 1:1 copy, transcription, mirroring, or preservation is in scope for this target.";
 
 export async function fidelitycopyCopy(args: Record<string, unknown>): Promise<unknown> {
   const mode = parseMode(args.mode);
@@ -73,6 +87,17 @@ export async function fidelitycopyCopy(args: Record<string, unknown>): Promise<u
 }
 
 export async function fidelitypassVerifyCopy(args: Record<string, unknown>): Promise<unknown> {
+  const scope = parseFidelityPassScope(args);
+  if ("error" in scope) return { error: scope.error };
+  if (scope.notApplicable) {
+    const receipt = buildNotApplicableReceipt(args);
+    return {
+      verdict: "N/A",
+      receipt,
+      action_needed: receipt.action_needed,
+    };
+  }
+
   const receiptPayload = parseReceipt(args.receipt_payload ?? args.receipt);
   const mode = parseMode(args.mode) ?? modeFromReceipt(receiptPayload);
   if (!mode) return { error: "mode must be one of: raw_bytes, text_exact, json_canonical, approved_transform" };
@@ -109,6 +134,41 @@ export async function fidelitypassVerifyCopy(args: Record<string, unknown>): Pro
   }
 
   return { verdict: receipt.verdict, receipt };
+}
+
+function parseFidelityPassScope(args: Record<string, unknown>): { notApplicable: boolean } | { error: string } {
+  const copyScope = readString(args.copy_scope);
+  const exactCopyRequired = args.exact_copy_required;
+
+  if (copyScope !== null && copyScope !== "" && copyScope !== "exact_copy" && copyScope !== "not_applicable") {
+    return { error: "copy_scope must be exact_copy or not_applicable" };
+  }
+  if (exactCopyRequired !== undefined && exactCopyRequired !== null && typeof exactCopyRequired !== "boolean") {
+    return { error: "exact_copy_required must be a boolean" };
+  }
+  if (copyScope === "exact_copy" && exactCopyRequired === false) {
+    return { error: "FidelityPass scope conflict: copy_scope=exact_copy cannot be combined with exact_copy_required=false." };
+  }
+  if (copyScope === "not_applicable" && exactCopyRequired === true) {
+    return { error: "FidelityPass scope conflict: copy_scope=not_applicable cannot be combined with exact_copy_required=true." };
+  }
+
+  return { notApplicable: copyScope === "not_applicable" || exactCopyRequired === false };
+}
+
+function buildNotApplicableReceipt(args: Record<string, unknown>): FidelityPassNotApplicableReceipt {
+  const reason = readString(args.scope_reason)?.trim() || DEFAULT_NOT_APPLICABLE_REASON;
+  return {
+    kind: "fidelitypass_scope_receipt_v1",
+    status: "not_applicable",
+    verdict: "N/A",
+    checked_scope: "no_exact_copy",
+    reason,
+    action_needed: [],
+    tool_version: TOOL_VERSION,
+    timestamp: new Date().toISOString(),
+    provenance_ref: readString(args.provenance_ref) || "mcp://fidelitypass/not-applicable",
+  };
 }
 
 function createCopyOutput(

--- a/packages/mcp-server/src/flowpass-runtime.ts
+++ b/packages/mcp-server/src/flowpass-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
 // @ts-nocheck
 /* Generated from @unclick/flowpass source so Vercel bundles FlowPass with the MCP function. */
 

--- a/packages/mcp-server/src/flowpass-tool.test.ts
+++ b/packages/mcp-server/src/flowpass-tool.test.ts
@@ -50,6 +50,7 @@ describe("flowpass-tool", () => {
   it("runs deterministic fixture checks and exposes reports", async () => {
     const run = await flowpassRun({
       target_url: "https://example.com/signup",
+      target_sha: "flow-sha-123",
       generated_at: "2026-05-28T00:00:00.000Z",
       journey_id: "signup",
       journey_name: "Signup journey",
@@ -75,10 +76,26 @@ describe("flowpass-tool", () => {
       pass: "flowpass",
       verdict: "ready",
       journey_readiness_score: 100,
+      target_sha: "flow-sha-123",
+      flowpass_receipt_v1: {
+        kind: "flowpass_receipt_v1",
+        status: "PASS",
+        target_sha: "flow-sha-123",
+        mode: "fixture",
+        score: 100,
+        checked: { fail: 0, unknown: 0 },
+        action_needed: [],
+      },
     });
+    expect(String((run.flowpass_receipt_v1 as Record<string, unknown>).boundaries)).toContain("does not drive live auth");
 
     const status = await flowpassStatus({ run_id: run.run_id }) as Record<string, unknown>;
-    expect(status).toMatchObject({ verdict: "ready", journey_readiness_score: 100 });
+    expect(status).toMatchObject({
+      verdict: "ready",
+      journey_readiness_score: 100,
+      target_sha: "flow-sha-123",
+      flowpass_receipt_v1: { target_sha: "flow-sha-123", status: "PASS" },
+    });
 
     const markdown = await flowpassReport({
       run_id: run.run_id,
@@ -105,7 +122,20 @@ describe("flowpass-tool", () => {
       status: "planned",
       mode: "plan-only",
       verdict: "unknown",
+      flowpass_receipt_v1: {
+        kind: "flowpass_receipt_v1",
+        status: "PENDING",
+        mode: "plan-only",
+      },
     });
+    expect(String((run.flowpass_receipt_v1 as Record<string, unknown>).action_needed)).toContain("fixture proof");
+  });
+
+  it("rejects blank target SHA values", async () => {
+    await expect(flowpassRun({
+      target_url: "https://example.com/signup",
+      target_sha: " ",
+    })).resolves.toMatchObject({ error: "target_sha must be a non-empty string when provided" });
   });
 
   it("registers YAML packs and can run them with a fixture", async () => {

--- a/packages/mcp-server/src/flowpass-tool.ts
+++ b/packages/mcp-server/src/flowpass-tool.ts
@@ -17,6 +17,7 @@ import {
 
 type ReportFormat = "json" | "markdown" | "html" | "fix_prompt";
 type FlowPassFixture = Record<string, unknown>;
+type FlowPassReceiptStatus = "PASS" | "WARN" | "BLOCKER" | "PENDING";
 
 interface FlowPassJourney {
   id: string;
@@ -38,21 +39,76 @@ interface FlowPassNormalizedPack {
 
 interface FlowPassReport {
   run_id?: string;
-  mode: string;
-  verdict: string;
+  mode: "plan-only" | "fixture" | "live-readonly";
+  profile: "smoke" | "standard" | "deep";
+  verdict: "ready" | "needs-work" | "blocked" | "unknown";
   journey_readiness_score: number;
   target_url: string;
   journey: FlowPassJourney;
-  summary?: unknown;
-  disagreements: Array<{ id: string } & Record<string, unknown>>;
+  summary?: {
+    counts_by_verdict?: Partial<Record<"pass" | "warn" | "fail" | "unknown", number>>;
+  } & Record<string, unknown>;
+  steps: Array<{
+    step_id: string;
+    label: string;
+    score: number;
+    verdict: "pass" | "warn" | "fail" | "unknown";
+    evidence?: FlowPassReceiptEvidence[];
+    findings?: FlowPassReceiptFinding[];
+  }>;
+  disagreements: Array<{ id: string; summary?: string } & Record<string, unknown>>;
+  not_checked: Array<{ label: string; reason: string }>;
+  notes: string[];
   generated_at: string;
+}
+
+interface FlowPassReceiptEvidence {
+  kind: string;
+  label: string;
+  source_url?: string;
+  summary: string;
+}
+
+interface FlowPassReceiptFinding {
+  id: string;
+  recommendation?: string;
+  title?: string;
+  evidence?: FlowPassReceiptEvidence[];
+}
+
+interface FlowPassMcpReceipt {
+  kind: "flowpass_receipt_v1";
+  status: FlowPassReceiptStatus;
+  run_id: string;
+  target_url: string;
+  target_sha?: string;
+  generated_at: string;
+  mode: FlowPassReport["mode"];
+  profile: FlowPassReport["profile"];
+  journey: FlowPassJourney;
+  score: number;
+  verdict: FlowPassReport["verdict"];
+  checked: {
+    total: number;
+    pass: number;
+    warn: number;
+    fail: number;
+    unknown: number;
+  };
+  evidence_sources: FlowPassReceiptEvidence[];
+  not_checked: Array<{ label: string; reason: string }>;
+  disagreements_open: number;
+  action_needed: string[];
+  boundaries: string[];
 }
 
 interface FlowPassRunRecord {
   run_id: string;
   status: "planned" | "complete";
   pack_id?: string;
+  target_sha?: string;
   report: FlowPassReport;
+  receipt: FlowPassMcpReceipt;
   reports: {
     json: object;
     markdown: string;
@@ -117,13 +173,119 @@ function resolvePack(args: Record<string, unknown>): FlowPassNormalizedPack | un
   return undefined;
 }
 
-function storeRun(report: FlowPassReport, pack?: FlowPassNormalizedPack): FlowPassRunRecord {
+function buildFlowPassReceipt(
+  report: FlowPassReport,
+  runId: string,
+  targetSha?: string,
+): FlowPassMcpReceipt {
+  const checked = checkedCounts(report);
+  const openDisagreements = report.disagreements.filter((item) => !RESOLVED_DISAGREEMENTS.has(item.id));
+  return {
+    kind: "flowpass_receipt_v1",
+    status: receiptStatus(report, checked, openDisagreements.length),
+    run_id: runId,
+    target_url: report.target_url,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: report.generated_at,
+    mode: report.mode,
+    profile: report.profile,
+    journey: report.journey,
+    score: report.journey_readiness_score,
+    verdict: report.verdict,
+    checked,
+    evidence_sources: receiptEvidence(report),
+    not_checked: report.not_checked,
+    disagreements_open: openDisagreements.length,
+    action_needed: receiptActions(report, openDisagreements),
+    boundaries: [
+      "FlowPass uses provided public fixture evidence from this MCP surface.",
+      "FlowPass does not drive live auth, checkout, billing, email, production data, or destructive submissions.",
+      "Plan-only results are not PASS receipts until fixture or live read-only proof is supplied.",
+    ],
+  };
+}
+
+function checkedCounts(report: FlowPassReport): FlowPassMcpReceipt["checked"] {
+  const summary = report.summary?.counts_by_verdict;
+  return {
+    total: report.steps.length,
+    pass: summary?.pass ?? report.steps.filter((step) => step.verdict === "pass").length,
+    warn: summary?.warn ?? report.steps.filter((step) => step.verdict === "warn").length,
+    fail: summary?.fail ?? report.steps.filter((step) => step.verdict === "fail").length,
+    unknown: summary?.unknown ?? report.steps.filter((step) => step.verdict === "unknown").length,
+  };
+}
+
+function receiptStatus(
+  report: FlowPassReport,
+  checked: FlowPassMcpReceipt["checked"],
+  disagreementsOpen: number,
+): FlowPassReceiptStatus {
+  if (report.mode === "plan-only" || report.verdict === "unknown" || checked.unknown > 0) return "PENDING";
+  if (report.verdict === "blocked" || checked.fail > 0) return "BLOCKER";
+  if (report.verdict === "needs-work" || checked.warn > 0 || disagreementsOpen > 0) {
+    return "WARN";
+  }
+  return "PASS";
+}
+
+function receiptEvidence(report: FlowPassReport): FlowPassReceiptEvidence[] {
+  const evidence = report.steps.flatMap((step) => [
+    ...(step.evidence ?? []),
+    ...((step.findings ?? []).flatMap((finding) => finding.evidence ?? [])),
+  ]);
+  const normalized = evidence.length > 0
+    ? evidence
+    : [{
+        kind: "manual-note",
+        label: "Plan-only note",
+        source_url: report.target_url,
+        summary: "Fixture proof is still required before FlowPass can act as a PASS receipt.",
+      }];
+  const seen = new Set<string>();
+  return normalized.filter((item) => {
+    const key = [item.kind, item.label, item.source_url ?? "", item.summary].join("\u0000");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).slice(0, 20);
+}
+
+function receiptActions(
+  report: FlowPassReport,
+  openDisagreements: Array<{ id: string; summary?: string }>,
+): string[] {
+  const actions = [
+    ...(report.mode === "plan-only"
+      ? ["Provide fixture proof before using this as a PASS receipt."]
+      : []),
+    ...openDisagreements.map((item) => `Resolve disagreement ${item.id}: ${item.summary ?? "review the open driver/verifier mismatch"}`),
+    ...report.steps.flatMap((step) =>
+      (step.findings ?? []).flatMap((finding) =>
+        finding.recommendation ? [`${finding.id}: ${finding.recommendation}`] : [],
+      ),
+    ),
+  ];
+  return Array.from(new Set(actions)).slice(0, 12);
+}
+
+function parseTargetSha(value: unknown): string | undefined | { error: string } {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  return value.trim();
+}
+
+function storeRun(report: FlowPassReport, pack?: FlowPassNormalizedPack, targetSha?: string): FlowPassRunRecord {
   const runId = report.run_id ?? `flowpass_plan_${RUNS.size + 1}`;
   const record: FlowPassRunRecord = {
     run_id: runId,
     status: report.mode === "fixture" ? "complete" : "planned",
     pack_id: pack?.id,
+    target_sha: targetSha,
     report,
+    receipt: buildFlowPassReceipt(report, runId, targetSha),
     reports: {
       json: generateFlowPassJsonReport(report),
       markdown: generateFlowPassMarkdownReport(report),
@@ -137,6 +299,8 @@ function storeRun(report: FlowPassReport, pack?: FlowPassNormalizedPack): FlowPa
 
 export async function flowpassRun(args: Record<string, unknown>): Promise<unknown> {
   try {
+    const targetSha = parseTargetSha(args.target_sha);
+    if (isRecord(targetSha)) return targetSha;
     const pack = resolvePack(args);
     const targetUrl =
       (typeof args.target_url === "string" && args.target_url.trim()) ||
@@ -180,12 +344,13 @@ export async function flowpassRun(args: Record<string, unknown>): Promise<unknow
         ...(pack ? [`Registered pack ${pack.id} supplied ${pack.plainEnglishSteps.length} plain-English step(s).`] : []),
       ],
     });
-    const record = storeRun(report, pack);
+    const record = storeRun(report, pack, targetSha);
     return {
       run_id: record.run_id,
       status: record.status,
       pass: "flowpass",
       pack_id: record.pack_id,
+      target_sha: record.target_sha,
       target_url: report.target_url,
       journey: report.journey,
       mode: report.mode,
@@ -197,6 +362,7 @@ export async function flowpassRun(args: Record<string, unknown>): Promise<unknow
       disagreements: report.disagreements,
       not_checked: report.not_checked,
       notes: report.notes,
+      flowpass_receipt_v1: record.receipt,
     };
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };
@@ -212,6 +378,7 @@ export async function flowpassStatus(args: Record<string, unknown>): Promise<unk
     run_id: record.run_id,
     status: record.status,
     pack_id: record.pack_id,
+    target_sha: record.target_sha,
     verdict: record.report.verdict,
     journey_readiness_score: record.report.journey_readiness_score,
     target_url: record.report.target_url,
@@ -221,6 +388,12 @@ export async function flowpassStatus(args: Record<string, unknown>): Promise<unk
       (item) => !RESOLVED_DISAGREEMENTS.has(item.id),
     ),
     completed_at: record.report.generated_at,
+    flowpass_receipt_v1: {
+      ...record.receipt,
+      disagreements_open: record.report.disagreements.filter(
+        (item) => !RESOLVED_DISAGREEMENTS.has(item.id),
+      ).length,
+    },
   };
 }
 

--- a/packages/mcp-server/src/geopass-runtime.ts
+++ b/packages/mcp-server/src/geopass-runtime.ts
@@ -1,0 +1,950 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var, no-empty */
+// @ts-nocheck
+/* Generated from @unclick/geopass source so Vercel bundles GEOPass with the MCP function. */
+
+// packages/geopass/src/schema.ts
+import { z } from "zod";
+var GeoPassSeveritySchema = z.enum([
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info"
+]);
+var GeoPassVerdictSchema = z.enum([
+  "ready",
+  "needs-work",
+  "blocked",
+  "unknown"
+]);
+var GeoPassEngineIdSchema = z.enum([
+  "chatgpt",
+  "claude",
+  "perplexity",
+  "gemini",
+  "copilot",
+  "grok",
+  "meta-ai"
+]);
+var GeoPassBotIdSchema = z.enum([
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+  "Twitterbot",
+  "FacebookBot"
+]);
+var GeoPassCheckIdSchema = z.enum([
+  "ai-bot-crawlability",
+  "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
+  "schema-org-citation-grade",
+  "brand-mention-readiness",
+  "wikidata-presence",
+  "common-crawl-presence",
+  "aggregate-ai-engine-readiness"
+]);
+var GeoPassEvidenceSchema = z.object({
+  kind: z.enum([
+    "robots-txt",
+    "llms-txt",
+    "schema-org",
+    "html",
+    "http",
+    "content",
+    "date",
+    "external-link",
+    "wikidata",
+    "common-crawl",
+    "brand-query",
+    "lighthouse",
+    "manual-note"
+  ]),
+  label: z.string().min(1),
+  source_url: z.string().url().optional(),
+  summary: z.string().min(1)
+});
+var GeoPassFindingSchema = z.object({
+  id: z.string().min(1),
+  check_id: GeoPassCheckIdSchema,
+  severity: GeoPassSeveritySchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  evidence: z.array(GeoPassEvidenceSchema).default([]),
+  recommendation: z.string().min(1).optional()
+});
+var GeoPassCheckResultSchema = z.object({
+  check_id: GeoPassCheckIdSchema,
+  label: z.string().min(1),
+  score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  findings: z.array(GeoPassFindingSchema).default([])
+});
+var GeoPassCrossPassSignalSchema = z.object({
+  pass: z.enum(["seopass", "flowpass", "legalpass", "sloppass", "uxpass"]),
+  signal: z.string().min(1),
+  score: z.number().min(0).max(100).optional()
+});
+var GeoPassReportSchema = z.object({
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.enum(["plan-only", "fixture", "live-readonly"]).default("plan-only"),
+  engines: z.array(GeoPassEngineIdSchema).min(1),
+  aggregate_ai_engine_readiness_score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  checks: z.array(GeoPassCheckResultSchema).min(1),
+  cross_pass_signals: z.array(GeoPassCrossPassSignalSchema).default([]),
+  notes: z.array(z.string().min(1)).default([])
+});
+var GeoPassReceiptSchema = z.object({
+  kind: z.literal("geopass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  generated_at: z.string().datetime(),
+  mode: z.literal("live-readonly"),
+  target_sha: z.string().min(1).optional(),
+  score: z.number().min(0).max(100),
+  verdict: GeoPassVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    ready: z.number().int().min(0),
+    needs_work: z.number().int().min(0),
+    blocked: z.number().int().min(0),
+    unknown: z.number().int().min(0)
+  }),
+  evidence_sources: z.array(GeoPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1))
+});
+
+// packages/geopass/src/scanner-plan.ts
+var DEFAULT_GEOPASS_ENGINES = [
+  "chatgpt",
+  "claude",
+  "perplexity",
+  "gemini",
+  "copilot",
+  "grok",
+  "meta-ai"
+];
+var DEFAULT_GEOPASS_BOTS = [
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot",
+  "Twitterbot",
+  "FacebookBot"
+];
+var DEFAULT_GEOPASS_SCANNER_STEPS = [
+  {
+    id: "ai-bot-crawlability",
+    label: "AI bot crawlability matrix",
+    purpose: "Plan robots.txt and public bot access checks for major generative engines.",
+    evidenceKinds: ["robots-txt", "manual-note"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "llms-txt",
+    label: "llms.txt presence and quality",
+    purpose: "Check whether the site publishes a useful llms.txt guide for AI readers.",
+    evidenceKinds: ["llms-txt"],
+    sharedWith: ["seopass", "sloppass"]
+  },
+  {
+    id: "answer-extractability",
+    label: "Answer extractability",
+    purpose: "Check whether public page copy contains direct, reusable answers rather than only abstract marketing claims.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "uxpass"]
+  },
+  {
+    id: "entity-clarity",
+    label: "Entity clarity",
+    purpose: "Check whether the page names the organization, product, or author clearly enough for answer engines to ground summaries.",
+    evidenceKinds: ["html", "schema-org"],
+    sharedWith: ["seopass", "legalpass"]
+  },
+  {
+    id: "citation-readiness",
+    label: "Citation and sourceability readiness",
+    purpose: "Check whether visible sources, support links, statistics, or evidence cues make claims easier to cite accurately.",
+    evidenceKinds: ["external-link", "content", "schema-org"],
+    sharedWith: ["seopass", "legalpass", "sloppass"]
+  },
+  {
+    id: "freshness-cues",
+    label: "Freshness and update cues",
+    purpose: "Check whether visible publication or update signals help answer engines avoid stale summaries.",
+    evidenceKinds: ["date", "html"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "content-structure",
+    label: "AI-readable content structure",
+    purpose: "Check heading, list, paragraph, and FAQ-style structure that helps AI systems extract reliable answers.",
+    evidenceKinds: ["html", "content"],
+    sharedWith: ["seopass", "flowpass", "uxpass"]
+  },
+  {
+    id: "schema-org-citation-grade",
+    label: "schema.org citation-grade validation",
+    purpose: "Plan structured data checks that make public facts easier to cite accurately.",
+    evidenceKinds: ["schema-org"],
+    sharedWith: ["seopass", "legalpass"]
+  },
+  {
+    id: "brand-mention-readiness",
+    label: "Brand mention readiness",
+    purpose: "Plan public-safe brand query fixtures without paid API calls or live prompts.",
+    evidenceKinds: ["brand-query"],
+    sharedWith: ["seopass", "uxpass"]
+  },
+  {
+    id: "wikidata-presence",
+    label: "Wikidata presence",
+    purpose: "Plan public entity presence checks for citation context and disambiguation.",
+    evidenceKinds: ["wikidata"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "common-crawl-presence",
+    label: "Common Crawl presence",
+    purpose: "Plan public web corpus presence checks without fetching private content.",
+    evidenceKinds: ["common-crawl"],
+    sharedWith: ["seopass"]
+  },
+  {
+    id: "aggregate-ai-engine-readiness",
+    label: "Aggregate AI engine readiness score",
+    purpose: "Combine public diagnostics into one readiness score and shared pass signals.",
+    evidenceKinds: ["lighthouse", "manual-note"],
+    sharedWith: ["seopass", "flowpass", "legalpass", "sloppass", "uxpass"]
+  }
+];
+var DISALLOWED_ACTIONS = [
+  "live crawler execution",
+  "paid API calls",
+  "credential access",
+  "production database writes",
+  "guaranteed citations"
+];
+function createGeoPassScannerPlan(input) {
+  const engines = (input.engines ?? DEFAULT_GEOPASS_ENGINES).map(
+    (engine) => GeoPassEngineIdSchema.parse(engine)
+  );
+  const bots = (input.bots ?? DEFAULT_GEOPASS_BOTS).map(
+    (bot) => GeoPassBotIdSchema.parse(bot)
+  );
+  const checks = new Set(
+    (input.checks ?? DEFAULT_GEOPASS_SCANNER_STEPS.map((step) => step.id)).map(
+      (check) => GeoPassCheckIdSchema.parse(check)
+    )
+  );
+  return {
+    targetUrl: new URL(input.targetUrl).toString(),
+    mode: "plan-only",
+    engines,
+    bots,
+    steps: DEFAULT_GEOPASS_SCANNER_STEPS.filter((step) => checks.has(step.id)),
+    disallowedActions: DISALLOWED_ACTIONS
+  };
+}
+
+// packages/geopass/src/runner.ts
+import { createHash, randomUUID } from "node:crypto";
+var DEFAULT_TIMEOUT_MS = 1e4;
+var DEFAULT_MAX_BODY_CHARS = 125e4;
+var LIVE_CHECKS = [
+  "ai-bot-crawlability",
+  "llms-txt",
+  "answer-extractability",
+  "entity-clarity",
+  "citation-readiness",
+  "freshness-cues",
+  "content-structure",
+  "schema-org-citation-grade",
+  "brand-mention-readiness",
+  "aggregate-ai-engine-readiness"
+];
+var AI_BOTS = [
+  "GPTBot",
+  "ClaudeBot",
+  "PerplexityBot",
+  "Google-Extended",
+  "Bingbot"
+];
+var RECEIPT_BOUNDARIES = [
+  "GEOPass reports public read-only readiness only.",
+  "GEOPass does not guarantee rankings, citations, AI Overview inclusion, or answer-engine placement.",
+  "This run fetches public http(s) pages only and does not use credentials, paid APIs, production data, or private prompts."
+];
+function normalizePublicHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.username || url.password) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+function stableRunId(targetUrl, generatedAt) {
+  const digest = createHash("sha256").update(`${targetUrl}:${generatedAt}:${randomUUID()}`).digest("hex").slice(0, 12);
+  return `geopass-${digest}`;
+}
+function headersToRecord(headers) {
+  const output = {};
+  headers.forEach((value, key) => {
+    output[key.toLowerCase()] = value;
+  });
+  return output;
+}
+async function fetchText(url, fetchImpl, timeoutMs, maxBodyChars) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      redirect: "follow",
+      signal: controller.signal,
+      headers: { "user-agent": "UnClick-GEOPass/0.1 (+https://unclick.world)" }
+    });
+    const body = await response.text();
+    const truncated = body.length > maxBodyChars;
+    return {
+      url: response.url || url,
+      status: response.status,
+      ok: response.ok,
+      headers: headersToRecord(response.headers),
+      body: truncated ? body.slice(0, maxBodyChars) : body,
+      truncated
+    };
+  } catch (error) {
+    return {
+      url,
+      status: 0,
+      ok: false,
+      headers: {},
+      body: "",
+      error: error instanceof Error ? error.message : String(error)
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+function stripHtml(html) {
+  return html.replace(/<script\b[\s\S]*?<\/script>/gi, " ").replace(/<style\b[\s\S]*?<\/style>/gi, " ").replace(/<[^>]+>/g, " ").replace(/&nbsp;/gi, " ").replace(/&amp;/gi, "&").replace(/&#39;/gi, "'").replace(/&quot;/gi, '"').replace(/\s+/g, " ").trim();
+}
+function firstMatch(html, pattern) {
+  return pattern.exec(html)?.[1]?.replace(/\s+/g, " ").trim() ?? "";
+}
+function allMatches(html, pattern) {
+  return Array.from(
+    html.matchAll(pattern),
+    (match) => stripHtml(match[1] ?? "").replace(/\s+/g, " ").trim()
+  ).filter(Boolean);
+}
+function countMatches(text, pattern) {
+  return Array.from(text.matchAll(pattern)).length;
+}
+function getMeta(html, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return firstMatch(
+    html,
+    new RegExp(`<meta[^>]+(?:name|property)=["']${escaped}["'][^>]+content=["']([^"']+)["'][^>]*>`, "i")
+  );
+}
+function hasSchemaType(html, typeName) {
+  const pattern = new RegExp(`"@type"\\s*:\\s*"?${typeName}"?`, "i");
+  return pattern.test(html);
+}
+function linkCount(html, baseUrl, external) {
+  let count = 0;
+  const base = new URL(baseUrl);
+  for (const match of html.matchAll(/<a\b[^>]+href=["']([^"']+)["'][^>]*>/gi)) {
+    try {
+      const href = new URL(match[1] ?? "", base);
+      if ((href.protocol === "http:" || href.protocol === "https:") && href.origin !== base.origin === external) {
+        count += 1;
+      }
+    } catch {
+    }
+  }
+  return count;
+}
+function hasAboutOrContactLink(html) {
+  return /<a\b[^>]+href=["'][^"']*(about|contact|company|team)[^"']*["'][^>]*>/i.test(html);
+}
+function analyzeHtml(html, targetUrl) {
+  const text = stripHtml(html);
+  const lower = text.toLowerCase();
+  const h1 = allMatches(html, /<h1\b[^>]*>([\s\S]*?)<\/h1>/gi);
+  const h2 = allMatches(html, /<h2\b[^>]*>([\s\S]*?)<\/h2>/gi);
+  const description = getMeta(html, "description") || getMeta(html, "og:description");
+  const title = firstMatch(html, /<title\b[^>]*>([\s\S]*?)<\/title>/i) || getMeta(html, "og:title");
+  const hasJsonLd = /<script\b[^>]+type=["']application\/ld\+json["'][^>]*>/i.test(html);
+  return {
+    title,
+    description,
+    h1,
+    h2,
+    text,
+    wordCount: text.split(/\s+/).filter(Boolean).length,
+    paragraphCount: countMatches(html, /<p\b/gi),
+    listCount: countMatches(html, /<(ul|ol|li)\b/gi),
+    questionCount: countMatches(`${h1.join(" ")} ${h2.join(" ")} ${text}`, /\b(what|why|how|when|where|who|can|does|is|are)\b[^.?!]{0,80}\?/gi),
+    externalLinkCount: linkCount(html, targetUrl, true),
+    hasJsonLd,
+    hasMicrodata: /\bitemscope\b/i.test(html),
+    hasRdfa: /\btypeof=["'][^"']+["']/i.test(html),
+    hasOrganizationSchema: hasJsonLd && (hasSchemaType(html, "Organization") || hasSchemaType(html, "LocalBusiness") || hasSchemaType(html, "Product")),
+    hasArticleSchema: hasJsonLd && (hasSchemaType(html, "Article") || hasSchemaType(html, "NewsArticle") || hasSchemaType(html, "BlogPosting")),
+    hasFaqSchema: hasJsonLd && hasSchemaType(html, "FAQPage"),
+    hasAuthorCue: /\b(author|byline|written by|reviewed by|editor|team)\b/i.test(lower),
+    hasAboutOrContactLink: hasAboutOrContactLink(html),
+    hasFreshnessCue: /<time\b/i.test(html) || /\b(updated|last updated|published|reviewed)\b/i.test(lower) || /\b20\d{2}[-/]\d{1,2}[-/]\d{1,2}\b/.test(text),
+    hasStatisticCue: /\b\d+(\.\d+)?%|\b\d+x\b|\b\d{2,}\b/.test(text),
+    hasSourceCue: /\b(source|sources|citation|research|study|report|evidence|according to|data from)\b/i.test(lower)
+  };
+}
+function evidence(kind, label, summary, sourceUrl) {
+  return {
+    kind,
+    label,
+    summary,
+    ...sourceUrl ? { source_url: sourceUrl } : {}
+  };
+}
+function finding(checkId, id, severity, title, summary, recommendation, findingEvidence) {
+  return {
+    id,
+    check_id: checkId,
+    severity,
+    title,
+    summary,
+    recommendation,
+    evidence: findingEvidence
+  };
+}
+function verdictFor(score, findings) {
+  if (findings.some((item) => item.severity === "critical" || item.severity === "high") && score < 55) {
+    return "blocked";
+  }
+  if (score >= 85) return "ready";
+  if (score >= 45) return "needs-work";
+  return "blocked";
+}
+function result(checkId, label, score, findings) {
+  return {
+    check_id: checkId,
+    label,
+    score: Math.max(0, Math.min(100, Math.round(score))),
+    verdict: verdictFor(score, findings),
+    findings
+  };
+}
+function pageUnavailableResult(checkId, targetUrl, page) {
+  return result(checkId, labelFor(checkId), 0, [
+    finding(
+      checkId,
+      `${checkId}-target-unavailable`,
+      "critical",
+      "Target page was not readable",
+      page.error ? `The public page fetch failed: ${page.error}.` : `The public page returned HTTP ${page.status}.`,
+      "Make the public page return readable HTML before using it as GEOPass evidence.",
+      [evidence("http", "Target fetch", page.error ?? `HTTP ${page.status}`, targetUrl)]
+    )
+  ]);
+}
+function labelFor(checkId) {
+  return {
+    "ai-bot-crawlability": "AI bot crawlability matrix",
+    "llms-txt": "llms.txt presence and quality",
+    "answer-extractability": "Answer extractability",
+    "entity-clarity": "Entity clarity",
+    "citation-readiness": "Citation and sourceability readiness",
+    "freshness-cues": "Freshness and update cues",
+    "content-structure": "AI-readable content structure",
+    "schema-org-citation-grade": "schema.org citation-grade validation",
+    "brand-mention-readiness": "Brand mention readiness",
+    "wikidata-presence": "Wikidata presence",
+    "common-crawl-presence": "Common Crawl presence",
+    "aggregate-ai-engine-readiness": "Aggregate AI engine readiness score"
+  }[checkId];
+}
+function robotsBlockedBots(robotsBody, pathname) {
+  const groups = [];
+  let current = null;
+  for (const rawLine of robotsBody.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*/, "").trim();
+    if (!line) continue;
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    if (key === "user-agent") {
+      current = { agents: [value.toLowerCase()], rules: [] };
+      groups.push(current);
+    } else if ((key === "allow" || key === "disallow") && current) {
+      current.rules.push({ directive: key, path: value });
+    }
+  }
+  return AI_BOTS.filter((bot) => {
+    const token = bot.toLowerCase();
+    const matching = groups.filter(
+      (group) => group.agents.some((agent) => agent === "*" || token.includes(agent.replace(/\*$/, "")))
+    );
+    const rules = matching.flatMap((group) => group.rules).filter((rule) => rule.path !== "");
+    const disallows = rules.filter((rule) => rule.directive === "disallow" && pathMatches(pathname, rule.path));
+    if (disallows.length === 0) return false;
+    const strongestDisallow = Math.max(...disallows.map((rule) => rule.path.length));
+    const strongestAllow = Math.max(
+      0,
+      ...rules.filter((rule) => rule.directive === "allow" && pathMatches(pathname, rule.path)).map((rule) => rule.path.length)
+    );
+    return strongestDisallow >= strongestAllow;
+  });
+}
+function pathMatches(pathname, rulePath) {
+  const cleanRule = rulePath.replace(/\*.*/, "");
+  if (cleanRule === "/" || cleanRule === "") return cleanRule === "/";
+  return pathname.startsWith(cleanRule);
+}
+function buildAiBotCrawlability(targetUrl, robots) {
+  if (robots.status === 0 || robots.status >= 500 || robots.status === 429) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 60, [
+      finding(
+        "ai-bot-crawlability",
+        "ai-bot-crawlability-robots-unavailable",
+        "medium",
+        "robots.txt was not safely checkable",
+        robots.error ? `robots.txt fetch failed: ${robots.error}.` : `robots.txt returned HTTP ${robots.status}.`,
+        "Make robots.txt consistently available so AI crawler access can be checked.",
+        [evidence("robots-txt", "robots.txt fetch", robots.error ?? `HTTP ${robots.status}`, new URL("/robots.txt", targetUrl).toString())]
+      )
+    ]);
+  }
+  if (robots.status === 404) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 88, []);
+  }
+  const blocked = robotsBlockedBots(robots.body, new URL(targetUrl).pathname || "/");
+  if (blocked.length === 0) {
+    return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 100, []);
+  }
+  return result("ai-bot-crawlability", labelFor("ai-bot-crawlability"), 35, [
+    finding(
+      "ai-bot-crawlability",
+      "ai-bot-crawlability-blocked",
+      "high",
+      "AI crawler access is blocked",
+      `robots.txt appears to block ${blocked.join(", ")} for this path.`,
+      "Review whether AI search crawlers should be allowed to read this public page.",
+      [evidence("robots-txt", "Blocked AI bot rules", blocked.join(", "), new URL("/robots.txt", targetUrl).toString())]
+    )
+  ]);
+}
+function buildLlmsTxt(targetUrl, llms) {
+  if (llms.ok && llms.body.trim().length >= 160) {
+    const score = /\[[^\]]+\]\(https?:\/\//.test(llms.body) ? 100 : 88;
+    return result("llms-txt", labelFor("llms-txt"), score, []);
+  }
+  if (llms.ok) {
+    return result("llms-txt", labelFor("llms-txt"), 68, [
+      finding(
+        "llms-txt",
+        "llms-txt-thin",
+        "medium",
+        "llms.txt exists but is thin",
+        "The llms.txt file exists but does not yet provide enough product context, summaries, or source links for AI readers.",
+        "Add a concise product summary, canonical docs links, and important public pages to llms.txt.",
+        [evidence("llms-txt", "Public llms.txt", "File exists but is short.", new URL("/llms.txt", targetUrl).toString())]
+      )
+    ]);
+  }
+  return result("llms-txt", labelFor("llms-txt"), 58, [
+    finding(
+      "llms-txt",
+      "llms-txt-missing",
+      "medium",
+      "llms.txt was not found",
+      "No public llms.txt file was available at the target origin.",
+      "Consider publishing llms.txt with public summaries and canonical links for AI readers.",
+      [evidence("llms-txt", "Public llms.txt", `HTTP ${llms.status || "fetch failed"}`, new URL("/llms.txt", targetUrl).toString())]
+    )
+  ]);
+}
+function buildAnswerExtractability(targetUrl, signals) {
+  const findings = [];
+  let score = 55;
+  if (signals.wordCount >= 350) score += 15;
+  if (signals.questionCount > 0 || signals.hasFaqSchema) score += 15;
+  if (signals.paragraphCount >= 4) score += 10;
+  if (signals.h2.length >= 2) score += 5;
+  if (signals.wordCount < 180) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-thin-page",
+      "medium",
+      "Page copy is thin for AI answer reuse",
+      "The page has limited visible body copy, which makes direct answer extraction brittle.",
+      "Add clear, visible answers to the main questions a customer or answer engine would ask.",
+      [evidence("content", "Visible body text", `${signals.wordCount} visible words`, targetUrl)]
+    ));
+  }
+  if (signals.questionCount === 0 && !signals.hasFaqSchema) {
+    findings.push(finding(
+      "answer-extractability",
+      "answer-extractability-no-questions",
+      "low",
+      "No explicit question-answer structure was found",
+      "AI answer engines often benefit from direct question headings, FAQ structure, or plain answer blocks.",
+      "Add direct headings or FAQ-style sections for important user questions.",
+      [evidence("html", "Heading scan", `${signals.h2.length} h2 heading(s), ${signals.questionCount} question heading(s)`, targetUrl)]
+    ));
+  }
+  return result("answer-extractability", labelFor("answer-extractability"), score, findings);
+}
+function buildEntityClarity(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.title) score += 15;
+  if (signals.description) score += 15;
+  if (signals.h1.length > 0) score += 10;
+  if (signals.hasOrganizationSchema) score += 15;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (!signals.hasOrganizationSchema) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-schema-missing",
+      "medium",
+      "Organization or product schema was not found",
+      "The page does not expose obvious Organization, LocalBusiness, or Product JSON-LD for entity grounding.",
+      "Add truthful schema that matches visible page content.",
+      [evidence("schema-org", "Schema scan", "No Organization, LocalBusiness, or Product JSON-LD found.", targetUrl)]
+    ));
+  }
+  if (!signals.description) {
+    findings.push(finding(
+      "entity-clarity",
+      "entity-clarity-description-missing",
+      "low",
+      "Meta description is missing",
+      "The page lacks a concise public description for summarizers and search snippets.",
+      "Add a clear meta description that states what the product, organization, or page is about.",
+      [evidence("html", "Meta description scan", "No description meta tag found.", targetUrl)]
+    ));
+  }
+  return result("entity-clarity", labelFor("entity-clarity"), score, findings);
+}
+function buildCitationReadiness(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.externalLinkCount >= 2) score += 20;
+  if (signals.hasSourceCue) score += 15;
+  if (signals.hasStatisticCue) score += 10;
+  if (signals.hasArticleSchema || signals.hasAuthorCue) score += 10;
+  if (signals.externalLinkCount === 0 && !signals.hasSourceCue) {
+    findings.push(finding(
+      "citation-readiness",
+      "citation-readiness-no-visible-sources",
+      "medium",
+      "Visible source cues are weak",
+      "The page has no obvious external source links or source/evidence wording for answer engines to cite.",
+      "Add visible support links, evidence, data sources, or authored references for important claims.",
+      [evidence("external-link", "External link scan", `${signals.externalLinkCount} external link(s) found.`, targetUrl)]
+    ));
+  }
+  return result("citation-readiness", labelFor("citation-readiness"), score, findings);
+}
+function buildFreshness(targetUrl, signals) {
+  if (signals.hasFreshnessCue) {
+    return result("freshness-cues", labelFor("freshness-cues"), 95, []);
+  }
+  return result("freshness-cues", labelFor("freshness-cues"), 62, [
+    finding(
+      "freshness-cues",
+      "freshness-cues-missing",
+      "low",
+      "Freshness cues are not visible",
+      "The page does not expose obvious published, reviewed, or last-updated cues.",
+      "Add visible freshness or review dates where current information matters.",
+      [evidence("date", "Freshness scan", "No visible time/date/update cue found.", targetUrl)]
+    )
+  ]);
+}
+function buildContentStructure(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.h1.length === 1) score += 15;
+  if (signals.h2.length >= 2) score += 15;
+  if (signals.paragraphCount >= 3) score += 10;
+  if (signals.listCount > 0) score += 10;
+  if (signals.hasFaqSchema || signals.questionCount > 0) score += 10;
+  if (signals.h1.length === 0) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-h1-missing",
+      "medium",
+      "No H1 was found",
+      "The page lacks a clear top-level heading.",
+      "Add one clear H1 that names the page subject.",
+      [evidence("html", "Heading scan", "No H1 found.", targetUrl)]
+    ));
+  }
+  if (signals.h2.length < 2) {
+    findings.push(finding(
+      "content-structure",
+      "content-structure-heading-depth-thin",
+      "low",
+      "Heading structure is thin",
+      "The page has limited subheading structure for answer extraction.",
+      "Break important topics into descriptive H2 sections.",
+      [evidence("html", "Heading scan", `${signals.h2.length} H2 heading(s) found.`, targetUrl)]
+    ));
+  }
+  return result("content-structure", labelFor("content-structure"), score, findings);
+}
+function buildSchemaCitationGrade(targetUrl, signals) {
+  const findings = [];
+  let score = 45;
+  if (signals.hasJsonLd) score += 25;
+  if (signals.hasMicrodata || signals.hasRdfa) score += 10;
+  if (signals.hasOrganizationSchema || signals.hasArticleSchema || signals.hasFaqSchema) score += 20;
+  if (!signals.hasJsonLd && !signals.hasMicrodata && !signals.hasRdfa) {
+    findings.push(finding(
+      "schema-org-citation-grade",
+      "schema-org-citation-grade-missing",
+      "medium",
+      "Structured data was not found",
+      "No JSON-LD, microdata, or RDFa was detected on the page.",
+      "Add truthful structured data that matches visible page facts.",
+      [evidence("schema-org", "Structured data scan", "No structured data detected.", targetUrl)]
+    ));
+  }
+  return result("schema-org-citation-grade", labelFor("schema-org-citation-grade"), score, findings);
+}
+function buildBrandMentionReadiness(targetUrl, signals) {
+  const findings = [];
+  let score = 55;
+  if (signals.title && signals.h1.length > 0) score += 15;
+  if (signals.description) score += 10;
+  if (signals.hasAboutOrContactLink) score += 10;
+  if (signals.hasOrganizationSchema) score += 10;
+  if (!signals.title || signals.h1.length === 0) {
+    findings.push(finding(
+      "brand-mention-readiness",
+      "brand-mention-readiness-weak-page-name",
+      "medium",
+      "Page naming is weak for brand/entity mention",
+      "The page needs both a clear title and visible H1 for answer engines to label it consistently.",
+      "Use a direct title and H1 that name the product, brand, organization, or topic.",
+      [evidence("brand-query", "Title and H1 scan", `title=${signals.title ? "present" : "missing"}; h1=${signals.h1.length}`, targetUrl)]
+    ));
+  }
+  return result("brand-mention-readiness", labelFor("brand-mention-readiness"), score, findings);
+}
+function buildPlanOnlyExternalIndex(checkId, targetUrl) {
+  return {
+    check_id: checkId,
+    label: labelFor(checkId),
+    score: 50,
+    verdict: "unknown",
+    findings: [
+      finding(
+        checkId,
+        `${checkId}-not-live-readonly`,
+        "info",
+        "External index lookup was not run",
+        "This GEOPass live-readonly slice does not query external entity or web-corpus APIs.",
+        "Run a separately scoped public API adapter before using this row as index-presence proof.",
+        [evidence(checkId === "wikidata-presence" ? "wikidata" : "common-crawl", "External index boundary", "Not queried in this public-safe run.", targetUrl)]
+      )
+    ]
+  };
+}
+function buildAggregate(targetUrl, checks) {
+  const source = checks.filter((check) => check.check_id !== "aggregate-ai-engine-readiness");
+  const score = Math.round(source.reduce((sum, check) => sum + check.score, 0) / Math.max(1, source.length));
+  const blockers = source.filter((check) => check.verdict === "blocked");
+  const weak = source.filter((check) => check.verdict === "needs-work");
+  const findings = [];
+  if (blockers.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-blockers",
+      "high",
+      "GEOPass has blocked rows",
+      `${blockers.length} check(s) are blocked: ${blockers.map((check) => check.check_id).join(", ")}.`,
+      "Resolve blocked rows before treating this page as AI-answer ready.",
+      [evidence("manual-note", "Aggregate readiness", `Blocked rows: ${blockers.map((check) => check.check_id).join(", ")}`, targetUrl)]
+    ));
+  } else if (weak.length > 0) {
+    findings.push(finding(
+      "aggregate-ai-engine-readiness",
+      "aggregate-ai-engine-readiness-needs-work",
+      "medium",
+      "GEOPass has readiness gaps",
+      `${weak.length} check(s) need work: ${weak.map((check) => check.check_id).join(", ")}.`,
+      "Use the row recommendations as the next public content fixes.",
+      [evidence("manual-note", "Aggregate readiness", `Needs-work rows: ${weak.map((check) => check.check_id).join(", ")}`, targetUrl)]
+    ));
+  }
+  return result("aggregate-ai-engine-readiness", labelFor("aggregate-ai-engine-readiness"), score, findings);
+}
+function verdictSummary(checks) {
+  return checks.reduce(
+    (summary, check) => {
+      if (check.verdict === "ready") summary.ready += 1;
+      if (check.verdict === "needs-work") summary.needs_work += 1;
+      if (check.verdict === "blocked") summary.blocked += 1;
+      if (check.verdict === "unknown") summary.unknown += 1;
+      return summary;
+    },
+    { ready: 0, needs_work: 0, blocked: 0, unknown: 0 }
+  );
+}
+function crossPassSignals(checks) {
+  const byId = new Map(checks.map((check) => [check.check_id, check]));
+  const signals = [];
+  const llms = byId.get("llms-txt");
+  if (llms && llms.verdict !== "ready") {
+    signals.push({ pass: "seopass", signal: "llms.txt gap also weakens AI-era search readiness", score: llms.score });
+  }
+  const schema = byId.get("schema-org-citation-grade");
+  if (schema && schema.verdict !== "ready") {
+    signals.push({ pass: "legalpass", signal: "schema must truthfully match visible public claims", score: schema.score });
+  }
+  const structure = byId.get("content-structure");
+  if (structure && structure.verdict !== "ready") {
+    signals.push({ pass: "uxpass", signal: "thin public structure can make answer extraction and human scanning weaker", score: structure.score });
+  }
+  const citation = byId.get("citation-readiness");
+  if (citation && citation.verdict !== "ready") {
+    signals.push({ pass: "sloppass", signal: "unsupported or source-light claims need copy/content cleanup", score: citation.score });
+  }
+  return signals;
+}
+function receiptFor(report, runId, targetSha) {
+  const summary = verdictSummary(report.checks);
+  const status = report.verdict === "ready" ? "PASS" : report.verdict === "blocked" ? "BLOCKER" : "WARN";
+  const evidenceSources = report.checks.flatMap((check) => check.findings).flatMap((item) => item.evidence).filter((item, index, all) => all.findIndex((candidate) => candidate.kind === item.kind && candidate.label === item.label && candidate.source_url === item.source_url) === index).slice(0, 12);
+  const actionNeeded = report.checks.flatMap((check) => check.findings).map((item) => item.recommendation).filter((item) => Boolean(item)).filter((item, index, all) => all.indexOf(item) === index).slice(0, 8);
+  return {
+    kind: "geopass_receipt_v1",
+    status,
+    run_id: runId,
+    target_url: report.target_url,
+    generated_at: report.generated_at,
+    mode: "live-readonly",
+    ...targetSha ? { target_sha: targetSha } : {},
+    score: report.aggregate_ai_engine_readiness_score,
+    verdict: report.verdict,
+    checked: {
+      total: report.checks.length,
+      ready: summary.ready,
+      needs_work: summary.needs_work,
+      blocked: summary.blocked,
+      unknown: summary.unknown
+    },
+    evidence_sources: evidenceSources,
+    action_needed: actionNeeded,
+    boundaries: RECEIPT_BOUNDARIES
+  };
+}
+async function runGeoPass(input) {
+  const rawUrl = input.url ?? input.targetUrl ?? "";
+  const targetUrl = normalizePublicHttpUrl(rawUrl);
+  if (!targetUrl) {
+    return { error: "GEOPass target URL must be a valid public http(s) URL without credentials" };
+  }
+  const generatedAt = input.generatedAt ?? (/* @__PURE__ */ new Date()).toISOString();
+  const fetchImpl = input.fetchImpl ?? globalThis.fetch;
+  if (!fetchImpl) return { error: "No fetch implementation is available for GEOPass live-readonly run" };
+  const selectedChecks = new Set(input.checks?.length ? input.checks : LIVE_CHECKS);
+  const page = await fetchText(targetUrl, fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS);
+  const analysisUrl = normalizePublicHttpUrl(page.url) ?? targetUrl;
+  const [robots, llms] = await Promise.all([
+    fetchText(new URL("/robots.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS),
+    fetchText(new URL("/llms.txt", analysisUrl).toString(), fetchImpl, input.timeoutMs ?? DEFAULT_TIMEOUT_MS, input.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS)
+  ]);
+  const htmlReadable = page.ok && (page.headers["content-type"] ?? "text/html").toLowerCase().includes("html");
+  const signals = htmlReadable ? analyzeHtml(page.body, analysisUrl) : null;
+  const checks = [];
+  for (const checkId of LIVE_CHECKS.filter((id) => selectedChecks.has(id))) {
+    if (!signals && checkId !== "ai-bot-crawlability" && checkId !== "llms-txt") {
+      checks.push(pageUnavailableResult(checkId, analysisUrl, page));
+      continue;
+    }
+    if (checkId === "ai-bot-crawlability") checks.push(buildAiBotCrawlability(analysisUrl, robots));
+    if (checkId === "llms-txt") checks.push(buildLlmsTxt(analysisUrl, llms));
+    if (signals && checkId === "answer-extractability") checks.push(buildAnswerExtractability(analysisUrl, signals));
+    if (signals && checkId === "entity-clarity") checks.push(buildEntityClarity(analysisUrl, signals));
+    if (signals && checkId === "citation-readiness") checks.push(buildCitationReadiness(analysisUrl, signals));
+    if (signals && checkId === "freshness-cues") checks.push(buildFreshness(analysisUrl, signals));
+    if (signals && checkId === "content-structure") checks.push(buildContentStructure(analysisUrl, signals));
+    if (signals && checkId === "schema-org-citation-grade") checks.push(buildSchemaCitationGrade(analysisUrl, signals));
+    if (signals && checkId === "brand-mention-readiness") checks.push(buildBrandMentionReadiness(analysisUrl, signals));
+  }
+  for (const externalCheckId of ["wikidata-presence", "common-crawl-presence"]) {
+    if (selectedChecks.has(externalCheckId)) checks.push(buildPlanOnlyExternalIndex(externalCheckId, analysisUrl));
+  }
+  if (selectedChecks.has("aggregate-ai-engine-readiness")) {
+    checks.push(buildAggregate(analysisUrl, checks));
+  }
+  const summary = verdictSummary(checks);
+  const aggregate = checks.find((check) => check.check_id === "aggregate-ai-engine-readiness");
+  const score = aggregate?.score ?? Math.round(checks.reduce((sum, check) => sum + check.score, 0) / Math.max(1, checks.length));
+  const verdict = summary.blocked > 0 ? "blocked" : score >= 85 ? "ready" : "needs-work";
+  const report = {
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    mode: "live-readonly",
+    engines: DEFAULT_GEOPASS_ENGINES,
+    aggregate_ai_engine_readiness_score: score,
+    verdict,
+    checks,
+    cross_pass_signals: crossPassSignals(checks),
+    notes: [
+      "Readiness only. GEOPass does not guarantee AI citations, rankings, or answer-engine placement.",
+      "This run used public http(s) fetches only and did not use credentials, paid APIs, production data, or private prompts.",
+      ...page.truncated ? ["The target page body was truncated for bounded analysis."] : []
+    ]
+  };
+  const runId = stableRunId(analysisUrl, generatedAt);
+  return {
+    run_id: runId,
+    status: "complete",
+    pass: "geopass",
+    target_url: analysisUrl,
+    generated_at: generatedAt,
+    ai_answer_readiness_score: score,
+    verdict,
+    verdict_summary: summary,
+    report,
+    geopass_receipt_v1: receiptFor(report, runId, input.targetSha)
+  };
+}
+export {
+  DEFAULT_GEOPASS_BOTS,
+  DEFAULT_GEOPASS_ENGINES,
+  DEFAULT_GEOPASS_SCANNER_STEPS,
+  GeoPassBotIdSchema,
+  GeoPassCheckIdSchema,
+  GeoPassCheckResultSchema,
+  GeoPassCrossPassSignalSchema,
+  GeoPassEngineIdSchema,
+  GeoPassEvidenceSchema,
+  GeoPassFindingSchema,
+  GeoPassReceiptSchema,
+  GeoPassReportSchema,
+  GeoPassSeveritySchema,
+  GeoPassVerdictSchema,
+  createGeoPassScannerPlan,
+  runGeoPass
+};

--- a/packages/mcp-server/src/geopass-tool.test.ts
+++ b/packages/mcp-server/src/geopass-tool.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { geopassRun, geopassStatus } from "./geopass-tool.js";
+import { ADDITIONAL_HANDLERS, ADDITIONAL_TOOLS } from "./tool-wiring.js";
+
+function installFetch(fixtures: Record<string, string | { status: number; body: string; headers?: Record<string, string>; url?: string }>): void {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    const normalized = new URL(url).toString();
+    const fixture = fixtures[normalized] ?? fixtures[normalized.replace(/\/$/, "")];
+    const status = typeof fixture === "object" ? fixture.status : fixture ? 200 : 404;
+    const body = typeof fixture === "object" ? fixture.body : fixture ?? "not found";
+    const headers = typeof fixture === "object" ? fixture.headers ?? { "content-type": "text/html" } : { "content-type": "text/html" };
+    return {
+      url: typeof fixture === "object" && fixture.url ? fixture.url : normalized,
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers(headers),
+      text: async () => body,
+    };
+  }));
+}
+
+const html = `<!doctype html>
+<html>
+  <head>
+    <title>GEOPass public AI answer readiness</title>
+    <meta name="description" content="Public readiness checks for AI answer engines.">
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"UnClick"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[]}</script>
+  </head>
+  <body>
+    <h1>GEOPass public AI answer readiness</h1>
+    <h2>What does GEOPass check?</h2>
+    <p>It checks answer extractability, entity clarity, citation readiness, freshness cues, and content structure for public pages.</p>
+    <h2>How does GEOPass stay honest?</h2>
+    <p>It reports readiness only and does not guarantee rankings or citations.</p>
+    <p>Updated <time datetime="2026-05-30">May 30, 2026</time>. Source: public Google guidance.</p>
+    <ul><li>AI bot visibility</li><li>Readable evidence</li><li>Public source links</li></ul>
+    <a href="https://developers.google.com/search/docs/appearance/ai-features">Google AI features guidance</a>
+    <a href="https://schema.org">schema.org</a>
+    <a href="/about">About</a>
+  </body>
+</html>`;
+
+describe("geopass-tool", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("registers GEOPass run and status tools", () => {
+    const names = ADDITIONAL_TOOLS.map((tool) => tool.name);
+
+    expect(names).toContain("geopass_run");
+    expect(names).toContain("geopass_status");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("geopass_run");
+    expect(ADDITIONAL_HANDLERS).toHaveProperty("geopass_status");
+  });
+
+  it("rejects missing or invalid targets before storing a run", async () => {
+    await expect(geopassRun({})).resolves.toMatchObject({ error: "url or target_url is required" });
+    await expect(geopassRun({ url: "file:///tmp/page.html" })).resolves.toMatchObject({
+      error: expect.stringContaining("public http(s)"),
+    });
+  });
+
+  it("runs GEOPass and exposes a receipt through status", async () => {
+    installFetch({
+      "https://unclick.world/": html,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nGEOPass gives AI answer engines public summaries and canonical docs links.\n\n[Docs](https://unclick.world/docs): Docs.",
+    });
+
+    const run = await geopassRun({
+      url: "https://unclick.world",
+      target_sha: "abc123",
+    }) as Record<string, unknown>;
+
+    expect(run).toMatchObject({
+      status: "complete",
+      pass: "geopass",
+    });
+    expect(String(run.run_id)).toMatch(/^geopass-/);
+    expect((run.geopass_receipt_v1 as Record<string, unknown>).kind).toBe("geopass_receipt_v1");
+    expect((run.geopass_receipt_v1 as Record<string, unknown>).target_sha).toBe("abc123");
+
+    const status = await geopassStatus({ run_id: run.run_id }) as Record<string, unknown>;
+    expect(status.run_id).toBe(run.run_id);
+    expect((status.report as { checks?: Array<{ check_id?: string }> }).checks?.map((check) => check.check_id)).toContain("answer-extractability");
+  });
+
+  it("keeps external index rows unknown when specifically requested", async () => {
+    installFetch({
+      "https://unclick.world/": html,
+      "https://unclick.world/robots.txt": "User-agent: *\nAllow: /\n",
+      "https://unclick.world/llms.txt": "# UnClick\n\nHelpful file.",
+    });
+
+    const run = await geopassRun({
+      target_url: "https://unclick.world",
+      checks: ["wikidata-presence", "common-crawl-presence"],
+    }) as Record<string, unknown>;
+
+    expect((run.geopass_receipt_v1 as { checked?: { unknown?: number } }).checked?.unknown).toBe(2);
+  });
+});

--- a/packages/mcp-server/src/geopass-tool.ts
+++ b/packages/mcp-server/src/geopass-tool.ts
@@ -1,0 +1,39 @@
+import { runGeoPass } from "./geopass-runtime.js";
+
+type GeoPassRunRecord = Awaited<ReturnType<typeof runGeoPass>>;
+
+const RUNS = new Map<string, Exclude<GeoPassRunRecord, { error: string }>>();
+
+function isGeoPassRun(value: GeoPassRunRecord): value is Exclude<GeoPassRunRecord, { error: string }> {
+  return typeof value === "object" && value !== null && !("error" in value);
+}
+
+function parseChecks(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+export async function geopassRun(args: Record<string, unknown>): Promise<unknown> {
+  const url =
+    (typeof args.url === "string" && args.url.trim()) ||
+    (typeof args.target_url === "string" && args.target_url.trim()) ||
+    "";
+  if (!url) return { error: "url or target_url is required" };
+
+  const run = await runGeoPass({
+    url,
+    checks: parseChecks(args.checks),
+    targetSha: typeof args.target_sha === "string" && args.target_sha.trim() ? args.target_sha.trim() : undefined,
+  });
+  if (!isGeoPassRun(run)) return run;
+  RUNS.set(run.run_id, run);
+  return run;
+}
+
+export async function geopassStatus(args: Record<string, unknown>): Promise<unknown> {
+  const runId = typeof args.run_id === "string" ? args.run_id.trim() : "";
+  if (!runId) return { error: "run_id is required" };
+  const run = RUNS.get(runId);
+  if (!run) return { error: `GEOPass run '${runId}' was not found in this MCP session` };
+  return run;
+}

--- a/packages/mcp-server/src/legalpass-tool.ts
+++ b/packages/mcp-server/src/legalpass-tool.ts
@@ -57,12 +57,36 @@ interface LegalPassMcpSummary {
   pass_rate: number;
 }
 
+interface LegalPassMcpReceipt {
+  kind: "legalpass_receipt_v1";
+  status: "PASS" | "WARN" | "BLOCKER";
+  run_id: string;
+  pack_id: string;
+  target: LegalPassMcpTarget;
+  target_sha?: string;
+  generated_at: string;
+  mode: "fixture" | "plan-only";
+  jurisdictions: LegalPassMcpJurisdiction[];
+  summary: LegalPassMcpSummary;
+  disclaimer_present: true;
+  safety: {
+    issue_spotter_only: true;
+    no_legal_advice: true;
+    no_transactional_instrument: true;
+  };
+  evidence_sources: Array<{ kind: "fixture" | "manual-note"; label: string; summary: string; source_url?: string }>;
+  action_needed: string[];
+  boundaries: string[];
+}
+
 interface LegalPassMcpRunRecord {
   status: "complete" | "planned";
   pass: "legalpass";
   run_id: string;
   pack_id: string;
   target: LegalPassMcpTarget;
+  target_sha?: string;
+  generated_at: string;
   profile: LegalPassMcpProfile;
   jurisdictions: LegalPassMcpJurisdiction[];
   summary: LegalPassMcpSummary;
@@ -76,6 +100,10 @@ interface LegalPassMcpRunRecord {
   };
   audit_log: Array<Record<string, unknown>>;
 }
+
+type LegalPassMcpRunResponse = LegalPassMcpRunRecord & {
+  legalpass_receipt_v1: LegalPassMcpReceipt;
+};
 
 interface LegalPassMcpPack {
   id: string;
@@ -121,6 +149,12 @@ const SUPPORTED_JURISDICTIONS = new Set<LegalPassMcpJurisdiction>([
 ]);
 const DEFAULT_PROFILE: LegalPassMcpProfile = "standard";
 const DEFAULT_JURISDICTIONS: LegalPassMcpJurisdiction[] = ["AU", "EU", "US-CA"];
+const RECEIPT_BOUNDARIES = [
+  "LegalPass is an issue-spotter and information tool only.",
+  "LegalPass does not provide legal advice, legal opinions, legal recommendations, or transactional instruments.",
+  "LegalPass does not create a lawyer-client, solicitor-client, or attorney-client relationship.",
+  "LegalPass receipts are scoped to the supplied public fixture, guarded plan, or declared target only.",
+];
 
 const DISCLAIMERS: Record<DisclaimerLength, string> = {
   chat:
@@ -421,18 +455,85 @@ function summaryFromItems(items: LegalPassMcpItem[]): LegalPassMcpSummary {
   return summary;
 }
 
-function cloneRun(record: LegalPassMcpRunRecord): LegalPassMcpRunRecord {
-  return structuredClone(record);
+function cloneRun(record: LegalPassMcpRunRecord): LegalPassMcpRunResponse {
+  const copy = structuredClone(record);
+  return {
+    ...copy,
+    legalpass_receipt_v1: buildLegalPassReceipt(copy),
+  };
 }
 
-function saveRun(record: LegalPassMcpRunRecord): LegalPassMcpRunRecord {
+function saveRun(record: LegalPassMcpRunRecord): LegalPassMcpRunResponse {
   const existing = runStore.get(record.run_id);
   if (existing) {
     return cloneRun(existing);
   }
 
-  runStore.set(record.run_id, cloneRun(record));
+  runStore.set(record.run_id, structuredClone(record));
   return cloneRun(record);
+}
+
+function buildLegalPassReceipt(record: LegalPassMcpRunRecord): LegalPassMcpReceipt {
+  const mode = record.status === "planned" ? "plan-only" : "fixture";
+  const evidence_sources = record.items
+    .flatMap((item) => item.evidence)
+    .map((item) => ({
+      kind: "fixture" as const,
+      label: item.source,
+      summary: item.excerpt,
+      ...(item.url ? { source_url: item.url } : {}),
+    }))
+    .filter((item, index, all) =>
+      all.findIndex((candidate) =>
+        candidate.label === item.label &&
+        candidate.summary === item.summary &&
+        candidate.source_url === item.source_url
+      ) === index,
+    )
+    .slice(0, 12);
+  const action_needed = legalPassActionNeeded(record);
+  const status: LegalPassMcpReceipt["status"] = record.safety.no_legal_advice !== true
+    ? "BLOCKER"
+    : record.status === "planned" || record.summary.pending > 0 || record.summary.fail > 0
+      ? "WARN"
+      : "PASS";
+
+  return {
+    kind: "legalpass_receipt_v1",
+    status,
+    run_id: record.run_id,
+    pack_id: record.pack_id,
+    target: record.target,
+    ...(record.target_sha ? { target_sha: record.target_sha } : {}),
+    generated_at: record.generated_at,
+    mode,
+    jurisdictions: record.jurisdictions,
+    summary: record.summary,
+    disclaimer_present: true,
+    safety: record.safety,
+    evidence_sources: evidence_sources.length > 0
+      ? evidence_sources
+      : [{ kind: "manual-note", label: "LegalPass boundary", summary: record.note }],
+    action_needed,
+    boundaries: RECEIPT_BOUNDARIES,
+  };
+}
+
+function legalPassActionNeeded(record: LegalPassMcpRunRecord): string[] {
+  const actions: string[] = [];
+  if (record.status === "planned") {
+    actions.push("Public fixture text or a later guarded ingestion path is still needed before this counts as completed LegalPass evidence.");
+  }
+  if (record.summary.fail > 0) {
+    actions.push("Practitioner review may be warranted before relying on flagged material.");
+  }
+  if (record.summary.pending > 0) {
+    actions.push("Pending LegalPass rows need public evidence before they count as checked.");
+  }
+  if (record.audit_log.length > 0) {
+    actions.push("Human reviewer edits are present; preserve the audit log with the receipt.");
+  }
+  return actions;
 }
 
 function fixtureChecksForPack(pack: LegalPassMcpPack): typeof FIXTURE_CHECKS {
@@ -504,6 +605,9 @@ export async function legalpassRun(args: Record<string, unknown>): Promise<unkno
     return parsedTarget;
   }
   const target = parsedTarget.target;
+  const parsedTargetSha = parseTargetSha(args.target_sha, target);
+  if ("error" in parsedTargetSha) return parsedTargetSha;
+  const targetSha = parsedTargetSha.target_sha;
   const parsedProfile = parseProfile(args.profile ?? pack.profile ?? DEFAULT_PROFILE, "profile");
   if ("error" in parsedProfile) return parsedProfile;
   const profile = parsedProfile.profile;
@@ -528,6 +632,8 @@ export async function legalpassRun(args: Record<string, unknown>): Promise<unkno
       run_id: buildRunId({ packId, pack_signature, target, profile, jurisdictions, fixtureText }),
       pack_id: packId,
       target,
+      ...(targetSha ? { target_sha: targetSha } : {}),
+      generated_at: new Date().toISOString(),
       profile,
       jurisdictions,
       summary: fixture.summary,
@@ -552,6 +658,8 @@ export async function legalpassRun(args: Record<string, unknown>): Promise<unkno
     run_id: runId,
     pack_id: packId,
     target,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: new Date().toISOString(),
     profile,
     jurisdictions,
     summary: summaryFromItems([]),
@@ -619,6 +727,22 @@ function parseTarget(args: Record<string, unknown>):
   }
 
   return { error: "target.kind or target_url is required" };
+}
+
+function parseTargetSha(value: unknown, target: LegalPassMcpTarget):
+  | { target_sha?: string }
+  | { error: string } {
+  if (value === undefined || value === null) {
+    return target.commit ? { target_sha: target.commit } : {};
+  }
+  if (typeof value !== "string") {
+    return { error: "target_sha must be a string" };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { error: "target_sha must not be blank" };
+  }
+  return { target_sha: trimmed };
 }
 
 function parseProfile(value: unknown, fieldName: string):
@@ -769,7 +893,7 @@ export async function legalpassEditItem(args: Record<string, unknown>): Promise<
     ...(reviewerNote ? { reviewer_note: reviewerNote } : {}),
   };
   record.audit_log.push(audit_entry);
-  runStore.set(runId, cloneRun(record));
+  runStore.set(runId, structuredClone(record));
 
   return {
     run_id: runId,

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -3289,7 +3289,7 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "sloppass_run",
-        "description": "Run SlopPass against caller-provided source files or a unified diff. Returns an evidence-backed slop-signal receipt plus JSON, markdown, and HTML reports. SlopPass does not execute code, read repositories, persist source content, or make paid model calls by default."
+        "description": "Run SlopPass against caller-provided source files, a unified diff, or a GitHub PR target whose public .diff should be fetched. Returns an evidence-backed slop-signal receipt plus JSON, markdown, and HTML reports. SlopPass does not execute code, clone repositories, persist source content, or make paid model calls by default."
       }
     ]
   },

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -3064,6 +3064,40 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "securitypass",
+    "category": "SecurityPass (scope-gated security receipts)",
+    "tools": [
+      {
+        "name": "securitypass_run",
+        "description": "Start a scope-gated SecurityPass scan against a registered pack or target URL. Returns a safe securitypass_receipt_v1 proof envelope without raw secrets or PoC payloads."
+      },
+      {
+        "name": "securitypass_status",
+        "description": "Poll the state of a SecurityPass run. Returns status, verdict summary, counts, and a safe securitypass_receipt_v1 proof envelope."
+      },
+      {
+        "name": "securitypass_report",
+        "description": "Fetch the synthesised report for a completed run (executive narrative + findings). format=json|markdown|html."
+      },
+      {
+        "name": "securitypass_register_pack",
+        "description": "Save a SecurityPack YAML for the calling tenant. Validates against the schema."
+      },
+      {
+        "name": "securitypass_verify_scope",
+        "description": "Verify scope authorisation for a target via DNS TXT or /.well-known proof. Required before any active probe runs."
+      },
+      {
+        "name": "securitypass_disclosure_status",
+        "description": "Check the 90+30 responsible-disclosure timer state for a finding (notified, acked, extended, public, withdrawn)."
+      },
+      {
+        "name": "securitypass_finding_detail",
+        "description": "Fetch a single finding including PoC payload (curl / prompt / payload) and remediation. PoC is generated, never auto-fired."
+      }
+    ]
+  },
+  {
     "app": "segment",
     "category": "Monitoring / CI / CDP / Email / Commerce / Inference",
     "tools": [

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -649,11 +649,11 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "copypass_run",
-        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, and optional CopyRoom exact-copy receipt."
+        "description": "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, a structured copypass_receipt_v1 proof envelope, and optional CopyRoom exact-copy receipt."
       },
       {
         "name": "copypass_status",
-        "description": "Fetch the current status, notes, deterministic findings, disclaimer, and CopyRoom receipt for a CopyPass run started in this MCP session."
+        "description": "Fetch the current status, notes, deterministic findings, disclaimer, copypass_receipt_v1 proof envelope, and CopyRoom receipt for a CopyPass run started in this MCP session."
       }
     ]
   },

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -4069,11 +4069,11 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "uxpass_run",
-        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
+        "description": "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, summary, and uxpass_receipt_v1. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The receipt calls out when browser visual snapshots, screenshots, or mobile/desktop proof are missing. The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry)."
       },
       {
         "name": "uxpass_status",
-        "description": "Fetch the status, UX Score, and summary for a UXPass run."
+        "description": "Fetch the status, UX Score, summary, and uxpass_receipt_v1 for a UXPass run."
       },
       {
         "name": "uxpass_report_html",

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1314,6 +1314,20 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "geopass",
+    "category": "GEOPass (AI answer-engine readiness QC, sister to SEOPass)",
+    "tools": [
+      {
+        "name": "geopass_run",
+        "description": "Run GEOPass against a public URL. Returns a live-readonly AI answer-engine readiness receipt covering answer extractability, entity clarity, citation/sourceability, freshness cues, content structure, llms.txt, and AI bot visibility. GEOPass reports readiness only and does not guarantee rankings or citations."
+      },
+      {
+        "name": "geopass_status",
+        "description": "Fetch the stored in-session GEOPass report and geopass_receipt_v1 envelope for a run started through geopass_run."
+      }
+    ]
+  },
+  {
     "app": "github",
     "category": "Developer / Productivity",
     "tools": [

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -4286,6 +4286,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "xpass-aggregated-verdict",
+    "category": "XPass (conductor receipt across product checks)",
+    "tools": [
+      {
+        "name": "xpass_aggregated_verdict",
+        "description": "Return one XPass conductor verdict for a target PR/change at a specific commit SHA. Selected PASS receipts must name the same head SHA; stale, unscoped, missing, or blocker receipts cannot produce a green verdict."
+      }
+    ]
+  },
+  {
     "app": "yelp",
     "category": "AI",
     "tools": [

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1111,7 +1111,7 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       },
       {
         "name": "fidelitypass_verify_copy",
-        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
+        "description": "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes, or return N/A when no exact 1:1 copy is in scope. Missing bytes, stale metadata, or prose-only AI proof cannot PASS."
       }
     ]
   },

--- a/packages/mcp-server/src/ptv-tool.ts
+++ b/packages/mcp-server/src/ptv-tool.ts
@@ -43,9 +43,9 @@ async function ptvFetch(path: string, params: Record<string, string> = {}): Prom
     });
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`);
+      throw new Error(`PTV API request timed out after ${PTV_TIMEOUT_MS}ms.`, { cause: err });
     }
-    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(`PTV API network error: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/mcp-server/src/securitypass-runtime.ts
+++ b/packages/mcp-server/src/securitypass-runtime.ts
@@ -1,0 +1,1639 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, no-var */
+// @ts-nocheck
+/* Generated from @unclick/securitypass source so Vercel bundles SecurityPass with the MCP function. */
+
+// packages/securitypass/src/mcp/tools.ts
+import { load as loadYaml } from "js-yaml";
+
+// packages/securitypass/src/types/pack-schema.ts
+import { z } from "zod";
+var SeveritySchema = z.enum(["critical", "high", "medium", "low", "info"]);
+var ProfileSchema = z.enum(["smoke", "standard", "deep"]);
+var TargetSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(["url", "git", "mcp", "api"]),
+  url: z.string().url().optional(),
+  repo: z.string().optional(),
+  branch: z.string().optional(),
+  notes: z.string().optional()
+}).superRefine((target, ctx) => {
+  if ((target.type === "url" || target.type === "api" || target.type === "mcp") && !target.url) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["url"],
+      message: `${target.type} targets require a URL.`
+    });
+  }
+  if (target.type === "git" && !target.repo) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["repo"],
+      message: "git targets require a repo path."
+    });
+  }
+});
+var ScopeContractSchema = z.object({
+  contract_id: z.string().min(1),
+  proof_method: z.enum(["dns_txt", "well_known", "bug_bounty_program", "signed_email"]),
+  expected_token: z.string().min(1).optional(),
+  bug_bounty_program: z.enum(["hackerone", "bugcrowd", "intigriti", "yeswehack"]).optional(),
+  in_scope_assets: z.array(z.string().min(1)).default([]),
+  out_of_scope_assets: z.array(z.string().min(1)).default([]),
+  signed_at: z.string().datetime().optional()
+});
+var CheckSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  category: z.string().min(1),
+  severity: SeveritySchema,
+  probe: z.string().min(1),
+  description: z.string().optional(),
+  expected: z.unknown().optional(),
+  on_fail: z.string().optional(),
+  remediation: z.string().optional(),
+  tags: z.array(z.string()).default([]),
+  profiles: z.array(ProfileSchema).default(["smoke", "standard", "deep"])
+});
+var HatSchema = z.object({
+  id: z.string().min(1),
+  role: z.enum([
+    "pen_tester",
+    "defensive_engineer",
+    "appsec_specialist",
+    "cloud_security",
+    "supply_chain_auditor",
+    "ai_ml_security",
+    "compliance_auditor",
+    "legal",
+    "threat_intel",
+    "customer"
+  ]),
+  veto: z.boolean().default(false),
+  brief: z.string().optional()
+});
+var ThresholdsSchema = z.object({
+  fail_on: z.array(SeveritySchema).default(["critical", "high"]),
+  warn_on: z.array(SeveritySchema).default(["medium"]),
+  min_pass_rate: z.number().min(0).max(1).default(0.9)
+});
+var HealBudgetSchema = z.object({
+  max_attempts: z.number().int().min(0).default(0),
+  max_cost_usd: z.number().min(0).default(0),
+  max_wall_seconds: z.number().int().min(0).default(0)
+});
+var MonitorSchema = z.object({
+  enabled: z.boolean().default(false),
+  cron: z.string().optional(),
+  channels: z.array(z.string()).default([]),
+  diff_only: z.boolean().default(true)
+});
+var FixtureSchema = z.object({
+  id: z.string().min(1),
+  kind: z.enum(["http_session", "credential_ref", "sample_payload", "graphql_query"]),
+  vault_ref: z.string().optional(),
+  value: z.unknown().optional()
+}).superRefine((fixture, ctx) => {
+  if (fixture.kind === "credential_ref" || fixture.kind === "http_session") {
+    if (!fixture.vault_ref) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["vault_ref"],
+        message: `${fixture.kind} fixtures require a BackstagePass vault reference.`
+      });
+    }
+    if (fixture.value !== void 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["value"],
+        message: `${fixture.kind} fixtures must not inline sensitive values.`
+      });
+    }
+  }
+});
+var SecurityPackSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, "must be semver"),
+  description: z.string().default(""),
+  targets: z.array(TargetSchema).min(1),
+  scope_contract: ScopeContractSchema,
+  checks: z.array(CheckSchema).min(1),
+  hats: z.array(HatSchema).default([]),
+  thresholds: ThresholdsSchema.default({
+    fail_on: ["critical", "high"],
+    warn_on: ["medium"],
+    min_pass_rate: 0.9
+  }),
+  heal_budget: HealBudgetSchema.default({
+    max_attempts: 0,
+    max_cost_usd: 0,
+    max_wall_seconds: 0
+  }),
+  monitor: MonitorSchema.default({
+    enabled: false,
+    channels: [],
+    diff_only: true
+  }),
+  fixtures: z.array(FixtureSchema).default([])
+});
+
+// packages/securitypass/src/runner/run-store.ts
+import { randomUUID } from "node:crypto";
+var RUNS = /* @__PURE__ */ new Map();
+var FINDINGS = /* @__PURE__ */ new Map();
+function emptySummary() {
+  return { total: 0, check: 0, na: 0, fail: 0, other: 0, pending: 0, pass_rate: 0 };
+}
+var SECURITYPASS_DISCLAIMER = {
+  headline: "SecurityPass is a scoped review, not a security guarantee.",
+  body: "SecurityPass reports evidence-based security risks it can observe in the target and scope for this run. It does not certify that the system is secure, replace a penetration test, or verify every dependency, provider, environment, or future change.",
+  compact: "Scoped review only. Not a pentest, certification, or guarantee of security."
+};
+function createRun(input) {
+  const id = randomUUID();
+  const row = {
+    id,
+    pack_id: input.pack_id,
+    target: input.target,
+    profile: input.profile ?? "smoke",
+    status: "queued",
+    verdict_summary: emptySummary(),
+    scope_performed: [],
+    not_checked: [],
+    score: null,
+    posture_summary: null,
+    disclaimer: SECURITYPASS_DISCLAIMER,
+    created_at: (/* @__PURE__ */ new Date()).toISOString(),
+    completed_at: null
+  };
+  RUNS.set(id, row);
+  FINDINGS.set(id, []);
+  return row;
+}
+function getRun(runId) {
+  return RUNS.get(runId);
+}
+function setRunStatus(runId, status) {
+  const row = RUNS.get(runId);
+  if (!row) return void 0;
+  row.status = status;
+  if (status !== "queued" && status !== "running") {
+    row.completed_at = (/* @__PURE__ */ new Date()).toISOString();
+  }
+  RUNS.set(runId, row);
+  return row;
+}
+function appendFinding(runId, finding) {
+  const list = FINDINGS.get(runId) ?? [];
+  const full = {
+    ...finding,
+    id: randomUUID(),
+    run_id: runId,
+    created_at: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  list.push(full);
+  FINDINGS.set(runId, list);
+  recomputeSummary(runId);
+  return full;
+}
+function appendScopePerformed(runId, scopeLine) {
+  const row = RUNS.get(runId);
+  if (!row) return void 0;
+  if (!row.scope_performed.includes(scopeLine)) {
+    row.scope_performed.push(scopeLine);
+  }
+  RUNS.set(runId, row);
+  return row;
+}
+function appendNotChecked(runId, item) {
+  const row = RUNS.get(runId);
+  if (!row) return void 0;
+  row.not_checked.push(item);
+  RUNS.set(runId, row);
+  return row;
+}
+function setRunNarrative(runId, patch) {
+  const row = RUNS.get(runId);
+  if (!row) return void 0;
+  row.score = patch.score;
+  row.posture_summary = patch.posture_summary;
+  RUNS.set(runId, row);
+  return row;
+}
+function listFindings(runId) {
+  return FINDINGS.get(runId) ?? [];
+}
+function getFinding(findingId) {
+  for (const list of FINDINGS.values()) {
+    const hit = list.find((f) => f.id === findingId);
+    if (hit) return hit;
+  }
+  return void 0;
+}
+function recomputeSummary(runId) {
+  const row = RUNS.get(runId);
+  if (!row) return;
+  const list = FINDINGS.get(runId) ?? [];
+  const summary = emptySummary();
+  summary.total = list.length;
+  for (const f of list) {
+    summary[f.verdict] += 1;
+  }
+  const decided = summary.check + summary.na + summary.fail + summary.other;
+  summary.pass_rate = decided > 0 ? summary.check / decided : 0;
+  row.verdict_summary = summary;
+  RUNS.set(runId, row);
+}
+
+// packages/securitypass/src/runner/pack-store.ts
+var PACKS = /* @__PURE__ */ new Map();
+function registerPack(pack) {
+  PACKS.set(pack.id, pack);
+  return pack;
+}
+function getRegisteredPack(packId) {
+  return PACKS.get(packId);
+}
+function __resetPackStoreForTests() {
+  PACKS.clear();
+}
+
+// packages/securitypass/src/runner/security-headers.ts
+var BASELINE_HEADERS = [
+  "content-security-policy",
+  "strict-transport-security",
+  "x-frame-options",
+  "x-content-type-options",
+  "permissions-policy"
+];
+var SEVERITY_BY_HEADER = {
+  "content-security-policy": "high",
+  "strict-transport-security": "high",
+  "x-frame-options": "medium",
+  "x-content-type-options": "medium",
+  "permissions-policy": "low"
+};
+async function checkSecurityHeaders(url, opts = {}) {
+  const { timeoutMs = 1e4, fetchImpl = fetch } = opts;
+  const controller = new AbortController();
+  const tid = setTimeout(() => controller.abort(), timeoutMs);
+  let res;
+  try {
+    res = await fetchImpl(url, {
+      method: "GET",
+      redirect: "follow",
+      signal: controller.signal
+    });
+  } finally {
+    clearTimeout(tid);
+  }
+  const checks = BASELINE_HEADERS.map((header) => {
+    const value = res.headers.get(header);
+    return {
+      header,
+      present: value !== null,
+      value,
+      severity: SEVERITY_BY_HEADER[header]
+    };
+  });
+  const missing = checks.filter((c) => !c.present);
+  const verdict = missing.length === 0 ? "check" : "fail";
+  const on_fail_comment = missing.length === 0 ? void 0 : `Missing headers: ${missing.map((c) => c.header).join(", ")}`;
+  return {
+    url,
+    fetched_at: (/* @__PURE__ */ new Date()).toISOString(),
+    status_code: res.status,
+    checks,
+    verdict,
+    on_fail_comment
+  };
+}
+var SKELETON_TARGET_URL = "https://unclick.world";
+
+// packages/securitypass/src/runner/reporter.ts
+var SEVERITY_WEIGHT = {
+  critical: 35,
+  high: 20,
+  medium: 10,
+  low: 3,
+  info: 0
+};
+function severityCounts(findings) {
+  const counts = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0
+  };
+  for (const finding of findings) counts[finding.severity] += 1;
+  return counts;
+}
+function computeScore(findings, notChecked2) {
+  let score = 100;
+  for (const finding of findings) {
+    if (finding.verdict === "fail") score -= SEVERITY_WEIGHT[finding.severity];
+  }
+  score -= Math.min(25, notChecked2.length * 5);
+  return Math.max(0, Math.round(score));
+}
+function postureSummary(findings, notChecked2) {
+  const failing = findings.filter((finding) => finding.verdict === "fail");
+  if (failing.length > 0) {
+    const critical = failing.filter((finding) => finding.severity === "critical").length;
+    const high = failing.filter((finding) => finding.severity === "high").length;
+    return `SecurityPass found ${failing.length} failing security finding(s), including ${critical} critical and ${high} high. Review the evidence before treating this target as ready.`;
+  }
+  if (notChecked2.length > 0) {
+    return `SecurityPass found no failing findings in the checks that ran, but ${notChecked2.length} check(s) were not performed. Treat this as incomplete coverage.`;
+  }
+  return "SecurityPass found no failing findings in the performed scope. This is still a scoped review, not a guarantee of security.";
+}
+function coverageNote(run) {
+  if (run.not_checked.length === 0) {
+    return "All selected checks returned evidence for this target and profile.";
+  }
+  return `${run.not_checked.length} selected check(s) were not performed. The run remains honest about untested areas.`;
+}
+function buildSecurityPassReport(run, findings) {
+  const score = computeScore(findings, run.not_checked);
+  const summary = postureSummary(findings, run.not_checked);
+  return {
+    run_id: run.id,
+    status: run.status,
+    target: run.target,
+    profile: run.profile,
+    disclaimer: run.disclaimer,
+    posture_summary: summary,
+    score,
+    severity_counts: severityCounts(findings),
+    verdict_summary: run.verdict_summary,
+    scope_performed: run.scope_performed,
+    findings,
+    not_checked: run.not_checked,
+    coverage_note: coverageNote(run),
+    completed_at: run.completed_at
+  };
+}
+function escapeHtml(value) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
+}
+function formatSecurityPassReport(report, format) {
+  if (format === "json") return report;
+  const markdown = [
+    `# SecurityPass Report`,
+    "",
+    `**Score:** ${report.score}`,
+    `**Status:** ${report.status}`,
+    `**Target:** ${report.target.url ?? report.target.repo ?? report.target.type}`,
+    "",
+    `> ${report.disclaimer.compact}`,
+    "",
+    report.posture_summary,
+    "",
+    "## Scope Performed",
+    ...report.scope_performed.length > 0 ? report.scope_performed.map((item) => `- ${item}`) : ["- No checks ran."],
+    "",
+    "## Findings",
+    ...report.findings.length > 0 ? report.findings.map((finding) => `- [${finding.severity}] ${finding.title} (${finding.verdict})`) : ["- No findings reported."],
+    "",
+    "## Not Checked",
+    ...report.not_checked.length > 0 ? report.not_checked.map((item) => `- ${item.title}: ${item.reason}`) : ["- No selected checks were skipped."]
+  ].join("\n");
+  if (format === "markdown") return markdown;
+  return [
+    "<article>",
+    `<h1>SecurityPass Report</h1>`,
+    `<p><strong>Score:</strong> ${report.score}</p>`,
+    `<p><strong>Status:</strong> ${escapeHtml(report.status)}</p>`,
+    `<p><strong>Target:</strong> ${escapeHtml(String(report.target.url ?? report.target.repo ?? report.target.type))}</p>`,
+    `<p><strong>${escapeHtml(report.disclaimer.headline)}</strong> ${escapeHtml(report.disclaimer.body)}</p>`,
+    `<p>${escapeHtml(report.posture_summary)}</p>`,
+    `<pre>${escapeHtml(markdown)}</pre>`,
+    "</article>"
+  ].join("\n");
+}
+
+// packages/securitypass/src/scope/verify.ts
+import { createHash } from "node:crypto";
+import { resolveTxt as nodeResolveTxt } from "node:dns/promises";
+function hashToken(token) {
+  return createHash("sha256").update(token).digest("hex");
+}
+function targetHost(target) {
+  if (!target.url) return null;
+  try {
+    return new URL(target.url).hostname;
+  } catch {
+    return null;
+  }
+}
+function targetOrigin(target) {
+  if (!target.url) return null;
+  try {
+    return new URL(target.url).origin;
+  } catch {
+    return null;
+  }
+}
+function tokenFromWellKnown(body) {
+  if (!body || typeof body !== "object") return [];
+  const record = body;
+  const candidates = [
+    record.token,
+    record.expected_token,
+    record.securitypass_token,
+    record.securitypass_scope?.token,
+    record.securitypass_scope?.expected_token
+  ];
+  if (Array.isArray(record.tokens)) candidates.push(...record.tokens);
+  return candidates.filter((value) => typeof value === "string");
+}
+function textContainsStandaloneToken(value, token) {
+  const trimmed = value.trim();
+  if (trimmed === token) return true;
+  return trimmed.split(/[\s,;]+/).some((part) => part === token || part.endsWith(`=${token}`) || part.endsWith(`:${token}`));
+}
+function failure(target, opts, reason, evidence = {}) {
+  return {
+    verified: false,
+    target,
+    proof_method: opts.proofMethod ?? null,
+    contract_id: opts.contractId ?? null,
+    checked_at: (/* @__PURE__ */ new Date()).toISOString(),
+    reason,
+    evidence
+  };
+}
+function success(target, opts, evidence) {
+  return {
+    verified: true,
+    target,
+    proof_method: opts.proofMethod ?? null,
+    contract_id: opts.contractId ?? null,
+    checked_at: (/* @__PURE__ */ new Date()).toISOString(),
+    evidence
+  };
+}
+async function verifyScope(target, opts = {}) {
+  const proofMethod = opts.proofMethod;
+  const expectedToken = opts.expectedToken?.trim();
+  if (!proofMethod) {
+    return failure(target, opts, "No scope proof method was supplied.");
+  }
+  if (proofMethod === "signed_email" || proofMethod === "bug_bounty_program") {
+    if (!opts.contractId || !expectedToken) {
+      return failure(target, opts, `${proofMethod} scope requires a contract id and expected token.`);
+    }
+    return success(target, opts, {
+      mode: "contract_attestation",
+      token_sha256: hashToken(expectedToken)
+    });
+  }
+  if (!expectedToken) {
+    return failure(target, opts, `${proofMethod} scope requires an expected token.`);
+  }
+  if (proofMethod === "dns_txt") {
+    const host = targetHost(target);
+    if (!host) return failure(target, opts, "DNS TXT scope verification requires a URL target.");
+    const resolveTxt = opts.resolveTxt ?? nodeResolveTxt;
+    const recordNames = [`_securitypass-scope.${host}`, host];
+    const checked = [];
+    for (const recordName of recordNames) {
+      try {
+        const txtRecords = await resolveTxt(recordName);
+        const flattened = txtRecords.map((parts) => parts.join(""));
+        const found = flattened.some((value) => textContainsStandaloneToken(value, expectedToken));
+        checked.push({ record: recordName, found });
+        if (found) {
+          return success(target, opts, {
+            record_name: recordName,
+            token_sha256: hashToken(expectedToken)
+          });
+        }
+      } catch {
+        checked.push({ record: recordName, found: false });
+      }
+    }
+    return failure(target, opts, "Expected SecurityPass DNS TXT token was not found.", { checked });
+  }
+  if (proofMethod === "well_known") {
+    const origin = targetOrigin(target);
+    if (!origin) return failure(target, opts, "Well-known scope verification requires a URL target.");
+    const proofUrl = `${origin}/.well-known/securitypass-scope.json`;
+    const fetchImpl = opts.fetchImpl ?? fetch;
+    const timeoutMs = opts.proofTimeoutMs ?? 1e4;
+    const controller = new AbortController();
+    const timeout = timeoutMs > 0 ? setTimeout(() => {
+      controller.abort();
+    }, timeoutMs) : null;
+    let response;
+    try {
+      response = await fetchImpl(proofUrl, {
+        method: "GET",
+        redirect: "follow",
+        signal: controller.signal
+      });
+    } catch (err) {
+      return failure(target, opts, "Well-known proof could not be fetched.", {
+        proof_url: proofUrl,
+        error: err instanceof Error ? err.message : String(err)
+      });
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+    const text = await response.text();
+    if (!response.ok) {
+      return failure(target, opts, "Well-known proof returned a non-success status.", {
+        proof_url: proofUrl,
+        status: response.status
+      });
+    }
+    try {
+      const parsed = JSON.parse(text);
+      if (tokenFromWellKnown(parsed).includes(expectedToken)) {
+        return success(target, opts, {
+          proof_url: proofUrl,
+          token_sha256: hashToken(expectedToken)
+        });
+      }
+    } catch {
+      if (textContainsStandaloneToken(text, expectedToken)) {
+        return success(target, opts, {
+          proof_url: proofUrl,
+          token_sha256: hashToken(expectedToken),
+          mode: "plain_text_fallback"
+        });
+      }
+    }
+    return failure(target, opts, "Expected token was not present in the well-known proof.", {
+      proof_url: proofUrl,
+      status: response.status
+    });
+  }
+  return failure(target, opts, `Unsupported scope proof method: ${proofMethod}`);
+}
+var ScopeUnverifiedError = class extends Error {
+  code = "scope_unverified";
+  target;
+  proof;
+  constructor(target, proof, message) {
+    super(
+      message ?? `SecurityPass refuses to probe ${target.url ?? target.repo ?? target.type}: ${proof?.reason ?? "scope verification failed"}.`
+    );
+    this.name = "ScopeUnverifiedError";
+    this.target = target;
+    this.proof = proof;
+  }
+};
+async function verifyScopeOrThrow(target, opts = {}) {
+  const result = await verifyScope(target, opts);
+  if (!result.verified) {
+    throw new ScopeUnverifiedError(target, result);
+  }
+  return result;
+}
+
+// packages/securitypass/src/probes/command-runner.ts
+import { spawn } from "node:child_process";
+var runCommand = (spec) => new Promise((resolve, reject) => {
+  const child = spawn(spec.command, spec.args, {
+    cwd: spec.cwd,
+    shell: false,
+    windowsHide: true
+  });
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+  const timeout = spec.timeoutMs && spec.timeoutMs > 0 ? setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+  }, spec.timeoutMs) : null;
+  child.stdout?.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  child.on("error", (err) => {
+    if (timeout) clearTimeout(timeout);
+    reject(err);
+  });
+  child.on("close", (code) => {
+    if (timeout) clearTimeout(timeout);
+    resolve({
+      exitCode: timedOut ? 124 : code ?? 1,
+      stdout,
+      stderr: timedOut ? `${stderr}
+Command timed out after ${spec.timeoutMs}ms.`.trim() : stderr
+    });
+  });
+});
+
+// packages/securitypass/src/probes/gitleaks.ts
+function buildGitleaksCommand(repoPath) {
+  return {
+    command: "gitleaks",
+    args: [
+      "git",
+      "--report-format",
+      "json",
+      "--report-path",
+      "-",
+      "--redact=100",
+      "--no-banner",
+      "--log-level",
+      "error",
+      repoPath
+    ],
+    cwd: repoPath,
+    timeoutMs: 12e4
+  };
+}
+function parseGitleaksJson(stdout) {
+  if (!stdout.trim()) return [];
+  const leaks = JSON.parse(stdout);
+  return leaks.map((leak) => ({
+    check_id: `securitypass.gitleaks.${leak.RuleID ?? "secret"}`,
+    title: leak.Description ?? "Potential secret detected",
+    severity: "critical",
+    verdict: "fail",
+    category: "secrets",
+    description: `Gitleaks reported a potential secret in ${leak.File ?? "an unknown file"}.`,
+    remediation: "Rotate the exposed credential, remove it from history, and replace it with a managed secret.",
+    evidence: {
+      rule_id: leak.RuleID ?? null,
+      file: leak.File ?? null,
+      start_line: leak.StartLine ?? null,
+      end_line: leak.EndLine ?? null,
+      commit: leak.Commit ?? null,
+      fingerprint: leak.Fingerprint ?? null,
+      secret_redacted: leak.Secret ? "[redacted]" : null
+    }
+  }));
+}
+function gitleaksResultFromCommand(target, command, result) {
+  return {
+    probe: "gitleaks",
+    target,
+    command,
+    findings: parseGitleaksJson(result.stdout),
+    raw: { exitCode: result.exitCode, stderr: result.stderr }
+  };
+}
+
+// packages/securitypass/src/probes/osv-scanner.ts
+function buildOsvScannerCommand(path) {
+  return {
+    command: "osv-scanner",
+    args: ["scan", "source", "--format", "json", "--recursive", "--no-call-analysis=rust", path],
+    cwd: path,
+    timeoutMs: 12e4
+  };
+}
+function roundUp1(score) {
+  return Math.ceil((score + Number.EPSILON) * 10) / 10;
+}
+function parseCvssVector(vector) {
+  const metrics = {};
+  for (const part of vector.split("/")) {
+    const [key, value] = part.split(":");
+    if (!key || !value || key === "CVSS") continue;
+    metrics[key] = value;
+  }
+  return metrics;
+}
+function cvssV3Score(vector) {
+  if (!vector.startsWith("CVSS:3.")) return null;
+  const metrics = parseCvssVector(vector);
+  const impactValues = { N: 0, L: 0.22, H: 0.56 };
+  const av = { N: 0.85, A: 0.62, L: 0.55, P: 0.2 }[metrics.AV];
+  const ac = { L: 0.77, H: 0.44 }[metrics.AC];
+  const ui = { N: 0.85, R: 0.62 }[metrics.UI];
+  const scope = metrics.S;
+  const pr = scope === "C" ? { N: 0.85, L: 0.68, H: 0.5 }[metrics.PR] : { N: 0.85, L: 0.62, H: 0.27 }[metrics.PR];
+  const c = impactValues[metrics.C];
+  const i = impactValues[metrics.I];
+  const a = impactValues[metrics.A];
+  if (av === void 0 || ac === void 0 || pr === void 0 || ui === void 0 || c === void 0 || i === void 0 || a === void 0 || !scope) return null;
+  const impactSubScore = 1 - (1 - c) * (1 - i) * (1 - a);
+  const impact = scope === "U" ? 6.42 * impactSubScore : 7.52 * (impactSubScore - 0.029) - 3.25 * Math.pow(impactSubScore - 0.02, 15);
+  if (impact <= 0) return 0;
+  const exploitability = 8.22 * av * ac * pr * ui;
+  const base = scope === "U" ? Math.min(impact + exploitability, 10) : Math.min(1.08 * (impact + exploitability), 10);
+  return roundUp1(base);
+}
+function cvssV2Score(vector) {
+  const metrics = parseCvssVector(vector);
+  const av = { L: 0.395, A: 0.646, N: 1 }[metrics.AV];
+  const ac = { H: 0.35, M: 0.61, L: 0.71 }[metrics.AC];
+  const au = { M: 0.45, S: 0.56, N: 0.704 }[metrics.Au];
+  const impactValues = { N: 0, P: 0.275, C: 0.66 };
+  const c = impactValues[metrics.C];
+  const i = impactValues[metrics.I];
+  const a = impactValues[metrics.A];
+  if (av === void 0 || ac === void 0 || au === void 0 || c === void 0 || i === void 0 || a === void 0) return null;
+  const impact = 10.41 * (1 - (1 - c) * (1 - i) * (1 - a));
+  if (impact <= 0) return 0;
+  const exploitability = 20 * av * ac * au;
+  return roundUp1((0.6 * impact + 0.4 * exploitability - 1.5) * 1.176);
+}
+function parsedCvssScoresFromOsv(severityEntries) {
+  return severityEntries.flatMap((severity) => {
+    const rawScore = severity.score?.trim();
+    if (!rawScore) return [];
+    let score = null;
+    if (rawScore.startsWith("CVSS:3.")) {
+      score = cvssV3Score(rawScore);
+    } else if (severity.type === "CVSS_V2" || /(^|\/)Au:/.test(rawScore)) {
+      score = cvssV2Score(rawScore);
+    }
+    return score === null ? [] : [{
+      type: severity.type ?? null,
+      vector: rawScore,
+      score
+    }];
+  });
+}
+function severityFromScore(score) {
+  if (score >= 9) return "critical";
+  if (score >= 7) return "high";
+  if (score >= 4) return "medium";
+  if (score > 0) return "low";
+  return "info";
+}
+function fallbackSeverityFromCvssVector(scoreText) {
+  if (!scoreText.includes("CVSS:")) return null;
+  if (/\/(?:VC|VI|VA|SC|SI|SA|C|I|A):H(?:\/|$)/.test(scoreText)) return "high";
+  if (/\/(?:VC|VI|VA|SC|SI|SA|C|I|A):(?:L|P)(?:\/|$)/.test(scoreText)) return "medium";
+  return "low";
+}
+function osvSeverityEntries(vuln) {
+  return [
+    ...vuln.severity ?? [],
+    ...(vuln.affected ?? []).flatMap((affected) => affected.severity ?? [])
+  ];
+}
+function cvssScoresFromOsv(vuln) {
+  return parsedCvssScoresFromOsv(osvSeverityEntries(vuln));
+}
+function severityFromOsv(vuln) {
+  const severityEntries = osvSeverityEntries(vuln);
+  const scores = severityEntries.map((severity) => severity.score).filter((score) => Boolean(score));
+  const text = scores.join(" ").toUpperCase();
+  if (text.includes("CRITICAL")) return "critical";
+  if (text.includes("HIGH")) return "high";
+  if (text.includes("MEDIUM")) return "medium";
+  if (text.includes("LOW")) return "low";
+  const numericScores = scores.map((score) => Number(String(score).trim())).filter((score) => Number.isFinite(score));
+  const numericScore = numericScores.length > 0 ? Math.max(...numericScores) : null;
+  if (numericScore !== null) {
+    return severityFromScore(numericScore);
+  }
+  const cvssScores = parsedCvssScoresFromOsv(severityEntries);
+  if (cvssScores.length > 0) {
+    return severityFromScore(Math.max(...cvssScores.map((score) => score.score)));
+  }
+  for (const score of scores) {
+    const fallback = fallbackSeverityFromCvssVector(score);
+    if (fallback) return fallback;
+  }
+  return "low";
+}
+function fixedVersionsFromOsv(vuln) {
+  const fixedVersions = /* @__PURE__ */ new Set();
+  for (const affected of vuln.affected ?? []) {
+    for (const range of affected.ranges ?? []) {
+      for (const event of range.events ?? []) {
+        if (event.fixed) fixedVersions.add(event.fixed);
+      }
+    }
+  }
+  return [...fixedVersions].sort();
+}
+function referencesFromOsv(vuln) {
+  return (vuln.references ?? []).filter((reference) => Boolean(reference.url)).map((reference) => ({
+    type: reference.type ?? null,
+    url: reference.url
+  }));
+}
+function callAnalysisForVulnerability(pkg, vuln) {
+  const vulnIds = new Set([vuln.id, ...vuln.aliases ?? []].filter(Boolean));
+  return (pkg.groups ?? []).filter((group) => (group.ids ?? []).some((id) => vulnIds.has(id))).map((group) => ({
+    ids: group.ids ?? [],
+    analysis: group.experimentalAnalysis ?? {}
+  }));
+}
+function parseOsvScannerJson(stdout) {
+  if (!stdout.trim()) return [];
+  const body = JSON.parse(stdout);
+  const findings = [];
+  for (const result of body.results ?? []) {
+    for (const pkg of result.packages ?? []) {
+      for (const vuln of pkg.vulnerabilities ?? []) {
+        findings.push({
+          check_id: `securitypass.osv.${vuln.id ?? "vulnerability"}`,
+          title: vuln.summary ?? "Open source vulnerability detected",
+          severity: severityFromOsv(vuln),
+          verdict: "fail",
+          category: "supply-chain",
+          description: vuln.details,
+          remediation: "Upgrade the affected package, apply a vendor patch, or document an accepted risk.",
+          evidence: {
+            id: vuln.id ?? null,
+            aliases: vuln.aliases ?? [],
+            package: pkg.package?.name ?? null,
+            version: pkg.package?.version ?? null,
+            ecosystem: pkg.package?.ecosystem ?? null,
+            fixed_versions: fixedVersionsFromOsv(vuln),
+            references: referencesFromOsv(vuln),
+            published: vuln.published ?? null,
+            modified: vuln.modified ?? null,
+            call_analysis: callAnalysisForVulnerability(pkg, vuln),
+            cvss_scores: cvssScoresFromOsv(vuln),
+            severity: vuln.severity ?? [],
+            source_path: result.source?.path ?? null,
+            source_type: result.source?.type ?? null
+          }
+        });
+      }
+    }
+  }
+  return findings;
+}
+function osvResultFromCommand(target, command, result) {
+  return {
+    probe: "osv-scanner",
+    target,
+    command,
+    findings: parseOsvScannerJson(result.stdout),
+    raw: { exitCode: result.exitCode, stderr: result.stderr }
+  };
+}
+
+// packages/securitypass/src/runner/index.ts
+function targetFromPackTarget(target) {
+  return {
+    id: target.id,
+    type: target.type,
+    url: target.url,
+    repo: target.repo,
+    branch: target.branch
+  };
+}
+function normalizeScopeAsset(asset) {
+  return asset.trim().replaceAll("\\", "/").replace(/\/+$/, "").toLowerCase();
+}
+function normalizedUrlPath(pathname) {
+  const path = pathname.replace(/\/+$/, "");
+  return path || "/";
+}
+function urlMatchesScopeAsset(targetUrl, asset) {
+  let target;
+  try {
+    target = new URL(targetUrl);
+  } catch {
+    return false;
+  }
+  const rawAsset = asset.trim();
+  const normalizedAsset = normalizeScopeAsset(rawAsset);
+  if (!normalizedAsset) return false;
+  if (normalizedAsset.startsWith("*.")) {
+    return target.hostname.toLowerCase().endsWith(`.${normalizedAsset.slice(2)}`);
+  }
+  try {
+    const assetUrl = new URL(rawAsset);
+    if (assetUrl.origin.toLowerCase() !== target.origin.toLowerCase()) return false;
+    const assetPath = normalizedUrlPath(assetUrl.pathname);
+    const targetPath = normalizedUrlPath(target.pathname);
+    if (assetPath === "/") return true;
+    return targetPath === assetPath || targetPath.startsWith(`${assetPath}/`);
+  } catch {
+    return target.hostname.toLowerCase() === normalizedAsset;
+  }
+}
+function repoMatchesScopeAsset(repo, asset) {
+  const normalizedRepo = normalizeScopeAsset(repo);
+  const normalizedAsset = normalizeScopeAsset(asset);
+  if (!normalizedAsset) return false;
+  return normalizedRepo === normalizedAsset || normalizedRepo.startsWith(`${normalizedAsset}/`);
+}
+function targetMatchesScopeAsset(target, asset) {
+  if (target.url && urlMatchesScopeAsset(target.url, asset)) return true;
+  if (target.repo && repoMatchesScopeAsset(target.repo, asset)) return true;
+  return false;
+}
+function scopeFailure(target, contract, reason, evidence) {
+  const proof = {
+    verified: false,
+    target,
+    proof_method: contract.proof_method,
+    contract_id: contract.contract_id,
+    checked_at: (/* @__PURE__ */ new Date()).toISOString(),
+    reason,
+    evidence
+  };
+  return new ScopeUnverifiedError(target, proof);
+}
+function assertTargetWithinDeclaredScope(pack, target) {
+  const contract = pack.scope_contract;
+  const outOfScopeHit = contract.out_of_scope_assets.find((asset) => targetMatchesScopeAsset(target, asset));
+  if (outOfScopeHit) {
+    throw scopeFailure(target, contract, "Target matches an explicitly out-of-scope asset.", {
+      matched_asset: outOfScopeHit,
+      target
+    });
+  }
+  if (contract.in_scope_assets.length === 0) return;
+  const inScopeHit = contract.in_scope_assets.find((asset) => targetMatchesScopeAsset(target, asset));
+  if (!inScopeHit) {
+    throw scopeFailure(target, contract, "Target is not listed in the signed in-scope assets.", {
+      in_scope_assets: contract.in_scope_assets,
+      target
+    });
+  }
+}
+function selectPackTarget(pack, targetId) {
+  if (targetId) {
+    const target2 = pack.targets.find((candidate) => candidate.id === targetId);
+    if (!target2) {
+      throw new Error(`SecurityPass target '${targetId}' was not found in pack '${pack.id}'.`);
+    }
+    return target2;
+  }
+  const target = pack.targets[0];
+  if (!target) {
+    throw new Error("SecurityPass pack must include at least one target.");
+  }
+  return target;
+}
+function checkAppliesToProfile(check, profile) {
+  return check.profiles.includes(profile);
+}
+function notChecked(check, reason, evidence = {}) {
+  return {
+    check_id: check.id,
+    title: check.title,
+    reason,
+    category: check.category,
+    severity: check.severity,
+    evidence
+  };
+}
+function findingFromProbe(check, finding) {
+  return {
+    check_id: finding.check_id,
+    title: finding.title,
+    severity: finding.severity,
+    verdict: finding.verdict,
+    category: finding.category,
+    description: finding.description ?? check.description,
+    remediation: finding.remediation ?? check.remediation,
+    on_fail_comment: check.on_fail,
+    evidence: finding.evidence
+  };
+}
+function checkedFinding(check, evidence) {
+  return {
+    check_id: check.id,
+    title: check.title,
+    severity: check.severity,
+    verdict: "check",
+    category: check.category,
+    description: check.description,
+    remediation: check.remediation,
+    on_fail_comment: check.on_fail,
+    evidence
+  };
+}
+function commandFailureNotChecked(check, command, err) {
+  const detail = err instanceof Error ? err.message : String(err);
+  return notChecked(check, `${command} could not run on this host.`, {
+    command,
+    detail
+  });
+}
+function unreadableJsonNotChecked(check, command, err) {
+  return notChecked(check, `${command} returned JSON evidence that SecurityPass could not parse.`, {
+    command,
+    detail: err instanceof Error ? err.message : String(err)
+  });
+}
+function appendProbeFindings(runId, check, findings, emptyEvidence) {
+  if (findings.length === 0) {
+    appendFinding(runId, checkedFinding(check, emptyEvidence));
+    return;
+  }
+  for (const finding of findings) {
+    appendFinding(runId, findingFromProbe(check, finding));
+  }
+}
+function finalizeRunNarrative(runId) {
+  const run = getRun(runId);
+  if (!run) {
+    throw new Error(`SecurityPass run '${runId}' was not found during finalisation.`);
+  }
+  const report = buildSecurityPassReport(run, listFindings(runId));
+  setRunNarrative(runId, {
+    score: report.score,
+    posture_summary: report.posture_summary
+  });
+  return getRun(runId) ?? run;
+}
+async function runSkeletonScan(input = {}, opts = {}) {
+  const url = input.target?.url ?? SKELETON_TARGET_URL;
+  const target = input.target ?? { type: "url", url };
+  await verifyScopeOrThrow(target, opts);
+  const run = createRun({
+    pack_id: input.pack_id ?? "securitypass-skeleton",
+    target,
+    profile: input.profile ?? "smoke"
+  });
+  appendScopePerformed(run.id, `Scope verified by ${opts.proofMethod ?? "unknown"} before active probing.`);
+  setRunStatus(run.id, "running");
+  let headers;
+  try {
+    headers = await checkSecurityHeaders(url, opts);
+  } catch (err) {
+    setRunStatus(run.id, "failed");
+    throw err;
+  }
+  const finding = appendFinding(run.id, {
+    check_id: "sec-headers.baseline",
+    title: "Baseline browser security headers present",
+    severity: "high",
+    verdict: headers.verdict,
+    category: "web.headers",
+    description: "Verifies the response advertises CSP, HSTS, X-Frame-Options, X-Content-Type-Options, and Permissions-Policy.",
+    remediation: "Configure the edge (Cloudflare / Vercel / nginx) to emit the missing headers with project-appropriate values.",
+    on_fail_comment: headers.on_fail_comment,
+    evidence: { status_code: headers.status_code, checks: headers.checks }
+  });
+  setRunStatus(run.id, "complete");
+  return { run: finalizeRunNarrative(run.id), finding, headers };
+}
+async function runSecurityPack(pack, input = {}, opts = {}) {
+  const profile = input.profile ?? "smoke";
+  const packTarget = selectPackTarget(pack, input.target_id);
+  const target = targetFromPackTarget(packTarget);
+  assertTargetWithinDeclaredScope(pack, target);
+  const scopeProof = await verifyScopeOrThrow(target, {
+    contractId: pack.scope_contract.contract_id,
+    proofMethod: pack.scope_contract.proof_method,
+    expectedToken: pack.scope_contract.expected_token,
+    proofTimeoutMs: opts.proofTimeoutMs,
+    fetchImpl: opts.fetchImpl,
+    resolveTxt: opts.resolveTxt
+  });
+  const run = createRun({
+    pack_id: pack.id,
+    target,
+    profile
+  });
+  appendScopePerformed(
+    run.id,
+    `Scope verified by ${scopeProof.proof_method ?? "unknown"} for contract ${scopeProof.contract_id ?? "unknown"}.`
+  );
+  setRunStatus(run.id, "running");
+  const commandRunner = opts.commandRunner ?? runCommand;
+  const checks = pack.checks.filter((check) => checkAppliesToProfile(check, profile));
+  if (checks.length === 0) {
+    appendNotChecked(run.id, {
+      check_id: "securitypass.profile.empty",
+      title: "No checks selected for this profile",
+      reason: `No checks in ${pack.id} apply to the ${profile} profile.`,
+      category: "coverage",
+      severity: "info"
+    });
+  }
+  for (const check of checks) {
+    if (check.probe === "security-headers") {
+      if (!target.url) {
+        appendNotChecked(run.id, notChecked(check, "Security headers check requires a URL target."));
+        continue;
+      }
+      try {
+        const headers = await checkSecurityHeaders(target.url, { fetchImpl: opts.fetchImpl });
+        appendScopePerformed(run.id, `${check.id}: fetched response headers from ${target.url}.`);
+        appendFinding(run.id, {
+          check_id: check.id,
+          title: check.title,
+          severity: check.severity,
+          verdict: headers.verdict,
+          category: check.category,
+          description: check.description,
+          remediation: check.remediation,
+          on_fail_comment: headers.on_fail_comment ?? check.on_fail,
+          evidence: { status_code: headers.status_code, checks: headers.checks }
+        });
+      } catch (err) {
+        appendNotChecked(run.id, notChecked(check, "Security headers check could not fetch the target.", {
+          detail: err instanceof Error ? err.message : String(err)
+        }));
+      }
+      continue;
+    }
+    if (check.probe === "gitleaks") {
+      const repoPath = target.repo;
+      if (!repoPath) {
+        appendNotChecked(run.id, notChecked(check, "Gitleaks check requires a git target with a repo path."));
+        continue;
+      }
+      const command = buildGitleaksCommand(repoPath);
+      try {
+        const result = await commandRunner(command);
+        if (result.exitCode !== 0 && !result.stdout.trim()) {
+          appendNotChecked(run.id, notChecked(check, "Gitleaks returned a non-zero exit without JSON evidence.", {
+            exit_code: result.exitCode,
+            stderr: result.stderr
+          }));
+          continue;
+        }
+        let findings;
+        try {
+          findings = gitleaksResultFromCommand(target, command, result).findings;
+        } catch (err) {
+          appendNotChecked(run.id, unreadableJsonNotChecked(check, "gitleaks", err));
+          continue;
+        }
+        appendScopePerformed(run.id, `${check.id}: ran gitleaks against ${repoPath}.`);
+        appendProbeFindings(run.id, check, findings, {
+          probe: "gitleaks",
+          exit_code: result.exitCode,
+          finding_count: 0
+        });
+      } catch (err) {
+        appendNotChecked(run.id, commandFailureNotChecked(check, "gitleaks", err));
+      }
+      continue;
+    }
+    if (check.probe === "osv-scanner") {
+      const repoPath = target.repo;
+      if (!repoPath) {
+        appendNotChecked(run.id, notChecked(check, "OSV-Scanner check requires a git target with a repo path."));
+        continue;
+      }
+      const command = buildOsvScannerCommand(repoPath);
+      try {
+        const result = await commandRunner(command);
+        if (result.exitCode !== 0 && !result.stdout.trim()) {
+          appendNotChecked(run.id, notChecked(check, "OSV-Scanner returned a non-zero exit without JSON evidence.", {
+            exit_code: result.exitCode,
+            stderr: result.stderr
+          }));
+          continue;
+        }
+        let findings;
+        try {
+          findings = osvResultFromCommand(target, command, result).findings;
+        } catch (err) {
+          appendNotChecked(run.id, unreadableJsonNotChecked(check, "osv-scanner", err));
+          continue;
+        }
+        appendScopePerformed(run.id, `${check.id}: ran osv-scanner against ${repoPath}.`);
+        appendProbeFindings(run.id, check, findings, {
+          probe: "osv-scanner",
+          exit_code: result.exitCode,
+          finding_count: 0
+        });
+      } catch (err) {
+        appendNotChecked(run.id, commandFailureNotChecked(check, "osv-scanner", err));
+      }
+      continue;
+    }
+    appendNotChecked(
+      run.id,
+      notChecked(check, `Probe '${check.probe}' is declared in the pack but not wired in this runner yet.`)
+    );
+  }
+  setRunStatus(run.id, "complete");
+  const finalRun = finalizeRunNarrative(run.id);
+  return { run: finalRun, findings: listFindings(run.id) };
+}
+
+// packages/securitypass/src/mcp/tools.ts
+var SECURITYPASS_TOOLS = [
+  {
+    name: "securitypass_run",
+    description: "Start a scope-gated SecurityPass scan against a registered pack or target URL. Returns a safe securitypass_receipt_v1 proof envelope without raw secrets or PoC payloads.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        pack_id: { type: "string", description: "Pack id, e.g. 'securitypass-web-baseline'" },
+        pack_yaml: { type: "string", description: "Optional pack YAML to validate and run without prior registration" },
+        target_id: { type: "string", description: "Target id inside the SecurityPass pack" },
+        target_url: { type: "string", description: "Target URL (must be in pack scope)" },
+        contract_id: { type: "string", description: "Scope contract id for skeleton URL scans" },
+        proof_method: {
+          type: "string",
+          enum: ["dns_txt", "well_known", "bug_bounty_program", "signed_email"]
+        },
+        expected_token: { type: "string", description: "Expected scope proof token" },
+        proof_timeout_ms: { type: "number", description: "Optional timeout for well-known proof fetches" },
+        profile: {
+          type: "string",
+          enum: ["smoke", "standard", "deep"],
+          default: "smoke"
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: "securitypass_status",
+    description: "Poll the state of a SecurityPass run. Returns status, verdict summary, counts, and a safe securitypass_receipt_v1 proof envelope.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string", description: "The run id returned by securitypass_run" }
+      },
+      required: ["run_id"]
+    }
+  },
+  {
+    name: "securitypass_report",
+    description: "Fetch the synthesised report for a completed run (executive narrative + findings). format=json|markdown|html.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string" },
+        format: { type: "string", enum: ["json", "markdown", "html"], default: "json" }
+      },
+      required: ["run_id"]
+    }
+  },
+  {
+    name: "securitypass_register_pack",
+    description: "Save a SecurityPack YAML for the calling tenant. Validates against the schema.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        pack_id: { type: "string" },
+        yaml: { type: "string", description: "Pack contents as YAML" }
+      },
+      required: ["pack_id", "yaml"]
+    }
+  },
+  {
+    name: "securitypass_verify_scope",
+    description: "Verify scope authorisation for a target via DNS TXT or /.well-known proof. Required before any active probe runs.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        target_type: { type: "string", enum: ["url", "git", "mcp", "api"] },
+        target_url: { type: "string" },
+        target_repo: { type: "string" },
+        proof_method: {
+          type: "string",
+          enum: ["dns_txt", "well_known", "bug_bounty_program", "signed_email"]
+        },
+        contract_id: { type: "string", description: "Signed scope contract id" },
+        expected_token: { type: "string", description: "Token to look for in DNS TXT or /.well-known" },
+        proof_timeout_ms: { type: "number", description: "Optional timeout for well-known proof fetches" }
+      },
+      required: ["proof_method"]
+    }
+  },
+  {
+    name: "securitypass_disclosure_status",
+    description: "Check the 90+30 responsible-disclosure timer state for a finding (notified, acked, extended, public, withdrawn).",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        finding_id: { type: "string" }
+      },
+      required: ["finding_id"]
+    }
+  },
+  {
+    name: "securitypass_finding_detail",
+    description: "Fetch a single finding including PoC payload (curl / prompt / payload) and remediation. PoC is generated, never auto-fired.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        finding_id: { type: "string" }
+      },
+      required: ["finding_id"]
+    }
+  }
+];
+function normalizeProfile(raw) {
+  return raw === "standard" || raw === "deep" ? raw : "smoke";
+}
+function normalizeFormat(raw) {
+  return raw === "markdown" || raw === "html" ? raw : "json";
+}
+function normalizeProofTimeout(raw) {
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : void 0;
+}
+function normalizeTargetType(raw, fallback) {
+  return raw === "git" || raw === "mcp" || raw === "api" || raw === "url" ? raw : fallback;
+}
+function parsePackYaml(yaml) {
+  let parsed;
+  try {
+    parsed = loadYaml(yaml);
+  } catch (err) {
+    return { error: { error: "yaml parse failed", detail: err instanceof Error ? err.message : String(err) } };
+  }
+  const result = SecurityPackSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      error: {
+        error: "schema validation failed",
+        issues: result.error.issues.map((i) => ({ path: i.path.join("."), message: i.message }))
+      }
+    };
+  }
+  return { pack: result.data };
+}
+function countBySeverity(findings) {
+  const counts = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0
+  };
+  for (const finding of findings) counts[finding.severity] += 1;
+  return counts;
+}
+function hasActiveProbeEvidence(run, findings) {
+  if (findings.length > 0) return true;
+  return run.scope_performed.some((line) => /\b(fetched|ran)\b/i.test(line));
+}
+function receiptStatus(run, findings) {
+  if (run.status === "failed" || run.status === "budget_exceeded") return "FAIL";
+  if (findings.some((finding) => finding.verdict === "fail")) return "FAIL";
+  if (run.status !== "complete" || run.not_checked.length > 0) return "WARN";
+  return "PASS";
+}
+function createSecurityPassReceipt(run, findings, report) {
+  const failingFindings = findings.filter((finding) => finding.verdict === "fail");
+  return {
+    kind: "securitypass_receipt_v1",
+    pass: "securitypass",
+    receipt_id: `securitypass:${run.id}`,
+    run_id: run.id,
+    status: receiptStatus(run, findings),
+    run_status: run.status,
+    checked_at: run.completed_at ?? run.created_at,
+    completed_at: run.completed_at,
+    target: run.target,
+    profile: run.profile,
+    score: report.score,
+    posture_summary: report.posture_summary,
+    verdict_summary: run.verdict_summary,
+    severity_counts: countBySeverity(findings),
+    finding_count: findings.length,
+    failing_finding_count: failingFindings.length,
+    not_checked_count: run.not_checked.length,
+    evidence: {
+      scope_verified: run.scope_performed.length > 0,
+      scope_performed_count: run.scope_performed.length,
+      active_probes_run: hasActiveProbeEvidence(run, findings),
+      raw_finding_evidence_exposed: false,
+      poc_payloads_exposed: false
+    },
+    boundaries: run.not_checked.map((item) => ({
+      check_id: item.check_id,
+      title: item.title,
+      reason: item.reason,
+      category: item.category,
+      severity: item.severity
+    })),
+    action_needed: failingFindings.map((finding) => ({
+      check_id: finding.check_id,
+      title: finding.title,
+      severity: finding.severity,
+      category: finding.category
+    }))
+  };
+}
+async function securitypassRun(args) {
+  const packId = String(args.pack_id ?? "");
+  const packYaml = String(args.pack_yaml ?? "");
+  const targetUrl = String(args.target_url ?? "");
+  let pack;
+  if (packYaml.trim()) {
+    const parsed = parsePackYaml(packYaml);
+    if (parsed.error) return parsed.error;
+    pack = parsed.pack;
+  } else if (packId) {
+    pack = getRegisteredPack(packId);
+  }
+  if (packId && !pack && !packYaml.trim() && !targetUrl) {
+    return { error: "pack not found", pack_id: packId };
+  }
+  try {
+    if (pack) {
+      const result2 = await runSecurityPack(pack, {
+        target_id: String(args.target_id ?? "") || void 0,
+        profile: normalizeProfile(args.profile)
+      }, {
+        proofTimeoutMs: normalizeProofTimeout(args.proof_timeout_ms)
+      });
+      const report2 = buildSecurityPassReport(result2.run, result2.findings);
+      return {
+        stub: false,
+        run_id: result2.run.id,
+        status: result2.run.status,
+        score: report2.score,
+        verdict_summary: result2.run.verdict_summary,
+        finding_count: result2.findings.length,
+        not_checked_count: result2.run.not_checked.length,
+        posture_summary: report2.posture_summary,
+        disclaimer: result2.run.disclaimer,
+        receipt: createSecurityPassReceipt(result2.run, result2.findings, report2)
+      };
+    }
+    if (!targetUrl) {
+      return { error: "pack_yaml, registered pack_id, or target_url is required" };
+    }
+    const result = await runSkeletonScan({
+      pack_id: packId || "securitypass-web-baseline",
+      target: { type: "url", url: targetUrl },
+      profile: normalizeProfile(args.profile)
+    }, {
+      contractId: String(args.contract_id ?? "") || void 0,
+      proofMethod: String(args.proof_method ?? "") || void 0,
+      expectedToken: String(args.expected_token ?? "") || void 0,
+      proofTimeoutMs: normalizeProofTimeout(args.proof_timeout_ms)
+    });
+    const report = buildSecurityPassReport(result.run, [result.finding]);
+    return {
+      stub: false,
+      run_id: result.run.id,
+      status: result.run.status,
+      score: report.score,
+      verdict_summary: result.run.verdict_summary,
+      finding_count: 1,
+      not_checked_count: result.run.not_checked.length,
+      posture_summary: report.posture_summary,
+      disclaimer: result.run.disclaimer,
+      receipt: createSecurityPassReceipt(result.run, [result.finding], report)
+    };
+  } catch (err) {
+    if (err instanceof ScopeUnverifiedError) {
+      return {
+        error: "scope_unverified",
+        detail: err.message,
+        next_step: "Call securitypass_verify_scope first, then rerun with contract_id, proof_method, and expected_token or use a pack with a verified scope contract."
+      };
+    }
+    if (err instanceof Error && /target '.+' was not found in pack/.test(err.message)) {
+      return {
+        error: "target_not_found",
+        detail: err.message
+      };
+    }
+    throw err;
+  }
+}
+async function securitypassStatus(args) {
+  const runId = String(args.run_id ?? "");
+  if (!runId) return { error: "run_id is required" };
+  const run = getRun(runId);
+  if (!run) return { error: "run not found", run_id: runId };
+  const findings = listFindings(runId);
+  const report = buildSecurityPassReport(run, findings);
+  return {
+    stub: false,
+    run_id: run.id,
+    status: run.status,
+    verdict_summary: run.verdict_summary,
+    score: report.score,
+    finding_count: findings.length,
+    not_checked_count: run.not_checked.length,
+    posture_summary: report.posture_summary,
+    coverage_note: report.coverage_note,
+    completed_at: run.completed_at,
+    receipt: createSecurityPassReceipt(run, findings, report)
+  };
+}
+async function securitypassReport(args) {
+  const runId = String(args.run_id ?? "");
+  if (!runId) return { error: "run_id is required" };
+  const run = getRun(runId);
+  if (!run) return { error: "run not found", run_id: runId };
+  const findings = listFindings(runId);
+  const report = buildSecurityPassReport(run, findings);
+  return formatSecurityPassReport(report, normalizeFormat(args.format));
+}
+async function securitypassRegisterPack(args) {
+  const packId = String(args.pack_id ?? "");
+  const yaml = String(args.yaml ?? "");
+  if (!packId) return { error: "pack_id is required" };
+  if (!yaml) return { error: "yaml is required" };
+  const parsed = parsePackYaml(yaml);
+  if (parsed.error) return parsed.error;
+  if (!parsed.pack) return { error: "schema validation failed" };
+  if (parsed.pack.id !== packId) {
+    return {
+      error: "pack_id mismatch",
+      detail: `Requested pack_id '${packId}' does not match YAML id '${parsed.pack.id}'.`
+    };
+  }
+  registerPack(parsed.pack);
+  return {
+    stub: false,
+    pack_id: parsed.pack.id,
+    requested_pack_id: packId,
+    persisted: true,
+    storage: "memory"
+  };
+}
+async function securitypassVerifyScope(args) {
+  const targetUrl = String(args.target_url ?? "");
+  const targetRepo = String(args.target_repo ?? "");
+  const proofMethod = String(args.proof_method ?? "");
+  if (!proofMethod) return { error: "proof_method is required" };
+  let target;
+  if (targetUrl) {
+    target = {
+      type: normalizeTargetType(args.target_type, "url"),
+      url: targetUrl
+    };
+  } else if (targetRepo) {
+    target = {
+      type: normalizeTargetType(args.target_type, "git"),
+      repo: targetRepo
+    };
+  } else {
+    return { error: "target_url or target_repo is required" };
+  }
+  const result = await verifyScope(
+    target,
+    {
+      contractId: String(args.contract_id ?? "") || void 0,
+      proofMethod,
+      expectedToken: String(args.expected_token ?? "") || void 0,
+      proofTimeoutMs: normalizeProofTimeout(args.proof_timeout_ms)
+    }
+  );
+  return { stub: false, ...result };
+}
+async function securitypassDisclosureStatus(args) {
+  const findingId = String(args.finding_id ?? "");
+  if (!findingId) return { error: "finding_id is required" };
+  const finding = getFinding(findingId);
+  const notifiedAt = finding?.created_at ?? null;
+  const ackDeadlineAt = notifiedAt ? new Date(Date.parse(notifiedAt) + 90 * 24 * 60 * 60 * 1e3).toISOString() : null;
+  const publicAt = ackDeadlineAt ? new Date(Date.parse(ackDeadlineAt) + 30 * 24 * 60 * 60 * 1e3).toISOString() : null;
+  return {
+    stub: false,
+    finding_id: findingId,
+    state: finding ? "notified" : "unknown",
+    notified_at: notifiedAt,
+    ack_deadline_at: ackDeadlineAt,
+    public_at: publicAt,
+    extension_until_at: null,
+    note: "SecurityPass keeps disclosure timers private and never auto-publishes a finding. Public disclosure remains a human decision."
+  };
+}
+async function securitypassFindingDetail(args) {
+  const findingId = String(args.finding_id ?? "");
+  if (!findingId) return { error: "finding_id is required" };
+  const finding = getFinding(findingId);
+  if (!finding) return { error: "finding not found", finding_id: findingId };
+  return {
+    stub: false,
+    finding,
+    // PoC stays absent until chunk 4 wires the generator. The runtime
+    // contract: PoCs are GENERATED, NEVER auto-fired. Any handler change
+    // must preserve that invariant.
+    poc: finding.poc ?? null
+  };
+}
+var SECURITYPASS_HANDLERS = {
+  securitypass_run: securitypassRun,
+  securitypass_status: securitypassStatus,
+  securitypass_report: securitypassReport,
+  securitypass_register_pack: securitypassRegisterPack,
+  securitypass_verify_scope: securitypassVerifyScope,
+  securitypass_disclosure_status: securitypassDisclosureStatus,
+  securitypass_finding_detail: securitypassFindingDetail
+};
+function __resetSecurityPassMcpForTests() {
+  __resetPackStoreForTests();
+}
+export {
+  SECURITYPASS_HANDLERS,
+  SECURITYPASS_TOOLS,
+  __resetSecurityPassMcpForTests,
+  securitypassDisclosureStatus,
+  securitypassFindingDetail,
+  securitypassRegisterPack,
+  securitypassReport,
+  securitypassRun,
+  securitypassStatus,
+  securitypassVerifyScope
+};

--- a/packages/mcp-server/src/securitypass-tool.ts
+++ b/packages/mcp-server/src/securitypass-tool.ts
@@ -1,0 +1,9 @@
+export {
+  securitypassRun,
+  securitypassStatus,
+  securitypassReport,
+  securitypassRegisterPack,
+  securitypassVerifyScope,
+  securitypassDisclosureStatus,
+  securitypassFindingDetail,
+} from "@unclick/securitypass/mcp";

--- a/packages/mcp-server/src/securitypass-tool.ts
+++ b/packages/mcp-server/src/securitypass-tool.ts
@@ -6,4 +6,4 @@ export {
   securitypassVerifyScope,
   securitypassDisclosureStatus,
   securitypassFindingDetail,
-} from "@unclick/securitypass/mcp";
+} from "./securitypass-runtime.js";

--- a/packages/mcp-server/src/seopass-tool.test.ts
+++ b/packages/mcp-server/src/seopass-tool.test.ts
@@ -51,6 +51,11 @@ describe("seopass-tool", () => {
     expect(result.error).toMatch(/http\(s\)/);
   });
 
+  it("rejects blank target SHA values", async () => {
+    const result = (await seopassRun({ url: "https://unclick.world", target_sha: " " })) as { error?: string };
+    expect(result.error).toMatch(/target_sha/);
+  });
+
   it("rejects invalid pack URLs and unsupported check ids before storing", async () => {
     const badUrl = (await seopassRegisterPack({
       pack_yaml: [
@@ -93,12 +98,21 @@ describe("seopass-tool", () => {
       "https://unclick.world/llms.txt": "# UnClick\n> Agent-native tooling.\n\n## Pages\n[Docs](https://unclick.world/docs): Docs.",
     });
 
-    const run = (await seopassRun({ url: "https://unclick.world" })) as {
+    const run = (await seopassRun({ url: "https://unclick.world", target_sha: "seo-sha-123" })) as {
       run_id?: string;
       status?: string;
       pass?: string;
       report?: { mode?: string };
       verdict_summary?: { fail?: number };
+      seopass_receipt_v1?: {
+        kind?: string;
+        status?: string;
+        target_sha?: string;
+        mode?: string;
+        checked?: { total?: number; fail?: number };
+        boundaries?: string[];
+        action_needed?: string[];
+      };
     };
 
     expect(run.status).toBe("complete");
@@ -106,10 +120,25 @@ describe("seopass-tool", () => {
     expect(run.report?.mode).toBe("live-readonly");
     expect(run.verdict_summary?.fail).toBe(0);
     expect(run.run_id).toMatch(/^seopass-/);
+    expect(run.seopass_receipt_v1).toMatchObject({
+      kind: "seopass_receipt_v1",
+      status: "WARN",
+      target_sha: "seo-sha-123",
+      mode: "live-readonly",
+      checked: { fail: 0 },
+    });
+    expect(run.seopass_receipt_v1?.checked?.total).toBeGreaterThan(0);
+    expect(run.seopass_receipt_v1?.boundaries?.join(" ")).toMatch(/does not guarantee rankings/);
+    expect(run.seopass_receipt_v1?.action_needed?.[0]).toContain("aio-freshness-missing");
 
-    const status = (await seopassStatus({ run_id: run.run_id })) as { run_id?: string; status?: string };
+    const status = (await seopassStatus({ run_id: run.run_id })) as {
+      run_id?: string;
+      status?: string;
+      seopass_receipt_v1?: { target_sha?: string };
+    };
     expect(status.run_id).toBe(run.run_id);
     expect(status.status).toBe("complete");
+    expect(status.seopass_receipt_v1?.target_sha).toBe("seo-sha-123");
   });
 
   it("returns a blocker verdict when robots and noindex block search", async () => {

--- a/packages/mcp-server/src/seopass-tool.ts
+++ b/packages/mcp-server/src/seopass-tool.ts
@@ -15,6 +15,7 @@ type SeoPassMcpRun = {
   status: "complete";
   pass: "seopass";
   target_url: string;
+  target_sha?: string;
   generated_at: string;
   search_engine_readiness_score: number;
   verdict: "ready" | "needs-work" | "blocked";
@@ -41,6 +42,37 @@ type SeoPassMcpRun = {
   };
 };
 
+type SeoPassMcpReceipt = {
+  kind: "seopass_receipt_v1";
+  status: "PASS" | "WARN" | "BLOCKER";
+  run_id: string;
+  target_url: string;
+  target_sha?: string;
+  generated_at: string;
+  mode: "live-readonly";
+  score: number;
+  verdict: SeoPassMcpRun["verdict"];
+  checked: {
+    total: number;
+    pass: number;
+    warn: number;
+    fail: number;
+  };
+  evidence_sources: Array<{
+    kind: string;
+    label: string;
+    source_url?: string;
+    summary: string;
+  }>;
+  action_needed: string[];
+  boundaries: string[];
+};
+
+type SeoPassMcpRunResponse = SeoPassMcpRun & {
+  seopass_receipt_v1: SeoPassMcpReceipt;
+  lighthouse_plan?: Record<string, unknown>;
+};
+
 type FetchTextResult = {
   url: string;
   status: number;
@@ -61,7 +93,7 @@ type CanonicalLink = {
   ignoredAttributes: string[];
 };
 
-const RUNS = new Map<string, SeoPassMcpRun>();
+const RUNS = new Map<string, SeoPassMcpRunResponse>();
 const DEFAULT_CHECKS = [
   "lighthouse-performance",
   "crawlability",
@@ -118,9 +150,77 @@ function lighthousePlan(pack: Record<string, unknown>): Record<string, unknown> 
   };
 }
 
+function buildSeoPassReceipt(run: SeoPassMcpRun, targetSha?: string): SeoPassMcpReceipt {
+  return {
+    kind: "seopass_receipt_v1",
+    status: receiptStatus(run),
+    run_id: run.run_id,
+    target_url: run.target_url,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    generated_at: run.generated_at,
+    mode: "live-readonly",
+    score: run.search_engine_readiness_score,
+    verdict: run.verdict,
+    checked: {
+      total: run.report.checks.length,
+      pass: run.verdict_summary.pass,
+      warn: run.verdict_summary.warn,
+      fail: run.verdict_summary.fail,
+    },
+    evidence_sources: run.report.evidence.map((source) => ({
+      kind: source.kind,
+      label: labelForEvidenceKind(source.kind),
+      source_url: source.source_url,
+      summary: source.summary,
+    })),
+    action_needed: receiptActions(run),
+    boundaries: [
+      "SEOPass reports public read-only search-readiness evidence only.",
+      "SEOPass does not guarantee rankings, indexing, AI Overview placement, or AI citations.",
+      "SEOPass does not mutate sites, submit URLs, use credentials, paid APIs, or private crawler data.",
+    ],
+  };
+}
+
+function receiptStatus(run: SeoPassMcpRun): SeoPassMcpReceipt["status"] {
+  if (run.verdict === "blocked" || run.verdict_summary.fail > 0) return "BLOCKER";
+  if (run.verdict === "needs-work" || run.verdict_summary.warn > 0) return "WARN";
+  return "PASS";
+}
+
+function receiptActions(run: SeoPassMcpRun): string[] {
+  const actions = run.report.checks.flatMap((check) =>
+    check.findings.map((finding) => `${finding.id}: ${finding.recommendation}`),
+  );
+  return Array.from(new Set(actions)).slice(0, 12);
+}
+
+function labelForEvidenceKind(kind: string): string {
+  const labels: Record<string, string> = {
+    "http-response": "HTTP response",
+    "robots-txt": "robots.txt",
+    "robots-policy": "Robots policy",
+    sitemap: "Sitemap",
+    "llms-txt": "llms.txt",
+    "html-head": "HTML head",
+    "page-snapshot": "Page snapshot",
+    canonical: "Canonical signal",
+    "structured-data": "Structured data",
+    "internal-link": "Internal link",
+    lighthouse: "Lighthouse",
+    "geopass-signal": "GEOPass signal",
+    "manual-note": "Manual note",
+  };
+  return labels[kind] ?? kind;
+}
+
 export async function seopassRun(args: Record<string, unknown>): Promise<unknown> {
   const url = typeof args.url === "string" ? args.url : undefined;
   const packName = typeof args.pack_name === "string" ? args.pack_name : undefined;
+  if (args.target_sha !== undefined && (typeof args.target_sha !== "string" || args.target_sha.trim().length === 0)) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  const targetSha = typeof args.target_sha === "string" ? args.target_sha.trim() : undefined;
   if (!url && !packName) return { error: "Either url or pack_name is required" };
 
   const pack = packName ? loadRegisteredPack(packName) : null;
@@ -136,11 +236,14 @@ export async function seopassRun(args: Record<string, unknown>): Promise<unknown
 
   const checkSelection = selectChecks(pack?.checks);
   const run = await runReadonlySeoPass(targetUrl, checkSelection.checks, pack ?? {}, checkSelection.ignored);
-  RUNS.set(run.run_id, run);
-  return {
+  const response: SeoPassMcpRunResponse = {
     ...run,
+    ...(targetSha ? { target_sha: targetSha } : {}),
+    seopass_receipt_v1: buildSeoPassReceipt(run, targetSha),
     lighthouse_plan: lighthousePlan({ ...(pack ?? {}), url: targetUrl }),
   };
+  RUNS.set(run.run_id, response);
+  return response;
 }
 
 export async function seopassStatus(args: Record<string, unknown>): Promise<unknown> {

--- a/packages/mcp-server/src/sloppass-tool.test.ts
+++ b/packages/mcp-server/src/sloppass-tool.test.ts
@@ -75,6 +75,122 @@ describe("sloppass-tool", () => {
     );
   });
 
+  it("fetches a GitHub PR diff target before calling the SlopPass API", async () => {
+    process.env.UNCLICK_API_KEY = "uc_test";
+    process.env.UNCLICK_API_URL = "https://example.test";
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const url = String(input);
+      if (url === "https://github.com/malamutemayhem/unclick/pull/1200.diff") {
+        expect(init?.headers).toMatchObject({ Accept: "text/plain" });
+        return new Response(
+          "diff --git a/src/a.ts b/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1 @@\n+export const ok = true;",
+          { status: 200, headers: { "Content-Type": "text/plain" } },
+        );
+      }
+      if (url === "https://example.test/api/sloppass?action=run") {
+        const body = JSON.parse(String(init?.body)) as {
+          target: { kind?: string; repo?: string; number?: number; url?: string };
+          diff?: string;
+        };
+        expect(body.target).toMatchObject({
+          kind: "pr",
+          repo: "malamutemayhem/unclick",
+          number: 1200,
+          url: "https://github.com/malamutemayhem/unclick/pull/1200",
+        });
+        expect(body.diff).toContain("diff --git");
+        return new Response(JSON.stringify({ run_id: "sloppass_pr_1200", status: "complete", verdict: "pass" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await sloppassRun({
+      target: { kind: "pr", label: "PR #1200", repo: "malamutemayhem/unclick", number: 1200 },
+      target_sha: "abc123",
+    });
+
+    expect(result).toMatchObject({ run_id: "sloppass_pr_1200", verdict: "pass" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts a GitHub PR URL target", async () => {
+    process.env.UNCLICK_API_KEY = "uc_test";
+    process.env.UNCLICK_API_URL = "https://example.test";
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const url = String(input);
+      if (url === "https://github.com/malamutemayhem/unclick/pull/1200.diff") {
+        return new Response(
+          "diff --git a/src/url.ts b/src/url.ts\n+++ b/src/url.ts\n@@ -1 +1 @@\n+export const urlTarget = true;",
+          { status: 200, headers: { "Content-Type": "text/plain" } },
+        );
+      }
+      if (url === "https://example.test/api/sloppass?action=run") {
+        const body = JSON.parse(String(init?.body)) as {
+          target: { repo?: string; number?: number; ref?: string };
+        };
+        expect(body.target).toMatchObject({
+          repo: "malamutemayhem/unclick",
+          number: 1200,
+          ref: "https://github.com/malamutemayhem/unclick/pull/1200",
+        });
+        return new Response(JSON.stringify({ run_id: "sloppass_url_1200", status: "complete", verdict: "pass" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await sloppassRun({
+      target: { kind: "pr", label: "PR URL", url: "https://github.com/malamutemayhem/unclick/pull/1200" },
+    });
+
+    expect(result).toMatchObject({ run_id: "sloppass_url_1200", verdict: "pass" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects unsafe or incomplete PR targets before fetching", async () => {
+    process.env.UNCLICK_API_KEY = "uc_test";
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(sloppassRun({ target: { kind: "pr", label: "missing repo" } })).resolves.toMatchObject({
+      error: "target.kind=pr requires target.repo plus target.number, or target.url/pr_url for a GitHub PR",
+    });
+    await expect(
+      sloppassRun({ target: { kind: "pr", label: "bad url", url: "https://example.test/owner/repo/pull/1" } }),
+    ).resolves.toMatchObject({
+      error: "target.url/pr_url must be a GitHub pull request URL",
+    });
+    await expect(
+      sloppassRun({ target: { kind: "pr", label: "bad number", repo: "malamutemayhem/unclick", number: 0 } }),
+    ).resolves.toMatchObject({
+      error: "target.number must be a positive integer",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns GitHub diff fetch errors before calling the SlopPass API", async () => {
+    process.env.UNCLICK_API_KEY = "uc_test";
+    process.env.UNCLICK_API_URL = "https://example.test";
+    const fetchMock = vi.fn(async () => new Response("missing", { status: 404 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      sloppassRun({
+        target: { kind: "pr", label: "missing", repo: "malamutemayhem/unclick", number: 999999 },
+      }),
+    ).resolves.toMatchObject({
+      error: "GitHub PR diff fetch failed (HTTP 404)",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("returns API errors without losing response details", async () => {
     process.env.UNCLICK_API_KEY = "uc_test";
     process.env.UNCLICK_API_URL = "https://example.test";

--- a/packages/mcp-server/src/sloppass-tool.ts
+++ b/packages/mcp-server/src/sloppass-tool.ts
@@ -2,9 +2,21 @@
  * sloppass-tool - MCP handler for deterministic SlopPass runs.
  *
  * The tool sends caller-provided file text or unified diff text to
- * /api/sloppass. SlopPass does not execute code, read repos, persist source
- * content, or make paid model calls by default.
+ * /api/sloppass. For GitHub PR targets it can fetch the public .diff before
+ * forwarding that diff. SlopPass does not execute code, clone repositories,
+ * persist source content, or make paid model calls by default.
  */
+
+const GITHUB_PR_DIFF_MAX_BYTES = 2_000_000;
+const GITHUB_REPO_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
+
+interface GithubPrDiffTarget {
+  repo: string;
+  number: number;
+  htmlUrl: string;
+  diffUrl: string;
+  label: string;
+}
 
 function getApiBase(): string {
   return (process.env.UNCLICK_API_URL ?? "https://unclick.world").replace(/\/$/, "");
@@ -38,7 +50,80 @@ async function callApi(body: Record<string, unknown>): Promise<unknown> {
   return parsed;
 }
 
-function hasSource(args: Record<string, unknown>): boolean {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parsePrNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === "string" && /^[1-9]\d*$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10);
+  }
+  return null;
+}
+
+function parseGithubPrUrl(value: unknown): GithubPrDiffTarget | { error: string } | null {
+  const raw = nonEmptyString(value);
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { error: "target.url/pr_url must be a GitHub pull request URL" };
+  }
+  if (url.protocol !== "https:" || url.hostname.toLowerCase() !== "github.com") {
+    return { error: "target.url/pr_url must be a GitHub pull request URL" };
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length < 4 || parts[2] !== "pull") {
+    return { error: "target.url/pr_url must be a GitHub pull request URL" };
+  }
+  const repo = `${parts[0]}/${parts[1]}`;
+  if (!GITHUB_REPO_PATTERN.test(repo)) return { error: "target.url/pr_url must be a GitHub pull request URL" };
+  const number = parsePrNumber(parts[3]);
+  if (!number) return { error: "target.url/pr_url must include a positive PR number" };
+  const htmlUrl = `https://github.com/${repo}/pull/${number}`;
+  return {
+    repo,
+    number,
+    htmlUrl,
+    diffUrl: `${htmlUrl}.diff`,
+    label: `GitHub PR ${repo}#${number}`,
+  };
+}
+
+function resolveGithubPrDiffTarget(target: Record<string, unknown>): GithubPrDiffTarget | { error: string } {
+  const fromUrl = parseGithubPrUrl(target.pr_url ?? target.url);
+  if (fromUrl) return fromUrl;
+
+  const repo = nonEmptyString(target.repo);
+  const ref = nonEmptyString(target.ref);
+  if (!repo && ref?.startsWith("https://github.com/")) {
+    const fromRef = parseGithubPrUrl(ref);
+    if (fromRef) return fromRef;
+  }
+  if (!repo) {
+    return { error: "target.kind=pr requires target.repo plus target.number, or target.url/pr_url for a GitHub PR" };
+  }
+  if (!GITHUB_REPO_PATTERN.test(repo)) return { error: "target.repo must use GitHub owner/repo form" };
+  const number = parsePrNumber(target.number);
+  if (!number) return { error: "target.number must be a positive integer" };
+
+  const htmlUrl = `https://github.com/${repo}/pull/${number}`;
+  return {
+    repo,
+    number,
+    htmlUrl,
+    diffUrl: `${htmlUrl}.diff`,
+    label: `GitHub PR ${repo}#${number}`,
+  };
+}
+
+function hasProvidedSource(args: Record<string, unknown>): boolean {
   const files = Array.isArray(args.files)
     ? args.files.filter(
         (file): file is { content: string } =>
@@ -55,22 +140,66 @@ function hasSource(args: Record<string, unknown>): boolean {
   );
 }
 
+function isPrTarget(args: Record<string, unknown>): boolean {
+  return asRecord(args.target)?.kind === "pr";
+}
+
 function hasValidChecks(args: Record<string, unknown>): boolean {
   return !("checks" in args) || !Array.isArray(args.checks) || args.checks.length > 0;
 }
 
+async function fetchGithubPrDiff(target: Record<string, unknown>): Promise<
+  { body: Record<string, unknown> } | { error: string }
+> {
+  const resolved = resolveGithubPrDiffTarget(target);
+  if ("error" in resolved) return resolved;
+
+  const response = await fetch(resolved.diffUrl, {
+    headers: { Accept: "text/plain" },
+  });
+  const diff = await response.text();
+  if (!response.ok) {
+    return { error: `GitHub PR diff fetch failed (HTTP ${response.status})` };
+  }
+  if (!diff.trim()) return { error: "GitHub PR diff was empty" };
+  if (diff.length > GITHUB_PR_DIFF_MAX_BYTES) {
+    return { error: "GitHub PR diff is too large for SlopPass" };
+  }
+
+  const label = nonEmptyString(target.label) ?? resolved.label;
+  return {
+    body: {
+      target: {
+        ...target,
+        kind: "pr",
+        label,
+        repo: resolved.repo,
+        number: resolved.number,
+        url: resolved.htmlUrl,
+        ref: nonEmptyString(target.ref) ?? resolved.htmlUrl,
+      },
+      diff,
+    },
+  };
+}
+
 export async function sloppassRun(args: Record<string, unknown>): Promise<unknown> {
-  if (!args.target || typeof args.target !== "object") {
+  const target = asRecord(args.target);
+  if (!target) {
     return { error: "target is required" };
   }
   if (!hasValidChecks(args)) {
     return { error: "checks must contain at least one SlopPass category when provided" };
   }
-  if (!hasSource(args)) {
+  const providedSource = hasProvidedSource(args);
+  if (!providedSource && !isPrTarget(args)) {
     return { error: "files or diff is required" };
   }
   try {
-    return await callApi(args);
+    if (providedSource) return await callApi(args);
+    const fetched = await fetchGithubPrDiff(target);
+    if ("error" in fetched) return fetched;
+    return await callApi({ ...args, ...fetched.body });
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };
   }

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12280,6 +12280,7 @@ export const ADDITIONAL_TOOLS = [
         profile: { type: "string", enum: ["smoke", "standard", "deep"], description: "Run profile (default: smoke)" },
         jurisdictions: { type: "array", items: { type: "string" }, description: "Optional jurisdiction routing hints" },
         fixture_text: { type: "string", description: "Public text to check deterministically for dogfood or local proof" },
+        target_sha: { type: "string", description: "Optional commit or target evidence SHA to bind the LegalPass receipt to a specific target version" },
       },
     },
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12348,7 +12348,7 @@ export const ADDITIONAL_TOOLS = [
   // ── uxpass-tool.ts (UI/UX QC, sister to TestPass) ──────────────────────────
   {
     name: "uxpass_run",
-    description: "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, and summary. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry).",
+    description: "Run a UI/UX quality check synchronously against a URL. Executes the deterministic uxpass-core check set (HTTP, HTML, accessibility, agent readability, performance, security) against the target and returns the run id, status, UX Score, summary, and uxpass_receipt_v1. Pass either url (a one-off check) or pack_name (resolves the registered pack's url). The receipt calls out when browser visual snapshots, screenshots, or mobile/desktop proof are missing. The hats parameter is accepted for forward compatibility but is currently ignored; LLM hats land in a later chunk. Response includes was_duplicate: boolean indicating whether the row was already present (idempotent retry).",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
@@ -12364,12 +12364,13 @@ export const ADDITIONAL_TOOLS = [
           type: "string",
           description: "Client-generated idempotency key (UUIDv5 from thread_id + prompt_hash + time_bucket recommended). Required for safe retry. If omitted, the server creates a fresh row and you lose retry safety; sending the same task_id twice returns the original run_id with was_duplicate=true instead of creating a duplicate.",
         },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks." },
       },
     },
   },
   {
     name: "uxpass_status",
-    description: "Fetch the status, UX Score, and summary for a UXPass run.",
+    description: "Fetch the status, UX Score, summary, and uxpass_receipt_v1 for a UXPass run.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12705,6 +12705,7 @@ export const ADDITIONAL_TOOLS = [
       properties: {
         repo_path: { type: "string", description: "Local repository path to scan. Defaults to the MCP server working directory." },
         target_name: { type: "string", description: "Human-readable target name for the report. Defaults to UnClick." },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks" },
       },
     },
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -841,6 +841,9 @@ import {
   COMMONSENSEPASS_CLAIM_KINDS,
 } from "./commonsensepass-tool.js";
 
+// --- XPass (conductor receipt across product checks) -------------------------
+import { xpassAggregatedVerdict } from "./xpass-aggregated-verdict-tool.js";
+
 // ─── Crews (Orchestrator Wizard) ──────────────────────────────────────────────
 import { crewsStartRun, crewsGetRun, crewsListRuns } from "./crews-tool.js";
 
@@ -12117,6 +12120,98 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // -- xpass-aggregated-verdict-tool.ts (conductor receipt with SHA binding) --
+  {
+    name: "xpass_aggregated_verdict",
+    description: "Return one XPass conductor verdict for a target PR/change at a specific commit SHA. Selected PASS receipts must name the same head SHA; stale, unscoped, missing, or blocker receipts cannot produce a green verdict.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        target: {
+          type: "object",
+          additionalProperties: false,
+          description: "Target change to inspect. target.sha or target.head_sha is required for anti-stale proof binding.",
+          properties: {
+            type: { type: "string", description: "Target type, such as pr, branch, commit, url, artifact, or change." },
+            kind: { type: "string", description: "Alias for target.type." },
+            id: { type: "string", description: "PR number, issue id, branch label, or artifact id." },
+            pr_number: { type: "number", description: "PR number when the target is a pull request." },
+            prNumber: { type: "number", description: "Alias for pr_number." },
+            sha: { type: "string", description: "Current target commit SHA." },
+            head_sha: { type: "string", description: "Alias for sha." },
+            headSha: { type: "string", description: "Alias for sha." },
+            url: { type: "string", description: "Optional target URL." },
+            ref: { type: "string", description: "Optional branch, PR, or artifact ref." },
+            title: { type: "string", description: "Optional target title used for check selection." },
+            description: { type: "string", description: "Optional target summary used for check selection." },
+            files: { type: "array", items: { type: "string" }, description: "Changed file paths for check selection." },
+            changed_files: { type: "array", items: { type: "string" }, description: "Alias for files." },
+          },
+        },
+        title: { type: "string", description: "Optional PR/change title used for check selection." },
+        description: { type: "string", description: "Optional PR/change description used for check selection." },
+        context: { type: "string", description: "Optional extra context used for check selection." },
+        body: { type: "string", description: "Optional body text used for check selection." },
+        summary: { type: "string", description: "Optional summary text used for check selection." },
+        tags: { type: "array", items: { type: "string" }, description: "Optional tags used for check selection." },
+        changed_files: { type: "array", items: { type: "string" }, description: "Changed file paths for check selection." },
+        changedFiles: { type: "array", items: { type: "string" }, description: "Alias for changed_files." },
+        files: { type: "array", items: { type: "string" }, description: "Alias for changed_files." },
+        owned_files: { type: "array", items: { type: "string" }, description: "Owned file paths for check selection." },
+        ownedFiles: { type: "array", items: { type: "string" }, description: "Alias for owned_files." },
+        enabled_checks: {
+          type: "array",
+          items: { type: "string", enum: ["testpass", "uxpass", "flowpass", "securitypass", "rotatepass", "copypass", "fidelitypass", "seopass", "geopass", "legalpass", "compliancepass", "commonsensepass", "wakepass", "sloppass"] },
+          description: "Optional suite restriction. When supplied, XPass only gates the selected checks that are enabled here.",
+        },
+        selected_checks: {
+          type: "array",
+          items: { type: "string", enum: ["testpass", "uxpass", "flowpass", "securitypass", "rotatepass", "copypass", "fidelitypass", "seopass", "geopass", "legalpass", "compliancepass", "commonsensepass", "wakepass", "sloppass"] },
+          description: "Optional explicit XPass product checks to require for this verdict.",
+        },
+        available_checks: {
+          type: "array",
+          items: { type: "string", enum: ["testpass", "uxpass", "flowpass", "securitypass", "rotatepass", "copypass", "fidelitypass", "seopass", "geopass", "legalpass", "compliancepass", "commonsensepass", "wakepass", "sloppass"] },
+          description: "Optional worker availability list. Selected checks outside this list are NOT RUN and cannot make the verdict green.",
+        },
+        pass_results: {
+          type: "array",
+          description: "Underlying Pass receipts or summarized results. Green results must include target_sha/head_sha matching target.sha.",
+          items: {
+            type: "object",
+            additionalProperties: true,
+            properties: {
+              check: { type: "string" },
+              name: { type: "string" },
+              status: { type: "string" },
+              result: { type: "string" },
+              verdict: { type: "string" },
+              run_id: { type: "string" },
+              receipt_id: { type: "string" },
+              url: { type: "string" },
+              summary: { type: "string" },
+              message: { type: "string" },
+              generated_at: { type: "string" },
+              target_sha: { type: "string" },
+              head_sha: { type: "string" },
+            },
+          },
+        },
+        results: {
+          type: "object",
+          additionalProperties: true,
+          description: "Map form of pass_results keyed by check name.",
+        },
+        require_council: { type: "boolean", description: "Force the Crews Council recommendation on this XPass receipt." },
+        force_council: { type: "boolean", description: "Alias for require_council." },
+        generated_at: { type: "string", description: "Optional deterministic timestamp for tests or replay." },
+        now: { type: "string", description: "Alias for generated_at." },
+      },
+      required: ["target"],
+    },
+  },
+
   // ── testpass-tool.ts ────────────────────────────────────────────────────────
   {
     name: "testpass_list_packs",
@@ -14061,6 +14156,9 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   // commonsensepass-tool.ts
   commonsensepass_check: (args) => commonsensepassCheckTool(args),
   commonsensepass_rules: (args) => commonsensepassRulesTool(args),
+
+  // xpass-aggregated-verdict-tool.ts
+  xpass_aggregated_verdict: (args) => xpassAggregatedVerdict(args),
 
   // legalpass-tool.ts
   legalpass_run:       (args) => legalpassRun(args),

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12509,6 +12509,7 @@ export const ADDITIONAL_TOOLS = [
         journey_name: { type: "string", description: "Optional journey name override" },
         journey_kind: { type: "string", enum: ["signup", "auth", "checkout", "onboarding", "support", "custom"] },
         generated_at: { type: "string", description: "Optional ISO timestamp for reproducible fixture tests" },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks" },
       },
     },
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12839,11 +12839,24 @@ export const ADDITIONAL_TOOLS = [
   {
     name: "fidelitypass_verify_copy",
     description:
-      "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes. Missing bytes, stale metadata, or prose-only AI proof cannot PASS.",
+      "Recompute a FidelityCopy/FidelityPass verdict from source and output bytes, or return N/A when no exact 1:1 copy is in scope. Missing bytes, stale metadata, or prose-only AI proof cannot PASS.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
+        exact_copy_required: {
+          type: "boolean",
+          description: "Set false only when the target has no exact 1:1 copy, transcription, mirroring, or preservation scope. Returns N/A.",
+        },
+        copy_scope: {
+          type: "string",
+          enum: ["exact_copy", "not_applicable"],
+          description: "Explicit FidelityPass scope. Use not_applicable to record the XPass N/A row when no exact copy is in scope.",
+        },
+        scope_reason: {
+          type: "string",
+          description: "Reason why FidelityPass is N/A for this target. Used only when exact_copy_required=false or copy_scope=not_applicable.",
+        },
         source_text: { type: "string", description: "Exact source text to verify. Mutually exclusive with source_base64." },
         source_base64: { type: "string", description: "Exact source bytes as base64. Mutually exclusive with source_text." },
         copyroom_source_packet: {

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -819,6 +819,17 @@ import {
   flowpassStatus,
 } from "./flowpass-tool.js";
 
+// ─── SecurityPass (scope-gated security receipts) ───────────────────────────
+import {
+  securitypassDisclosureStatus,
+  securitypassFindingDetail,
+  securitypassRegisterPack,
+  securitypassReport,
+  securitypassRun,
+  securitypassStatus,
+  securitypassVerifyScope,
+} from "./securitypass-tool.js";
+
 // ─── CopyPass (copy quality QC, sister to SecurityPass) ─────────────────────
 import {
   copypassRun,
@@ -12631,6 +12642,107 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── securitypass-tool.ts (scope-gated security receipts) ─────────────────
+  {
+    name: "securitypass_run",
+    description: "Start a scope-gated SecurityPass scan against a registered pack or target URL. Returns a safe securitypass_receipt_v1 proof envelope without raw secrets or PoC payloads.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        pack_id: { type: "string", description: "Pack id, e.g. 'securitypass-web-baseline'" },
+        pack_yaml: { type: "string", description: "Optional pack YAML to validate and run without prior registration" },
+        target_id: { type: "string", description: "Target id inside the SecurityPass pack" },
+        target_url: { type: "string", description: "Target URL (must be in pack scope)" },
+        contract_id: { type: "string", description: "Scope contract id for skeleton URL scans" },
+        proof_method: { type: "string", enum: ["dns_txt", "well_known", "bug_bounty_program", "signed_email"] },
+        expected_token: { type: "string", description: "Expected scope proof token" },
+        proof_timeout_ms: { type: "number", description: "Optional timeout for well-known proof fetches" },
+        profile: { type: "string", enum: ["smoke", "standard", "deep"], default: "smoke" },
+      },
+    },
+  },
+  {
+    name: "securitypass_status",
+    description: "Poll the state of a SecurityPass run. Returns status, verdict summary, counts, and a safe securitypass_receipt_v1 proof envelope.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string", description: "The run id returned by securitypass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: "securitypass_report",
+    description: "Fetch the synthesised report for a completed run (executive narrative + findings). format=json|markdown|html.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string" },
+        format: { type: "string", enum: ["json", "markdown", "html"], default: "json" },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: "securitypass_register_pack",
+    description: "Save a SecurityPack YAML for the calling tenant. Validates against the schema.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        pack_id: { type: "string" },
+        yaml: { type: "string", description: "Pack contents as YAML" },
+      },
+      required: ["pack_id", "yaml"],
+    },
+  },
+  {
+    name: "securitypass_verify_scope",
+    description: "Verify scope authorisation for a target via DNS TXT or /.well-known proof. Required before any active probe runs.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        target_type: { type: "string", enum: ["url", "git", "mcp", "api"] },
+        target_url: { type: "string" },
+        target_repo: { type: "string" },
+        proof_method: { type: "string", enum: ["dns_txt", "well_known", "bug_bounty_program", "signed_email"] },
+        contract_id: { type: "string", description: "Signed scope contract id" },
+        expected_token: { type: "string", description: "Token to look for in DNS TXT or /.well-known" },
+        proof_timeout_ms: { type: "number", description: "Optional timeout for well-known proof fetches" },
+      },
+      required: ["proof_method"],
+    },
+  },
+  {
+    name: "securitypass_disclosure_status",
+    description: "Check the 90+30 responsible-disclosure timer state for a finding (notified, acked, extended, public, withdrawn).",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        finding_id: { type: "string" },
+      },
+      required: ["finding_id"],
+    },
+  },
+  {
+    name: "securitypass_finding_detail",
+    description: "Fetch a single finding including PoC payload (curl / prompt / payload) and remediation. PoC is generated, never auto-fired.",
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        finding_id: { type: "string" },
+      },
+      required: ["finding_id"],
+    },
+  },
+
   // ── sloppass-tool.ts (AI-code quality QC and diff review) ────────────────
   {
     name: "sloppass_run",
@@ -14099,6 +14211,15 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   flowpass_record:             (args) => flowpassRecord(args),
   flowpass_quarantine:         (args) => flowpassQuarantine(args),
   flowpass_disagreement_queue: (args) => flowpassDisagreementQueue(args),
+
+  // securitypass-tool.ts
+  securitypass_run:               (args) => securitypassRun(args),
+  securitypass_status:            (args) => securitypassStatus(args),
+  securitypass_report:            (args) => securitypassReport(args),
+  securitypass_register_pack:     (args) => securitypassRegisterPack(args),
+  securitypass_verify_scope:      (args) => securitypassVerifyScope(args),
+  securitypass_disclosure_status: (args) => securitypassDisclosureStatus(args),
+  securitypass_finding_detail:    (args) => securitypassFindingDetail(args),
 
   // copypass-tool.ts
   copypass_run:            (args) => copypassRun(args),

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -800,6 +800,12 @@ import {
   seopassLighthousePlan,
 } from "./seopass-tool.js";
 
+// --- GEOPass (AI answer-engine readiness QC, sister to SEOPass) -------------
+import {
+  geopassRun,
+  geopassStatus,
+} from "./geopass-tool.js";
+
 // ─── CompliancePass (public name for EnterprisePass readiness) ───────────────
 import {
   compliancepassRun,
@@ -12480,6 +12486,67 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // -- geopass-tool.ts (AI answer-engine readiness QC, sister to SEOPass) ----
+  {
+    name: "geopass_run",
+    description: "Run GEOPass against a public URL. Returns a live-readonly AI answer-engine readiness receipt covering answer extractability, entity clarity, citation/sourceability, freshness cues, content structure, llms.txt, and AI bot visibility. GEOPass reports readiness only and does not guarantee rankings or citations.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        url: { type: "string", description: "Target public http(s) URL for a one-off GEOPass read-only run" },
+        target_url: { type: "string", description: "Alias for url" },
+        checks: {
+          type: "array",
+          minItems: 1,
+          description: "Optional GEOPass check ids. Defaults to the public-safe live checklist.",
+          items: {
+            type: "string",
+            enum: [
+              "ai-bot-crawlability",
+              "llms-txt",
+              "answer-extractability",
+              "entity-clarity",
+              "citation-readiness",
+              "freshness-cues",
+              "content-structure",
+              "schema-org-citation-grade",
+              "brand-mention-readiness",
+              "wikidata-presence",
+              "common-crawl-presence",
+              "aggregate-ai-engine-readiness",
+            ],
+          },
+        },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks." },
+      },
+    },
+  },
+  {
+    name: "geopass_status",
+    description: "Fetch the stored in-session GEOPass report and geopass_receipt_v1 envelope for a run started through geopass_run.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object" as const,
+      additionalProperties: false,
+      properties: {
+        run_id: { type: "string", description: "The GEOPass run id returned by geopass_run" },
+      },
+      required: ["run_id"],
+    },
+  },
+
   // ── flowpass-tool.ts (end-to-end journey QC with fixture proof) ────────────
   {
     name: "flowpass_run",
@@ -14084,6 +14151,10 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   seopass_status:          (args) => seopassStatus(args),
   seopass_register_pack:   (args) => seopassRegisterPack(args),
   seopass_lighthouse_plan: (args) => seopassLighthousePlan(args),
+
+  // geopass-tool.ts
+  geopass_run:             (args) => geopassRun(args),
+  geopass_status:          (args) => geopassStatus(args),
 
   // compliancepass-tool.ts
   compliancepass_run:         (args) => compliancepassRun(args),

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12748,7 +12748,7 @@ export const ADDITIONAL_TOOLS = [
   // ── copypass-tool.ts (copy quality QC with CopyRoom receipt support) ─────
   {
     name: "copypass_run",
-    description: "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, and optional CopyRoom exact-copy receipt.",
+    description: "Start a deterministic CopyPass review for caller-provided AI-generated copy. Returns evidence-backed copy findings, scope boundaries, disclaimer text, a structured copypass_receipt_v1 proof envelope, and optional CopyRoom exact-copy receipt.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
@@ -12782,7 +12782,7 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "copypass_status",
-    description: "Fetch the current status, notes, deterministic findings, disclaimer, and CopyRoom receipt for a CopyPass run started in this MCP session.",
+    description: "Fetch the current status, notes, deterministic findings, disclaimer, copypass_receipt_v1 proof envelope, and CopyRoom receipt for a CopyPass run started in this MCP session.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12634,21 +12634,44 @@ export const ADDITIONAL_TOOLS = [
   // ── sloppass-tool.ts (AI-code quality QC and diff review) ────────────────
   {
     name: "sloppass_run",
-    description: "Run SlopPass against caller-provided source files or a unified diff. Returns an evidence-backed slop-signal receipt plus JSON, markdown, and HTML reports. SlopPass does not execute code, read repositories, persist source content, or make paid model calls by default.",
+    description: "Run SlopPass against caller-provided source files, a unified diff, or a GitHub PR target whose public .diff should be fetched. Returns an evidence-backed slop-signal receipt plus JSON, markdown, and HTML reports. SlopPass does not execute code, clone repositories, persist source content, or make paid model calls by default.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
-      anyOf: [{ required: ["files"] }, { required: ["diff"] }],
+      anyOf: [
+        { required: ["files"] },
+        { required: ["diff"] },
+        {
+          required: ["target"],
+          properties: {
+            target: {
+              type: "object",
+              required: ["kind"],
+              properties: { kind: { type: "string", enum: ["pr"] } },
+            },
+          },
+        },
+      ],
       properties: {
         target: {
           type: "object",
           additionalProperties: false,
-          description: "Target being inspected.",
+          description: "Target being inspected. For live GitHub PR review, use kind=pr with repo plus number, or url/pr_url.",
           properties: {
             kind: { type: "string", enum: ["repo", "branch", "diff", "files", "pr", "artifact"] },
             label: { type: "string", minLength: 1 },
             files: { type: "array", items: { type: "string", minLength: 1 } },
             ref: { type: "string" },
+            repo: { type: "string", pattern: "^[A-Za-z0-9][A-Za-z0-9-]{0,38}/[A-Za-z0-9._-]{1,100}$", description: "GitHub repo in owner/name form for kind=pr." },
+            number: {
+              oneOf: [
+                { type: "integer", minimum: 1 },
+                { type: "string", pattern: "^[1-9][0-9]*$" },
+              ],
+              description: "GitHub pull request number for kind=pr.",
+            },
+            url: { type: "string", description: "GitHub pull request URL for kind=pr." },
+            pr_url: { type: "string", description: "GitHub pull request URL for kind=pr." },
           },
           required: ["kind", "label"],
         },
@@ -12681,6 +12704,7 @@ export const ADDITIONAL_TOOLS = [
               "test_proof_theatre",
               "slopocalypse_failure_mode",
               "maintenance_change_risk",
+              "vcs_integration_risk",
             ],
           },
         },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -12438,6 +12438,7 @@ export const ADDITIONAL_TOOLS = [
       properties: {
         url: { type: "string", description: "Target URL for a one-off SEOPass read-only run" },
         pack_name: { type: "string", description: "Name of a registered SEOPass pack; the pack URL is used as the target" },
+        target_sha: { type: "string", description: "Optional PR or commit SHA for receipt staleness checks" },
       },
     },
   },

--- a/packages/mcp-server/src/uxpass-tool.test.ts
+++ b/packages/mcp-server/src/uxpass-tool.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { uxpassRun, uxpassStatus } from "./uxpass-tool.js";
+
+type ApiHandler = (url: string, init: { body?: unknown }) => Record<string, unknown>;
+
+function installUxPassApi(handler: ApiHandler): Array<{ url: string; body: Record<string, unknown> }> {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown, init?: { body?: unknown }) => {
+    const url = String(input);
+    const body = typeof init?.body === "string"
+      ? JSON.parse(init.body) as Record<string, unknown>
+      : {};
+    calls.push({ url, body });
+    return new Response(JSON.stringify(handler(url, { body })), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }));
+  return calls;
+}
+
+describe("uxpass-tool", () => {
+  beforeEach(() => {
+    vi.stubEnv("UNCLICK_API_KEY", "uc_test_key");
+    vi.stubEnv("UNCLICK_API_URL", "https://unclick.world");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("adds an explicit warning receipt when browser visual evidence is missing", async () => {
+    const calls = installUxPassApi(() => ({
+      run_id: "uxpass-run-1",
+      status: "complete",
+      ux_score: 92,
+      target_url: "https://unclick.world/",
+      stats: { total: 25, pass: 18, fail: 0, na: 7, pass_rate: 1 },
+      was_duplicate: false,
+    }));
+
+    const result = await uxpassRun({
+      url: "https://unclick.world/",
+      target_sha: "abc123",
+    }) as Record<string, unknown>;
+
+    const receipt = result.uxpass_receipt_v1 as Record<string, unknown>;
+    expect(result.target_sha).toBe("abc123");
+    expect(receipt).toMatchObject({
+      kind: "uxpass_receipt_v1",
+      status: "WARN",
+      run_id: "uxpass-run-1",
+      target_url: "https://unclick.world/",
+      target_sha: "abc123",
+      checked: { total: 25, pass: 18, fail: 0, na: 7, finding_count: null },
+      visual_evidence: {
+        browser_snapshot: "missing",
+        screenshot_proof: "unknown",
+        mobile_desktop_coverage: "unknown",
+      },
+    });
+    expect(receipt.action_needed).toEqual(expect.arrayContaining([
+      expect.stringMatching(/browser-backed visual snapshots/i),
+      expect.stringMatching(/mobile and desktop evidence/i),
+      expect.stringMatching(/screenshot proof/i),
+    ]));
+    expect(calls[0].body).toMatchObject({
+      target_url: "https://unclick.world/",
+      pack_slug: "uxpass-core",
+    });
+    expect(calls[0].body).not.toHaveProperty("target_sha");
+  });
+
+  it("retains target SHA and blocks when status exposes findings", async () => {
+    installUxPassApi((url) => {
+      if (url.includes("action=status")) {
+        return {
+          run_id: "uxpass-run-2",
+          status: "complete",
+          ux_score: 74,
+          target_url: "https://unclick.world/admin",
+          finding_count: 2,
+          breakdown: {
+            by_hat: {
+              frontend: { pass: 4, fail: 0, na: 0 },
+              "visual-designer": { pass: 2, fail: 2, na: 0 },
+            },
+          },
+        };
+      }
+      return {
+        run_id: "uxpass-run-2",
+        status: "complete",
+        ux_score: 74,
+        target_url: "https://unclick.world/admin",
+        stats: { total: 8, pass: 6, fail: 2, na: 0, pass_rate: 0.75 },
+      };
+    });
+
+    await uxpassRun({
+      url: "https://unclick.world/admin",
+      target_sha: "head-sha",
+    });
+    const status = await uxpassStatus({ run_id: "uxpass-run-2" }) as Record<string, unknown>;
+    const receipt = status.uxpass_receipt_v1 as Record<string, unknown>;
+
+    expect(status.target_sha).toBe("head-sha");
+    expect(receipt).toMatchObject({
+      kind: "uxpass_receipt_v1",
+      status: "BLOCKER",
+      run_id: "uxpass-run-2",
+      target_sha: "head-sha",
+      checked: { total: 8, pass: 6, fail: 2, na: 0, finding_count: 2 },
+    });
+    expect(receipt.action_needed).toEqual(expect.arrayContaining([
+      expect.stringMatching(/Fix failing UXPass findings/i),
+    ]));
+  });
+
+  it("rejects blank target SHA before calling the API", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await uxpassRun({
+      url: "https://unclick.world/",
+      target_sha: "   ",
+    }) as { error?: string };
+
+    expect(result.error).toMatch(/target_sha must be a non-empty string/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server/src/uxpass-tool.ts
+++ b/packages/mcp-server/src/uxpass-tool.ts
@@ -35,6 +35,42 @@ const REQUIRED_PACK_KEYS = [
   "remediation",
 ] as const;
 
+type UxPassReceiptStatus = "PASS" | "WARN" | "BLOCKER" | "PENDING";
+
+interface UxPassRunContext {
+  target_sha?: string;
+  target_url?: string;
+  receipt?: UxPassMcpReceipt;
+}
+
+interface UxPassMcpReceipt {
+  kind: "uxpass_receipt_v1";
+  status: UxPassReceiptStatus;
+  run_id: string;
+  target_url: string | null;
+  target_sha: string | null;
+  generated_at: string;
+  ux_score: number | null;
+  checked: {
+    total: number | null;
+    pass: number | null;
+    fail: number | null;
+    na: number | null;
+    finding_count: number | null;
+  };
+  visual_evidence: {
+    browser_snapshot: "attached" | "missing" | "unknown";
+    screenshot_proof: "present" | "missing" | "unknown";
+    mobile_desktop_coverage: "covered" | "missing" | "unknown";
+    note: string;
+  };
+  evidence_sources: string[];
+  action_needed: string[];
+  boundaries: string[];
+}
+
+const RUN_CONTEXT = new Map<string, UxPassRunContext>();
+
 function getApiKey(): string {
   const key = process.env.UNCLICK_API_KEY?.trim();
   if (!key) {
@@ -67,6 +103,165 @@ async function callApi(
   return body;
 }
 
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseTargetSha(args: Record<string, unknown>): { value?: string; error?: string } {
+  if (args.target_sha === undefined || args.target_sha === null) return {};
+  if (typeof args.target_sha !== "string" || !args.target_sha.trim()) {
+    return { error: "target_sha must be a non-empty string when provided" };
+  }
+  return { value: args.target_sha.trim() };
+}
+
+function checkedStats(body: Record<string, unknown>): UxPassMcpReceipt["checked"] {
+  const stats = recordValue(body.stats);
+  const breakdown = recordValue(body.breakdown);
+  const byHat = recordValue(breakdown.by_hat);
+  const findingCount = numberValue(body.finding_count);
+
+  if (Object.keys(byHat).length > 0) {
+    let pass = 0;
+    let fail = 0;
+    let na = 0;
+    for (const value of Object.values(byHat)) {
+      const row = recordValue(value);
+      pass += numberValue(row.pass) ?? 0;
+      fail += numberValue(row.fail) ?? 0;
+      na += numberValue(row.na) ?? 0;
+    }
+    return { total: pass + fail + na, pass, fail, na, finding_count: findingCount };
+  }
+
+  const total = numberValue(stats.total);
+  const pass = numberValue(stats.pass);
+  const fail = numberValue(stats.fail);
+  const na = numberValue(stats.na);
+  return { total, pass, fail, na, finding_count: findingCount };
+}
+
+function hasScreenshotEvidence(body: Record<string, unknown>): boolean | null {
+  const direct = stringValue(body.screenshot_url) ?? stringValue(body.screenshotUrl);
+  if (direct) return true;
+  const evidence = recordValue(body.evidence);
+  const viewports = Array.isArray(evidence.viewports) ? evidence.viewports : [];
+  if (viewports.some((viewport) => stringValue(recordValue(viewport).screenshot_url))) return true;
+  if (viewports.length > 0) return false;
+  return null;
+}
+
+function viewportCoverage(body: Record<string, unknown>): "covered" | "missing" | "unknown" {
+  const evidence = recordValue(body.evidence);
+  const viewports = Array.isArray(evidence.viewports) ? evidence.viewports : [];
+  const names = new Set(viewports.map((viewport) => stringValue(recordValue(viewport).name)).filter(Boolean));
+  if (names.size === 0) return "unknown";
+  return names.has("mobile") && names.has("desktop") ? "covered" : "missing";
+}
+
+function receiptStatus(body: Record<string, unknown>, checked: UxPassMcpReceipt["checked"]): UxPassReceiptStatus {
+  const status = stringValue(body.status);
+  if (body.error || status === "failed" || status === "budget_exceeded") return "BLOCKER";
+  if (status === "queued" || status === "running") return "PENDING";
+  if ((checked.fail ?? 0) > 0 || (checked.finding_count ?? 0) > 0) return "BLOCKER";
+  if ((checked.na ?? 0) > 0) return "WARN";
+  if (!status || status !== "complete") return "WARN";
+  return "PASS";
+}
+
+function buildUxPassReceipt(
+  body: Record<string, unknown>,
+  context: { runId: string; targetSha?: string; targetUrl?: string },
+): UxPassMcpReceipt {
+  const checked = checkedStats(body);
+  const status = receiptStatus(body, checked);
+  const screenshotEvidence = hasScreenshotEvidence(body);
+  const coverage = viewportCoverage(body);
+  const browserSnapshot = (checked.na ?? 0) > 0 ? "missing" : checked.na === 0 ? "attached" : "unknown";
+  const screenshotProof = screenshotEvidence === true ? "present" : screenshotEvidence === false ? "missing" : "unknown";
+  const actionNeeded: string[] = [];
+
+  if (status === "BLOCKER") {
+    actionNeeded.push("Fix failing UXPass findings before claiming the surface is UX-ready.");
+  }
+  if (status === "PENDING") {
+    actionNeeded.push("Wait for the UXPass run to complete before using this receipt as proof.");
+  }
+  if (browserSnapshot === "missing") {
+    actionNeeded.push("Attach browser-backed visual snapshots so layout, hierarchy, target-size, and contrast checks are not N/A.");
+  }
+  if (coverage !== "covered") {
+    actionNeeded.push("Capture both mobile and desktop evidence before calling the visual critique complete.");
+  }
+  if (screenshotProof !== "present") {
+    actionNeeded.push("Add screenshot proof for UI/UX Boardroom closure or before/after comparison.");
+  }
+  if (!context.targetSha) {
+    actionNeeded.push("Bind the receipt to a target SHA when it is used for PR or release proof.");
+  }
+
+  return {
+    kind: "uxpass_receipt_v1",
+    status,
+    run_id: context.runId,
+    target_url: stringValue(body.target_url) ?? context.targetUrl ?? null,
+    target_sha: context.targetSha ?? null,
+    generated_at: new Date().toISOString(),
+    ux_score: numberValue(body.ux_score),
+    checked,
+    visual_evidence: {
+      browser_snapshot: browserSnapshot,
+      screenshot_proof: screenshotProof,
+      mobile_desktop_coverage: coverage,
+      note: "Fetch-only UXPass checks are useful but do not prove visual polish without browser snapshots and screenshot evidence.",
+    },
+    evidence_sources: [
+      "uxpass_api_response",
+      checked.na !== null ? "uxpass_check_stats" : "uxpass_status_fields",
+      screenshotProof === "present" ? "screenshot_evidence" : "screenshot_required",
+    ],
+    action_needed: Array.from(new Set(actionNeeded)),
+    boundaries: [
+      "UXPass is product UX readiness evidence, not a guarantee that every user path is polished.",
+      "Fetch-only runs do not prove layout, hierarchy, mobile, contrast, or screenshot quality unless browser evidence is attached.",
+      "This receipt must not include secrets, private production data, or local filesystem paths in public comments.",
+    ],
+  };
+}
+
+function attachUxPassReceipt(
+  data: unknown,
+  context: { runId?: string; targetSha?: string; targetUrl?: string },
+): unknown {
+  const body = recordValue(data);
+  const runId = stringValue(body.run_id) ?? context.runId;
+  if (!runId) return data;
+  const prior = RUN_CONTEXT.get(runId);
+  const receipt = buildUxPassReceipt(body, {
+    runId,
+    targetSha: context.targetSha ?? prior?.target_sha,
+    targetUrl: context.targetUrl ?? prior?.target_url,
+  });
+  RUN_CONTEXT.set(runId, {
+    target_sha: receipt.target_sha ?? undefined,
+    target_url: receipt.target_url ?? undefined,
+    receipt,
+  });
+  return {
+    ...body,
+    target_sha: receipt.target_sha,
+    uxpass_receipt_v1: receipt,
+  };
+}
+
 function ensurePacksDir(): void {
   try {
     fs.mkdirSync(PACKS_DIR, { recursive: true });
@@ -83,6 +278,8 @@ export async function uxpassRun(args: Record<string, unknown>): Promise<unknown>
   const url = typeof args.url === "string" ? args.url : undefined;
   const packName = typeof args.pack_name === "string" ? args.pack_name : undefined;
   const taskId = typeof args.task_id === "string" && args.task_id ? args.task_id : undefined;
+  const targetSha = parseTargetSha(args);
+  if (targetSha.error) return { error: targetSha.error };
 
   if (!url && !packName) {
     return { error: "Either url or pack_name is required" };
@@ -108,16 +305,18 @@ export async function uxpassRun(args: Record<string, unknown>): Promise<unknown>
 
   const body: Record<string, unknown> = { target_url: targetUrl, pack_slug: "uxpass-core" };
   if (taskId) body.task_id = taskId;
-  return callApi("?action=start_run", {
+  const response = await callApi("?action=start_run", {
     method: "POST",
     body,
   });
+  return attachUxPassReceipt(response, { targetSha: targetSha.value, targetUrl });
 }
 
 export async function uxpassStatus(args: Record<string, unknown>): Promise<unknown> {
   const runId = typeof args.run_id === "string" ? args.run_id : "";
   if (!runId) return { error: "run_id is required" };
-  return callApi(`?action=status&run_id=${encodeURIComponent(runId)}`);
+  const response = await callApi(`?action=status&run_id=${encodeURIComponent(runId)}`);
+  return attachUxPassReceipt(response, { runId });
 }
 
 export async function uxpassReportHtml(args: Record<string, unknown>): Promise<unknown> {

--- a/packages/mcp-server/src/xpass-aggregated-verdict-tool.test.ts
+++ b/packages/mcp-server/src/xpass-aggregated-verdict-tool.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { xpassAggregatedVerdict } from "./xpass-aggregated-verdict-tool.js";
+
+type XPassResult = {
+  ok?: boolean;
+  verdict?: string;
+  result?: string;
+  reason?: string;
+  missing_checks?: string[];
+  stale_checks?: string[];
+  unscoped_checks?: string[];
+  auto_merge_gate?: {
+    merge_ready?: boolean;
+    verdict_matches_head?: boolean;
+    required_head_sha?: string;
+  };
+  receipt?: {
+    evidence?: unknown[];
+    action_needed?: string[];
+    full_checklist?: Array<{ check?: string; status?: string; reason?: string }>;
+    provenance?: { head_sha?: string; invalidates_on?: string[] };
+    staleness?: { stale_checks?: string[]; unscoped_checks?: string[] };
+  };
+  error?: string;
+};
+
+describe("xpass_aggregated_verdict", () => {
+  it("requires a target SHA for PR-head binding", async () => {
+    const result = await xpassAggregatedVerdict({
+      target: { type: "pr", id: "547" },
+      changed_files: ["src/pages/admin/You.tsx"],
+    }) as XPassResult;
+
+    expect(result.verdict).toBe("fail");
+    expect(result.reason).toBe("missing_target_sha");
+    expect(result.error).toMatch(/target\.sha/);
+  });
+
+  it("passes only when every selected receipt is green and bound to the same head", async () => {
+    const result = await xpassAggregatedVerdict({
+      generated_at: "2026-05-30T00:00:00.000Z",
+      target: { type: "pr", id: "547", sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "UXPass", status: "passed", run_id: "ux-1", target_sha: "abc123", url: "https://example.test/ux" },
+        { check: "FlowPass", status: "passed", run_id: "flow-1", target_sha: "abc123" },
+        { check: "SlopPass", status: "green", run_id: "slop-1", target_sha: "abc123" },
+      ],
+    }) as XPassResult;
+
+    expect(result.ok).toBe(true);
+    expect(result.verdict).toBe("pass");
+    expect(result.result).toBe("passed");
+    expect(result.auto_merge_gate?.merge_ready).toBe(true);
+    expect(result.auto_merge_gate?.verdict_matches_head).toBe(true);
+    expect(result.auto_merge_gate?.required_head_sha).toBe("abc123");
+    expect(result.receipt?.provenance?.head_sha).toBe("abc123");
+    expect(result.receipt?.provenance?.invalidates_on).toContain("new_commit");
+    expect(result.receipt?.evidence).toHaveLength(3);
+    expect(result.receipt?.action_needed).toEqual([]);
+  });
+
+  it("returns pending with a full checklist when selected receipts are missing", async () => {
+    const result = await xpassAggregatedVerdict({
+      target: { type: "pr", id: "547", sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+    }) as XPassResult;
+
+    expect(result.ok).toBe(false);
+    expect(result.verdict).toBe("pending");
+    expect(result.result).toBe("xpass_needed");
+    expect(result.missing_checks).toEqual(["uxpass", "flowpass", "sloppass"]);
+    expect(result.receipt?.full_checklist?.some((item) => item.check === "uxpass" && item.status === "MISSING")).toBe(true);
+    expect(result.receipt?.full_checklist?.some((item) => item.check === "fidelitypass" && item.status === "N/A")).toBe(true);
+  });
+
+  it("fails stale receipts generated for an older head", async () => {
+    const result = await xpassAggregatedVerdict({
+      target: { type: "pr", id: "547", sha: "new-head" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "UXPass", status: "passed", run_id: "ux-1", target_sha: "old-head" },
+        { check: "FlowPass", status: "passed", run_id: "flow-1", target_sha: "new-head" },
+        { check: "SlopPass", status: "passed", run_id: "slop-1", target_sha: "new-head" },
+      ],
+    }) as XPassResult;
+
+    expect(result.ok).toBe(false);
+    expect(result.verdict).toBe("fail");
+    expect(result.reason).toBe("stale_pass_result");
+    expect(result.stale_checks).toEqual(["uxpass"]);
+    expect(result.receipt?.staleness?.stale_checks).toEqual(["uxpass"]);
+    expect(result.receipt?.action_needed?.join("\n")).toMatch(/stale/);
+  });
+
+  it("fails unscoped receipts that do not name the target head", async () => {
+    const result = await xpassAggregatedVerdict({
+      target: { type: "pr", id: "547", sha: "abc123" },
+      changed_files: ["src/pages/admin/You.tsx"],
+      pass_results: [
+        { check: "UXPass", status: "passed", run_id: "ux-1" },
+        { check: "FlowPass", status: "passed", run_id: "flow-1", target_sha: "abc123" },
+        { check: "SlopPass", status: "passed", run_id: "slop-1", target_sha: "abc123" },
+      ],
+    }) as XPassResult;
+
+    expect(result.ok).toBe(false);
+    expect(result.verdict).toBe("fail");
+    expect(result.reason).toBe("unscoped_pass_result");
+    expect(result.unscoped_checks).toEqual(["uxpass"]);
+    expect(result.receipt?.staleness?.unscoped_checks).toEqual(["uxpass"]);
+    expect(result.receipt?.action_needed?.join("\n")).toMatch(/missing target SHA scope/);
+  });
+});

--- a/packages/mcp-server/src/xpass-aggregated-verdict-tool.ts
+++ b/packages/mcp-server/src/xpass-aggregated-verdict-tool.ts
@@ -458,7 +458,7 @@ function selectXPassChecks(input: Record<string, unknown> = {}): SelectedCheck[]
   const needsExactCopyProof = exactCopyRequest(allText);
 
   for (const path of files) {
-    const pathWords = path.replace(/[\/_.-]+/g, " ");
+    const pathWords = path.replace(/[/_.-]+/g, " ");
     const passProduct = passProductForPath(path);
 
     if (passProduct) {

--- a/packages/mcp-server/src/xpass-aggregated-verdict-tool.ts
+++ b/packages/mcp-server/src/xpass-aggregated-verdict-tool.ts
@@ -1,0 +1,801 @@
+import { createHash } from "node:crypto";
+
+const CHECK_ORDER = [
+  "testpass",
+  "uxpass",
+  "flowpass",
+  "securitypass",
+  "rotatepass",
+  "copypass",
+  "fidelitypass",
+  "seopass",
+  "geopass",
+  "legalpass",
+  "compliancepass",
+  "commonsensepass",
+  "wakepass",
+  "sloppass",
+] as const;
+
+type XPassCheck = (typeof CHECK_ORDER)[number];
+type NormalizedStatus = "passed" | "blocker" | "skipped" | "missing";
+type ChecklistStatus = "PASS" | "BLOCKER" | "MISSING" | "NOT RUN" | "N/A";
+
+interface SelectedCheck {
+  check: XPassCheck;
+  name: string;
+  reasons: string[];
+}
+
+interface NormalizedPassResult {
+  check: string;
+  name: string;
+  status: NormalizedStatus;
+  raw_status: string | null;
+  run_id: string;
+  url: string;
+  summary: string;
+  generated_at: string | null;
+  target_sha: string;
+}
+
+interface InspectedTarget {
+  type: string;
+  id: string;
+  sha: string;
+  url: string;
+  ref: string;
+}
+
+interface SkippedCheck {
+  check: XPassCheck;
+  name: string;
+  reason: string;
+}
+
+const CHECK_LABELS: Record<XPassCheck, string> = {
+  testpass: "TestPass",
+  uxpass: "UXPass",
+  flowpass: "FlowPass",
+  securitypass: "SecurityPass",
+  rotatepass: "RotatePass",
+  copypass: "CopyPass",
+  fidelitypass: "FidelityPass",
+  seopass: "SEOPass",
+  geopass: "GEOPass",
+  legalpass: "LegalPass",
+  compliancepass: "CompliancePass",
+  commonsensepass: "CommonSensePass",
+  wakepass: "WakePass",
+  sloppass: "SlopPass",
+};
+
+const PASS_PRODUCT_CHECKS = new Map<string, XPassCheck>([
+  ["commonsensepass", "commonsensepass"],
+  ["copypass", "copypass"],
+  ["fidelitypass", "fidelitypass"],
+  ["flowpass", "flowpass"],
+  ["geopass", "geopass"],
+  ["enterprisepass", "compliancepass"],
+  ["compliancepass", "compliancepass"],
+  ["legalpass", "legalpass"],
+  ["securitypass", "securitypass"],
+  ["seopass", "seopass"],
+  ["sloppass", "sloppass"],
+  ["testpass", "testpass"],
+  ["uxpass", "uxpass"],
+  ["wakepass", "wakepass"],
+  ["rotatepass", "rotatepass"],
+]);
+
+const ENTERPRISE_READINESS_TERMS = [
+  "enterprisepass",
+  "compliancepass",
+  "enterprise readiness",
+  "compliance readiness",
+  "ai governance",
+  "model inventory",
+  "technical documentation",
+  "training data",
+];
+
+const COUNCIL_TRIGGER_TERMS = [
+  "ambiguous",
+  "council",
+  "crew",
+  "crews",
+  "debate",
+  "decide",
+  "decision",
+  "dissent",
+  "good enough",
+  "go no go",
+  "go/no-go",
+  "judgement",
+  "judgment",
+  "launch",
+  "opinion",
+  "opinions",
+  "positioning",
+  "ready to ship",
+  "risk acceptance",
+  "strategy",
+  "taste",
+  "trade-off",
+  "tradeoff",
+  "unclear",
+];
+
+const COUNCIL_HIGH_JUDGMENT_CHECKS = new Set<XPassCheck>([
+  "securitypass",
+  "legalpass",
+  "commonsensepass",
+  "rotatepass",
+]);
+
+const COUNCIL_LITE_QUESTIONS = [
+  "What would make this answer or change wrong?",
+  "What evidence is missing, stale, or too weak?",
+  "Who would object: user, maintainer, reviewer, legal, security, or operator?",
+  "What is the smallest proof needed before saying ready?",
+];
+
+const PASS_STATUS = new Set(["pass", "passed", "success", "green", "ok", "ready"]);
+const BLOCKER_STATUS = new Set(["fail", "failed", "failure", "blocker", "blocked", "red", "needs-work"]);
+const SKIP_STATUS = new Set(["skip", "skipped", "not_applicable", "not-applicable", "na", "n/a"]);
+
+export async function xpassAggregatedVerdict(args: Record<string, unknown>): Promise<unknown> {
+  const inspectedTarget = target(args);
+  if (!inspectedTarget.sha) {
+    return {
+      error: "target.sha or target.head_sha is required so the XPass verdict can be bound to the exact PR head.",
+      verdict: "fail",
+      reason: "missing_target_sha",
+    };
+  }
+
+  return evaluateXPassAggregatedVerdict(args, inspectedTarget);
+}
+
+export function evaluateXPassAggregatedVerdict(
+  input: Record<string, unknown> = {},
+  inspectedTarget = target(input),
+): Record<string, unknown> {
+  const now = readString(input.generated_at ?? input.generatedAt ?? input.now) || new Date().toISOString();
+  const selected = enabledSelection(input, selectXPassChecks(input));
+  const selectedChecks = selected.map((check) => check.check);
+  const available = new Set(readKnownCheckList(input.available_checks ?? input.availableChecks));
+  const hasAvailability = available.size > 0;
+  const results = resultMap(input.pass_results ?? input.passResults ?? input.results);
+  const council = selectCrewsCouncilTrigger(input, selected, results);
+
+  const skipped: SkippedCheck[] = [];
+  const missing: XPassCheck[] = [];
+  const provided: NormalizedPassResult[] = [];
+  const blockers: NormalizedPassResult[] = [];
+  const stale: NormalizedPassResult[] = [];
+  const unscoped: NormalizedPassResult[] = [];
+
+  for (const selectedCheck of selectedChecks) {
+    if (hasAvailability && !available.has(selectedCheck)) {
+      skipped.push({ check: selectedCheck, name: CHECK_LABELS[selectedCheck], reason: "pass_not_available" });
+      continue;
+    }
+
+    const result = results.get(selectedCheck);
+    if (!result) {
+      missing.push(selectedCheck);
+      continue;
+    }
+
+    provided.push(result);
+    if (result.status === "blocker") blockers.push(result);
+    if (result.status === "missing") missing.push(selectedCheck);
+    if (isStaleForTarget(result, inspectedTarget)) stale.push(result);
+    if (isUnscopedForTarget(result, inspectedTarget)) unscoped.push(result);
+    if (result.status === "skipped") {
+      skipped.push({ check: selectedCheck, name: CHECK_LABELS[selectedCheck], reason: result.summary || "pass_result_skipped" });
+    }
+  }
+
+  const uniqueMissing = uniq(missing);
+  const unavailable = skipped.filter((item) => item.reason === "pass_not_available");
+  const hardIssues = blockers.length + stale.length + unscoped.length;
+  const pendingIssues = uniqueMissing.length + unavailable.length;
+  const result = selected.length === 0
+    ? "no_relevant_checks"
+    : hardIssues > 0
+      ? "blocker"
+      : pendingIssues > 0
+        ? "xpass_needed"
+        : "passed";
+  const verdict = result === "passed" ? "pass" : result === "blocker" ? "fail" : "pending";
+  const ok = verdict === "pass";
+  const receipt = makeReceipt({
+    inspectedTarget,
+    selected,
+    provided,
+    missing: uniqueMissing,
+    blockers,
+    stale,
+    unscoped,
+    skipped,
+    council,
+    now,
+    verdict,
+    result,
+  });
+
+  return {
+    kind: "xpass_aggregated_verdict",
+    ok,
+    verdict,
+    result,
+    reason: resultReason(result, selected.length, blockers, stale, unscoped),
+    target: inspectedTarget,
+    selected_checks: selected,
+    missing_checks: uniqueMissing,
+    blocked_checks: blockers.map((item) => item.check),
+    stale_checks: stale.map((item) => item.check),
+    unscoped_checks: unscoped.map((item) => item.check),
+    skipped_checks: skipped,
+    crews_council: council,
+    auto_merge_gate: {
+      status: ok ? "ready" : "blocked",
+      merge_ready: ok,
+      required_head_sha: inspectedTarget.sha,
+      verdict_head_sha: inspectedTarget.sha,
+      verdict_matches_head: ok && receipt.provenance.head_sha === inspectedTarget.sha,
+      rule: "merge only when xpass_aggregated_verdict.verdict is pass and provenance.head_sha equals current PR HEAD",
+    },
+    receipt,
+  };
+}
+
+function makeReceipt({
+  inspectedTarget,
+  selected,
+  provided,
+  missing,
+  blockers,
+  stale,
+  unscoped,
+  skipped,
+  council,
+  now,
+  verdict,
+  result,
+}: {
+  inspectedTarget: InspectedTarget;
+  selected: SelectedCheck[];
+  provided: NormalizedPassResult[];
+  missing: XPassCheck[];
+  blockers: NormalizedPassResult[];
+  stale: NormalizedPassResult[];
+  unscoped: NormalizedPassResult[];
+  skipped: SkippedCheck[];
+  council: Record<string, unknown>;
+  now: string;
+  verdict: "pass" | "pending" | "fail";
+  result: string;
+}) {
+  const selectedByCheck = new Map(selected.map((check) => [check.check, check]));
+  const providedByCheck = new Map(provided.map((item) => [item.check, item]));
+  const missingSet = new Set(missing);
+  const blockerSet = new Set(blockers.map((item) => item.check));
+  const staleSet = new Set(stale.map((item) => item.check));
+  const unscopedSet = new Set(unscoped.map((item) => item.check));
+  const skippedByCheck = new Map(skipped.map((item) => [item.check, item]));
+  const fullChecklist = CHECK_ORDER.map((check) => checklistItem({
+    check,
+    selected: selectedByCheck.has(check),
+    skipped: skippedByCheck.get(check),
+    result: providedByCheck.get(check),
+    missing: missingSet.has(check),
+    blocker: blockerSet.has(check),
+    stale: staleSet.has(check),
+    unscoped: unscopedSet.has(check),
+  }));
+  const evidence = provided.map((item) => ({
+    check: item.check,
+    name: item.name,
+    status: item.status,
+    raw_status: item.raw_status,
+    run_id: item.run_id || null,
+    url: item.url || null,
+    summary: item.summary || null,
+    generated_at: item.generated_at,
+    target_sha: item.target_sha || null,
+  }));
+  const actionNeeded = [
+    ...missing.map((check) => `Run ${CHECK_LABELS[check]}.`),
+    ...blockers.map((item) => `${item.name} returned ${item.status}.`),
+    ...stale.map((item) => `${item.name} receipt is stale for ${inspectedTarget.sha}.`),
+    ...unscoped.map((item) => `${item.name} receipt is missing target SHA scope for ${inspectedTarget.sha}.`),
+    ...skipped
+      .filter((item) => item.reason === "pass_not_available")
+      .map((item) => `${item.name} is selected but not available in this run.`),
+  ];
+  const provenance = {
+    source_tool: "xpass_aggregated_verdict",
+    target_type: inspectedTarget.type || "change",
+    target_id: inspectedTarget.id || null,
+    target_ref: inspectedTarget.ref || null,
+    target_url: inspectedTarget.url || null,
+    head_sha: inspectedTarget.sha,
+    invalidates_on: ["new_commit"],
+    binding_rule: "Every selected PASS receipt must name this head_sha; stale or unscoped receipts block the verdict.",
+  };
+  const receiptBase = {
+    kind: "xpass_receipt_v1",
+    generated_at: now,
+    target: inspectedTarget,
+    verdict,
+    result,
+    full_checklist: fullChecklist,
+    checks_selected: selected.map((item) => ({
+      check: item.check,
+      name: item.name,
+      reasons: item.reasons,
+    })),
+    checks_skipped: skipped,
+    improvement_signals: improvementSignals(missing, blockers, stale, unscoped, skipped),
+    evidence,
+    action_needed: actionNeeded,
+    staleness: {
+      stale_checks: stale.map((item) => item.check),
+      unscoped_checks: unscoped.map((item) => item.check),
+      target_sha: inspectedTarget.sha,
+    },
+    crews_council: council,
+    provenance,
+  };
+
+  return {
+    receipt_id: receiptId(receiptBase),
+    ...receiptBase,
+  };
+}
+
+function checklistItem({
+  check,
+  selected,
+  skipped,
+  result,
+  missing,
+  blocker,
+  stale,
+  unscoped,
+}: {
+  check: XPassCheck;
+  selected: boolean;
+  skipped?: SkippedCheck;
+  result?: NormalizedPassResult;
+  missing: boolean;
+  blocker: boolean;
+  stale: boolean;
+  unscoped: boolean;
+}): { check: XPassCheck; name: string; status: ChecklistStatus; reason: string } {
+  if (!selected) return { check, name: CHECK_LABELS[check], status: "N/A", reason: "not_selected_for_target" };
+  if (stale) return { check, name: CHECK_LABELS[check], status: "BLOCKER", reason: "stale_receipt_for_target_sha" };
+  if (unscoped) return { check, name: CHECK_LABELS[check], status: "BLOCKER", reason: "receipt_missing_target_sha" };
+  if (blocker) return { check, name: CHECK_LABELS[check], status: "BLOCKER", reason: result?.summary || "pass_result_blocker" };
+  if (skipped) return { check, name: CHECK_LABELS[check], status: "NOT RUN", reason: skipped.reason };
+  if (result?.status === "passed") return { check, name: CHECK_LABELS[check], status: "PASS", reason: "receipt_green" };
+  if (result?.status === "skipped") return { check, name: CHECK_LABELS[check], status: "N/A", reason: result.summary || "pass_result_skipped" };
+  if (missing) return { check, name: CHECK_LABELS[check], status: "MISSING", reason: "selected_but_no_receipt" };
+  return { check, name: CHECK_LABELS[check], status: "NOT RUN", reason: "selected_without_receipt" };
+}
+
+function improvementSignals(
+  missing: XPassCheck[],
+  blockers: NormalizedPassResult[],
+  stale: NormalizedPassResult[],
+  unscoped: NormalizedPassResult[],
+  skipped: SkippedCheck[],
+) {
+  return [
+    ...missing.map((check) => ({
+      check,
+      name: CHECK_LABELS[check],
+      signal: "selected_check_missing_receipt",
+      action: "Add or rerun the receipt, then decide whether the pass needs a stronger runner or worker reminder.",
+    })),
+    ...blockers.map((item) => ({
+      check: item.check,
+      name: item.name,
+      signal: "pass_returned_blocker",
+      action: "Fix the target or improve the pass rule if this blocker is noisy.",
+    })),
+    ...stale.map((item) => ({
+      check: item.check,
+      name: item.name,
+      signal: "stale_receipt",
+      action: "Tighten receipt freshness or rerun behavior for this pass.",
+    })),
+    ...unscoped.map((item) => ({
+      check: item.check,
+      name: item.name,
+      signal: "unscoped_receipt",
+      action: "Teach the pass to bind evidence to the target SHA, URL, or artifact.",
+    })),
+    ...skipped
+      .filter((item) => item.reason === "pass_not_available")
+      .map((item) => ({
+        check: item.check,
+        name: item.name,
+        signal: "pass_not_available",
+        action: "Create a closure-board job if this pass should be available for this target class.",
+      })),
+  ];
+}
+
+function enabledSelection(input: Record<string, unknown>, selected: SelectedCheck[]): SelectedCheck[] {
+  const enabled = readKnownCheckList(input.enabled_checks ?? input.enabledChecks);
+  const explicit = readKnownCheckList(input.selected_checks ?? input.selectedChecks);
+  const byCheck = new Map<XPassCheck, SelectedCheck>();
+  for (const item of selected) byCheck.set(item.check, item);
+
+  for (const check of explicit) {
+    if (!byCheck.has(check)) {
+      byCheck.set(check, { check, name: CHECK_LABELS[check], reasons: ["caller selected this XPass product check"] });
+    }
+  }
+
+  if (enabled.length === 0) return [...byCheck.values()];
+  if (byCheck.size === 0) {
+    return enabled.map((check) => ({ check, name: CHECK_LABELS[check], reasons: ["enabled for this XPass run"] }));
+  }
+
+  return [...byCheck.values()].filter((item) => enabled.includes(item.check));
+}
+
+function selectXPassChecks(input: Record<string, unknown> = {}): SelectedCheck[] {
+  const files = changedFiles(input);
+  const text = targetText(input);
+  const reasons = new Map<XPassCheck, Set<string>>();
+  const allText = `${text} ${files.join(" ")}`;
+  const needsExactCopyProof = exactCopyRequest(allText);
+
+  for (const path of files) {
+    const pathWords = path.replace(/[\/_.-]+/g, " ");
+    const passProduct = passProductForPath(path);
+
+    if (passProduct) {
+      addReason(reasons, "testpass", `XPass product implementation needs proof tests: ${path}`);
+      addReason(reasons, passProduct, `XPass product should dogfood its own specialist check: ${path}`);
+      if (codeFile(path) && !testFile(path)) addReason(reasons, "sloppass", `XPass product implementation needs code-quality dogfood: ${path}`);
+    }
+
+    if (enterpriseReadinessSurface(path, allText)) {
+      addReason(reasons, "testpass", `enterprise-readiness evidence needs runnable proof: ${path}`);
+      addReason(reasons, "securitypass", `enterprise-readiness evidence covers security and credential hygiene: ${path}`);
+      addReason(reasons, "commonsensepass", `enterprise-readiness evidence must avoid false compliance claims: ${path}`);
+      addReason(reasons, "copypass", `enterprise-readiness wording surface: ${path}`);
+      addReason(reasons, "legalpass", `compliance/readiness positioning surface: ${path}`);
+      if (codeFile(path) && !testFile(path)) addReason(reasons, "sloppass", `enterprise-readiness implementation quality surface: ${path}`);
+    }
+
+    if (path.includes("xpass") || path.includes("qcpass")) {
+      addReason(reasons, "testpass", `multi-pass gate needs runnable proof: ${path}`);
+      addReason(reasons, "commonsensepass", `multi-pass gate must avoid false green receipts: ${path}`);
+    }
+
+    if (path.startsWith("packages/mcp-server/") || path.includes("/mcp") || path.endsWith("mcp.json") || path.includes("/tools/") || path.includes("connector") || path.includes("native-endpoints") || path.includes("testpass") || path.includes("uxpass") || path.includes("flowpass")) {
+      addReason(reasons, "testpass", `tool or MCP surface: ${path}`);
+    }
+
+    if (path.startsWith("src/pages/") || path.startsWith("src/components/") || path.startsWith("src/layout") || path.startsWith("src/app") || /\.(tsx|jsx|css|scss|html)$/.test(path) || path === "index.html") {
+      addReason(reasons, "uxpass", `user interface surface: ${path}`);
+    }
+
+    if (path.includes("flowpass") || path.includes("onboarding") || path.includes("checkout") || path.includes("signup") || path.includes("sign-up") || path.includes("login") || path.includes("handoff") || path.includes("navigation") || path.includes("journey") || path.includes("funnel") || path.includes("route") || path.startsWith("src/pages/")) {
+      addReason(reasons, "flowpass", `journey or route surface: ${path}`);
+    }
+
+    if (path.startsWith("public/") || path === "index.html" || path.includes("landing") || path.includes("homepage") || path.includes("geopass") || path.includes("llms.txt") || path.includes("schema.org") || hasAny(pathWords, ["seo", "meta", "sitemap", "robots", "canonical", "schema"])) {
+      addReason(reasons, "seopass", `public/SEO surface: ${path}`);
+    }
+
+    if (path.includes("geopass") || path.includes("llms.txt") || path.includes("schema.org") || path.includes("common-crawl") || path.includes("wikidata") || path.includes("structured-data") || hasAny(pathWords, ["geo", "generative", "engine", "ai", "answer", "crawlability", "sitemap", "robots", "canonical", "schema", "gptbot", "claudebot", "perplexitybot", "wikidata"])) {
+      addReason(reasons, "geopass", `AI discovery/readiness surface: ${path}`);
+    }
+
+    if (path.includes("flowpass") || hasAny(pathWords, ["flow", "journey", "onboarding", "checkout", "handoff", "route", "cta", "form", "success", "failure"])) {
+      addReason(reasons, "flowpass", `product journey surface: ${path}`);
+    }
+
+    if (/\.(md|mdx|txt)$/.test(path) || path.includes("copy") || path.includes("homepage") || path.includes("landing") || path.includes("pricing") || path.includes("docs/")) {
+      if (!needsExactCopyProof) addReason(reasons, "copypass", `copy or docs surface: ${path}`);
+    }
+
+    if (path.includes("legal") || path.includes("terms") || path.includes("privacy") || path.includes("license") || path.includes("billing") || path.includes("pricing") || path.includes("subprocessor") || path.includes("dpa")) {
+      addReason(reasons, "legalpass", `legal or commercial surface: ${path}`);
+    }
+
+    if (path.includes("enterprise") || path.includes("compliance") || path.includes("audit") || path.includes("evidence") || path.includes("receipt") || path.includes("policy") || path.includes("ruleset") || path.includes("secret-scanning") || path.endsWith("package-lock.json") || path.endsWith("pnpm-lock.yaml") || path.endsWith("yarn.lock") || path.includes("dependabot") || hasAny(pathWords, ["soc", "iso", "gdpr", "dpa"])) {
+      addReason(reasons, "compliancepass", `enterprise/compliance evidence surface: ${path}`);
+    }
+
+    if (path.includes("auth") || path.includes("oauth") || path.includes("session") || path.includes("password") || path.includes("passkey") || path.includes("keychain") || path.includes("credential") || path.includes("credentials") || path.includes("token") || path.includes("secret") || path.includes("security") || path.includes("redaction") || path.includes("sanitize") || path.includes("csrf") || path.includes("csp") || path.includes("rls") || path.includes("supabase/migrations") || path.endsWith("package.json") || path.endsWith("package-lock.json") || path.endsWith("pnpm-lock.yaml") || path.endsWith("yarn.lock") || path.includes("dependabot")) {
+      addReason(reasons, "securitypass", `security-sensitive surface: ${path}`);
+    }
+
+    if (path.includes("rotatepass") || path.includes("credential") || path.includes("credentials") || path.includes("revocation") || path.includes("local-session") || path.includes("browser-profile") || path.includes("token") || path.includes("secret") || path.includes("keychain") || path.includes("password") || path.includes("redaction") || path.includes("system-credentials") || path.includes("provider-response") || path.includes("rotation")) {
+      addReason(reasons, "rotatepass", `credential rotation/redaction surface: ${path}`);
+    }
+
+    if (path.includes("commonsensepass") || path.includes("orchestrator") || path.includes("heartbeat") || path.includes("runner") || path.includes("queue") || path.includes("boardroom") || path.includes("claim") || path.includes("proof") || path.includes("receipt") || path.includes("merge-ready") || path.includes("no-work") || path.includes("done")) {
+      addReason(reasons, "commonsensepass", `claim/proof sanity surface: ${path}`);
+    }
+
+    if (path.includes("wakepass") || path.includes("pinballwake") || path.startsWith(".github/workflows/") || path.includes("workflow") || path.includes("heartbeat") || path.includes("dispatch") || hasAny(pathWords, ["ack"]) || path.includes("scheduled") || path.includes("cron") || path.includes("stale") || path.includes("lease") || path.includes("runner") || path.includes("queue")) {
+      addReason(reasons, "wakepass", `wake/runner reliability surface: ${path}`);
+    }
+
+    if (codeFile(path) && !testFile(path)) addReason(reasons, "sloppass", `code quality surface: ${path}`);
+  }
+
+  if (hasAny(allText, ["mcp", "tool", "tools", "connector", "connectors", "api endpoint", "native endpoint"])) addReason(reasons, "testpass", "target text mentions tools/connectors/MCP");
+  if (hasAny(allText, ["ui", "ux", "visual", "screen", "screenshots", "navigation", "dashboard", "admin page", "admin ui", "admin screen", "admin dashboard", "accessibility", "wcag", "keyboard", "screen reader", "focus", "target size"])) addReason(reasons, "uxpass", "target text mentions UI/UX/visual changes");
+  if (hasAny(allText, ["flow", "journey", "path", "route", "checkout", "signup", "sign up", "onboarding", "handoff", "navigation", "funnel", "success state", "failure state"])) addReason(reasons, "flowpass", "target text mentions journey/flow completion");
+  if (hasAny(allText, ["security", "auth", "oauth", "credential", "credentials", "token", "tokens", "secret", "secrets", "key", "keys", "password", "redaction", "prompt injection", "insecure output", "llm", "model output", "sandbox"])) addReason(reasons, "securitypass", "target text mentions security/auth/keys");
+  if (hasAny(allText, ["rotatepass", "rotation", "rotate", "revocation", "credential", "credentials", "token", "tokens", "secret", "secrets", "key", "keys", "redaction", "system credentials", "local session", "browser profile", "password"])) addReason(reasons, "rotatepass", "target text mentions credential rotation/redaction");
+  if (hasAny(allText, ["copy", "wording", "homepage", "landing", "docs", "faq", "marketing", "public claim", "public claims"]) && !needsExactCopyProof) addReason(reasons, "copypass", "target text mentions copy/docs/claims");
+  if (needsExactCopyProof) addReason(reasons, "fidelitypass", "target text asks for exact 1:1 copy proof");
+  if (hasAny(allText, ["seo", "search", "meta", "sitemap", "robots", "canonical", "schema", "structured data"])) addReason(reasons, "seopass", "target text mentions SEO");
+  if (hasAny(allText, ["geo", "geopass", "generative engine", "ai discovery", "ai citation", "llms", "crawlability", "common crawl", "wikidata", "brand mention", "answer engine"])) addReason(reasons, "geopass", "target text mentions generative-engine readiness");
+  if (hasAny(allText, ["legal", "privacy", "terms", "license", "pricing", "billing", "invoice", "subprocessor", "compliance"])) addReason(reasons, "legalpass", "target text mentions legal/commercial risk");
+  if (hasAny(allText, ["enterprise", "enterprisepass", "compliancepass", "compliance", "audit", "evidence", "receipt", "policy", "soc", "iso", "gdpr", "dpa", "secret scanning", "push protection"])) addReason(reasons, "compliancepass", "target text mentions enterprise/compliance evidence");
+  if (hasAny(allText, ["commonsensepass", "common sense", "healthy", "quiet", "no work", "no_work", "done", "merge ready", "merge_ready", "stale proof", "green chip", "claim", "completion proof"])) addReason(reasons, "commonsensepass", "target text mentions claim/proof sanity");
+  if (hasAny(allText, ["wakepass", "pinballwake", "wake", "heartbeat", "dispatch", "ack", "lease", "stale check", "scheduled", "cron", "runner", "queue", "job claim"])) addReason(reasons, "wakepass", "target text mentions wake/runner reliability");
+  if (hasAny(allText, ["quality", "slop", "refactor", "code smell", "bug", "bugfix"])) addReason(reasons, "sloppass", "target text mentions quality or code risk");
+
+  return CHECK_ORDER
+    .filter((check) => reasons.has(check))
+    .map((check) => ({ check, name: CHECK_LABELS[check], reasons: [...(reasons.get(check) ?? [])] }));
+}
+
+function selectCrewsCouncilTrigger(
+  input: Record<string, unknown>,
+  selected: SelectedCheck[],
+  results: Map<string, NormalizedPassResult>,
+): Record<string, unknown> {
+  const files = changedFiles(input);
+  const text = targetText(input);
+  const allText = `${text} ${files.join(" ")}`;
+  const selectedChecks = selected.map((item) => item.check);
+  const selectedSet = new Set(selectedChecks);
+  const providedResults = [...results.values()];
+  const passedResults = providedResults.filter((item) => item.status === "passed");
+  const blockerResults = providedResults.filter((item) => item.status === "blocker");
+  const skippedResults = providedResults.filter((item) => item.status === "skipped");
+  const highJudgmentChecks = selectedChecks.filter((check) => COUNCIL_HIGH_JUDGMENT_CHECKS.has(check));
+  const reasons = new Set<string>();
+
+  if (input.require_council === true || input.requireCouncil === true || input.force_council === true || input.forceCouncil === true) reasons.add("Council explicitly requested for this target.");
+  if (hasAny(allText, COUNCIL_TRIGGER_TERMS)) reasons.add("Target language asks for judgement, debate, launch readiness, or a decision.");
+  if (files.some((path) => path.includes("/crews/") || path.includes("crews") || path.includes("council"))) reasons.add("Crews or Council surface changed; dogfood Crews with its own Council judgement.");
+  if (selectedChecks.length >= 4) reasons.add(`Broad XPass surface selected ${selectedChecks.length} checks; use a Council to interpret the combined evidence.`);
+  if (highJudgmentChecks.length >= 2) reasons.add(`High-judgement checks overlap: ${highJudgmentChecks.map((check) => CHECK_LABELS[check]).join(", ")}.`);
+  if ((selectedSet.has("legalpass") || selectedSet.has("securitypass")) && (selectedSet.has("copypass") || selectedSet.has("uxpass") || selectedSet.has("seopass")) && hasAny(allText, ["public", "publish", "release", "launch", "pricing", "homepage", "landing", "claims", "enterprise", "compliance"])) {
+    reasons.add("Public, commercial, legal, or security evidence needs a named final judgement before release.");
+  }
+  if (blockerResults.length > 0 && passedResults.length > 0) reasons.add("Pass evidence is mixed; a Council should decide what the blockers mean before owners treat the target as ready.");
+  if (skippedResults.length > 0 && selectedChecks.length >= 3) reasons.add("Some checks were skipped on a multi-pass target; use a Council to record accepted exclusions.");
+
+  const triggerScore = Math.min(100, (reasons.size * 22) + Math.min(30, selectedChecks.length * 5));
+  const needed = reasons.size > 0;
+  const liteNeeded = Boolean(files.length || text || selectedChecks.length || providedResults.length);
+
+  return {
+    needed,
+    status: needed ? (triggerScore >= 55 ? "recommended" : "consider") : "not_needed",
+    trigger_score: triggerScore,
+    suggested_template: needed ? "Council" : null,
+    suggested_tool: needed ? "start_crew_run" : null,
+    reasons: [...reasons],
+    note: needed ? "Crews should interpret the evidence; XPass still owns the checks and receipts." : "XPass can handle this without a Crews Council.",
+    lite_check: {
+      needed: liteNeeded,
+      status: liteNeeded ? "baseline" : "not_needed",
+      suggested_template: liteNeeded ? "Council Lite" : null,
+      mode: "anti_rubber_stamp",
+      questions: liteNeeded ? COUNCIL_LITE_QUESTIONS : [],
+      note: liteNeeded
+        ? "Use this tiny dissent check before treating the answer as ready; escalate to full Council only when the recommendation says consider or recommended."
+        : "No meaningful target was supplied for a light Crews check.",
+    },
+  };
+}
+
+function resultReason(
+  result: string,
+  selectedCount: number,
+  blockers: NormalizedPassResult[],
+  stale: NormalizedPassResult[],
+  unscoped: NormalizedPassResult[],
+) {
+  if (selectedCount === 0) return "no_relevant_xpass_product_checks";
+  if (result === "passed") return "xpass_receipt_green";
+  if (result === "xpass_needed") return "missing_relevant_pass_results";
+  if (blockers.length) return "pass_result_blocker";
+  if (stale.length) return "stale_pass_result";
+  if (unscoped.length) return "unscoped_pass_result";
+  return "xpass_not_ready";
+}
+
+function normalizePassResult(value: unknown): NormalizedPassResult {
+  const result = asRecord(value);
+  const check = normalizeCheckName(result.check ?? result.name ?? result.id ?? result.pass);
+  const status = normalize(result.status ?? result.result ?? result.verdict);
+  let normalized: NormalizedStatus = "missing";
+  if (PASS_STATUS.has(status)) normalized = "passed";
+  if (BLOCKER_STATUS.has(status)) normalized = "blocker";
+  if (SKIP_STATUS.has(status)) normalized = "skipped";
+
+  return {
+    check,
+    name: CHECK_LABELS[check as XPassCheck] || compactText(result.name ?? check, 80),
+    status: normalized,
+    raw_status: status || null,
+    run_id: compactText(result.run_id ?? result.runId ?? result.receipt_id ?? result.receiptId, 160),
+    url: compactText(result.url ?? result.target_url ?? result.targetUrl ?? result.details_url ?? result.detailsUrl, 500),
+    summary: compactText(result.summary ?? result.message, 500),
+    generated_at: readString(result.generated_at ?? result.generatedAt) || null,
+    target_sha: compactText(result.target_sha ?? result.targetSha ?? result.head_sha ?? result.headSha, 80),
+  };
+}
+
+function resultMap(value: unknown): Map<string, NormalizedPassResult> {
+  if (Array.isArray(value)) {
+    return new Map(value.map((item) => {
+      const normalized = normalizePassResult(item);
+      return [normalized.check, normalized] as const;
+    }));
+  }
+  if (value && typeof value === "object") {
+    return new Map(Object.entries(value as Record<string, unknown>).map(([check, item]) => {
+      const normalized = normalizePassResult({ check, ...asRecord(item) });
+      return [normalized.check, normalized] as const;
+    }));
+  }
+  return new Map();
+}
+
+function target(input: Record<string, unknown>): InspectedTarget {
+  const value = asRecord(input.target);
+  return {
+    type: compactText(value.type ?? value.kind ?? input.target_type ?? input.targetType ?? "change", 80),
+    id: compactText(value.id ?? value.pr_number ?? value.prNumber ?? input.pr_number ?? input.prNumber ?? input.id, 160),
+    sha: compactText(value.sha ?? value.head_sha ?? value.headSha ?? input.sha ?? input.head_sha ?? input.headSha, 80),
+    url: compactText(value.url ?? input.url, 500),
+    ref: compactText(value.ref ?? input.ref, 500),
+  };
+}
+
+function isStaleForTarget(result: NormalizedPassResult, inspectedTarget: InspectedTarget): boolean {
+  return Boolean(result.target_sha && inspectedTarget.sha && result.target_sha !== inspectedTarget.sha);
+}
+
+function isUnscopedForTarget(result: NormalizedPassResult, inspectedTarget: InspectedTarget): boolean {
+  return Boolean(inspectedTarget.sha && !result.target_sha);
+}
+
+function targetText(input: Record<string, unknown>): string {
+  const value = asRecord(input.target);
+  return [
+    input.title,
+    input.description,
+    input.context,
+    input.body,
+    input.summary,
+    value.title,
+    value.description,
+    ...safeList(input.tags),
+  ].map((item) => String(item ?? "")).join(" ").toLowerCase();
+}
+
+function changedFiles(input: Record<string, unknown>): string[] {
+  const value = asRecord(input.target);
+  return uniq([
+    ...safeList(input.changed_files),
+    ...safeList(input.changedFiles),
+    ...safeList(input.files),
+    ...safeList(input.owned_files),
+    ...safeList(input.ownedFiles),
+    ...safeList(value.changed_files),
+    ...safeList(value.files),
+  ].map(normalizePath));
+}
+
+function passProductForPath(path: string): XPassCheck | "" {
+  const packageMatch = path.match(/^packages\/([^/]*pass)(?:\/|$)/);
+  if (packageMatch && PASS_PRODUCT_CHECKS.has(packageMatch[1] ?? "")) return PASS_PRODUCT_CHECKS.get(packageMatch[1] ?? "") ?? "";
+
+  const docMatch = path.match(/^docs\/([^/]*pass)(?:[-_.].*)?\.(?:md|mdx|txt|json)$/);
+  if (docMatch && PASS_PRODUCT_CHECKS.has(docMatch[1] ?? "")) return PASS_PRODUCT_CHECKS.get(docMatch[1] ?? "") ?? "";
+
+  const apiMatch = path.match(/^api\/([^/]*pass)(?:[-_.].*)?\.(?:mjs|js|cjs|ts|tsx|jsx|json)$/);
+  if (apiMatch && PASS_PRODUCT_CHECKS.has(apiMatch[1] ?? "")) return PASS_PRODUCT_CHECKS.get(apiMatch[1] ?? "") ?? "";
+
+  return "";
+}
+
+function enterpriseReadinessSurface(path: string, allText: string): boolean {
+  return path.includes("enterprise") || path.includes("compliance") || path.startsWith("public/enterprise/") || hasAny(allText, ENTERPRISE_READINESS_TERMS);
+}
+
+function normalizeCheckName(value: unknown): string {
+  const key = normalize(value).replace(/[\s_-]+/g, "");
+  if (key === "qualitypass" || key === "quality") return "sloppass";
+  if (key === "enterprisepass" || key === "enterprise" || key === "compliance") return "compliancepass";
+  return CHECK_ORDER.find((check) => check === key || CHECK_LABELS[check].toLowerCase() === key) || key;
+}
+
+function readKnownCheckList(value: unknown): XPassCheck[] {
+  return uniq(safeList(value).map(normalizeCheckName).filter(isKnownCheck));
+}
+
+function isKnownCheck(value: string): value is XPassCheck {
+  return (CHECK_ORDER as readonly string[]).includes(value);
+}
+
+function safeList(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalize(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function compactText(value: unknown, max = 500): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text;
+}
+
+function normalizePath(value: unknown): string {
+  return String(value ?? "").replace(/\\/g, "/").replace(/^\/+/, "").trim().toLowerCase();
+}
+
+function uniq<T>(values: T[]): T[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function hasAny(text: string, terms: string[]): boolean {
+  return terms.some((term) => new RegExp(`\\b${escapeRegex(term)}\\b`, "i").test(text));
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function exactCopyRequest(text: string): boolean {
+  return /(\b1:1\b|\b1 for 1\b|\bone-to-one\b|\bone for one\b|\bexact copy\b|\bcopy exactly\b|\bcopy this without changing\b|\bexactly as source\b|\bverbatim\b|\bword-for-word\b|\bbyte-level\b|\btranscribe\b|\bmirror\b|\bpreserve exactly\b)/i.test(text);
+}
+
+function codeFile(path: string): boolean {
+  return /\.(mjs|js|cjs|ts|tsx|jsx|json|yaml|yml|css|scss|html)$/.test(path);
+}
+
+function testFile(path: string): boolean {
+  return /(^|\/)(__tests__|tests?)\//.test(path) || /\.(test|spec)\.(mjs|js|ts|tsx|jsx)$/.test(path);
+}
+
+function addReason(map: Map<XPassCheck, Set<string>>, check: XPassCheck, reason: string): void {
+  if (!map.has(check)) map.set(check, new Set());
+  map.get(check)?.add(reason);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function receiptId(value: Record<string, unknown>): string {
+  const hash = createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 16);
+  return `xpass_${hash}`;
+}

--- a/packages/securitypass/src/__tests__/mcp-tools.test.ts
+++ b/packages/securitypass/src/__tests__/mcp-tools.test.ts
@@ -23,6 +23,7 @@ describe("SECURITYPASS_TOOLS registration", () => {
   it("each tool has an inputSchema", () => {
     for (const tool of SECURITYPASS_TOOLS) {
       expect(tool.inputSchema.type).toBe("object");
+      expect(tool.inputSchema.additionalProperties).toBe(false);
       expect(tool.inputSchema.properties).toBeDefined();
     }
   });
@@ -164,16 +165,56 @@ describe("SECURITYPASS_HANDLERS validation behaviour", () => {
       target_id: "repo",
     })) as {
       stub?: boolean;
+      run_id?: string;
       status?: string;
       not_checked_count?: number;
       posture_summary?: string;
       disclaimer?: { compact?: string };
+      receipt?: {
+        kind?: string;
+        pass?: string;
+        run_id?: string;
+        receipt_id?: string;
+        status?: string;
+        evidence?: {
+          scope_verified?: boolean;
+          active_probes_run?: boolean;
+          raw_finding_evidence_exposed?: boolean;
+          poc_payloads_exposed?: boolean;
+        };
+        boundaries?: unknown[];
+        action_needed?: unknown[];
+      };
     };
     expect(result.stub).toBe(false);
     expect(result.status).toBe("complete");
     expect(result.not_checked_count).toBe(1);
     expect(result.posture_summary).toMatch(/incomplete coverage/i);
     expect(result.disclaimer?.compact).toMatch(/not a pentest/i);
+    expect(result.receipt).toMatchObject({
+      kind: "securitypass_receipt_v1",
+      pass: "securitypass",
+      run_id: result.run_id,
+      receipt_id: `securitypass:${result.run_id}`,
+      status: "WARN",
+      evidence: {
+        scope_verified: true,
+        active_probes_run: false,
+        raw_finding_evidence_exposed: false,
+        poc_payloads_exposed: false,
+      },
+    });
+    expect(result.receipt?.boundaries).toHaveLength(1);
+    expect(result.receipt?.action_needed).toEqual([]);
+
+    const status = (await SECURITYPASS_HANDLERS.securitypass_status({
+      run_id: result.run_id,
+    })) as { receipt?: { kind?: string; run_id?: string; not_checked_count?: number } };
+    expect(status.receipt).toMatchObject({
+      kind: "securitypass_receipt_v1",
+      run_id: result.run_id,
+      not_checked_count: 1,
+    });
   });
 
   it("securitypass_run reports unknown pack targets without fallback", async () => {

--- a/packages/securitypass/src/mcp/tools.ts
+++ b/packages/securitypass/src/mcp/tools.ts
@@ -16,7 +16,7 @@ import {
   verifyScope,
   type ScopeProofMethod,
 } from "../scope/verify.js";
-import type { RunProfile, SecurityRunTarget } from "../types/index.js";
+import type { Finding, RunProfile, RunRow, SecurityRunTarget, Severity } from "../types/index.js";
 import type { SecurityPack } from "../types/pack-schema.js";
 
 // Shared MCP tool descriptor shape. Mirrors the structure used by
@@ -27,6 +27,7 @@ export interface SecurityPassToolDef {
   description: string;
   inputSchema: {
     type: "object";
+    additionalProperties?: false;
     properties: Record<string, unknown>;
     required?: string[];
   };
@@ -36,9 +37,10 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
   {
     name: "securitypass_run",
     description:
-      "Start a SecurityPass scan against a registered pack. Returns the run id; poll securitypass_status for completion.",
+      "Start a scope-gated SecurityPass scan against a registered pack or target URL. Returns a safe securitypass_receipt_v1 proof envelope without raw secrets or PoC payloads.",
     inputSchema: {
       type: "object",
+      additionalProperties: false,
       properties: {
         pack_id: { type: "string", description: "Pack id, e.g. 'securitypass-web-baseline'" },
         pack_yaml: { type: "string", description: "Optional pack YAML to validate and run without prior registration" },
@@ -63,9 +65,10 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
   {
     name: "securitypass_status",
     description:
-      "Poll the state of a SecurityPass run. Returns status, verdict summary, and counts.",
+      "Poll the state of a SecurityPass run. Returns status, verdict summary, counts, and a safe securitypass_receipt_v1 proof envelope.",
     inputSchema: {
       type: "object",
+      additionalProperties: false,
       properties: {
         run_id: { type: "string", description: "The run id returned by securitypass_run" },
       },
@@ -78,6 +81,7 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
       "Fetch the synthesised report for a completed run (executive narrative + findings). format=json|markdown|html.",
     inputSchema: {
       type: "object",
+      additionalProperties: false,
       properties: {
         run_id: { type: "string" },
         format: { type: "string", enum: ["json", "markdown", "html"], default: "json" },
@@ -90,6 +94,7 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
     description: "Save a SecurityPack YAML for the calling tenant. Validates against the schema.",
     inputSchema: {
       type: "object",
+      additionalProperties: false,
       properties: {
         pack_id: { type: "string" },
         yaml: { type: "string", description: "Pack contents as YAML" },
@@ -103,6 +108,7 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
       "Verify scope authorisation for a target via DNS TXT or /.well-known proof. Required before any active probe runs.",
     inputSchema: {
       type: "object",
+      additionalProperties: false,
       properties: {
         target_type: { type: "string", enum: ["url", "git", "mcp", "api"] },
         target_url: { type: "string" },
@@ -124,6 +130,7 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
       "Check the 90+30 responsible-disclosure timer state for a finding (notified, acked, extended, public, withdrawn).",
     inputSchema: {
       type: "object",
+      additionalProperties: false,
       properties: {
         finding_id: { type: "string" },
       },
@@ -136,6 +143,7 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
       "Fetch a single finding including PoC payload (curl / prompt / payload) and remediation. PoC is generated, never auto-fired.",
     inputSchema: {
       type: "object",
+      additionalProperties: false,
       properties: {
         finding_id: { type: "string" },
       },
@@ -145,6 +153,46 @@ export const SECURITYPASS_TOOLS: SecurityPassToolDef[] = [
 ];
 
 export type SecurityPassHandler = (args: Record<string, unknown>) => Promise<unknown>;
+
+export interface SecurityPassReceipt {
+  kind: "securitypass_receipt_v1";
+  pass: "securitypass";
+  receipt_id: string;
+  run_id: string;
+  status: "PASS" | "WARN" | "FAIL";
+  run_status: RunRow["status"];
+  checked_at: string;
+  completed_at: string | null;
+  target: SecurityRunTarget;
+  profile: RunProfile;
+  score: number;
+  posture_summary: string;
+  verdict_summary: RunRow["verdict_summary"];
+  severity_counts: Record<Severity, number>;
+  finding_count: number;
+  failing_finding_count: number;
+  not_checked_count: number;
+  evidence: {
+    scope_verified: boolean;
+    scope_performed_count: number;
+    active_probes_run: boolean;
+    raw_finding_evidence_exposed: false;
+    poc_payloads_exposed: false;
+  };
+  boundaries: Array<{
+    check_id: string;
+    title: string;
+    reason: string;
+    category: string;
+    severity: Severity;
+  }>;
+  action_needed: Array<{
+    check_id: string;
+    title: string;
+    severity: Severity;
+    category: string;
+  }>;
+}
 
 function normalizeProfile(raw: unknown): RunProfile {
   return raw === "standard" || raw === "deep" ? raw : "smoke";
@@ -180,6 +228,77 @@ function parsePackYaml(yaml: string): { pack?: SecurityPack; error?: unknown } {
     };
   }
   return { pack: result.data };
+}
+
+function countBySeverity(findings: Finding[]): Record<Severity, number> {
+  const counts: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+  for (const finding of findings) counts[finding.severity] += 1;
+  return counts;
+}
+
+function hasActiveProbeEvidence(run: RunRow, findings: Finding[]): boolean {
+  if (findings.length > 0) return true;
+  return run.scope_performed.some((line) => /\b(fetched|ran)\b/i.test(line));
+}
+
+function receiptStatus(run: RunRow, findings: Finding[]): SecurityPassReceipt["status"] {
+  if (run.status === "failed" || run.status === "budget_exceeded") return "FAIL";
+  if (findings.some((finding) => finding.verdict === "fail")) return "FAIL";
+  if (run.status !== "complete" || run.not_checked.length > 0) return "WARN";
+  return "PASS";
+}
+
+function createSecurityPassReceipt(
+  run: RunRow,
+  findings: Finding[],
+  report: ReturnType<typeof buildSecurityPassReport>,
+): SecurityPassReceipt {
+  const failingFindings = findings.filter((finding) => finding.verdict === "fail");
+  return {
+    kind: "securitypass_receipt_v1",
+    pass: "securitypass",
+    receipt_id: `securitypass:${run.id}`,
+    run_id: run.id,
+    status: receiptStatus(run, findings),
+    run_status: run.status,
+    checked_at: run.completed_at ?? run.created_at,
+    completed_at: run.completed_at,
+    target: run.target,
+    profile: run.profile,
+    score: report.score,
+    posture_summary: report.posture_summary,
+    verdict_summary: run.verdict_summary,
+    severity_counts: countBySeverity(findings),
+    finding_count: findings.length,
+    failing_finding_count: failingFindings.length,
+    not_checked_count: run.not_checked.length,
+    evidence: {
+      scope_verified: run.scope_performed.length > 0,
+      scope_performed_count: run.scope_performed.length,
+      active_probes_run: hasActiveProbeEvidence(run, findings),
+      raw_finding_evidence_exposed: false,
+      poc_payloads_exposed: false,
+    },
+    boundaries: run.not_checked.map((item) => ({
+      check_id: item.check_id,
+      title: item.title,
+      reason: item.reason,
+      category: item.category,
+      severity: item.severity,
+    })),
+    action_needed: failingFindings.map((finding) => ({
+      check_id: finding.check_id,
+      title: finding.title,
+      severity: finding.severity,
+      category: finding.category,
+    })),
+  };
 }
 
 export async function securitypassRun(args: Record<string, unknown>): Promise<unknown> {
@@ -219,6 +338,7 @@ export async function securitypassRun(args: Record<string, unknown>): Promise<un
         not_checked_count: result.run.not_checked.length,
         posture_summary: report.posture_summary,
         disclaimer: result.run.disclaimer,
+        receipt: createSecurityPassReceipt(result.run, result.findings, report),
       };
     }
 
@@ -247,6 +367,7 @@ export async function securitypassRun(args: Record<string, unknown>): Promise<un
       not_checked_count: result.run.not_checked.length,
       posture_summary: report.posture_summary,
       disclaimer: result.run.disclaimer,
+      receipt: createSecurityPassReceipt(result.run, [result.finding], report),
     };
   } catch (err) {
     if (err instanceof ScopeUnverifiedError) {
@@ -285,6 +406,7 @@ export async function securitypassStatus(args: Record<string, unknown>): Promise
     posture_summary: report.posture_summary,
     coverage_note: report.coverage_note,
     completed_at: run.completed_at,
+    receipt: createSecurityPassReceipt(run, findings, report),
   };
 }
 

--- a/packages/seopass/src/__tests__/schema.test.ts
+++ b/packages/seopass/src/__tests__/schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   SeoPassFindingSchema,
   SeoPassGeoPassAdapterSchema,
+  SeoPassReceiptSchema,
   SeoPassReportSchema,
 } from "../schema.js";
 
@@ -66,5 +67,36 @@ describe("SEOPass schema", () => {
     });
 
     expect(report.checks[0]?.findings).toEqual([]);
+  });
+
+  it("validates a live-readonly receipt envelope", () => {
+    const receipt = SeoPassReceiptSchema.parse({
+      kind: "seopass_receipt_v1",
+      status: "WARN",
+      run_id: "seopass-123",
+      target_url: "https://example.com/",
+      target_sha: "abc123",
+      generated_at: "2026-05-30T13:50:00.000Z",
+      mode: "live-readonly",
+      score: 72,
+      verdict: "needs-work",
+      checked: { total: 3, pass: 1, warn: 2, fail: 0 },
+      evidence_sources: [
+        {
+          kind: "sitemap",
+          label: "Sitemap",
+          source_url: "https://example.com/sitemap.xml",
+          summary: "2 URL(s) found.",
+        },
+      ],
+      action_needed: ["Add missing metadata."],
+      boundaries: [
+        "SEOPass reports public read-only search-readiness evidence only.",
+        "SEOPass does not guarantee rankings, indexing, AI Overview placement, or AI citations.",
+      ],
+    });
+
+    expect(receipt.kind).toBe("seopass_receipt_v1");
+    expect(receipt.target_sha).toBe("abc123");
   });
 });

--- a/packages/seopass/src/schema.ts
+++ b/packages/seopass/src/schema.ts
@@ -115,6 +115,27 @@ export const SeoPassReportSchema = z.object({
   notes: z.array(z.string().min(1)).default([]),
 });
 
+export const SeoPassReceiptSchema = z.object({
+  kind: z.literal("seopass_receipt_v1"),
+  status: z.enum(["PASS", "WARN", "BLOCKER"]),
+  run_id: z.string().min(1),
+  target_url: z.string().url(),
+  target_sha: z.string().min(1).optional(),
+  generated_at: z.string().datetime(),
+  mode: z.literal("live-readonly"),
+  score: z.number().min(0).max(100),
+  verdict: SeoPassReportVerdictSchema,
+  checked: z.object({
+    total: z.number().int().min(0),
+    pass: z.number().int().min(0),
+    warn: z.number().int().min(0),
+    fail: z.number().int().min(0),
+  }),
+  evidence_sources: z.array(SeoPassEvidenceSchema).default([]),
+  action_needed: z.array(z.string().min(1)).default([]),
+  boundaries: z.array(z.string().min(1)).min(1),
+});
+
 export const SeoPassGeoPassAdapterSchema = z.object({
   source: z.literal("geopass"),
   target_url: z.string().url(),
@@ -167,4 +188,5 @@ export type SeoPassCheckResult = z.infer<typeof SeoPassCheckResultSchema>;
 export type SeoPassScannerSource = z.infer<typeof SeoPassScannerSourceSchema>;
 export type SeoPassCrossPassSignal = z.infer<typeof SeoPassCrossPassSignalSchema>;
 export type SeoPassReport = z.infer<typeof SeoPassReportSchema>;
+export type SeoPassReceipt = z.infer<typeof SeoPassReceiptSchema>;
 export type SeoPassGeoPassAdapter = z.infer<typeof SeoPassGeoPassAdapterSchema>;

--- a/packages/sloppass/src/__tests__/schema.test.ts
+++ b/packages/sloppass/src/__tests__/schema.test.ts
@@ -41,6 +41,29 @@ describe("SlopPass run schema", () => {
     expect(parsed.provider).toBe("http");
   });
 
+  it("keeps GitHub PR target metadata on diff-backed runs", () => {
+    const parsed = SlopPassRunInputSchema.parse({
+      target: {
+        kind: "pr",
+        label: "PR #1200",
+        repo: "malamutemayhem/unclick",
+        number: 1200,
+        url: "https://github.com/malamutemayhem/unclick/pull/1200",
+      },
+      diff: [
+        "diff --git a/src/example.ts b/src/example.ts",
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1 +1 @@",
+        "+export const ok = true;",
+      ].join("\n"),
+    });
+
+    expect(parsed.target.repo).toBe("malamutemayhem/unclick");
+    expect(parsed.target.number).toBe(1200);
+    expect(parsed.target.url).toBe("https://github.com/malamutemayhem/unclick/pull/1200");
+  });
+
   it("accepts git_context as a review source", () => {
     const parsed = SlopPassRunInputSchema.parse({
       target: { kind: "pr", label: "PR 123", ref: "123" },

--- a/packages/sloppass/src/runner/index.ts
+++ b/packages/sloppass/src/runner/index.ts
@@ -3,7 +3,7 @@ import { SLOPPASS_DISCLAIMER } from "../disclaimer.js";
 import { sourceFilesFromUnifiedDiff } from "../diff.js";
 import { detectStaleOverwrites } from "../lenses/stale-overwrite.js";
 import { SlopPassRunInputSchema, type SlopPassRunInput } from "../schema.js";
-import type { SlopPassResult, SlopPassSeverity } from "../types.js";
+import type { SlopPassCategory, SlopPassResult, SlopPassSeverity } from "../types.js";
 import { detectSlopSignals } from "./detectors.js";
 import { getProvider } from "../vendor/promptfoo-lite/index.js";
 import { toSlopPassVerdict } from "../verdict-pack.js";
@@ -41,6 +41,7 @@ export async function runSlopPass(input: SlopPassRunInput): Promise<SlopPassResu
   const checks = parsed.checks ?? DEFAULT_CHECKS;
   const wantsStaleOverwrite = checks.includes("vcs_integration_risk");
   const sourceChecks = checks.filter((check) => check !== "vcs_integration_risk");
+  const sourceCheckSet = new Set<SlopPassCategory>(sourceChecks);
   const attemptedChecks = checks.filter((check) =>
     check !== "vcs_integration_risk" || Boolean(parsed.git_context)
   );
@@ -51,7 +52,7 @@ export async function runSlopPass(input: SlopPassRunInput): Promise<SlopPassResu
   const provider = getProvider(parsed.provider);
   const providerFindings = await provider.evaluate(files, sourceChecks);
   const heuristicFindings = detectSlopSignals(files).filter((finding) =>
-    sourceChecks.includes(finding.category)
+    sourceCheckSet.has(finding.category)
   );
   const staleOverwriteFindings =
     parsed.git_context && wantsStaleOverwrite
@@ -62,7 +63,7 @@ export async function runSlopPass(input: SlopPassRunInput): Promise<SlopPassResu
   for (const finding of findings) counts[finding.severity]++;
 
   const checkedLabels = new Set(checks);
-  const notChecked = DEFAULT_CHECKS.filter((category) => !checkedLabels.has(category)).map((category) => ({
+  const notChecked: Array<{ label: string; reason: string }> = DEFAULT_CHECKS.filter((category) => !checkedLabels.has(category)).map((category) => ({
     label: category,
     reason: "Check was not requested for this scoped run.",
   }));

--- a/packages/sloppass/src/schema.ts
+++ b/packages/sloppass/src/schema.ts
@@ -23,6 +23,10 @@ export const SlopPassTargetSchema = z.object({
   label: z.string().min(1),
   files: z.array(z.string()).optional(),
   ref: z.string().optional(),
+  repo: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9._-]{1,100}$/).optional(),
+  number: z.union([z.number().int().positive(), z.string().regex(/^[1-9]\d*$/)]).optional(),
+  url: z.string().url().optional(),
+  pr_url: z.string().url().optional(),
 });
 
 export const SlopPassSourceFileSchema = z.object({

--- a/packages/sloppass/src/verdict-pack.ts
+++ b/packages/sloppass/src/verdict-pack.ts
@@ -81,7 +81,7 @@ function parseChecks(checks?: SlopPassCategory[]): SlopPassCategory[] {
   return (checks ?? DEFAULT_CHECKS).map((check) => SlopPassCategorySchema.parse(check));
 }
 
-function createNotChecked(checks: SlopPassCategory[], reason: string) {
+function createNotChecked(checks: SlopPassCategory[], reason: string): Array<{ label: string; reason: string }> {
   const requested = new Set(checks);
   return DEFAULT_CHECKS.filter((category) => !requested.has(category)).map((category) => ({
     label: category,

--- a/scripts/build-xpass-boundary-sweep.mjs
+++ b/scripts/build-xpass-boundary-sweep.mjs
@@ -200,6 +200,100 @@ function normalizeProductResult(product, commandResult, now) {
   };
 }
 
+function statusForReceipt(product, matrixRow) {
+  if (product.status === "failing" || matrixRow?.status === "failing") return "BLOCKER";
+  if (matrixRow?.status === "pending" || matrixRow?.status === "blocked") return "PENDING";
+  return "PASS";
+}
+
+function checkStatus(passed) {
+  return passed ? "PASS" : "BLOCKER";
+}
+
+function buildWakePassReceipt(product, matrixRow, { targetSha, now }) {
+  const status = statusForReceipt(product, matrixRow);
+  const commandPassed = product.status === "passing";
+  const actionNeeded = [];
+  if (!commandPassed) actionNeeded.push("Fix WakePass public-safe ACK, stale reclaim, and liveness guards before using this boundary receipt.");
+  if (matrixRow?.status && matrixRow.status !== "passing") {
+    actionNeeded.push("Refresh cross-pass reviewer proof from TestPass, CommonSensePass, and FlowPass.");
+  }
+  if (!targetSha) actionNeeded.push("Bind WakePass boundary proof to the PR or release SHA before using it as merge evidence.");
+
+  return {
+    kind: "wakepass_boundary_receipt_v1",
+    status,
+    product_id: "wakepass",
+    target_url: product.target_url,
+    target_sha: targetSha || null,
+    checked_at: now,
+    evidence_mode: "public_safe_boundary",
+    lifecycle_evidence: {
+      live_queue_touched: false,
+      live_worker_woken: false,
+      notification_sent: false,
+      route_delivery_attempted: false,
+      secret_values_seen: false,
+      ack_tracking: "fixture_and_schema_only",
+      stale_reclaim_tracking: "fixture_and_schema_only",
+      liveness_tracking: "fixture_and_schema_only",
+    },
+    checks: [
+      {
+        id: "event-wake-router",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/event-wake-router.test.mjs",
+        summary: commandPassed
+          ? "Wake handoffs are classified as ACK-required dispatches with bounded routing metadata."
+          : "Wake event routing boundary failed.",
+      },
+      {
+        id: "pinballwake-ack-ledger",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/pinballwake-ack-ledger-room.test.mjs",
+        summary: commandPassed
+          ? "ACK ledger fixtures keep accepted, blocked, and completed worker states visible."
+          : "ACK ledger boundary failed.",
+      },
+      {
+        id: "pinballwake-stale-reclaim",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/pinballwake-stale-room.test.mjs",
+        summary: commandPassed
+          ? "Stale work fixtures produce explicit reclaim evidence instead of silent healthy claims."
+          : "Stale reclaim boundary failed.",
+      },
+      {
+        id: "worker-liveness-watchdog",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/worker-liveness-watchdog.test.mjs",
+        summary: commandPassed
+          ? "Worker liveness fixtures surface missed check-ins without touching live workers."
+          : "Worker liveness watchdog boundary failed.",
+      },
+    ],
+    cross_pass_reviewers: matrixRow?.reviewers ?? [],
+    action_needed: actionNeeded,
+    boundaries: [
+      "WakePass boundary proof does not touch live queues, wake live workers, send notifications, or call route adapters.",
+      "This receipt uses public-safe fixtures and schemas for ACK, stale reclaim, and liveness evidence.",
+      "Healthy means the boundary fixtures passed; it is not proof that every live worker is awake.",
+      "Live wake attempts require explicit future scope, idempotency keys, rate limits, and redacted route metadata only.",
+    ],
+  };
+}
+
+function attachBoundaryReceipts(productResults, matrix, { targetSha, now }) {
+  const matrixByTarget = new Map(matrix.map((row) => [row.target_id, row]));
+  return productResults.map((product) => {
+    if (product.id !== "wakepass") return product;
+    return {
+      ...product,
+      wakepass_receipt_v1: buildWakePassReceipt(product, matrixByTarget.get("wakepass"), { targetSha, now }),
+    };
+  });
+}
+
 function actionNeeded(productResults, matrix, packageSweepState) {
   return [
     ...(packageSweepState?.stale
@@ -240,6 +334,7 @@ export async function buildXPassBoundarySweep({
   }
 
   const matrix = buildCrossPassMatrix(productResults, packageSweepState);
+  const productsWithReceipts = attachBoundaryReceipts(productResults, matrix, { targetSha, now });
   const productStatus = statusFromRows(productResults);
   const matrixStatus = statusFromRows(matrix);
   const status = productStatus === "failing" || matrixStatus === "failing"
@@ -267,7 +362,7 @@ export async function buildXPassBoundarySweep({
     status,
     summary: `XPass boundary sweep ${status} across ${productResults.length} public-safe boundary product(s).`,
     product_count: productResults.length,
-    products: productResults,
+    products: productsWithReceipts,
     cross_pass_matrix: matrix,
     action_needed: actionNeeded(productResults, matrix, packageSweepState),
   };

--- a/scripts/build-xpass-boundary-sweep.mjs
+++ b/scripts/build-xpass-boundary-sweep.mjs
@@ -200,6 +200,92 @@ function normalizeProductResult(product, commandResult, now) {
   };
 }
 
+function statusForReceipt(product, matrixRow) {
+  if (product.status === "failing" || matrixRow?.status === "failing") return "BLOCKER";
+  if (matrixRow?.status === "pending" || matrixRow?.status === "blocked") return "PENDING";
+  return "PASS";
+}
+
+function checkStatus(passed) {
+  return passed ? "PASS" : "BLOCKER";
+}
+
+function buildRotatePassReceipt(product, matrixRow, { targetSha, now }) {
+  const status = statusForReceipt(product, matrixRow);
+  const commandPassed = product.status === "passing";
+  const actionNeeded = [];
+  if (!commandPassed) actionNeeded.push("Fix RotatePass public-safe redaction guard before using this boundary receipt.");
+  if (matrixRow?.status && matrixRow.status !== "passing") {
+    actionNeeded.push("Refresh cross-pass reviewer proof from SecurityPass, LegalPass, and CommonSensePass.");
+  }
+  if (!targetSha) actionNeeded.push("Bind RotatePass boundary proof to the PR or release SHA before using it as merge evidence.");
+
+  return {
+    kind: "rotatepass_boundary_receipt_v1",
+    status,
+    product_id: "rotatepass",
+    target_url: product.target_url,
+    target_sha: targetSha || null,
+    checked_at: now,
+    evidence_mode: "public_safe_boundary",
+    lifecycle_evidence: {
+      credential_values_seen: false,
+      live_secret_probe: "not_run",
+      rotation_action_taken: false,
+      ownership_tracking: "metadata_only",
+      staleness_tracking: "metadata_only",
+      blast_radius_mapping: "used_by_tags_and_verification_targets",
+    },
+    checks: [
+      {
+        id: "rotatepass-redaction-guard",
+        status: checkStatus(commandPassed),
+        evidence: "scripts/rotatepass-redaction-guard.test.mjs",
+        summary: commandPassed
+          ? "Public RotatePass and System Credentials surfaces stayed free of secret-shaped values."
+          : "Public RotatePass redaction guard failed.",
+      },
+      {
+        id: "metadata-intake-contract",
+        status: "PASS",
+        evidence: "docs/rotatepass-connector-metadata.md",
+        summary: "RotatePass consumes credential metadata such as owner, staleness, and safe probe status, not secret contents.",
+      },
+      {
+        id: "local-session-boundary",
+        status: "PASS",
+        evidence: "docs/rotatepass-local-phase0.md",
+        summary: "Browser cookies, passkeys, MFA state, and provider sessions stay local and are not exported to agents.",
+      },
+      {
+        id: "blast-radius-fixture",
+        status: "PASS",
+        evidence: "tests/rotatepass/fixtures/system-credentials.metadata.json",
+        summary: "Fixture evidence maps used-by tags and verification targets without including raw credential values.",
+      },
+    ],
+    cross_pass_reviewers: matrixRow?.reviewers ?? [],
+    action_needed: actionNeeded,
+    boundaries: [
+      "RotatePass boundary proof never reads, prints, exports, or syncs raw credential values.",
+      "This receipt does not perform provider rotation, revocation, token refresh, or destructive provider changes.",
+      "Healthy means no rotation action is due from metadata evidence; it is not a security certification.",
+      "Live credential probes require explicit future scope and must return redacted status metadata only.",
+    ],
+  };
+}
+
+function attachBoundaryReceipts(productResults, matrix, { targetSha, now }) {
+  const matrixByTarget = new Map(matrix.map((row) => [row.target_id, row]));
+  return productResults.map((product) => {
+    if (product.id !== "rotatepass") return product;
+    return {
+      ...product,
+      rotatepass_receipt_v1: buildRotatePassReceipt(product, matrixByTarget.get("rotatepass"), { targetSha, now }),
+    };
+  });
+}
+
 function actionNeeded(productResults, matrix, packageSweepState) {
   return [
     ...(packageSweepState?.stale
@@ -240,6 +326,7 @@ export async function buildXPassBoundarySweep({
   }
 
   const matrix = buildCrossPassMatrix(productResults, packageSweepState);
+  const productsWithReceipts = attachBoundaryReceipts(productResults, matrix, { targetSha, now });
   const productStatus = statusFromRows(productResults);
   const matrixStatus = statusFromRows(matrix);
   const status = productStatus === "failing" || matrixStatus === "failing"
@@ -267,7 +354,7 @@ export async function buildXPassBoundarySweep({
     status,
     summary: `XPass boundary sweep ${status} across ${productResults.length} public-safe boundary product(s).`,
     product_count: productResults.length,
-    products: productResults,
+    products: productsWithReceipts,
     cross_pass_matrix: matrix,
     action_needed: actionNeeded(productResults, matrix, packageSweepState),
   };

--- a/scripts/build-xpass-boundary-sweep.test.mjs
+++ b/scripts/build-xpass-boundary-sweep.test.mjs
@@ -58,6 +58,24 @@ test("XPass boundary sweep records public-safe boundary and cross-pass proof", a
     assert.equal(rotatepass?.proof.kind, "public_safe_boundary_test");
     assert.match(rotatepass?.summary ?? "", /public-safe boundary tests passed/i);
     assert.equal(wakepass?.status, "passing");
+    assert.equal(wakepass?.wakepass_receipt_v1?.kind, "wakepass_boundary_receipt_v1");
+    assert.equal(wakepass?.wakepass_receipt_v1?.status, "PASS");
+    assert.equal(wakepass?.wakepass_receipt_v1?.lifecycle_evidence.live_queue_touched, false);
+    assert.equal(wakepass?.wakepass_receipt_v1?.lifecycle_evidence.live_worker_woken, false);
+    assert.equal(wakepass?.wakepass_receipt_v1?.lifecycle_evidence.route_delivery_attempted, false);
+    assert.deepEqual(
+      wakepass?.wakepass_receipt_v1?.checks.map((check) => check.id),
+      [
+        "event-wake-router",
+        "pinballwake-ack-ledger",
+        "pinballwake-stale-reclaim",
+        "worker-liveness-watchdog",
+      ],
+    );
+    assert.match(
+      wakepass?.wakepass_receipt_v1?.boundaries.join("\n") ?? "",
+      /does not touch live queues, wake live workers, send notifications, or call route adapters/i,
+    );
     assert.equal(enterprisepass, undefined);
 
     const rotatepassMatrix = receipt.cross_pass_matrix.find((row) => row.target_id === "rotatepass");
@@ -83,6 +101,10 @@ test("XPass boundary sweep stays pending without fresh package reviewer proof", 
   assert.equal(receipt.status, "pending");
   assert.match(receipt.action_needed.join("\n"), /package reviewer proof is missing/i);
   assert.equal(
+    receipt.products.find((product) => product.id === "wakepass")?.wakepass_receipt_v1?.status,
+    "PENDING",
+  );
+  assert.equal(
     receipt.cross_pass_matrix.find((row) => row.target_id === "wakepass")?.status,
     "pending",
   );
@@ -107,6 +129,7 @@ test("XPass boundary sweep fails honestly without leaking raw command output", a
     assert.equal(receipt.status, "failing");
     const wakepass = receipt.products.find((product) => product.id === "wakepass");
     assert.equal(wakepass?.status, "failing");
+    assert.equal(wakepass?.wakepass_receipt_v1?.status, "BLOCKER");
     assert.equal(wakepass?.failure_hint, "Process exited with code 17.");
     assert.doesNotMatch(JSON.stringify(receipt), /super-secret|raw-token|stack trace/i);
   } finally {

--- a/scripts/build-xpass-boundary-sweep.test.mjs
+++ b/scripts/build-xpass-boundary-sweep.test.mjs
@@ -57,6 +57,24 @@ test("XPass boundary sweep records public-safe boundary and cross-pass proof", a
     assert.equal(rotatepass?.status, "passing");
     assert.equal(rotatepass?.proof.kind, "public_safe_boundary_test");
     assert.match(rotatepass?.summary ?? "", /public-safe boundary tests passed/i);
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.kind, "rotatepass_boundary_receipt_v1");
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.status, "PASS");
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.lifecycle_evidence.credential_values_seen, false);
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.lifecycle_evidence.live_secret_probe, "not_run");
+    assert.equal(rotatepass?.rotatepass_receipt_v1?.lifecycle_evidence.blast_radius_mapping, "used_by_tags_and_verification_targets");
+    assert.deepEqual(
+      rotatepass?.rotatepass_receipt_v1?.checks.map((check) => check.id),
+      [
+        "rotatepass-redaction-guard",
+        "metadata-intake-contract",
+        "local-session-boundary",
+        "blast-radius-fixture",
+      ],
+    );
+    assert.match(
+      rotatepass?.rotatepass_receipt_v1?.boundaries.join("\n") ?? "",
+      /never reads, prints, exports, or syncs raw credential values/i,
+    );
     assert.equal(wakepass?.status, "passing");
     assert.equal(enterprisepass, undefined);
 
@@ -82,6 +100,10 @@ test("XPass boundary sweep stays pending without fresh package reviewer proof", 
 
   assert.equal(receipt.status, "pending");
   assert.match(receipt.action_needed.join("\n"), /package reviewer proof is missing/i);
+  assert.equal(
+    receipt.products.find((product) => product.id === "rotatepass")?.rotatepass_receipt_v1?.status,
+    "PENDING",
+  );
   assert.equal(
     receipt.cross_pass_matrix.find((row) => row.target_id === "wakepass")?.status,
     "pending",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,6 +182,7 @@ const App = () => (
             <Route path="jobsmith" element={<AdminJobsmith />} />
             <Route path="todos" element={<Navigate to="/admin/jobs" replace />} />
             <Route path="checks" element={<AdminChecks />} />
+            <Route path="checks/:productId" element={<AdminChecks />} />
             <Route path="ledger" element={<AdminLedger />} />
             <Route path="billing" element={<AdminBilling />} />
             <Route path="testpass"              element={<TestPassCatalog />} />

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -122,11 +122,77 @@ const AUTOPILOT_LINKS = [
   { path: "/admin/autopilot/expressbuild", label: "DraftRoom", icon: FileCode2 },
   { path: "/admin/boardroom", label: "Boardroom", icon: MessagesSquare },
   { path: "/admin/jobs", label: "Jobs", icon: ListTodo },
-  { path: "/admin/checks", label: "XPass", icon: ClipboardCheck },
+  { path: "/admin/checks", label: "XPass", icon: ClipboardCheck, hasChildren: true },
   { path: "/admin/projects", label: "Projects", icon: FolderKanban },
   { path: "/admin/ledger", label: "Ledger", icon: ReceiptText },
   { path: "/admin/workers", label: "Workers", icon: Bot },
 ] as const;
+
+const XPASS_LINKS = [
+  { path: "/admin/checks/testpass", label: "TestPass" },
+  { path: "/admin/checks/uxpass", label: "UXPass" },
+  { path: "/admin/checks/securitypass", label: "SecurityPass" },
+  { path: "/admin/checks/copypass", label: "CopyPass" },
+  { path: "/admin/checks/fidelitypass", label: "FidelityPass" },
+  { path: "/admin/checks/legalpass", label: "LegalPass" },
+  { path: "/admin/checks/sloppass", label: "SlopPass" },
+  { path: "/admin/checks/commonsensepass", label: "CommonSensePass" },
+  { path: "/admin/checks/seopass", label: "SEOPass" },
+  { path: "/admin/checks/geopass", label: "GEOPass" },
+  { path: "/admin/checks/flowpass", label: "FlowPass" },
+  { path: "/admin/checks/rotatepass", label: "RotatePass" },
+  { path: "/admin/checks/wakepass", label: "WakePass" },
+  { path: "/admin/checks/compliancepass", label: "CompliancePass" },
+] as const;
+
+function XPassNavItem({ onClick }: { onClick?: () => void }) {
+  const location = useLocation();
+  const isXPass = location.pathname === "/admin/checks" || location.pathname.startsWith("/admin/checks/");
+
+  return (
+    <div>
+      <NavLink
+        to="/admin/checks"
+        onClick={onClick}
+        className={() =>
+          `flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+            isXPass
+              ? "bg-primary/10 text-primary"
+              : "text-muted-foreground hover:bg-card/40 hover:text-foreground"
+          }`
+        }
+      >
+        <ClipboardCheck className="h-4 w-4 shrink-0" />
+        <span className="flex-1">XPass</span>
+        {isXPass
+          ? <ChevronDown className="h-3 w-3 shrink-0" />
+          : <ChevronRight className="h-3 w-3 shrink-0" />}
+      </NavLink>
+      {isXPass && (
+        <div className="ml-7 mt-0.5 flex flex-col gap-0.5">
+          {XPASS_LINKS.map(({ path, label }) => {
+            const active = location.pathname === path;
+
+            return (
+              <Link
+                key={path}
+                to={path}
+                onClick={onClick}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-card/40 hover:text-body"
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function AutopilotNavGroup({ onLinkClick }: { onLinkClick?: () => void }) {
   const location = useLocation();
@@ -139,13 +205,17 @@ function AutopilotNavGroup({ onLinkClick }: { onLinkClick?: () => void }) {
       {open && (
         <div className="mt-1 space-y-0.5 border-l border-primary/20 pl-3">
           {AUTOPILOT_LINKS.map((item) => (
-            <SurfaceLink
-              key={item.path}
-              path={item.path}
-              label={item.label}
-              icon={item.icon}
-              onClick={onLinkClick}
-            />
+            item.hasChildren ? (
+              <XPassNavItem key={item.path} onClick={onLinkClick} />
+            ) : (
+              <SurfaceLink
+                key={item.path}
+                path={item.path}
+                label={item.label}
+                icon={item.icon}
+                onClick={onLinkClick}
+              />
+            )
           ))}
         </div>
       )}

--- a/src/pages/admin/AdminXPassHub.test.tsx
+++ b/src/pages/admin/AdminXPassHub.test.tsx
@@ -15,10 +15,10 @@ describe("AdminXPassHub", () => {
   it("shows the suite landing page with checklist and reports", () => {
     renderHub();
 
-    expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
-    expect(screen.getByText(/AutoPilot's roadworthy check/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "XPass Report" })).toBeInTheDocument();
+    expect(screen.getByText(/AutoPilot's roadworthy checklist/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Reports" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Guided run planner" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Start a report" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Checklist" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /All XPass/i })).toBeInTheDocument();
     expect(screen.getAllByText("FidelityPass").length).toBeGreaterThan(0);
@@ -37,10 +37,10 @@ describe("AdminXPassHub", () => {
   it("switches report context from the report ledger", () => {
     renderHub();
 
-    fireEvent.click(screen.getByRole("button", { name: /Copy and source fidelity/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Exact copy check/i }));
 
-    expect(screen.getByText(/Only applies when the target includes exact source text/i)).toBeInTheDocument();
-    expect(screen.getAllByText("Copy and source fidelity").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Use this only when wording/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Exact copy check").length).toBeGreaterThan(0);
   });
 
   it("guides a run from a plain-English target", () => {
@@ -51,6 +51,6 @@ describe("AdminXPassHub", () => {
     expect(screen.getByText(/Capture desktop and mobile proof/i)).toBeInTheDocument();
     expect(screen.getAllByText("UXPass").length).toBeGreaterThan(0);
     expect(screen.getAllByText("FlowPass").length).toBeGreaterThan(0);
-    expect(screen.getByText(/N\/A means the check was considered/i)).toBeInTheDocument();
+    expect(screen.getByText(/N\/A means the check was considered and does not fit this job/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/AdminXPassHub.test.tsx
+++ b/src/pages/admin/AdminXPassHub.test.tsx
@@ -1,56 +1,48 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import AdminXPassHub from "./AdminXPassHub";
 
-function renderHub() {
+function renderHub(path = "/admin/checks") {
   render(
-    <MemoryRouter>
-      <AdminXPassHub />
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/admin/checks" element={<AdminXPassHub />} />
+        <Route path="/admin/checks/:productId" element={<AdminXPassHub />} />
+      </Routes>
     </MemoryRouter>,
   );
 }
 
 describe("AdminXPassHub", () => {
-  it("shows the suite landing page with checklist and reports", () => {
+  it("shows a simple XPass family card grid", () => {
     renderHub();
 
-    expect(screen.getByRole("heading", { name: "XPass Report" })).toBeInTheDocument();
-    expect(screen.getByText(/AutoPilot's roadworthy checklist/i)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Reports" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Start a report" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Checklist" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /All XPass/i })).toBeInTheDocument();
-    expect(screen.getAllByText("FidelityPass").length).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
+    expect(screen.getByText(/roadworthy inspection/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "XPass family" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /TestPass/i })).toHaveAttribute("href", "/admin/checks/testpass");
+    expect(screen.getByRole("link", { name: /SecurityPass/i })).toHaveAttribute("href", "/admin/checks/securitypass");
+    expect(screen.getByText("Was it copied exactly?")).toBeInTheDocument();
   });
 
-  it("filters the checklist to one product", () => {
-    renderHub();
+  it("shows a product report with recent reports and thin checklist rows", () => {
+    renderHub("/admin/checks/securitypass");
 
-    fireEvent.click(screen.getByRole("button", { name: /CopyPass/i }));
-
-    expect(screen.getAllByText("Is the wording clear?").length).toBeGreaterThan(0);
-    expect(screen.getByText(/Use on hero copy/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Open CopyPass/i })).toHaveAttribute("href", "/admin/copypass");
+    expect(screen.getByRole("heading", { name: "SecurityPass" })).toBeInTheDocument();
+    expect(screen.getByText("Is it safe enough?")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Recent reports" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Roadworthy checks" })).toBeInTheDocument();
+    expect(screen.getByText("Scope is clear")).toBeInTheDocument();
+    expect(screen.getByText(/plain comment any person can understand/i)).toBeInTheDocument();
+    expect(screen.getAllByText("PASS").length).toBeGreaterThan(0);
   });
 
-  it("switches report context from the report ledger", () => {
-    renderHub();
+  it("marks FidelityPass exact-copy scope as N/A when source copy is not in scope", () => {
+    renderHub("/admin/checks/fidelitypass");
 
-    fireEvent.click(screen.getByRole("button", { name: /Exact copy check/i }));
-
-    expect(screen.getByText(/Use this only when wording/i)).toBeInTheDocument();
-    expect(screen.getAllByText("Exact copy check").length).toBeGreaterThan(0);
-  });
-
-  it("guides a run from a plain-English target", () => {
-    renderHub();
-
-    fireEvent.click(screen.getByRole("button", { name: /Screen or journey/i }));
-
-    expect(screen.getByText(/Capture desktop and mobile proof/i)).toBeInTheDocument();
-    expect(screen.getAllByText("UXPass").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("FlowPass").length).toBeGreaterThan(0);
-    expect(screen.getByText(/N\/A means the check was considered and does not fit this job/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "FidelityPass" })).toBeInTheDocument();
+    expect(screen.getByText(/N\/A is correct when no exact source copy is in scope/i)).toBeInTheDocument();
+    expect(screen.getAllByText("N/A").length).toBeGreaterThan(0);
   });
 });

--- a/src/pages/admin/AdminXPassHub.tsx
+++ b/src/pages/admin/AdminXPassHub.tsx
@@ -209,12 +209,12 @@ const PRODUCT_DETAILS: Record<string, ProductDetail> = {
 
 const STATUS_STYLE: Record<XPassStatus, { label: string; classes: string; icon: ComponentType<{ className?: string }> }> = {
   PASS: {
-    label: "PASS",
+    label: "Tick",
     classes: "border-[#61C1C4]/35 bg-[#61C1C4]/10 text-[#9edfe1]",
     icon: CheckCircle2,
   },
   BLOCKER: {
-    label: "BLOCKER",
+    label: "Cross",
     classes: "border-red-500/35 bg-red-500/10 text-red-300",
     icon: XCircle,
   },
@@ -224,7 +224,7 @@ const STATUS_STYLE: Record<XPassStatus, { label: string; classes: string; icon: 
     icon: CircleMinus,
   },
   "NOT RUN": {
-    label: "NOT RUN",
+    label: "Waiting",
     classes: "border-[#E2B93B]/35 bg-[#E2B93B]/10 text-[#f1d878]",
     icon: Clock3,
   },
@@ -238,26 +238,26 @@ const STATUS_STYLE: Record<XPassStatus, { label: string; classes: string; icon: 
 const REPORTS: ReportRow[] = [
   {
     id: "public-dogfood",
-    title: "Public dogfood receipt",
-    date: "Latest public run",
+    title: "Latest XPass report",
+    date: "Current public proof",
     status: statusFromDogfood(dogfoodReport.status),
-    note: "Reads the public dogfood receipt and keeps the suite honest about what actually ran.",
+    note: "The current checklist. Each row has a result and a plain comment.",
     productIds: [...PRODUCT_ORDER],
   },
   {
     id: "pr-backed-sweep",
-    title: "PR-backed XPass sweep",
-    date: "May 30, 2026",
+    title: "Full suite closeout",
+    date: "In progress",
     status: "NOT RUN",
-    note: "Recent product receipts are PR-ready and cloud-green; final main verdict waits until those PRs land.",
+    note: "The final family report appears here after every product check is folded into main.",
     productIds: ["securitypass", "copypass", "legalpass", "seopass", "geopass", "flowpass", "uxpass", "rotatepass", "wakepass", "compliancepass"],
   },
   {
     id: "source-copy",
-    title: "Copy and source fidelity",
+    title: "Exact copy check",
     date: "On demand",
     status: "N/A",
-    note: "Only applies when the target includes exact source text, tables, labels, prompts, or wording.",
+    note: "Use this only when wording, tables, prompts, or labels must match exactly.",
     productIds: ["copypass", "fidelitypass", "commonsensepass"],
   },
 ];
@@ -269,7 +269,7 @@ const GUIDED_RUNS: RunTemplate[] = [
     target: "Pull request, MCP tool, backend change, or release.",
     passIds: ["testpass", "securitypass", "sloppass", "commonsensepass"],
     notApplicableIds: ["fidelitypass"],
-    firstAction: "Run XPass on the PR head, then compare every receipt to the current SHA.",
+    firstAction: "Check the change, record the result for each useful Pass, and explain any skipped rows.",
   },
   {
     id: "screen-flow",
@@ -338,10 +338,19 @@ function findDogfoodResult(productId: string): DogfoodPassResult | undefined {
 
 function commentFor(product: ProductDetail, report: ReportRow): string {
   if (product.id === "fidelitypass" && report.id !== "source-copy") {
-    return "Not applicable unless exact 1:1 copying is in scope.";
+    return "N/A because this report is not checking exact copied source material.";
   }
 
   const result = findDogfoodResult(product.id);
+  if (result?.status === "passing" && product.id === "securitypass") {
+    return "Tick. The safe security boundary passed without exposing secrets or running unsafe probes.";
+  }
+  if (result?.status === "passing" && product.id === "compliancepass") {
+    return "Tick. The readiness scan passed and the wording stays careful about certification.";
+  }
+  if (result?.status === "pending") {
+    return "Waiting. This check is available, but this report has not run it yet.";
+  }
   if (result?.summary) return result.summary;
 
   return product.plain;
@@ -499,10 +508,10 @@ function GuidedRunPlanner({
         <div>
           <div className="flex items-center gap-2">
             <PlayCircle className="h-4 w-4 text-[#61C1C4]" />
-            <h2 className="text-sm font-semibold text-white">Guided run planner</h2>
+            <h2 className="text-sm font-semibold text-white">Start a report</h2>
           </div>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
-            Pick what you are building. XPass shows the checks to run, the checks to mark N/A, and the first proof step.
+            Pick the closest job type. XPass shows which checks matter and which ones can be marked N/A.
           </p>
         </div>
         <Link
@@ -547,7 +556,7 @@ function GuidedRunPlanner({
             <ProductNameList ids={activeRun.notApplicableIds} productsById={productsById} />
           </div>
           <p className="mt-4 text-xs leading-5 text-white/45">
-            N/A means the check was considered and honestly does not fit this target.
+            N/A means the check was considered and does not fit this job.
           </p>
         </div>
       </div>
@@ -615,10 +624,10 @@ export default function AdminXPassHub() {
         </div>
         <div className="mt-5 grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(260px,0.7fr)] lg:items-end">
           <div className="min-w-0">
-            <h1 className="text-3xl font-semibold tracking-tight text-white">XPass</h1>
+            <h1 className="text-3xl font-semibold tracking-tight text-white">XPass Report</h1>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-white/60">
-              XPass is AutoPilot's roadworthy check for work. It looks at the whole suite, marks each product as PASS,
-              BLOCKER, N/A, MISSING, or NOT RUN, then leaves plain-English comments.
+              XPass is AutoPilot's roadworthy checklist for work. Pick a report, read the rows, and use the comment
+              to see what passed, what needs attention, and what does not apply.
             </p>
           </div>
           <div className="grid grid-cols-3 gap-3 text-center">
@@ -643,15 +652,15 @@ export default function AdminXPassHub() {
           <div className="flex items-start gap-3">
             <LayoutList className="mt-0.5 h-5 w-5 shrink-0 text-[#61C1C4]" />
             <div>
-              <h2 className="text-sm font-semibold text-white">How XPass thinks</h2>
+              <h2 className="text-sm font-semibold text-white">How to read it</h2>
               <p className="mt-2 text-sm leading-6 text-white/55">
-                First it names the target. Then it chooses the relevant Pass products, records what did not apply,
-                links the evidence, and sends weak or noisy checks back to Continuous Improver.
+                Tick means the check is okay. Cross means it needs attention. N/A means it does not apply. Waiting
+                means the check exists but this report has not run it yet.
               </p>
             </div>
           </div>
           <div className="mt-5 grid gap-3 sm:grid-cols-4">
-            {["Target", "Checks", "Evidence", "Improve"].map((label) => (
+            {["Report", "Result", "Comment", "Next step"].map((label) => (
               <div key={label} className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-xs font-medium text-white/65">
                 {label}
               </div>
@@ -661,7 +670,7 @@ export default function AdminXPassHub() {
             to="/admin/testpass/new"
             className="mt-4 inline-flex min-h-8 items-center gap-1.5 text-sm font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
           >
-            Start a guided run
+            Start a report
             <ExternalLink className="h-3.5 w-3.5" />
           </Link>
         </div>
@@ -691,14 +700,14 @@ export default function AdminXPassHub() {
       <section className="space-y-3">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 className="text-sm font-semibold text-white">Products</h2>
-            <p className="mt-1 text-xs text-white/45">Pick one product or keep the whole suite in view.</p>
+            <h2 className="text-sm font-semibold text-white">Pass checks</h2>
+            <p className="mt-1 text-xs text-white/45">Pick one check or keep the whole list in view.</p>
           </div>
           <Link
             to="/dogfood"
             className="inline-flex min-h-8 items-center gap-1.5 text-xs font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
           >
-            Public XPass receipt
+            Public report
             <ExternalLink className="h-3.5 w-3.5" />
           </Link>
         </div>
@@ -717,7 +726,7 @@ export default function AdminXPassHub() {
               <Sparkles className="h-4 w-4 shrink-0 text-[#61C1C4]" />
               <span className="text-sm font-semibold text-white">All XPass</span>
             </div>
-            <p className="mt-1 text-xs leading-5 text-white/50">Whole-suite checklist</p>
+            <p className="mt-1 text-xs leading-5 text-white/50">Whole checklist</p>
           </button>
           {products.map((product) => (
             <ProductTab

--- a/src/pages/admin/AdminXPassHub.tsx
+++ b/src/pages/admin/AdminXPassHub.tsx
@@ -1,5 +1,4 @@
-import { useMemo, useState, type ComponentType } from "react";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import {
   BadgeCheck,
   CheckCircle2,
@@ -8,792 +7,465 @@ import {
   Clock3,
   ExternalLink,
   FileText,
-  GitPullRequest,
   KeyRound,
-  LayoutList,
+  LayoutGrid,
   MessagesSquare,
-  PlayCircle,
-  RefreshCw,
   SearchCheck,
   ShieldCheck,
   Sparkles,
   UserCheck,
   Workflow,
   XCircle,
+  type LucideIcon,
 } from "lucide-react";
-import {
-  dogfoodReport,
-  type DogfoodPassResult,
-  type DogfoodStatus,
-  type XPassIndexEntry,
-} from "@/data/dogfoodReport";
+import { dogfoodReport, type DogfoodStatus } from "@/data/dogfoodReport";
 
-type XPassStatus = "PASS" | "BLOCKER" | "N/A" | "NOT RUN" | "MISSING";
+type ProductId =
+  | "testpass"
+  | "uxpass"
+  | "securitypass"
+  | "copypass"
+  | "fidelitypass"
+  | "legalpass"
+  | "sloppass"
+  | "commonsensepass"
+  | "seopass"
+  | "geopass"
+  | "flowpass"
+  | "rotatepass"
+  | "wakepass"
+  | "compliancepass";
 
-type ProductDetail = {
-  id: string;
+type RowStatus = "PASS" | "FAIL" | "N/A" | "WARNING" | "WAITING";
+
+type XPassProduct = {
+  id: ProductId;
   name: string;
-  short: string;
-  plain: string;
-  useWhen: string;
-  href?: string;
-  icon: ComponentType<{ className?: string }>;
+  subtitle: string;
+  description: string;
+  icon: LucideIcon;
+  externalHref?: string;
 };
 
-type ReportRow = {
-  id: string;
-  title: string;
+type RecentReport = {
   date: string;
-  status: XPassStatus;
-  note: string;
-  productIds: string[];
+  title: string;
+  status: RowStatus;
 };
 
 type ChecklistRow = {
-  id: string;
-  product: ProductDetail;
-  status: XPassStatus;
-  comment: string;
-};
-
-type RunTemplate = {
-  id: string;
   title: string;
-  target: string;
-  passIds: string[];
-  notApplicableIds: string[];
-  firstAction: string;
+  comment: string;
+  status: RowStatus;
 };
 
-type ImprovementRow = {
-  id: string;
-  productId: string;
-  signal: string;
-  nextAction: string;
-  proof: string;
+type ChecklistGroup = {
+  title: string;
+  rows: ChecklistRow[];
 };
 
-const PRODUCT_ORDER = [
-  "testpass",
-  "uxpass",
-  "securitypass",
-  "copypass",
-  "fidelitypass",
-  "legalpass",
-  "sloppass",
-  "commonsensepass",
-  "seopass",
-  "geopass",
-  "flowpass",
-  "rotatepass",
-  "wakepass",
-  "compliancepass",
-] as const;
-
-const PRODUCT_DETAILS: Record<string, ProductDetail> = {
-  testpass: {
+const PRODUCTS: XPassProduct[] = [
+  {
     id: "testpass",
     name: "TestPass",
-    short: "Does it work?",
-    plain: "Checks the build, tool, or workflow behaves the way it says it does.",
-    useWhen: "Use on PRs, MCP tools, releases, and anything that needs functional proof.",
-    href: "/admin/testpass",
+    subtitle: "Does it work?",
+    description: "Checks builds, tools, jobs, and releases before work is trusted.",
     icon: ClipboardCheck,
+    externalHref: "/admin/testpass",
   },
-  uxpass: {
+  {
     id: "uxpass",
     name: "UXPass",
-    short: "Is it easy to use?",
-    plain: "Checks screens, flows, mobile fit, hierarchy, clarity, and polish.",
-    useWhen: "Use on admin pages, public pages, onboarding, forms, and product changes.",
+    subtitle: "Is it easy to use?",
+    description: "Checks screens, mobile fit, hierarchy, clarity, and polish.",
     icon: UserCheck,
   },
-  securitypass: {
+  {
     id: "securitypass",
     name: "SecurityPass",
-    short: "Is it safe enough?",
-    plain: "Checks safe security evidence without exposing secrets or running unsafe probes.",
-    useWhen: "Use on auth, keys, connectors, APIs, protected routes, and risky changes.",
+    subtitle: "Is it safe enough?",
+    description: "Checks security boundaries without exposing secrets or running unsafe probes.",
     icon: ShieldCheck,
   },
-  copypass: {
+  {
     id: "copypass",
     name: "CopyPass",
-    short: "Is the wording clear?",
-    plain: "Checks copy, claims, tone, trust, and AI-slop risk.",
-    useWhen: "Use on hero copy, emails, product text, pricing, ads, docs, and support wording.",
-    href: "/admin/copypass",
+    subtitle: "Is the wording clear?",
+    description: "Checks copy, claims, tone, trust, and AI-slop risk.",
     icon: FileText,
+    externalHref: "/admin/copypass",
   },
-  fidelitypass: {
+  {
     id: "fidelitypass",
     name: "FidelityPass",
-    short: "Was it copied exactly?",
-    plain: "Wraps CopyRoom proof when wording, labels, prompts, or tables must match 1:1.",
-    useWhen: "Use when the job asks for exact copying, transcription, mirroring, or preservation.",
+    subtitle: "Was it copied exactly?",
+    description: "Checks exact-copy work against CopyRoom proof when 1:1 copying matters.",
     icon: BadgeCheck,
   },
-  legalpass: {
+  {
     id: "legalpass",
     name: "LegalPass",
-    short: "Is the risk language honest?",
-    plain: "Checks policy, terms, disclaimers, and legal-risk wording as guidance, not legal advice.",
-    useWhen: "Use on terms, privacy, claims, disclaimers, and regulated-sounding promises.",
+    subtitle: "Is the risk language honest?",
+    description: "Checks policy, disclaimer, promise, and legal-risk wording as guidance.",
     icon: FileText,
   },
-  sloppass: {
+  {
     id: "sloppass",
     name: "SlopPass",
-    short: "Is the code sloppy?",
-    plain: "Checks AI-code smells, maintainability risk, stale diffs, and public code quality signals.",
-    useWhen: "Use on PR diffs, generated code, rushed patches, and quality-review requests.",
+    subtitle: "Is the work sloppy?",
+    description: "Checks rough code, stale diffs, rushed patches, and maintainability risk.",
     icon: SearchCheck,
   },
-  commonsensepass: {
+  {
     id: "commonsensepass",
     name: "CommonSensePass",
-    short: "Does the claim make sense?",
-    plain: "Stops false green lights, proofless DONE claims, stale receipts, and noisy health claims.",
-    useWhen: "Use before healthy, quiet, done, merge-ready, PASS, or no-work claims.",
+    subtitle: "Does the claim make sense?",
+    description: "Stops proofless done claims, stale green lights, and false quiet states.",
     icon: MessagesSquare,
   },
-  seopass: {
+  {
     id: "seopass",
     name: "SEOPass",
-    short: "Can search read it?",
-    plain: "Checks metadata, crawl basics, public page readiness, and search-result clarity.",
-    useWhen: "Use on public pages, metadata, sitemap, robots, docs, and launch pages.",
+    subtitle: "Can search read it?",
+    description: "Checks public page basics such as metadata, crawl clues, and search clarity.",
     icon: SearchCheck,
   },
-  geopass: {
+  {
     id: "geopass",
     name: "GEOPass",
-    short: "Can answer engines understand it?",
-    plain: "Checks AI-search readability, structured context, and answer-engine handoff quality.",
-    useWhen: "Use on public pages that need to be understood by AI assistants and answer engines.",
+    subtitle: "Can AI answer engines understand it?",
+    description: "Checks if AI assistants can understand and explain the page clearly.",
     icon: Sparkles,
   },
-  flowpass: {
+  {
     id: "flowpass",
     name: "FlowPass",
-    short: "Can the user finish the path?",
-    plain: "Checks journeys, handoffs, forms, onboarding, and completion evidence.",
-    useWhen: "Use on sign-up, checkout, setup, job flow, admin flow, and handoff paths.",
+    subtitle: "Can the user finish the path?",
+    description: "Checks journeys, forms, handoffs, onboarding, and completion paths.",
     icon: Workflow,
   },
-  rotatepass: {
+  {
     id: "rotatepass",
     name: "RotatePass",
-    short: "Are credentials handled cleanly?",
-    plain: "Checks rotation hygiene and redaction boundaries without touching real secrets.",
-    useWhen: "Use on Passport, keys, connector hygiene, and credential lifecycle work.",
+    subtitle: "Are credentials handled cleanly?",
+    description: "Checks key rotation and redaction boundaries without touching real secrets.",
     icon: KeyRound,
   },
-  wakepass: {
+  {
     id: "wakepass",
     name: "WakePass",
-    short: "Will someone act on it?",
-    plain: "Checks stale work, missed ACKs, owner handoff, and action-needed routing.",
-    useWhen: "Use when proof needs an owner, a schedule misses, or a receipt goes stale.",
+    subtitle: "Will someone act on it?",
+    description: "Checks stale work, missed ACKs, owner handoff, and action-needed routing.",
     icon: Clock3,
   },
-  compliancepass: {
+  {
     id: "compliancepass",
     name: "CompliancePass",
-    short: "Is the readiness story sensible?",
-    plain: "Checks compliance posture and enterprise-readiness evidence without claiming certification.",
-    useWhen: "Use on enterprise, audit, readiness, policy, and future-regret reviews.",
+    subtitle: "Is the readiness story sensible?",
+    description: "Checks readiness evidence without pretending to certify compliance.",
     icon: ShieldCheck,
   },
-};
+];
 
-const STATUS_STYLE: Record<XPassStatus, { label: string; classes: string; icon: ComponentType<{ className?: string }> }> = {
+const STATUS_STYLE: Record<RowStatus, { label: string; className: string; icon: LucideIcon }> = {
   PASS: {
-    label: "Tick",
-    classes: "border-[#61C1C4]/35 bg-[#61C1C4]/10 text-[#9edfe1]",
+    label: "PASS",
+    className: "bg-[#46c76f] text-black",
     icon: CheckCircle2,
   },
-  BLOCKER: {
-    label: "Cross",
-    classes: "border-red-500/35 bg-red-500/10 text-red-300",
+  FAIL: {
+    label: "FAIL",
+    className: "bg-red-500 text-white",
     icon: XCircle,
   },
   "N/A": {
     label: "N/A",
-    classes: "border-white/15 bg-white/[0.04] text-white/55",
+    className: "bg-orange-400 text-black",
     icon: CircleMinus,
   },
-  "NOT RUN": {
-    label: "Waiting",
-    classes: "border-[#E2B93B]/35 bg-[#E2B93B]/10 text-[#f1d878]",
+  WARNING: {
+    label: "Warning",
+    className: "bg-[#E2B93B] text-black",
     icon: Clock3,
   },
-  MISSING: {
-    label: "MISSING",
-    classes: "border-orange-400/35 bg-orange-400/10 text-orange-200",
-    icon: XCircle,
+  WAITING: {
+    label: "Waiting",
+    className: "bg-white/12 text-white/70",
+    icon: Clock3,
   },
 };
 
-const REPORTS: ReportRow[] = [
-  {
-    id: "public-dogfood",
-    title: "Latest XPass report",
-    date: "Current public proof",
-    status: statusFromDogfood(dogfoodReport.status),
-    note: "The current checklist. Each row has a result and a plain comment.",
-    productIds: [...PRODUCT_ORDER],
-  },
-  {
-    id: "pr-backed-sweep",
-    title: "Full suite closeout",
-    date: "In progress",
-    status: "NOT RUN",
-    note: "The final family report appears here after every product check is folded into main.",
-    productIds: ["securitypass", "copypass", "legalpass", "seopass", "geopass", "flowpass", "uxpass", "rotatepass", "wakepass", "compliancepass"],
-  },
-  {
-    id: "source-copy",
-    title: "Exact copy check",
-    date: "On demand",
-    status: "N/A",
-    note: "Use this only when wording, tables, prompts, or labels must match exactly.",
-    productIds: ["copypass", "fidelitypass", "commonsensepass"],
-  },
-];
-
-const GUIDED_RUNS: RunTemplate[] = [
-  {
-    id: "code-pr",
-    title: "Code or PR",
-    target: "Pull request, MCP tool, backend change, or release.",
-    passIds: ["testpass", "securitypass", "sloppass", "commonsensepass"],
-    notApplicableIds: ["fidelitypass"],
-    firstAction: "Check the change, record the result for each useful Pass, and explain any skipped rows.",
-  },
-  {
-    id: "screen-flow",
-    title: "Screen or journey",
-    target: "Admin page, public page, form, signup, or onboarding path.",
-    passIds: ["uxpass", "flowpass", "copypass", "seopass", "geopass", "commonsensepass"],
-    notApplicableIds: ["fidelitypass", "rotatepass"],
-    firstAction: "Capture desktop and mobile proof, then leave a plain checklist comment.",
-  },
-  {
-    id: "copy-source",
-    title: "Copy or exact source",
-    target: "Wording, table, label, prompt, supplied text, or source material.",
-    passIds: ["copypass", "fidelitypass", "legalpass", "commonsensepass"],
-    notApplicableIds: ["uxpass", "rotatepass"],
-    firstAction: "Use CopyRoom when exact copying is in scope, then wrap the receipt with FidelityPass.",
-  },
-  {
-    id: "keys-policy",
-    title: "Keys or policy",
-    target: "Credentials, auth, privacy, compliance, public claims, or trust wording.",
-    passIds: ["securitypass", "rotatepass", "legalpass", "compliancepass", "commonsensepass"],
-    notApplicableIds: ["fidelitypass"],
-    firstAction: "Prove redaction boundaries first, then keep compliance and legal language guidance-only.",
-  },
-];
-
-const IMPROVEMENT_QUEUE: ImprovementRow[] = [
-  {
-    id: "ux-visual-depth",
-    productId: "uxpass",
-    signal: "Visual critique needs stronger hierarchy and mobile judgment.",
-    nextAction: "Add annotated reports and recurring visual proof that does not clog the queue.",
-    proof: "UXPass closure item",
-  },
-  {
-    id: "na-reasons",
-    productId: "fidelitypass",
-    signal: "N/A rows must explain why exact copying was not in scope.",
-    nextAction: "Keep the FidelityPass wrapper tied to CopyRoom receipts and explicit N/A reasons.",
-    proof: "FidelityPass receipt wrapper",
-  },
-  {
-    id: "stale-green",
-    productId: "commonsensepass",
-    signal: "Green-looking work can still be stale, proofless, or out of scope.",
-    nextAction: "Keep stale receipt and proofless DONE checks near every XPass run.",
-    proof: "CommonSensePass worker exposure",
-  },
-];
-
-function statusFromDogfood(status: DogfoodStatus): XPassStatus {
+function dogfoodToRowStatus(status?: DogfoodStatus): RowStatus {
   if (status === "passing") return "PASS";
-  if (status === "failing" || status === "blocked") return "BLOCKER";
-  return "NOT RUN";
+  if (status === "failing" || status === "blocked") return "FAIL";
+  return "WAITING";
 }
 
-function formatStage(entry?: XPassIndexEntry): string {
-  if (!entry) return "Package-ready";
-  return entry.label;
+function productById(id?: string): XPassProduct | undefined {
+  return PRODUCTS.find((product) => product.id === id);
 }
 
-function findDogfoodResult(productId: string): DogfoodPassResult | undefined {
-  return dogfoodReport.results.find((result) => result.id === productId);
+function resultFor(id: ProductId) {
+  return dogfoodReport.results.find((result) => result.id === id);
 }
 
-function commentFor(product: ProductDetail, report: ReportRow): string {
-  if (product.id === "fidelitypass" && report.id !== "source-copy") {
-    return "N/A because this report is not checking exact copied source material.";
-  }
+function reportsFor(product: XPassProduct): RecentReport[] {
+  const result = resultFor(product.id);
+  const status = dogfoodToRowStatus(result?.status);
 
-  const result = findDogfoodResult(product.id);
-  if (result?.status === "passing" && product.id === "securitypass") {
-    return "Tick. The safe security boundary passed without exposing secrets or running unsafe probes.";
-  }
-  if (result?.status === "passing" && product.id === "compliancepass") {
-    return "Tick. The readiness scan passed and the wording stays careful about certification.";
-  }
-  if (result?.status === "pending") {
-    return "Waiting. This check is available, but this report has not run it yet.";
-  }
-  if (result?.summary) return result.summary;
-
-  return product.plain;
+  return [
+    {
+      date: "Latest",
+      title: result?.summary ?? `${product.name} report`,
+      status,
+    },
+    {
+      date: "On demand",
+      title: `${product.name} checklist`,
+      status: product.id === "fidelitypass" ? "N/A" : "WAITING",
+    },
+    {
+      date: "Next",
+      title: result?.nextProof ?? "Ready for the next XPass run",
+      status: status === "PASS" ? "PASS" : "WARNING",
+    },
+  ];
 }
 
-function statusFor(productId: string, report: ReportRow): XPassStatus {
-  if (!report.productIds.includes(productId)) return "N/A";
-  if (productId === "fidelitypass" && report.id !== "source-copy") return "N/A";
-  if (report.id === "source-copy") return productId === "fidelitypass" ? "N/A" : "NOT RUN";
+function checklistFor(product: XPassProduct): ChecklistGroup[] {
+  const result = resultFor(product.id);
+  const currentStatus = dogfoodToRowStatus(result?.status);
+  const exactCopy = product.id === "fidelitypass";
 
-  const result = findDogfoodResult(productId);
-  return result ? statusFromDogfood(result.status) : report.status;
+  return [
+    {
+      title: "Roadworthy checks",
+      rows: [
+        {
+          title: "Scope is clear",
+          comment: `This report knows when to use ${product.name}.`,
+          status: "PASS",
+        },
+        {
+          title: "Evidence is available",
+          comment: result?.summary ?? "The product exists, but this public report has not run it yet.",
+          status: currentStatus,
+        },
+        {
+          title: "Result is easy to explain",
+          comment: "The row must have a short plain comment any person can understand.",
+          status: "PASS",
+        },
+        {
+          title: "Skipped work is honest",
+          comment: exactCopy
+            ? "N/A is correct when no exact source copy is in scope."
+            : "If this check does not apply, XPass must say why.",
+          status: exactCopy ? "N/A" : "PASS",
+        },
+        {
+          title: "Needs owner action",
+          comment: currentStatus === "FAIL" ? "Someone needs to fix this before the report is green." : "No blocker in the current report.",
+          status: currentStatus === "FAIL" ? "FAIL" : "PASS",
+        },
+      ],
+    },
+    {
+      title: "Continuous improvement",
+      rows: [
+        {
+          title: "Weak comments get improved",
+          comment: "If a result is vague, XPass should improve the checklist for next time.",
+          status: "PASS",
+        },
+        {
+          title: "Repeated misses create a job",
+          comment: "Real misses should feed the improvement queue instead of being forgotten.",
+          status: "PASS",
+        },
+        {
+          title: "Internal proof stays available",
+          comment: "Technical receipts exist behind the report, but do not clutter the main view.",
+          status: "PASS",
+        },
+      ],
+    },
+  ];
 }
 
-function StatusPill({ status }: { status: XPassStatus }) {
+function StatusBadge({ status }: { status: RowStatus }) {
   const style = STATUS_STYLE[status];
   const Icon = style.icon;
 
   return (
-    <span className={`inline-flex min-w-[86px] items-center justify-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold ${style.classes}`}>
-      <Icon className="h-3.5 w-3.5" />
+    <span className={`inline-flex min-w-[74px] items-center justify-center gap-1 rounded px-2 py-0.5 text-[11px] font-bold ${style.className}`}>
+      <Icon className="h-3 w-3" />
       {style.label}
     </span>
   );
 }
 
-function ReportButton({
-  report,
-  selected,
-  onClick,
-}: {
-  report: ReportRow;
-  selected: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      aria-pressed={selected}
-      onClick={onClick}
-      className={`w-full rounded-lg border px-3 py-3 text-left transition-colors ${
-        selected
-          ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
-          : "border-white/[0.06] bg-[#111] hover:border-white/15 hover:bg-white/[0.03]"
-      }`}
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-white">{report.title}</p>
-          <p className="mt-0.5 text-xs text-white/45">{report.date}</p>
-        </div>
-        <StatusPill status={report.status} />
-      </div>
-      <p className="mt-2 text-xs leading-5 text-white/50">{report.note}</p>
-    </button>
-  );
-}
-
-function ProductTab({
-  product,
-  selected,
-  onClick,
-}: {
-  product: ProductDetail;
-  selected: boolean;
-  onClick: () => void;
-}) {
+function ProductCard({ product }: { product: XPassProduct }) {
   const Icon = product.icon;
 
   return (
-    <button
-      type="button"
-      aria-pressed={selected}
-      onClick={onClick}
-      className={`min-h-[72px] rounded-lg border px-3 py-3 text-left transition-colors ${
-        selected
-          ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
-          : "border-white/[0.06] bg-[#111] hover:border-white/15 hover:bg-white/[0.03]"
-      }`}
+    <Link
+      to={`/admin/checks/${product.id}`}
+      className="min-h-[132px] rounded-lg border border-white/[0.08] bg-[#111] p-4 transition-colors hover:border-[#61C1C4]/45 hover:bg-[#61C1C4]/[0.07]"
     >
-      <div className="flex items-center gap-2">
-        <Icon className="h-4 w-4 shrink-0 text-[#61C1C4]" />
-        <span className="truncate text-sm font-semibold text-white">{product.name}</span>
-      </div>
-      <p className="mt-1 line-clamp-2 text-xs leading-5 text-white/50">{product.short}</p>
-    </button>
-  );
-}
-
-function ChecklistRows({ rows }: { rows: ChecklistRow[] }) {
-  return (
-    <div className="overflow-hidden rounded-lg border border-white/[0.08]">
-      {rows.map((row) => {
-        const Icon = row.product.icon;
-
-        return (
-          <div
-            key={row.id}
-            className="grid min-h-12 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-2 border-b border-white/[0.06] bg-[#0f0f0f] px-3 py-2.5 text-sm last:border-b-0 sm:grid-cols-[minmax(150px,0.75fr)_96px_minmax(0,1.35fr)] sm:items-center"
-          >
-            <div className="flex min-w-0 items-center gap-2">
-              <Icon className="h-4 w-4 shrink-0 text-white/45" />
-              <div className="min-w-0">
-                <p className="truncate font-medium text-white">{row.product.name}</p>
-                <p className="truncate text-xs text-white/40">{row.product.short}</p>
-              </div>
-            </div>
-            <StatusPill status={row.status} />
-            <p className="col-span-2 min-w-0 text-xs leading-5 text-white/55 sm:col-span-1">{row.comment}</p>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function ProductNameList({
-  ids,
-  productsById,
-}: {
-  ids: string[];
-  productsById: Map<string, ProductDetail>;
-}) {
-  return (
-    <div className="flex flex-wrap gap-2">
-      {ids.map((id) => {
-        const product = productsById.get(id);
-        if (!product) return null;
-
-        return (
-          <span
-            key={id}
-            className="inline-flex min-h-7 items-center rounded-full border border-white/[0.08] bg-black/20 px-2.5 text-xs font-medium text-white/65"
-          >
-            {product.name}
-          </span>
-        );
-      })}
-    </div>
-  );
-}
-
-function GuidedRunPlanner({
-  activeRun,
-  productsById,
-  onSelectRun,
-}: {
-  activeRun: RunTemplate;
-  productsById: Map<string, ProductDetail>;
-  onSelectRun: (runId: string) => void;
-}) {
-  return (
-    <section className="rounded-lg border border-white/[0.08] bg-[#111] p-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <div className="flex items-center gap-2">
-            <PlayCircle className="h-4 w-4 text-[#61C1C4]" />
-            <h2 className="text-sm font-semibold text-white">Start a report</h2>
-          </div>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-white/55">
-            Pick the closest job type. XPass shows which checks matter and which ones can be marked N/A.
-          </p>
+      <div className="flex items-center gap-3">
+        <span className="flex h-9 w-9 items-center justify-center rounded-md border border-white/10 bg-black/30">
+          <Icon className="h-4 w-4 text-[#61C1C4]" />
+        </span>
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-semibold text-white">{product.name}</h2>
+          <p className="truncate text-xs text-white/45">{product.subtitle}</p>
         </div>
-        <Link
-          to="/admin/testpass/new"
-          className="inline-flex min-h-8 shrink-0 items-center gap-1.5 text-sm font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
-        >
-          Open guided run
-          <ExternalLink className="h-3.5 w-3.5" />
-        </Link>
       </div>
+      <p className="mt-3 line-clamp-3 text-xs leading-5 text-white/55">{product.description}</p>
+      <div className="mt-3 flex justify-end text-[#61C1C4]">
+        <ExternalLink className="h-3.5 w-3.5" />
+      </div>
+    </Link>
+  );
+}
 
-      <div className="mt-5 grid gap-3 md:grid-cols-4">
-        {GUIDED_RUNS.map((run) => (
-          <button
-            key={run.id}
-            type="button"
-            aria-pressed={run.id === activeRun.id}
-            onClick={() => onSelectRun(run.id)}
-            className={`min-h-[78px] rounded-lg border px-3 py-3 text-left transition-colors ${
-              run.id === activeRun.id
-                ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
-                : "border-white/[0.06] bg-black/20 hover:border-white/15 hover:bg-white/[0.03]"
-            }`}
-          >
-            <p className="text-sm font-semibold text-white">{run.title}</p>
-            <p className="mt-1 line-clamp-2 text-xs leading-5 text-white/50">{run.target}</p>
-          </button>
+function RecentReports({ product }: { product: XPassProduct }) {
+  return (
+    <aside className="rounded-lg border border-white/[0.08] bg-[#111] p-4">
+      <h2 className="text-sm font-semibold text-white">Recent reports</h2>
+      <div className="mt-3 space-y-2">
+        {reportsFor(product).map((report) => (
+          <div key={`${report.date}-${report.title}`} className="rounded-md border border-white/[0.07] bg-black/20 px-3 py-2">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[11px] font-semibold text-white/55">{report.date}</p>
+              <StatusBadge status={report.status} />
+            </div>
+            <p className="mt-1 line-clamp-2 text-xs leading-5 text-white/65">{report.title}</p>
+          </div>
         ))}
       </div>
+      <Link
+        to="/dogfood"
+        className="mt-4 inline-flex min-h-7 items-center gap-1.5 text-xs font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
+      >
+        View public report
+        <ExternalLink className="h-3.5 w-3.5" />
+      </Link>
+    </aside>
+  );
+}
 
-      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(220px,0.6fr)]">
-        <div className="rounded-lg border border-white/[0.06] bg-black/20 p-4">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-white/35">Run these</p>
-          <div className="mt-3">
-            <ProductNameList ids={activeRun.passIds} productsById={productsById} />
+function ChecklistGroupView({ group }: { group: ChecklistGroup }) {
+  return (
+    <section className="rounded-lg border border-white/[0.08] bg-[#111] p-4">
+      <h2 className="text-sm font-semibold text-white">{group.title}</h2>
+      <div className="mt-3 overflow-hidden rounded-md border border-white/[0.08]">
+        {group.rows.map((row) => (
+          <div
+            key={`${group.title}-${row.title}`}
+            className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-white/[0.06] bg-black/20 px-3 py-2 last:border-b-0 md:grid-cols-[220px_minmax(0,1fr)_90px] md:items-center"
+          >
+            <p className="truncate text-xs font-semibold text-white">{row.title}</p>
+            <p className="col-span-2 text-xs leading-5 text-white/55 md:col-span-1">{row.comment}</p>
+            <StatusBadge status={row.status} />
           </div>
-          <p className="mt-4 text-sm leading-6 text-white/55">{activeRun.firstAction}</p>
-        </div>
-        <div className="rounded-lg border border-white/[0.06] bg-black/20 p-4">
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-white/35">Mark N/A now</p>
-          <div className="mt-3">
-            <ProductNameList ids={activeRun.notApplicableIds} productsById={productsById} />
-          </div>
-          <p className="mt-4 text-xs leading-5 text-white/45">
-            N/A means the check was considered and does not fit this job.
-          </p>
-        </div>
+        ))}
       </div>
     </section>
   );
 }
 
-function ImprovementQueue({ productsById }: { productsById: Map<string, ProductDetail> }) {
+function XPassHome() {
   return (
-    <div className="mt-5 overflow-hidden rounded-lg border border-[#E2B93B]/20">
-      {IMPROVEMENT_QUEUE.map((row) => {
-        const product = productsById.get(row.productId);
-
-        return (
-          <div
-            key={row.id}
-            className="grid gap-2 border-b border-[#E2B93B]/15 bg-black/15 px-3 py-2.5 text-sm last:border-b-0 md:grid-cols-[140px_minmax(0,1fr)_minmax(0,1fr)_150px] md:items-center"
-          >
-            <p className="font-medium text-white">{product?.name ?? row.productId}</p>
-            <p className="text-xs leading-5 text-[#e8dca8]">{row.signal}</p>
-            <p className="text-xs leading-5 text-[#e8dca8]/75">{row.nextAction}</p>
-            <p className="text-xs text-white/45">{row.proof}</p>
+    <div className="space-y-8">
+      <section className="rounded-lg border border-white/[0.08] bg-[#111] p-6">
+        <div className="flex items-start gap-4">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-black/30">
+            <LayoutGrid className="h-5 w-5 text-[#61C1C4]" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-[#61C1C4]">AutoPilot / XPass</p>
+            <h1 className="mt-2 text-2xl font-semibold text-white">XPass</h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60">
+              XPass is the roadworthy inspection for UnClick work. Each Pass checks one part of the job, then leaves
+              a simple result and a plain comment.
+            </p>
           </div>
-        );
-      })}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-sm font-semibold text-white">XPass family</h2>
+        <p className="mt-1 text-xs text-white/45">Pick a Pass to see its report, recent runs, and checklist.</p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {PRODUCTS.map((product) => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function XPassProductReport({ product }: { product: XPassProduct }) {
+  const Icon = product.icon;
+
+  return (
+    <div className="space-y-6">
+      <Link to="/admin/checks" className="inline-flex min-h-8 items-center text-sm font-medium text-[#61C1C4] hover:opacity-80">
+        Back to XPass
+      </Link>
+
+      <section className="rounded-lg border border-white/[0.08] bg-[#111] p-6">
+        <div className="flex items-start gap-4">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-black/30">
+            <Icon className="h-5 w-5 text-[#61C1C4]" />
+          </span>
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold text-white">{product.name}</h1>
+            <p className="mt-1 text-sm font-semibold text-white/70">{product.subtitle}</p>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60">{product.description}</p>
+            {product.externalHref ? (
+              <Link
+                to={product.externalHref}
+                className="mt-4 inline-flex min-h-8 items-center gap-1.5 text-sm font-medium text-[#61C1C4] hover:opacity-80"
+              >
+                Open full tool
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="space-y-5">
+          {checklistFor(product).map((group) => (
+            <ChecklistGroupView key={group.title} group={group} />
+          ))}
+        </div>
+        <RecentReports product={product} />
+      </div>
     </div>
   );
 }
 
 export default function AdminXPassHub() {
-  const [activeProductId, setActiveProductId] = useState<string>("all");
-  const [activeReportId, setActiveReportId] = useState<string>(REPORTS[0].id);
-  const [activeRunId, setActiveRunId] = useState<string>(GUIDED_RUNS[0].id);
+  const { productId } = useParams();
+  const product = productById(productId);
 
-  const products = useMemo(
-    () => PRODUCT_ORDER.map((id) => PRODUCT_DETAILS[id]).filter(Boolean),
-    [],
-  );
-  const productsById = useMemo(
-    () => new Map(products.map((product) => [product.id, product])),
-    [products],
-  );
-  const activeReport = REPORTS.find((report) => report.id === activeReportId) ?? REPORTS[0];
-  const activeRun = GUIDED_RUNS.find((run) => run.id === activeRunId) ?? GUIDED_RUNS[0];
-  const xpassIndexById = new Map(dogfoodReport.xpassIndex.map((entry) => [entry.id, entry]));
-  const filteredProducts = activeProductId === "all"
-    ? products
-    : products.filter((product) => product.id === activeProductId);
-  const checklistRows = filteredProducts.map((product) => ({
-    id: `${activeReport.id}-${product.id}`,
-    product,
-    status: statusFor(product.id, activeReport),
-    comment: commentFor(product, activeReport),
-  }));
-  const liveCount = dogfoodReport.xpassIndex.filter((entry) =>
-    entry.stage === "live_gate" || entry.stage === "live_dogfood",
-  ).length;
+  if (productId && !product) {
+    return (
+      <div className="rounded-lg border border-white/[0.08] bg-[#111] p-6">
+        <h1 className="text-xl font-semibold text-white">Pass not found</h1>
+        <p className="mt-2 text-sm text-white/55">That XPass product is not in the family list.</p>
+        <Link to="/admin/checks" className="mt-4 inline-flex min-h-8 items-center text-sm font-medium text-[#61C1C4]">
+          Back to XPass
+        </Link>
+      </div>
+    );
+  }
 
-  return (
-    <div className="space-y-8">
-      <section className="min-w-0">
-        <div className="inline-flex items-center gap-2 rounded-full border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-3 py-1 text-xs font-medium text-[#61C1C4]">
-          <ClipboardCheck className="h-3.5 w-3.5" />
-          AutoPilot / XPass
-        </div>
-        <div className="mt-5 grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(260px,0.7fr)] lg:items-end">
-          <div className="min-w-0">
-            <h1 className="text-3xl font-semibold tracking-tight text-white">XPass Report</h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/60">
-              XPass is AutoPilot's roadworthy checklist for work. Pick a report, read the rows, and use the comment
-              to see what passed, what needs attention, and what does not apply.
-            </p>
-          </div>
-          <div className="grid grid-cols-3 gap-3 text-center">
-            <div>
-              <p className="text-2xl font-semibold text-white">{products.length}</p>
-              <p className="mt-1 text-[11px] text-white/45">Products</p>
-            </div>
-            <div>
-              <p className="text-2xl font-semibold text-white">{liveCount}</p>
-              <p className="mt-1 text-[11px] text-white/45">Live lanes</p>
-            </div>
-            <div>
-              <p className="text-2xl font-semibold text-white">{REPORTS.length}</p>
-              <p className="mt-1 text-[11px] text-white/45">Reports</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(300px,0.8fr)]">
-        <div className="self-start rounded-lg border border-white/[0.08] bg-[#111] p-5">
-          <div className="flex items-start gap-3">
-            <LayoutList className="mt-0.5 h-5 w-5 shrink-0 text-[#61C1C4]" />
-            <div>
-              <h2 className="text-sm font-semibold text-white">How to read it</h2>
-              <p className="mt-2 text-sm leading-6 text-white/55">
-                Tick means the check is okay. Cross means it needs attention. N/A means it does not apply. Waiting
-                means the check exists but this report has not run it yet.
-              </p>
-            </div>
-          </div>
-          <div className="mt-5 grid gap-3 sm:grid-cols-4">
-            {["Report", "Result", "Comment", "Next step"].map((label) => (
-              <div key={label} className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-xs font-medium text-white/65">
-                {label}
-              </div>
-            ))}
-          </div>
-          <Link
-            to="/admin/testpass/new"
-            className="mt-4 inline-flex min-h-8 items-center gap-1.5 text-sm font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
-          >
-            Start a report
-            <ExternalLink className="h-3.5 w-3.5" />
-          </Link>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <GitPullRequest className="h-4 w-4 text-[#E2B93B]" />
-            <h2 className="text-sm font-semibold text-white">Reports</h2>
-          </div>
-          {REPORTS.map((report) => (
-            <ReportButton
-              key={report.id}
-              report={report}
-              selected={report.id === activeReport.id}
-              onClick={() => setActiveReportId(report.id)}
-            />
-          ))}
-        </div>
-      </section>
-
-      <GuidedRunPlanner
-        activeRun={activeRun}
-        productsById={productsById}
-        onSelectRun={setActiveRunId}
-      />
-
-      <section className="space-y-3">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 className="text-sm font-semibold text-white">Pass checks</h2>
-            <p className="mt-1 text-xs text-white/45">Pick one check or keep the whole list in view.</p>
-          </div>
-          <Link
-            to="/dogfood"
-            className="inline-flex min-h-8 items-center gap-1.5 text-xs font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
-          >
-            Public report
-            <ExternalLink className="h-3.5 w-3.5" />
-          </Link>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <button
-            type="button"
-            aria-pressed={activeProductId === "all"}
-            onClick={() => setActiveProductId("all")}
-            className={`min-h-[72px] rounded-lg border px-3 py-3 text-left transition-colors ${
-              activeProductId === "all"
-                ? "border-[#61C1C4]/40 bg-[#61C1C4]/10"
-                : "border-white/[0.06] bg-[#111] hover:border-white/15 hover:bg-white/[0.03]"
-            }`}
-          >
-            <div className="flex items-center gap-2">
-              <Sparkles className="h-4 w-4 shrink-0 text-[#61C1C4]" />
-              <span className="text-sm font-semibold text-white">All XPass</span>
-            </div>
-            <p className="mt-1 text-xs leading-5 text-white/50">Whole checklist</p>
-          </button>
-          {products.map((product) => (
-            <ProductTab
-              key={product.id}
-              product={product}
-              selected={activeProductId === product.id}
-              onClick={() => setActiveProductId(product.id)}
-            />
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-3">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 className="text-sm font-semibold text-white">Checklist</h2>
-            <p className="mt-1 text-xs text-white/45">{activeReport.title}</p>
-          </div>
-          {activeProductId !== "all" ? (
-            <div className="text-xs text-white/45">
-              {formatStage(xpassIndexById.get(activeProductId))}
-            </div>
-          ) : null}
-        </div>
-        <ChecklistRows rows={checklistRows} />
-      </section>
-
-      {activeProductId !== "all" ? (
-        <section className="rounded-lg border border-white/[0.08] bg-[#111] p-5">
-          {filteredProducts.map((product) => (
-            <div key={product.id} className="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-              <div>
-                <p className="text-xs font-medium uppercase tracking-[0.18em] text-white/35">{product.name}</p>
-                <h2 className="mt-2 text-lg font-semibold text-white">{product.short}</h2>
-                <p className="mt-2 text-sm leading-6 text-white/55">{product.plain}</p>
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-white">Use when</p>
-                <p className="mt-2 text-sm leading-6 text-white/55">{product.useWhen}</p>
-                {product.href ? (
-                  <Link
-                    to={product.href}
-                    className="mt-4 inline-flex min-h-8 items-center gap-1.5 text-sm font-medium text-[#61C1C4] transition-opacity hover:opacity-80"
-                  >
-                    Open {product.name}
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </Link>
-                ) : null}
-              </div>
-            </div>
-          ))}
-        </section>
-      ) : null}
-
-      <section className="rounded-lg border border-[#E2B93B]/25 bg-[#E2B93B]/[0.06] p-5">
-        <div className="flex items-start gap-3">
-          <RefreshCw className="mt-0.5 h-5 w-5 shrink-0 text-[#E2B93B]" />
-          <div>
-            <h2 className="text-sm font-semibold text-white">Continuous improvement</h2>
-            <p className="mt-2 text-sm leading-6 text-[#e8dca8]">
-              If a Pass misses a real issue, blocks too loudly, or cannot explain its result, XPass should create an
-              improvement signal. The checklist improves because real work teaches it what to check next.
-            </p>
-          </div>
-        </div>
-        <ImprovementQueue productsById={productsById} />
-      </section>
-    </div>
-  );
+  return product ? <XPassProductReport product={product} /> : <XPassHome />;
 }


### PR DESCRIPTION
## What changed

- Reconciles the XPass product-family PR work into one final branch so the suite can be judged together instead of scattered across stale PRs.
- Reshapes Admin XPass into the simple roadworthy-inspection model: master product grid, per-Pass report pages, recent reports, and thin grouped checklist rows.
- Updates XPass closure docs and BrainMap so workers know the public UnClick Suite rule and the simple Admin presentation rule.
- Keeps generated/internal proof details behind the report surface instead of making the UI feel like a PR dashboard.

## Proof

- npm exec tsc -- --noEmit
- npm exec vitest run src/pages/admin/AdminXPassHub.test.tsx src/pages/admin/AdminShell.test.tsx
- node --test scripts/build-xpass-boundary-sweep.test.mjs
- npm run brainmap:check
- npm run test:brainmap
- npm test --workspace=packages/mcp-server
- npm run build
- npm run lint: 0 errors, existing warnings only
- npm test: 129 files, 952 tests, plus API import guard
- XPass package sweep: passing, full scope, 10/10 packages, 0 actions
- XPass boundary sweep: passing, RotatePass and WakePass, 0 actions
- Final xpass_aggregated_verdict: PASS, 14 selected checks, no missing/blocker/stale/unscoped checks, receipt xpass_18a9d2e5d86f7cb4 on 57a9feef29c67cdf7c27cbc12fb0605a4c9f741d

## Notes

- Local scheduled dogfood report could not run TestPass/UXPass API calls because this local shell has no DOGFOOD_TESTPASS_TOKEN, TESTPASS_TOKEN, DOGFOOD_UXPASS_TOKEN, UXPASS_TOKEN, or CRON_SECRET. The actual local package and boundary sweeps passed, and cloud checks will be the live proof source.
- Ignore Cursor Bugbot if it appears; that check is discontinued for this repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-cutting changes to how operators and workers judge trust (QC receipts, SecurityPass exposure, aggregated verdict rules); mostly additive but mistakes could mis-route merge or security confidence.
> 
> **Overview**
> This PR **reconciles the XPass product family** into one branch: updated closure docs and BrainMap/tool indexes, plus CI that also builds `@unclick/securitypass`.
> 
> **Admin** routes `/admin/checks` through a new **roadworthy-inspection** hub—a product card grid, per-Pass report pages at `/admin/checks/:productId`, thin checklist rows, and recent reports—with engineering proof kept behind the surface.
> 
> **MCP and packages** add structured `*_receipt_v1` envelopes across CopyPass, CompliancePass, FlowPass, LegalPass, and others; **GEOPass** gains a live-readonly public URL runner; **SecurityPass** is wired into the gateway with scope-gated, redacted receipts; **FidelityPass** can return explicit **N/A** when exact copy is out of scope; **SlopPass** can target GitHub PR diffs; and **`xpass_aggregated_verdict`** binds a green suite verdict to a single target SHA from scoped Pass results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a9feef29c67cdf7c27cbc12fb0605a4c9f741d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->