### PR TITLE
fix(xpass): show real product QC checklists

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8154,8 +8154,8 @@
     },
     {
       "source": "src/pages/XPass.tsx",
-      "hash": "96f38c4d74a7",
-      "bytes": 8617
+      "hash": "1d38db07a967",
+      "bytes": 8682
     },
     {
       "source": "scripts/pinballwake-ack-ledger-room.mjs",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8154,8 +8154,8 @@
     },
     {
       "source": "src/pages/XPass.tsx",
-      "hash": "1d38db07a967",
-      "bytes": 8682
+      "hash": "e6ad3bd5a7a3",
+      "bytes": 8705
     },
     {
       "source": "scripts/pinballwake-ack-ledger-room.mjs",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -119,7 +119,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/tools/Scheduling.tsx | 3e54b020fe15 | 9647 |
 | src/pages/tools/Solve.tsx | 97da18319f81 | 13431 |
 | src/pages/Tools.tsx | 1b9bc9d666a7 | 15377 |
-| src/pages/XPass.tsx | 96f38c4d74a7 | 8617 |
+| src/pages/XPass.tsx | 1d38db07a967 | 8682 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
 | scripts/pinballwake-buildbait-room.mjs | 42445fca7b1e | 4811 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -119,7 +119,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/tools/Scheduling.tsx | 3e54b020fe15 | 9647 |
 | src/pages/tools/Solve.tsx | 97da18319f81 | 13431 |
 | src/pages/Tools.tsx | 1b9bc9d666a7 | 15377 |
-| src/pages/XPass.tsx | 1d38db07a967 | 8682 |
+| src/pages/XPass.tsx | e6ad3bd5a7a3 | 8705 |
 | scripts/pinballwake-ack-ledger-room.mjs | e7dcb642bc75 | 12719 |
 | scripts/pinballwake-buildbait-room.mjs | 42445fca7b1e | 4811 |
 | scripts/pinballwake-close-supersede-room.mjs | 4d31f6a6a8c2 | 3891 |

--- a/docs/pass-family-index.md
+++ b/docs/pass-family-index.md
@@ -1,7 +1,7 @@
 # XPass product index
 
 **Status**: Canonical lookup for every XPass product. Aligns with the locked naming contract in [`docs/prd/xpass.md`](./prd/xpass.md). File path is retained for link stability.
-**Last updated**: 2026-05-30.
+**Last updated**: 2026-05-31.
 **Owner**: Product and XPass maintainers.
 
 ## How to read this
@@ -10,7 +10,7 @@ Each row names a Pass, its current promotion tier, the brief that owns the scope
 
 If a row here disagrees with the locked PRD, the PRD wins. If a row here disagrees with an individual brief, the brief wins for scope details and this file wins for tier and routing.
 
-Status note: the 2026-05-30 XPass completion run produced cloud-green PRs for the receipt surfaces listed in [`docs/prd/xpass-closure-board.md`](./prd/xpass-closure-board.md). Until those PRs are merged, treat those rows as PR-ready and cloud-dogfooded rather than already landed on `main`.
+Status note: PR #1219 merged the 2026-05-30 XPass receipt surfaces into `main`. The current correction is presentation and checklist depth: each Pass should expose a large product-specific QC checklist, not only a small receipt summary.
 
 ## Live gates or public dogfood
 

--- a/docs/pass-family-index.md
+++ b/docs/pass-family-index.md
@@ -10,7 +10,7 @@ Each row names a Pass, its current promotion tier, the brief that owns the scope
 
 If a row here disagrees with the locked PRD, the PRD wins. If a row here disagrees with an individual brief, the brief wins for scope details and this file wins for tier and routing.
 
-Status note: PR #1219 merged the 2026-05-30 XPass receipt surfaces into `main`. The current correction is presentation and checklist depth: each Pass should expose a large product-specific QC checklist, not only a small receipt summary.
+Status note: PR #1219 merged the 2026-05-30 XPass receipt surfaces into `main`. The current correction is presentation and checklist depth: each Pass should expose a large product-specific QC checklist, with hundreds of rows across the XPass family, not only a small receipt summary.
 
 ## Live gates or public dogfood
 

--- a/docs/prd/xpass-closure-board.md
+++ b/docs/prd/xpass-closure-board.md
@@ -1,12 +1,12 @@
 # XPass Closure Board
 
 **Status:** working inventory and completion board  
-**Last truth refresh:** 2026-05-30 Australia/Sydney. Open PRs listed below are PR-ready and cloud-green, not claimed as merged until GitHub shows them merged.
+**Last truth refresh:** 2026-05-31 Australia/Sydney. PR #1219 merged the family reconciliation to `main`; this follow-up corrects the Admin UI from a tiny receipt wrapper into the intended large QC checklist view.
 **Purpose:** keep the XPass product family honest until every check is either complete, deliberately parked, or clearly not applicable for a run.
 
 ## Operating Model
 
-XPass should be a full checklist.
+XPass should be a full QC checklist system.
 
 That means every XPass run considers the whole family and records each row as one of:
 
@@ -17,27 +17,27 @@ That means every XPass run considers the whole family and records each row as on
 | ✗ | not built enough to count |
 | N/A | not applicable to this target or request |
 
-This does not mean every expensive runner executes every time. The lightweight checklist always runs. Deep runners only run when the row applies.
+This does not mean every expensive runner executes every time. The lightweight checklist always considers the whole product family and every product-specific row. Deep runners only run when the row applies.
 
 ## Current Completion Board
 
 | XPass product | Keep? | Complete? | Current truth | To close the loop |
 | --- | --- | --- | --- | --- |
 | TestPass | Yes | ✓ | Strongest XPass product today. Package exists, tests exist, live MCP proof and dogfood receipt exist. TestPass PR smoke is the standing cloud gate for the suite. | Keep as default trust gate and make sure receipts stay scoped to the target. |
-| UXPass | Yes | ✓ | Annotated visual evidence receipt is PR-ready and cloud-green in PR #1212. Fetch-only runs warn when screenshot/mobile/desktop proof is missing. | Keep improving visual critique quality beyond accessibility and fixture checks. |
-| SecurityPass | Yes | ✓ | Safe receipt surface is PR-ready and cloud-green in PR #1204. It exposes redacted SecurityPass run/status proof without leaking secrets. | Keep deny-by-default scope gates, and only add active probes with explicit future authorisation. |
-| CopyPass | Yes | ✓ | Live receipt envelope is PR-ready and cloud-green in PR #1203. It separates copy-quality proof from exact 1:1 fidelity. | Keep CopyPass for wording, claims, tone, clarity, and product-copy risk. |
-| FidelityPass | Yes | ✓ | CopyRoom wrapper with explicit `N/A` behavior is PR-ready and cloud-green in PR #1200. It does not duplicate CopyRoom. | Use FidelityPass only when exact 1:1 copying, transcription, mirroring, or preservation is in scope. |
+| UXPass | Yes | ✓ | Annotated visual evidence receipt landed through PR #1219. Fetch-only runs warn when screenshot/mobile/desktop proof is missing. | Keep improving visual critique quality beyond accessibility and fixture checks. |
+| SecurityPass | Yes | ✓ | Safe receipt surface landed through PR #1219. It exposes redacted SecurityPass run/status proof without leaking secrets. | Keep deny-by-default scope gates, and only add active probes with explicit future authorisation. |
+| CopyPass | Yes | ✓ | Live receipt envelope landed through PR #1219. It separates copy-quality proof from exact 1:1 fidelity. | Keep CopyPass for wording, claims, tone, clarity, and product-copy risk. |
+| FidelityPass | Yes | ✓ | CopyRoom wrapper with explicit `N/A` behavior landed through PR #1219. It does not duplicate CopyRoom. | Use FidelityPass only when exact 1:1 copying, transcription, mirroring, or preservation is in scope. |
 | CopyRoom | Adjacent | ✓ | Official exact-copy room remains the source of truth for 1:1 copy receipts. FidelityPass wraps it rather than replacing it. | Require a CopyRoom receipt whenever exact copying is requested. |
-| LegalPass | Yes | ✓ | Scoped receipt surface is PR-ready and cloud-green in PR #1207 with clear guidance-only and "not legal advice" boundaries. | Keep policy checks scoped and avoid certification or legal-advice claims. |
-| SlopPass | Yes | ✓ | Live PR diff support is PR-ready and cloud-green in PR #1201. SlopPass is the public code-quality name; QualityPass stays retired. | Keep PR diff receipts target-SHA scoped and avoid forked quality-brand names. |
+| LegalPass | Yes | ✓ | Scoped receipt surface landed through PR #1219 with clear guidance-only and "not legal advice" boundaries. | Keep policy checks scoped and avoid certification or legal-advice claims. |
+| SlopPass | Yes | ✓ | Live PR diff support landed through PR #1219. SlopPass is the public code-quality name; QualityPass stays retired. | Keep PR diff receipts target-SHA scoped and avoid forked quality-brand names. |
 | CommonSensePass | Yes | ✓ | Worker-available tools, protocol playbook, fixture pack, and dogfood receipt were verified as no-code-needed and Boardroom-closed on 2026-05-30. | Enforce it before healthy, quiet, PASS, no-work, done, merge-ready, or duplicate-wake claims. |
-| SEOPass | Yes | ✓ | Live metadata/search-readiness receipt is PR-ready and cloud-green in PR #1209. | Keep public-page, sitemap, robots, canonical, and search-readiness receipts current. |
-| GEOPass | Yes | ✓ | Live AI-answer/readability receipt is PR-ready and cloud-green in PR #1206. | Feed shared answer-engine evidence back to SEOPass where useful. |
-| FlowPass | Yes | ✓ | Live journey receipt envelope is PR-ready and cloud-green in PR #1210. | Keep journey evidence scoped to route, task, console, screenshot, and completion proof. |
-| RotatePass | Yes | ✓ | Boundary receipt is PR-ready and cloud-green in PR #1213. It records credential ownership, staleness, blast-radius, and no-live-secret boundaries. | Keep proof public-safe: no raw credential values, no live secret probes, no destructive provider action. |
-| WakePass | Yes | ✓ | Boundary receipt is PR-ready and cloud-green in PR #1214. It records ACK, stale reclaim, liveness, and no-live-wake boundaries. | Keep proof public-safe: no live queue touch, no live workers, no notifications, no route adapter calls. |
-| CompliancePass | Yes | ✓ | Readiness receipt envelope is PR-ready and cloud-green in PR #1211 with "not certification" language. | Keep automated evidence checks readiness-only and cross-reference other Pass receipts. |
+| SEOPass | Yes | ✓ | Live metadata/search-readiness receipt landed through PR #1219. | Keep public-page, sitemap, robots, canonical, and search-readiness receipts current. |
+| GEOPass | Yes | ✓ | Live AI-answer/readability receipt landed through PR #1219. | Feed shared answer-engine evidence back to SEOPass where useful. |
+| FlowPass | Yes | ✓ | Live journey receipt envelope landed through PR #1219. | Keep journey evidence scoped to route, task, console, screenshot, and completion proof. |
+| RotatePass | Yes | ✓ | Boundary receipt landed through PR #1219. It records credential ownership, staleness, blast-radius, and no-live-secret boundaries. | Keep proof public-safe: no raw credential values, no live secret probes, no destructive provider action. |
+| WakePass | Yes | ✓ | Boundary receipt landed through PR #1219. It records ACK, stale reclaim, liveness, and no-live-wake boundaries. | Keep proof public-safe: no live queue touch, no live workers, no notifications, no route adapter calls. |
+| CompliancePass | Yes | ✓ | Readiness receipt envelope landed through PR #1219 with "not certification" language. | Keep automated evidence checks readiness-only and cross-reference other Pass receipts. |
 
 ## 2026-05-30 Proof Snapshot
 
@@ -62,13 +62,14 @@ These rows were closed or verified during the 2026-05-30 XPass completion run:
 
 ## Admin Presentation Rule
 
-The Admin XPass page should feel like a roadworthy inspection, not an engineering dashboard.
+The Admin XPass page should feel like a large QC checklist, not an engineering dashboard and not a tiny receipt wrapper.
 
-1. The XPass home shows a plain product card grid.
-2. Each product card opens a simple report page for that Pass.
-3. Each report page shows a short title, plain description, recent reports, and grouped thin checklist rows.
-4. Each checklist row uses simple marks: `PASS`, `FAIL`, `N/A`, `WARNING`, or `WAITING`, with a short comment.
-5. PR numbers, hashes, and internal proof details stay behind the report, unless an operator deliberately opens evidence.
+1. The XPass home shows a plain product card grid with the number of checklist rows per Pass.
+2. Each product card opens that Pass's full QC checklist, not a five-row meta summary.
+3. Each Pass owns product-specific groups. Example: CopyPass checks wording, claims, tone, source-copy, and AI-slop risk. SecurityPass checks secrets, auth, tenant scope, safe errors, and destructive-action gates.
+4. Each checklist row uses simple marks: `PASS`, `FAIL`, `N/A`, `WARNING`, `ALERT`, or `WAITING`, with a short comment.
+5. A report is green only when every relevant row is `PASS` or `N/A`.
+6. PR numbers, hashes, and internal proof details stay behind the report, unless an operator deliberately opens evidence.
 
 ## Retired Or Historical Names
 
@@ -84,8 +85,8 @@ The Admin XPass page should feel like a roadworthy inspection, not an engineerin
 Every XPass receipt should show:
 
 1. target inspected
-2. full checklist row list
-3. row status: `PASS`, `BLOCKER`, `MISSING`, `N/A`, or `NOT RUN`
+2. full product-specific checklist row list
+3. row status: `PASS`, `FAIL`, `ALERT`, `WARNING`, `N/A`, or `WAITING`
 4. evidence link or reason
 5. owner action if blocked or missing
 6. staleness or target SHA when relevant
@@ -110,8 +111,8 @@ This keeps the XPass range agile. The checklist does not just judge the product.
 
 ## Next Closure Order
 
-1. Merge or rebase the cloud-green PRs in an order that avoids one-file conflicts, especially the boundary-sweep updates.
-2. Run `xpass_aggregated_verdict` again after the PRs land so the final suite proof is bound to the current main SHA.
+1. Ship the large per-Pass checklist catalog and Admin UI so operators see the real QC lists.
+2. Wire future live XPass runs to populate each checklist row with real `PASS`, `FAIL`, `ALERT`, `WARNING`, or `N/A` results.
 3. Keep UXPass improving toward real visual critique, not only accessibility or fixture checks.
-4. Keep scheduled package and boundary sweeps target-SHA scoped; stale receipts must stay `PENDING`, not green.
+4. Keep scheduled package and boundary sweeps target-SHA scoped; stale receipts must stay `WAITING`, not green.
 5. When a Pass emits weak, noisy, or missing evidence, create a focused Continuous Improver job instead of marking the suite healthy by vibes.

--- a/docs/prd/xpass-closure-board.md
+++ b/docs/prd/xpass-closure-board.md
@@ -6,16 +6,18 @@
 
 ## Operating Model
 
-XPass should be a full QC checklist system.
+XPass should be a full QC checklist system with hundreds of checks across the family, not a small generic receipt wrapper.
 
 That means every XPass run considers the whole family and records each row as one of:
 
 | Mark | Meaning |
 | --- | --- |
-| ✓ | complete enough to run as evidence today |
-| ~ | real but not 100 percent complete |
-| ✗ | not built enough to count |
+| PASS | complete enough to run as evidence today |
+| WARNING | real risk or weak evidence that needs attention |
+| ALERT | stop-sign risk that should pause release until cleared |
+| FAIL | not built enough to count |
 | N/A | not applicable to this target or request |
+| WAITING | not run or not proven yet |
 
 This does not mean every expensive runner executes every time. The lightweight checklist always considers the whole product family and every product-specific row. Deep runners only run when the row applies.
 
@@ -64,7 +66,7 @@ These rows were closed or verified during the 2026-05-30 XPass completion run:
 
 The Admin XPass page should feel like a large QC checklist, not an engineering dashboard and not a tiny receipt wrapper.
 
-1. The XPass home shows a plain product card grid with the number of checklist rows per Pass.
+1. The XPass home shows a plain product card grid with the number of checklist rows per Pass and the family-wide checklist total.
 2. Each product card opens that Pass's full QC checklist, not a five-row meta summary.
 3. Each Pass owns product-specific groups. Example: CopyPass checks wording, claims, tone, source-copy, and AI-slop risk. SecurityPass checks secrets, auth, tenant scope, safe errors, and destructive-action gates.
 4. Each checklist row uses simple marks: `PASS`, `FAIL`, `N/A`, `WARNING`, `ALERT`, or `WAITING`, with a short comment.

--- a/docs/prd/xpass.md
+++ b/docs/prd/xpass.md
@@ -184,7 +184,7 @@ XPass should recommend full Crews only for judgement-heavy targets. It should no
 
 For material targets, XPass may also attach `lite_check` anti-rubber-stamp questions. Council Lite is a prompt/checklist, not a full Crews run. It keeps dissent visible without bloating every proof run.
 
-An XPass receipt should behave like a complete checklist: every known XPass product should appear as `PASS`, `BLOCKER`, `MISSING`, `N/A`, or `NOT RUN`. `N/A` is the correct result when a check was considered and does not apply to the target.
+An XPass receipt should behave like a complete QC checklist: every known XPass product should appear, and every product should expose its own large row list. Rows use `PASS`, `FAIL`, `ALERT`, `WARNING`, `N/A`, or `WAITING`. `N/A` is the correct result when a check was considered and does not apply to the target. The run is green only when every relevant row is `PASS` or `N/A`.
 
 ### Receipt schema sketch
 
@@ -213,8 +213,13 @@ interface XPassReceipt {
   }>;
   full_checklist: Array<{
     pass: XPassProductId;
-    status: 'PASS' | 'BLOCKER' | 'MISSING' | 'NOT RUN' | 'N/A';
-    reason: string;
+    group: string;
+    row_id: string;
+    title: string;
+    status: 'PASS' | 'FAIL' | 'ALERT' | 'WARNING' | 'WAITING' | 'N/A';
+    comment: string;
+    evidence_ref?: string;
+    owner_action?: string;
   }>;
   verdict: 'pass' | 'warn' | 'fail' | 'pending';
   action_needed?: Array<{

--- a/docs/prd/xpass.md
+++ b/docs/prd/xpass.md
@@ -184,7 +184,7 @@ XPass should recommend full Crews only for judgement-heavy targets. It should no
 
 For material targets, XPass may also attach `lite_check` anti-rubber-stamp questions. Council Lite is a prompt/checklist, not a full Crews run. It keeps dissent visible without bloating every proof run.
 
-An XPass receipt should behave like a complete QC checklist: every known XPass product should appear, and every product should expose its own large row list. Rows use `PASS`, `FAIL`, `ALERT`, `WARNING`, `N/A`, or `WAITING`. `N/A` is the correct result when a check was considered and does not apply to the target. The run is green only when every relevant row is `PASS` or `N/A`.
+An XPass receipt should behave like a complete QC checklist: every known XPass product should appear, and every product should expose its own large row list. The family should add up to hundreds of rows before project-specific rows are generated for a run. Rows use `PASS`, `FAIL`, `ALERT`, `WARNING`, `N/A`, or `WAITING`. `N/A` is the correct result when a check was considered and does not apply to the target. The run is green only when every relevant row is `PASS` or `N/A`.
 
 ### Receipt schema sketch
 

--- a/src/pages/XPass.test.tsx
+++ b/src/pages/XPass.test.tsx
@@ -26,7 +26,7 @@ describe("XPassPage", () => {
     renderXPassPage();
 
     expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
-    expect(screen.getByText(/AutoPilot's roadworthy checklist/i)).toBeInTheDocument();
+    expect(screen.getByText(/AutoPilot's quality-control checklist/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /View public receipt/i })).toHaveAttribute("href", "/dogfood");
     expect(screen.getByRole("link", { name: /Open XPass in Admin/i })).toHaveAttribute("href", "/admin/checks");
     expect(screen.getByRole("heading", { name: "XPass family" })).toBeInTheDocument();

--- a/src/pages/XPass.tsx
+++ b/src/pages/XPass.tsx
@@ -82,10 +82,10 @@ function StatusTag({ status }: { status: string }) {
 export default function XPassPage() {
   useCanonical("/xpass");
   useMetaTags({
-    title: "UnClick XPass - AutoPilot's Roadworthy Checklist",
-    description: "XPass is the simple UnClick checklist that proves AI work before it ships.",
+    title: "UnClick XPass - AutoPilot's QC Checklist",
+    description: "XPass is the UnClick quality-control checklist system that proves AI work before it ships.",
     ogTitle: "UnClick XPass",
-    ogDescription: "AutoPilot uses XPass like a roadworthy checklist for AI work.",
+    ogDescription: "AutoPilot uses XPass as a large QC checklist for AI work.",
     ogUrl: "https://unclick.world/xpass",
   });
 
@@ -110,8 +110,8 @@ export default function XPassPage() {
                 XPass
               </h1>
               <p className="mt-5 max-w-3xl text-lg leading-8 text-body sm:text-xl">
-                XPass is AutoPilot's roadworthy checklist for AI work. It checks the work, records what passed,
-                explains what did not apply, and keeps the proof easy to read.
+                XPass is AutoPilot's quality-control checklist for AI work. Each Pass owns a large list of checks,
+                records PASS, FAIL, Warning, Alert, or N/A with comments, and keeps looping until the relevant rows are green.
               </p>
             </FadeIn>
 
@@ -160,7 +160,7 @@ export default function XPassPage() {
               </div>
               <p className="mt-3 text-sm leading-7 text-body">
                 XPass does not ask people to remember every product name. Tell AutoPilot what the work is, and XPass
-                decides which checks belong in the receipt.
+                decides which checklist rows belong in the report.
               </p>
             </div>
 
@@ -185,7 +185,7 @@ export default function XPassPage() {
                   <h2 className="text-sm font-semibold text-heading">XPass family</h2>
                 </div>
                 <p className="mt-3 max-w-2xl text-sm leading-7 text-body">
-                  Each product owns one kind of check. XPass ties them together into one readable receipt.
+                  Each product owns one kind of checklist. XPass ties them together into one readable report.
                 </p>
               </div>
               <Link

--- a/src/pages/XPass.tsx
+++ b/src/pages/XPass.tsx
@@ -110,8 +110,8 @@ export default function XPassPage() {
                 XPass
               </h1>
               <p className="mt-5 max-w-3xl text-lg leading-8 text-body sm:text-xl">
-                XPass is AutoPilot's quality-control checklist for AI work. Each Pass owns a large list of checks,
-                records PASS, FAIL, Warning, Alert, or N/A with comments, and keeps looping until the relevant rows are green.
+                XPass is AutoPilot's quality-control checklist for AI work. The family holds hundreds of checks across
+                the Pass products, records PASS, FAIL, Warning, Alert, or N/A with comments, and keeps looping until the relevant rows are green.
               </p>
             </FadeIn>
 

--- a/src/pages/admin/AdminXPassHub.test.tsx
+++ b/src/pages/admin/AdminXPassHub.test.tsx
@@ -19,30 +19,43 @@ describe("AdminXPassHub", () => {
     renderHub();
 
     expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
-    expect(screen.getByText(/roadworthy inspection/i)).toBeInTheDocument();
+    expect(screen.getByText(/quality-control checklist/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "XPass family" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /TestPass/i })).toHaveAttribute("href", "/admin/checks/testpass");
     expect(screen.getByRole("link", { name: /SecurityPass/i })).toHaveAttribute("href", "/admin/checks/securitypass");
     expect(screen.getByText("Was it copied exactly?")).toBeInTheDocument();
+    expect(screen.getAllByText(/checks$/i).length).toBeGreaterThan(10);
   });
 
-  it("shows a product report with recent reports and thin checklist rows", () => {
+  it("shows a product report with a large product-specific checklist", () => {
     renderHub("/admin/checks/securitypass");
 
     expect(screen.getByRole("heading", { name: "SecurityPass" })).toBeInTheDocument();
     expect(screen.getByText("Is it safe enough?")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Recent reports" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Roadworthy checks" })).toBeInTheDocument();
-    expect(screen.getByText("Scope is clear")).toBeInTheDocument();
-    expect(screen.getByText(/plain comment any person can understand/i)).toBeInTheDocument();
-    expect(screen.getAllByText("PASS").length).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { name: "Secrets and auth" })).toBeInTheDocument();
+    expect(screen.getByText("No secret exposure")).toBeInTheDocument();
+    expect(screen.getByText("Database scope is tenant-safe")).toBeInTheDocument();
+    expect(screen.getAllByText(/Green only when every relevant row is PASS or N\/A/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Alert")).toBeInTheDocument();
+    expect(screen.getAllByTestId("xpass-check-row").length).toBeGreaterThan(20);
   });
 
   it("marks FidelityPass exact-copy scope as N/A when source copy is not in scope", () => {
     renderHub("/admin/checks/fidelitypass");
 
     expect(screen.getByRole("heading", { name: "FidelityPass" })).toBeInTheDocument();
-    expect(screen.getByText(/N\/A is correct when no exact source copy is in scope/i)).toBeInTheDocument();
+    expect(screen.getByText(/N\/A only when the job does not require source-copy fidelity/i)).toBeInTheDocument();
     expect(screen.getAllByText("N/A").length).toBeGreaterThan(0);
+  });
+
+  it("shows CopyPass copy-specific checks instead of the generic receipt wrapper", () => {
+    renderHub("/admin/checks/copypass");
+
+    expect(screen.getByRole("heading", { name: "CopyPass" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Message clarity" })).toBeInTheDocument();
+    expect(screen.getByText("Headline promise is true")).toBeInTheDocument();
+    expect(screen.getByText("No AI slop")).toBeInTheDocument();
+    expect(screen.getAllByTestId("xpass-check-row").length).toBeGreaterThan(20);
   });
 });

--- a/src/pages/admin/AdminXPassHub.test.tsx
+++ b/src/pages/admin/AdminXPassHub.test.tsx
@@ -20,6 +20,7 @@ describe("AdminXPassHub", () => {
 
     expect(screen.getByRole("heading", { name: "XPass" })).toBeInTheDocument();
     expect(screen.getByText(/quality-control checklist/i)).toBeInTheDocument();
+    expect(screen.getByText(/live checklist rows across 14 Passes/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "XPass family" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /TestPass/i })).toHaveAttribute("href", "/admin/checks/testpass");
     expect(screen.getByRole("link", { name: /SecurityPass/i })).toHaveAttribute("href", "/admin/checks/securitypass");
@@ -38,7 +39,7 @@ describe("AdminXPassHub", () => {
     expect(screen.getByText("Database scope is tenant-safe")).toBeInTheDocument();
     expect(screen.getAllByText(/Green only when every relevant row is PASS or N\/A/i).length).toBeGreaterThan(0);
     expect(screen.getByText("Alert")).toBeInTheDocument();
-    expect(screen.getAllByTestId("xpass-check-row").length).toBeGreaterThan(20);
+    expect(screen.getAllByTestId("xpass-check-row").length).toBeGreaterThan(55);
   });
 
   it("marks FidelityPass exact-copy scope as N/A when source copy is not in scope", () => {
@@ -56,6 +57,7 @@ describe("AdminXPassHub", () => {
     expect(screen.getByRole("heading", { name: "Message clarity" })).toBeInTheDocument();
     expect(screen.getByText("Headline promise is true")).toBeInTheDocument();
     expect(screen.getByText("No AI slop")).toBeInTheDocument();
-    expect(screen.getAllByTestId("xpass-check-row").length).toBeGreaterThan(20);
+    expect(screen.getByText("No filler adjectives")).toBeInTheDocument();
+    expect(screen.getAllByTestId("xpass-check-row").length).toBeGreaterThan(55);
   });
 });

--- a/src/pages/admin/AdminXPassHub.tsx
+++ b/src/pages/admin/AdminXPassHub.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from "react-router-dom";
 import {
+  AlertTriangle,
   BadgeCheck,
   CheckCircle2,
   CircleMinus,
@@ -9,6 +10,7 @@ import {
   FileText,
   KeyRound,
   LayoutGrid,
+  ListChecks,
   MessagesSquare,
   SearchCheck,
   ShieldCheck,
@@ -19,27 +21,17 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { dogfoodReport, type DogfoodStatus } from "@/data/dogfoodReport";
-
-type ProductId =
-  | "testpass"
-  | "uxpass"
-  | "securitypass"
-  | "copypass"
-  | "fidelitypass"
-  | "legalpass"
-  | "sloppass"
-  | "commonsensepass"
-  | "seopass"
-  | "geopass"
-  | "flowpass"
-  | "rotatepass"
-  | "wakepass"
-  | "compliancepass";
-
-type RowStatus = "PASS" | "FAIL" | "N/A" | "WARNING" | "WAITING";
+import {
+  countChecklistGroups,
+  countChecklistRows,
+  XPASS_PRODUCT_CHECKLISTS,
+  type XPassChecklistGroup,
+  type XPassProductId,
+  type XPassRowStatus,
+} from "./xpassChecklistCatalog";
 
 type XPassProduct = {
-  id: ProductId;
+  id: XPassProductId;
   name: string;
   subtitle: string;
   description: string;
@@ -50,18 +42,7 @@ type XPassProduct = {
 type RecentReport = {
   date: string;
   title: string;
-  status: RowStatus;
-};
-
-type ChecklistRow = {
-  title: string;
-  comment: string;
-  status: RowStatus;
-};
-
-type ChecklistGroup = {
-  title: string;
-  rows: ChecklistRow[];
+  status: XPassRowStatus;
 };
 
 const PRODUCTS: XPassProduct[] = [
@@ -167,7 +148,7 @@ const PRODUCTS: XPassProduct[] = [
   },
 ];
 
-const STATUS_STYLE: Record<RowStatus, { label: string; className: string; icon: LucideIcon }> = {
+const STATUS_STYLE: Record<XPassRowStatus, { label: string; className: string; icon: LucideIcon }> = {
   PASS: {
     label: "PASS",
     className: "bg-[#46c76f] text-black",
@@ -188,6 +169,11 @@ const STATUS_STYLE: Record<RowStatus, { label: string; className: string; icon: 
     className: "bg-[#E2B93B] text-black",
     icon: Clock3,
   },
+  ALERT: {
+    label: "Alert",
+    className: "bg-[#FF8A3D] text-black",
+    icon: AlertTriangle,
+  },
   WAITING: {
     label: "Waiting",
     className: "bg-white/12 text-white/70",
@@ -195,7 +181,9 @@ const STATUS_STYLE: Record<RowStatus, { label: string; className: string; icon: 
   },
 };
 
-function dogfoodToRowStatus(status?: DogfoodStatus): RowStatus {
+const STATUS_LEGEND: XPassRowStatus[] = ["PASS", "FAIL", "ALERT", "WARNING", "N/A", "WAITING"];
+
+function dogfoodToRowStatus(status?: DogfoodStatus): XPassRowStatus {
   if (status === "passing") return "PASS";
   if (status === "failing" || status === "blocked") return "FAIL";
   return "WAITING";
@@ -205,7 +193,7 @@ function productById(id?: string): XPassProduct | undefined {
   return PRODUCTS.find((product) => product.id === id);
 }
 
-function resultFor(id: ProductId) {
+function resultFor(id: XPassProductId) {
   return dogfoodReport.results.find((result) => result.id === id);
 }
 
@@ -232,68 +220,46 @@ function reportsFor(product: XPassProduct): RecentReport[] {
   ];
 }
 
-function checklistFor(product: XPassProduct): ChecklistGroup[] {
+function checklistFor(product: XPassProduct): XPassChecklistGroup[] {
   const result = resultFor(product.id);
   const currentStatus = dogfoodToRowStatus(result?.status);
-  const exactCopy = product.id === "fidelitypass";
 
   return [
     {
-      title: "Roadworthy checks",
+      title: "Current run gate",
       rows: [
         {
-          title: "Scope is clear",
-          comment: `This report knows when to use ${product.name}.`,
-          status: "PASS",
+          title: "Build request selected",
+          comment: `Pick or generate a report so ${product.name} can score every relevant checklist row.`,
+          status: "WAITING",
         },
         {
-          title: "Evidence is available",
-          comment: result?.summary ?? "The product exists, but this public report has not run it yet.",
+          title: "Latest receipt evidence",
+          comment: result?.summary ?? "No live receipt has been selected for this checklist view yet.",
           status: currentStatus,
         },
         {
-          title: "Result is easy to explain",
-          comment: "The row must have a short plain comment any person can understand.",
-          status: "PASS",
+          title: "Loop until green",
+          comment: "The report must keep working through failures until every relevant row is PASS or N/A.",
+          status: "WAITING",
         },
         {
-          title: "Skipped work is honest",
-          comment: exactCopy
-            ? "N/A is correct when no exact source copy is in scope."
-            : "If this check does not apply, XPass must say why.",
-          status: exactCopy ? "N/A" : "PASS",
+          title: "N/A is explained",
+          comment: "A skipped row is only N/A when the comment explains why the check does not apply.",
+          status: "WAITING",
         },
         {
-          title: "Needs owner action",
-          comment: currentStatus === "FAIL" ? "Someone needs to fix this before the report is green." : "No blocker in the current report.",
-          status: currentStatus === "FAIL" ? "FAIL" : "PASS",
+          title: "Owner action is clear",
+          comment: "Any FAIL, ALERT, or Warning row must say who or what fixes it next.",
+          status: currentStatus === "FAIL" ? "FAIL" : "WAITING",
         },
       ],
     },
-    {
-      title: "Continuous improvement",
-      rows: [
-        {
-          title: "Weak comments get improved",
-          comment: "If a result is vague, XPass should improve the checklist for next time.",
-          status: "PASS",
-        },
-        {
-          title: "Repeated misses create a job",
-          comment: "Real misses should feed the improvement queue instead of being forgotten.",
-          status: "PASS",
-        },
-        {
-          title: "Internal proof stays available",
-          comment: "Technical receipts exist behind the report, but do not clutter the main view.",
-          status: "PASS",
-        },
-      ],
-    },
+    ...XPASS_PRODUCT_CHECKLISTS[product.id],
   ];
 }
 
-function StatusBadge({ status }: { status: RowStatus }) {
+function StatusBadge({ status }: { status: XPassRowStatus }) {
   const style = STATUS_STYLE[status];
   const Icon = style.icon;
 
@@ -307,6 +273,8 @@ function StatusBadge({ status }: { status: RowStatus }) {
 
 function ProductCard({ product }: { product: XPassProduct }) {
   const Icon = product.icon;
+  const checkCount = countChecklistRows(product.id);
+  const groupCount = countChecklistGroups(product.id);
 
   return (
     <Link
@@ -323,10 +291,22 @@ function ProductCard({ product }: { product: XPassProduct }) {
         </div>
       </div>
       <p className="mt-3 line-clamp-3 text-xs leading-5 text-white/55">{product.description}</p>
-      <div className="mt-3 flex justify-end text-[#61C1C4]">
-        <ExternalLink className="h-3.5 w-3.5" />
+      <div className="mt-3 flex items-center justify-between gap-3 text-xs text-white/45">
+        <span>{checkCount} checks</span>
+        <span>{groupCount} groups</span>
+        <ExternalLink className="h-3.5 w-3.5 text-[#61C1C4]" />
       </div>
     </Link>
+  );
+}
+
+function StatusLegend() {
+  return (
+    <div className="mt-3 flex flex-wrap gap-2" aria-label="XPass status legend">
+      {STATUS_LEGEND.map((status) => (
+        <StatusBadge key={status} status={status} />
+      ))}
+    </div>
   );
 }
 
@@ -356,19 +336,24 @@ function RecentReports({ product }: { product: XPassProduct }) {
   );
 }
 
-function ChecklistGroupView({ group }: { group: ChecklistGroup }) {
+function ChecklistGroupView({ group }: { group: XPassChecklistGroup }) {
   return (
     <section className="rounded-lg border border-white/[0.08] bg-[#111] p-4">
-      <h2 className="text-sm font-semibold text-white">{group.title}</h2>
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold text-white">{group.title}</h2>
+        <span className="text-[11px] font-medium text-white/40">{group.rows.length} checks</span>
+      </div>
       <div className="mt-3 overflow-hidden rounded-md border border-white/[0.08]">
-        {group.rows.map((row) => (
+        {group.rows.map((row, index) => (
           <div
             key={`${group.title}-${row.title}`}
-            className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-white/[0.06] bg-black/20 px-3 py-2 last:border-b-0 md:grid-cols-[220px_minmax(0,1fr)_90px] md:items-center"
+            data-testid="xpass-check-row"
+            className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-white/[0.06] bg-black/20 px-3 py-2 last:border-b-0 md:grid-cols-[34px_220px_minmax(0,1fr)_90px] md:items-center"
           >
+            <p className="hidden text-[11px] font-semibold text-white/35 md:block">{index + 1}</p>
             <p className="truncate text-xs font-semibold text-white">{row.title}</p>
             <p className="col-span-2 text-xs leading-5 text-white/55 md:col-span-1">{row.comment}</p>
-            <StatusBadge status={row.status} />
+            <StatusBadge status={row.status ?? "WAITING"} />
           </div>
         ))}
       </div>
@@ -388,8 +373,8 @@ function XPassHome() {
             <p className="text-xs font-medium text-[#61C1C4]">AutoPilot / XPass</p>
             <h1 className="mt-2 text-2xl font-semibold text-white">XPass</h1>
             <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60">
-              XPass is the roadworthy inspection for UnClick work. Each Pass checks one part of the job, then leaves
-              a simple result and a plain comment.
+              XPass is the quality-control checklist for UnClick work. Each Pass owns a large set of checks, scores
+              every relevant row, explains every result, and keeps looping until the non-N/A rows are green.
             </p>
           </div>
         </div>
@@ -397,7 +382,7 @@ function XPassHome() {
 
       <section>
         <h2 className="text-sm font-semibold text-white">XPass family</h2>
-        <p className="mt-1 text-xs text-white/45">Pick a Pass to see its report, recent runs, and checklist.</p>
+        <p className="mt-1 text-xs text-white/45">Pick a Pass to see its product-specific checklist and recent reports.</p>
         <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {PRODUCTS.map((product) => (
             <ProductCard key={product.id} product={product} />
@@ -410,6 +395,8 @@ function XPassHome() {
 
 function XPassProductReport({ product }: { product: XPassProduct }) {
   const Icon = product.icon;
+  const checkCount = countChecklistRows(product.id) + 5;
+  const groupCount = countChecklistGroups(product.id) + 1;
 
   return (
     <div className="space-y-6">
@@ -426,6 +413,19 @@ function XPassProductReport({ product }: { product: XPassProduct }) {
             <h1 className="text-2xl font-semibold text-white">{product.name}</h1>
             <p className="mt-1 text-sm font-semibold text-white/70">{product.subtitle}</p>
             <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60">{product.description}</p>
+            <div className="mt-4 flex flex-wrap gap-2 text-xs text-white/55">
+              <span className="inline-flex min-h-7 items-center gap-1.5 rounded-md border border-white/[0.08] bg-black/25 px-2.5">
+                <ListChecks className="h-3.5 w-3.5 text-[#61C1C4]" />
+                {checkCount} checklist rows
+              </span>
+              <span className="inline-flex min-h-7 items-center rounded-md border border-white/[0.08] bg-black/25 px-2.5">
+                {groupCount} groups
+              </span>
+              <span className="inline-flex min-h-7 items-center rounded-md border border-white/[0.08] bg-black/25 px-2.5">
+                Green only when every relevant row is PASS or N/A
+              </span>
+            </div>
+            <StatusLegend />
             {product.externalHref ? (
               <Link
                 to={product.externalHref}

--- a/src/pages/admin/AdminXPassHub.tsx
+++ b/src/pages/admin/AdminXPassHub.tsx
@@ -23,6 +23,7 @@ import {
 import { dogfoodReport, type DogfoodStatus } from "@/data/dogfoodReport";
 import {
   countChecklistGroups,
+  countFamilyChecklistRows,
   countChecklistRows,
   XPASS_PRODUCT_CHECKLISTS,
   type XPassChecklistGroup,
@@ -273,8 +274,8 @@ function StatusBadge({ status }: { status: XPassRowStatus }) {
 
 function ProductCard({ product }: { product: XPassProduct }) {
   const Icon = product.icon;
-  const checkCount = countChecklistRows(product.id);
-  const groupCount = countChecklistGroups(product.id);
+  const checkCount = countChecklistRows(product.id) + 5;
+  const groupCount = countChecklistGroups(product.id) + 1;
 
   return (
     <Link
@@ -362,6 +363,8 @@ function ChecklistGroupView({ group }: { group: XPassChecklistGroup }) {
 }
 
 function XPassHome() {
+  const familyCheckCount = countFamilyChecklistRows() + PRODUCTS.length * 5;
+
   return (
     <div className="space-y-8">
       <section className="rounded-lg border border-white/[0.08] bg-[#111] p-6">
@@ -375,6 +378,9 @@ function XPassHome() {
             <p className="mt-3 max-w-3xl text-sm leading-6 text-white/60">
               XPass is the quality-control checklist for UnClick work. Each Pass owns a large set of checks, scores
               every relevant row, explains every result, and keeps looping until the non-N/A rows are green.
+            </p>
+            <p className="mt-3 text-xs font-medium text-white/45">
+              {familyCheckCount} live checklist rows across {PRODUCTS.length} Passes, before the run adds project-specific rows.
             </p>
           </div>
         </div>

--- a/src/pages/admin/AdminYou.test.tsx
+++ b/src/pages/admin/AdminYou.test.tsx
@@ -1,20 +1,25 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminYou from "./AdminYou";
 
-vi.mock("@/lib/auth", () => ({
-  useSession: () => ({
-    session: { access_token: "test-session-token" },
-    user: {
-      email: "owner@example.com",
-      created_at: "2026-01-01T00:00:00.000Z",
-      app_metadata: { provider: "email" },
-    },
-    loading: false,
-  }),
-  signOut: vi.fn(),
-}));
+vi.mock("@/lib/auth", () => {
+  const session = { access_token: "test-session-token" };
+  const user = {
+    email: "owner@example.com",
+    created_at: "2026-01-01T00:00:00.000Z",
+    app_metadata: { provider: "email" },
+  };
+
+  return {
+    useSession: () => ({
+      session,
+      user,
+      loading: false,
+    }),
+    signOut: vi.fn(),
+  };
+});
 
 function renderPage() {
   render(
@@ -74,6 +79,17 @@ function stubFetch(generatedKey: string | null) {
   });
 }
 
+async function waitForInitialAdminYouFetches() {
+  const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("admin_profile"), expect.any(Object));
+  });
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("auth_device_list"), expect.any(Object));
+  });
+}
+
 describe("AdminYou API key card", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -95,6 +111,7 @@ describe("AdminYou API key card", () => {
     expect(await screen.findByRole("button", { name: /Copy API key/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Copy MCP URL/i })).toBeInTheDocument();
     expect(screen.getByText(/Copy it now or copy the ready-made MCP URL/i)).toBeInTheDocument();
+    await waitForInitialAdminYouFetches();
   });
 
   it("explains why an old key cannot be copied after the raw value is gone", async () => {
@@ -104,5 +121,6 @@ describe("AdminYou API key card", () => {
 
     expect(await screen.findByText(/stores only a hash after setup/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Create new copyable key/i })).toBeInTheDocument();
+    await waitForInitialAdminYouFetches();
   });
 });

--- a/src/pages/admin/xpassChecklistCatalog.ts
+++ b/src/pages/admin/xpassChecklistCatalog.ts
@@ -58,7 +58,7 @@ function improvementLoop(productName: string): XPassChecklistGroup {
   };
 }
 
-export const XPASS_PRODUCT_CHECKLISTS: Record<XPassProductId, XPassChecklistGroup[]> = {
+const BASE_XPASS_PRODUCT_CHECKLISTS: Record<XPassProductId, XPassChecklistGroup[]> = {
   testpass: [
     {
       title: "Build and test proof",
@@ -526,10 +526,303 @@ export const XPASS_PRODUCT_CHECKLISTS: Record<XPassProductId, XPassChecklistGrou
   ],
 };
 
+const deepRunLoop = (productName: string, focus: string): XPassChecklistGroup[] => [
+  {
+    title: "Build request mapping",
+    rows: [
+      waiting("User request is parsed", `${productName} knows what the user asked to build or change before scoring ${focus}.`),
+      waiting("Affected surfaces are listed", `${productName} names the pages, APIs, jobs, copy, or files that are in scope.`),
+      waiting("Acceptance criteria are written", `${productName} has plain pass/fail criteria instead of a vague green result.`),
+      waiting("Non-goals are marked", `${productName} marks unrelated work as N/A with a short reason.`),
+      waiting("Risky assumptions are called out", `${productName} turns uncertain assumptions into WARNING or ALERT rows.`),
+      waiting("Input evidence is attached", `${productName} points to the request, source packet, diff, screenshot, or route being checked.`),
+      waiting("Relevant Passes are selected", `${productName} says which other XPass products must also run for this build.`),
+      waiting("Skipped Passes have N/A reasons", `${productName} cannot hide skipped XPass work behind a generic pass.`),
+    ],
+  },
+  {
+    title: "Evidence and replay",
+    rows: [
+      waiting("Automated proof exists", `${productName} records the command, tool, route, or receipt that proves the row.`),
+      waiting("Manual proof is labeled", `${productName} labels any human or visual check so it is not mistaken for automation.`),
+      waiting("Before state is known", `${productName} can explain what was wrong or unknown before the run.`),
+      waiting("After state is known", `${productName} can explain what changed after the run.`),
+      waiting("Edge case is checked", `${productName} checks at least one boundary case for ${focus}.`),
+      waiting("Failure case is checked", `${productName} proves bad input or missing proof does not quietly become PASS.`),
+      waiting("Receipt can be reopened", `${productName} leaves enough detail for another worker to verify the result later.`),
+      waiting("Timestamp is present", `${productName} records when the evidence was produced or last refreshed.`),
+    ],
+  },
+  {
+    title: "Loop until green",
+    rows: [
+      waiting("FAIL creates a fix task", `${productName} turns each FAIL into a clear repair step.`),
+      warning("WARNING has a decision", `${productName} keeps WARNING visible until it is accepted, fixed, or promoted to FAIL.`),
+      warning("ALERT pauses release", `${productName} treats ALERT rows as stop signs until the owner clears them.`),
+      waiting("N/A is justified", `${productName} only uses N/A when the row truly does not apply to this build.`),
+      waiting("Fix is rechecked", `${productName} reruns the row after a fix instead of trusting the first attempt.`),
+      waiting("Regression proof is kept", `${productName} saves proof that the same miss is less likely next time.`),
+      waiting("Summary matches rows", `${productName} cannot say green while any relevant row is FAIL, ALERT, WARNING, or WAITING.`),
+      waiting("Next run learns", `${productName} updates the checklist when this run exposes a missing check.`),
+    ],
+  },
+];
+
+const PRODUCT_DEEP_CHECKS: Record<XPassProductId, XPassChecklistGroup[]> = {
+  testpass: [
+    {
+      title: "Deep TestPass checklist",
+      rows: [
+        waiting("Fresh checkout can run", "A clean checkout can reproduce the test path without hidden local state."),
+        waiting("Changed package tests run", "Every package touched by the build has its own focused proof."),
+        waiting("Root tests still run", "Shared app behavior is checked after package-level proof passes."),
+        waiting("Mocked paths are named", "Mocked services are called out so nobody mistakes mocks for live proof."),
+        waiting("Live smoke is separate", "Preview or production smoke proof is recorded separately from local tests."),
+        waiting("Flaky test is not ignored", "Flakes create a warning or fix task instead of being waved through."),
+        waiting("Failure output is useful", "A failed test points to the broken behavior, not only a generic crash."),
+        waiting("Release gate is current", "The final green state is tied to the current commit or deployed build."),
+      ],
+    },
+  ],
+  uxpass: [
+    {
+      title: "Deep UXPass checklist",
+      rows: [
+        waiting("Desktop screenshot reviewed", "Desktop layout is visually checked for fit, hierarchy, and scan speed."),
+        waiting("Mobile screenshot reviewed", "Mobile layout is visually checked for fit, touch targets, and reading order."),
+        waiting("Long text is tested", "Long labels, comments, and product names do not break the layout."),
+        waiting("Empty data is tested", "The screen still makes sense when no report or result exists yet."),
+        waiting("Dense data is tested", "Large lists stay readable with thin rows and steady spacing."),
+        waiting("Primary path is obvious", "A new user can tell what to click or read first."),
+        waiting("Internal terms are hidden", "Worker-only terms stay out of the main human-facing view."),
+        waiting("Visual change has proof", "Screenshots or browser checks are attached when the UI changes."),
+      ],
+    },
+  ],
+  securitypass: [
+    {
+      title: "Deep SecurityPass checklist",
+      rows: [
+        waiting("Session boundary is tested", "Protected routes reject unauthenticated or wrong-tenant access."),
+        waiting("Admin boundary is tested", "Admin-only behavior cannot be reached by normal users."),
+        waiting("Secret display is controlled", "Raw keys appear only at creation time or from a safe local cache."),
+        waiting("Secret copy is safe", "Copy buttons do not log, persist, or echo secret values."),
+        waiting("Webhook input is verified", "External callbacks are authenticated before side effects run."),
+        waiting("Database writes are scoped", "Write paths include tenant, owner, or permission checks."),
+        waiting("Dangerous commands are blocked", "Tools cannot run deletes, resets, or rotations without the right gate."),
+        waiting("Security receipt is redacted", "The report proves the check without exposing sensitive evidence."),
+      ],
+    },
+  ],
+  copypass: [
+    {
+      title: "Deep CopyPass checklist",
+      rows: [
+        waiting("Main promise is specific", "The main promise names the useful outcome without hype."),
+        waiting("Subcopy removes doubt", "Supporting copy answers the user's next obvious question."),
+        waiting("CTA matches destination", "Button copy matches the screen, action, or tool it opens."),
+        waiting("Error wording is fixable", "The user can tell what to do after an error."),
+        waiting("Empty wording is useful", "Empty states explain what is missing and how to continue."),
+        waiting("No filler adjectives", "Words like powerful, seamless, and intelligent are justified or removed."),
+        waiting("No fake urgency", "The copy does not pressure the user with unsupported urgency."),
+        waiting("Tone matches UnClick", "The copy sounds plain, capable, and human across related screens."),
+      ],
+    },
+  ],
+  fidelitypass: [
+    {
+      title: "Deep FidelityPass checklist",
+      rows: [
+        waiting("Source packet hash is known", "The exact source can be identified again later."),
+        waiting("Destination packet is known", "The target location is clear enough to verify."),
+        waiting("Exact-copy rows are exact", "Exact text preserves punctuation, casing, order, and numbers."),
+        waiting("Allowed edits are listed", "Approved changes are named instead of hidden in the output."),
+        waiting("Normalization is declared", "Whitespace or markdown normalization rules are explicit."),
+        waiting("Missing source blocks pass", "No source packet means FAIL or N/A, never guessed PASS."),
+        waiting("Diff is human-readable", "A reviewer can see every meaningful change."),
+        waiting("CopyRoom receipt exists", "The final proof links source, destination, and verdict."),
+      ],
+    },
+  ],
+  legalpass: [
+    {
+      title: "Deep LegalPass checklist",
+      rows: [
+        waiting("Legal-risk words are found", "Terms like guarantee, certified, compliant, secure, or unlimited are checked."),
+        waiting("Policy claim has source", "Privacy, terms, billing, and retention claims point to a real source."),
+        waiting("Jurisdiction is explicit", "Location-specific claims name the jurisdiction or are marked unsupported."),
+        waiting("Disclaimer is near claim", "Risk wording appears close to the claim it qualifies."),
+        waiting("User consent is visible", "Consent, opt-in, opt-out, and notification points are checked."),
+        waiting("High-risk claim is escalated", "Legal-sensitive rows name the human or lane for review."),
+        warning("No certification implied", "LegalPass can flag readiness, but it does not certify legal compliance."),
+        waiting("Change history is kept", "Sensitive wording changes keep date, reason, and evidence."),
+      ],
+    },
+  ],
+  sloppass: [
+    {
+      title: "Deep SlopPass checklist",
+      rows: [
+        waiting("AI filler is removed", "Generic assistant wording is replaced with specific useful text."),
+        waiting("Dead code is spotted", "Unused exports, branches, comments, and assets are flagged."),
+        waiting("Duplicate logic is spotted", "Repeated logic is consolidated or justified."),
+        waiting("Naming is plain", "Names explain what the code or product does."),
+        waiting("Magic behavior is explained", "Non-obvious decisions have proof or a short comment."),
+        waiting("Diff is focused", "The change does not include unrelated churn."),
+        waiting("Generated noise is separated", "Generated files are updated only when needed and named as such."),
+        waiting("Slop creates cleanup task", "Mess that cannot be fixed now becomes a tracked task."),
+      ],
+    },
+  ],
+  commonsensepass: [
+    {
+      title: "Deep CommonSensePass checklist",
+      rows: [
+        waiting("Claim matches reality", "The report does not say complete, live, or green without observable proof."),
+        waiting("User expectation is honored", "The solution matches what the user meant, not just the literal words."),
+        waiting("Over-complexity is reduced", "A simpler answer is preferred when it solves the same problem."),
+        waiting("Obvious missing step is caught", "The checklist asks what a normal person would expect next."),
+        waiting("Bad analogy is not overused", "Analogies help the concept but do not become the product."),
+        waiting("Plain-language proof exists", "A non-technical reader can understand the result."),
+        waiting("Contradiction is blocked", "The UI, docs, PR, and Boardroom cannot disagree silently."),
+        waiting("Common-sense fail blocks green", "If the result feels obviously wrong, it cannot be marked PASS."),
+      ],
+    },
+  ],
+  seopass: [
+    {
+      title: "Deep SEOPass checklist",
+      rows: [
+        waiting("One clear H1 exists", "The page has one meaningful main heading."),
+        waiting("Title is not generic", "The browser title names the product, offer, or page purpose."),
+        waiting("Description is useful", "The meta description reads like a helpful search snippet."),
+        waiting("Internal anchor exists", "Relevant pages link to the page with meaningful text."),
+        waiting("Image text is useful", "Important visual content has alt text or nearby plain text."),
+        waiting("Duplicate intent is avoided", "Nearby pages do not compete for the same search intent."),
+        waiting("Indexing state is intentional", "Noindex, robots, canonical, and status code are checked."),
+        waiting("Search claim is backed", "Search-facing claims match actual product capability."),
+      ],
+    },
+  ],
+  geopass: [
+    {
+      title: "Deep GEOPass checklist",
+      rows: [
+        waiting("AI summary is obvious", "A model can summarize the page accurately in one sentence."),
+        waiting("Entity relationship is clear", "UnClick, AutoPilot, XPass, and product names connect cleanly."),
+        waiting("Use cases are explicit", "The page states when the product should be used."),
+        waiting("Audience is explicit", "The page names who the product is for."),
+        waiting("Examples reduce guessing", "Concrete examples stop answer engines inventing details."),
+        waiting("Definitions are stable", "The same product is not defined two different ways."),
+        waiting("Public proof is available", "Answer engines can cite safe public evidence where appropriate."),
+        waiting("AI answer drift feeds back", "Bad generated answers become new checklist rows."),
+      ],
+    },
+  ],
+  flowpass: [
+    {
+      title: "Deep FlowPass checklist",
+      rows: [
+        waiting("First step is visible", "The user can tell where to begin the journey."),
+        waiting("Current step is visible", "The user can tell what is happening now."),
+        waiting("Next step is visible", "The user can tell what happens after this screen."),
+        waiting("Back path is safe", "Going back does not silently lose important work."),
+        waiting("Retry path is safe", "Recoverable failures offer a clear retry or fix path."),
+        waiting("Blocked state is honest", "Blocked journeys say what is missing."),
+        waiting("Completion state is useful", "Done states say what was completed and where proof lives."),
+        waiting("Loop path is real", "Failed checks route back into work until they are green or N/A."),
+      ],
+    },
+  ],
+  rotatepass: [
+    {
+      title: "Deep RotatePass checklist",
+      rows: [
+        waiting("Secret owner is known", "The service or team responsible for the credential is named."),
+        waiting("Secret consumers are listed", "Apps, jobs, and integrations that use the secret are identified."),
+        waiting("New value is stored safely", "The new secret goes only into the approved secret store."),
+        waiting("No raw value in output", "Logs, receipts, and comments never print the secret."),
+        waiting("Dependent deploy is checked", "Services that need the new secret are redeployed or refreshed."),
+        waiting("Old value is revoked", "The old credential is removed after safe proof."),
+        waiting("Rollback is known", "The operator knows how to recover if rotation fails."),
+        waiting("Next rotation is tracked", "Expiry or review timing is recorded when known."),
+      ],
+    },
+  ],
+  wakepass: [
+    {
+      title: "Deep WakePass checklist",
+      rows: [
+        waiting("Owner check-in is fresh", "The active owner has checked in within the expected window."),
+        waiting("Work is not orphaned", "Open jobs have an owner, blocker, or routing decision."),
+        waiting("Stale work escalates", "Stale in-progress work creates a useful signal."),
+        waiting("Handoff is acknowledged", "Direct handoffs receive an ACK, next action, and ETA."),
+        waiting("Proof closes the loop", "Done jobs include proof, not just a done word."),
+        waiting("Noise wake is avoided", "Repeated wake messages do not spam the room without progress."),
+        waiting("Human touch is minimized", "Workers proceed without asking the user when proof is discoverable."),
+        waiting("Queue health is honest", "The system cannot call itself quiet while actionable work is queued."),
+      ],
+    },
+  ],
+  compliancepass: [
+    {
+      title: "Deep CompliancePass checklist",
+      rows: [
+        waiting("Control owner is named", "Each readiness row has an owner or responsible lane."),
+        waiting("Evidence type is named", "The row says whether it needs policy, log, screenshot, receipt, or review evidence."),
+        waiting("Evidence date is visible", "Proof has a date or freshness marker."),
+        waiting("Gap severity is ranked", "Missing readiness is ranked by release or business risk."),
+        waiting("Exception is documented", "Accepted risk has an owner, reason, and review timing."),
+        waiting("Framework language is accurate", "Framework names and claims are not invented or overstated."),
+        warning("Formal certification is not implied", "CompliancePass checks readiness; it does not replace an auditor."),
+        waiting("Recheck trigger exists", "A future trigger or schedule keeps readiness from going stale."),
+      ],
+    },
+  ],
+};
+
+const PRODUCT_NAMES: Record<XPassProductId, string> = {
+  testpass: "TestPass",
+  uxpass: "UXPass",
+  securitypass: "SecurityPass",
+  copypass: "CopyPass",
+  fidelitypass: "FidelityPass",
+  legalpass: "LegalPass",
+  sloppass: "SlopPass",
+  commonsensepass: "CommonSensePass",
+  seopass: "SEOPass",
+  geopass: "GEOPass",
+  flowpass: "FlowPass",
+  rotatepass: "RotatePass",
+  wakepass: "WakePass",
+  compliancepass: "CompliancePass",
+};
+
+export const XPASS_PRODUCT_CHECKLISTS: Record<XPassProductId, XPassChecklistGroup[]> = (
+  Object.keys(BASE_XPASS_PRODUCT_CHECKLISTS) as XPassProductId[]
+).reduce(
+  (catalog, productId) => {
+    catalog[productId] = [
+      ...BASE_XPASS_PRODUCT_CHECKLISTS[productId],
+      ...PRODUCT_DEEP_CHECKS[productId],
+      ...deepRunLoop(PRODUCT_NAMES[productId], productId),
+    ];
+    return catalog;
+  },
+  {} as Record<XPassProductId, XPassChecklistGroup[]>,
+);
+
 export function countChecklistRows(productId: XPassProductId): number {
   return XPASS_PRODUCT_CHECKLISTS[productId].reduce((total, group) => total + group.rows.length, 0);
 }
 
 export function countChecklistGroups(productId: XPassProductId): number {
   return XPASS_PRODUCT_CHECKLISTS[productId].length;
+}
+
+export function countFamilyChecklistRows(): number {
+  return (Object.keys(XPASS_PRODUCT_CHECKLISTS) as XPassProductId[]).reduce(
+    (total, productId) => total + countChecklistRows(productId),
+    0,
+  );
 }

--- a/src/pages/admin/xpassChecklistCatalog.ts
+++ b/src/pages/admin/xpassChecklistCatalog.ts
@@ -1,0 +1,535 @@
+export type XPassProductId =
+  | "testpass"
+  | "uxpass"
+  | "securitypass"
+  | "copypass"
+  | "fidelitypass"
+  | "legalpass"
+  | "sloppass"
+  | "commonsensepass"
+  | "seopass"
+  | "geopass"
+  | "flowpass"
+  | "rotatepass"
+  | "wakepass"
+  | "compliancepass";
+
+export type XPassRowStatus = "PASS" | "FAIL" | "N/A" | "WARNING" | "ALERT" | "WAITING";
+
+export type XPassChecklistRow = {
+  title: string;
+  comment: string;
+  status?: XPassRowStatus;
+};
+
+export type XPassChecklistGroup = {
+  title: string;
+  rows: XPassChecklistRow[];
+};
+
+const waiting = (title: string, comment: string): XPassChecklistRow => ({
+  title,
+  comment,
+  status: "WAITING",
+});
+
+const warning = (title: string, comment: string): XPassChecklistRow => ({
+  title,
+  comment,
+  status: "WARNING",
+});
+
+const na = (title: string, comment: string): XPassChecklistRow => ({
+  title,
+  comment,
+  status: "N/A",
+});
+
+function improvementLoop(productName: string): XPassChecklistGroup {
+  return {
+    title: "Continuous improvement loop",
+    rows: [
+      waiting("Weak comment check", `${productName} must rewrite vague comments into plain next actions.`),
+      waiting("Repeated miss check", `Repeated ${productName} misses must create or update a checklist item.`),
+      waiting("Regression capture check", `A fixed ${productName} miss must leave proof that it cannot quietly return.`),
+      waiting("Owner handoff check", `${productName} failures must name the person, worker, or lane that can fix them.`),
+      waiting("Final green rule", `${productName} is green only when every relevant row is PASS or N/A.`),
+    ],
+  };
+}
+
+export const XPASS_PRODUCT_CHECKLISTS: Record<XPassProductId, XPassChecklistGroup[]> = {
+  testpass: [
+    {
+      title: "Build and test proof",
+      rows: [
+        waiting("Install completes", "Dependencies install from the committed lockfile without manual fixes."),
+        waiting("Type check passes", "The project type checker finishes cleanly for touched code."),
+        waiting("Unit tests pass", "Focused tests cover the changed behavior and pass."),
+        waiting("Integration tests pass", "Cross-module paths touched by the work are exercised."),
+        waiting("Package build passes", "The package or app that owns the change builds successfully."),
+        waiting("Generated files are current", "Generated indexes, maps, and registries are refreshed where needed."),
+      ],
+    },
+    {
+      title: "Runtime proof",
+      rows: [
+        waiting("Happy path runs", "The primary user path works from start to finish."),
+        waiting("Failure path runs", "Known bad input returns a clear error instead of crashing."),
+        waiting("No console-breaking errors", "Browser or server logs do not show new runtime failures."),
+        waiting("API response shape is stable", "Changed endpoints return the expected status and body shape."),
+        waiting("Background job exits cleanly", "Workers, scripts, and scheduled jobs finish with a useful receipt."),
+      ],
+    },
+    {
+      title: "Cloud proof",
+      rows: [
+        waiting("PR checks pass", "GitHub checks that matter for the change are green."),
+        waiting("Preview deploy responds", "The preview URL serves the changed surface successfully."),
+        waiting("Production deploy responds", "After merge, the live route serves the expected page or API."),
+        waiting("Smoke check passes", "A real smoke check runs against the deployed surface."),
+        warning("Discontinued checks ignored", "Known retired checks are ignored only when a standing rule says so."),
+      ],
+    },
+    improvementLoop("TestPass"),
+  ],
+  uxpass: [
+    {
+      title: "Visual layout",
+      rows: [
+        waiting("Desktop layout fits", "No text, cards, controls, or media overlap at desktop width."),
+        waiting("Mobile layout fits", "The same surface fits mobile without horizontal scrolling."),
+        waiting("Text stays inside controls", "Button, badge, and row labels do not clip or overflow."),
+        waiting("Hierarchy is obvious", "The eye can find the title, current state, and next action quickly."),
+        waiting("Density matches the job", "Work tools stay compact enough for repeated use."),
+        waiting("No decorative noise", "Decoration does not compete with the task or hide real content."),
+      ],
+    },
+    {
+      title: "Interaction quality",
+      rows: [
+        waiting("Primary action is clear", "The most likely next action is visible and named in plain English."),
+        waiting("Empty state helps", "Empty states explain what happens next instead of looking broken."),
+        waiting("Loading state helps", "Loading states preserve layout and tell the user what is happening."),
+        waiting("Error state helps", "Errors tell the user what failed and what to try next."),
+        waiting("Keyboard path works", "Important controls can be reached without pointer-only interaction."),
+      ],
+    },
+    {
+      title: "Polish and trust",
+      rows: [
+        waiting("Copy sounds human", "Interface text is short, calm, and specific."),
+        waiting("Color has meaning", "Green, red, amber, and neutral states are used consistently."),
+        waiting("Spacing is steady", "Rows and sections do not jump when status or comments change."),
+        waiting("Visual proof captured", "Screenshots or visual smoke checks exist for important surfaces."),
+        waiting("User goal is protected", "The screen solves the task before it explains the system."),
+      ],
+    },
+    improvementLoop("UXPass"),
+  ],
+  securitypass: [
+    {
+      title: "Secrets and auth",
+      rows: [
+        waiting("No secret exposure", "Keys, tokens, passwords, and one-time codes are never shown in logs or UI."),
+        waiting("Redaction holds", "Receipts and errors redact secret-shaped values before saving."),
+        waiting("Auth boundary holds", "Protected pages and APIs require the correct user session."),
+        waiting("Role boundary holds", "Admin-only and tenant-only actions are blocked for the wrong role."),
+        waiting("Token lifecycle is safe", "Create, copy, rotate, and revoke flows do not leak old raw secrets."),
+      ],
+    },
+    {
+      title: "Input and data boundaries",
+      rows: [
+        waiting("Inputs are validated", "User-controlled values are checked before reaching sensitive logic."),
+        waiting("File paths are bounded", "Local paths cannot escape the intended workspace or tenant scope."),
+        waiting("External URLs are safe", "Remote fetches avoid unsafe schemes and unexpected hosts."),
+        waiting("Database scope is tenant-safe", "Queries cannot read or write another tenant's data."),
+        waiting("Error messages are safe", "Errors explain the problem without exposing internals or secrets."),
+      ],
+    },
+    {
+      title: "Operational safety",
+      rows: [
+        waiting("Destructive action gated", "Deletes, rotations, deploys, and writes have the right confirmation path."),
+        waiting("Audit trail exists", "Sensitive actions leave a safe receipt with actor, target, and result."),
+        waiting("Dependency risk checked", "New packages or network surfaces have a reason and a risk check."),
+        waiting("Security fallback is clear", "If proof is missing, the result is blocked instead of guessed green."),
+        na("Exploit testing in scope", "N/A unless the job explicitly authorizes active security testing."),
+      ],
+    },
+    improvementLoop("SecurityPass"),
+  ],
+  copypass: [
+    {
+      title: "Message clarity",
+      rows: [
+        waiting("Headline promise is true", "The headline matches what the product actually does."),
+        waiting("Subheading explains value", "The subheading adds meaning instead of repeating the headline."),
+        waiting("Body copy is plain", "A normal user can understand the wording without internal jargon."),
+        waiting("CTA says the action", "Buttons describe the action the user will take."),
+        waiting("Empty state copy helps", "Empty states say what is missing and how to continue."),
+        waiting("Error copy helps", "Error messages are specific, calm, and fixable."),
+      ],
+    },
+    {
+      title: "Trust and claims",
+      rows: [
+        waiting("No fake certainty", "The copy does not overclaim proof, safety, compliance, or automation."),
+        waiting("No AI slop", "The wording avoids filler, vague hype, and generic assistant language."),
+        waiting("Audience matches", "The copy speaks to the actual user of this screen."),
+        waiting("Feature names are consistent", "Product, Pass, and tool names match the canonical naming."),
+        waiting("Screens say the same thing", "Public, admin, and report wording do not contradict each other."),
+      ],
+    },
+    {
+      title: "CopyRoom fidelity",
+      rows: [
+        waiting("Source text identified", "Any exact wording request points to the source text or packet."),
+        waiting("Edited copy is intentional", "Changed wording has a reason, not accidental drift."),
+        waiting("Claims keep evidence", "Evidence-backed claims stay attached to the source proof."),
+        na("Exact copy required", "N/A unless the request asks for 1:1 wording or source-copy work."),
+        waiting("Final copy receipt exists", "The result says what was copied, changed, or left alone."),
+      ],
+    },
+    improvementLoop("CopyPass"),
+  ],
+  fidelitypass: [
+    {
+      title: "Source copy scope",
+      rows: [
+        waiting("Source packet exists", "The exact source text, table, prompt, label, or code is available."),
+        waiting("Destination is named", "The target file, field, page, or artifact is clear."),
+        waiting("Copy mode is declared", "The run says whether it is exact copy, adapted copy, or N/A."),
+        waiting("Whitespace rules are known", "Line breaks, punctuation, casing, and formatting rules are clear."),
+        na("No exact source in scope", "N/A only when the job does not require source-copy fidelity."),
+      ],
+    },
+    {
+      title: "Exactness checks",
+      rows: [
+        waiting("Text matches source", "Exact-copy text matches the source after approved normalization."),
+        waiting("Order is preserved", "Lists, rows, steps, and labels stay in the intended order."),
+        waiting("Numbers are preserved", "Prices, dates, counts, limits, and scores are not altered by mistake."),
+        waiting("Names are preserved", "Product, person, company, and file names stay exact where required."),
+        waiting("Omissions are listed", "Anything skipped is called out with a reason."),
+      ],
+    },
+    {
+      title: "Drift prevention",
+      rows: [
+        waiting("Copy receipt links source", "The receipt points to the source packet or CopyRoom proof."),
+        waiting("Diff is reviewable", "Differences between source and output are visible."),
+        waiting("Adapted copy is labeled", "Non-exact edits are labeled as adaptation, not exact copy."),
+        waiting("Reviewer can verify", "A human or worker can re-check the copy without guessing."),
+        waiting("Fidelity failure blocks green", "Unexplained drift marks the report FAIL or ALERT."),
+      ],
+    },
+    improvementLoop("FidelityPass"),
+  ],
+  legalpass: [
+    {
+      title: "Risk wording",
+      rows: [
+        waiting("No legal advice claim", "The page does not imply UnClick gives legal advice unless approved."),
+        waiting("Disclaimers are plain", "Disclaimers are understandable and close to the relevant claim."),
+        waiting("Promise is bounded", "Guarantees, certifications, and assurance language are not overstated."),
+        waiting("Jurisdiction is not guessed", "Country or state-specific claims are not invented."),
+        waiting("Human review flag exists", "High-risk legal language has a clear review path."),
+      ],
+    },
+    {
+      title: "Policy surfaces",
+      rows: [
+        waiting("Privacy claim matches policy", "Privacy wording matches the actual privacy policy."),
+        waiting("Terms claim matches terms", "Terms wording matches the actual terms page."),
+        waiting("Refund or billing claim matches", "Money-related wording matches the real billing behavior."),
+        waiting("Data retention claim matches", "Storage and deletion promises match implementation or policy."),
+        waiting("User consent is clear", "Opt-in, opt-out, and notice copy is visible where required."),
+      ],
+    },
+    {
+      title: "Evidence handling",
+      rows: [
+        waiting("Source policy linked", "The report links the policy or source that backs the row."),
+        waiting("Unverified claim blocks", "Claims without source proof become WARNING or FAIL."),
+        warning("Specialist review needed", "LegalPass flags legal-risk wording; it does not certify legality."),
+        waiting("Change log exists", "Legal-sensitive wording changes leave a date and reason."),
+        waiting("N/A reason is explicit", "N/A explains why the legal check is not relevant to the job."),
+      ],
+    },
+    improvementLoop("LegalPass"),
+  ],
+  sloppass: [
+    {
+      title: "Code quality",
+      rows: [
+        waiting("Smallest useful change", "The patch solves the task without unrelated churn."),
+        waiting("No dead code", "Unused code, stale branches, and abandoned helpers are removed or explained."),
+        waiting("Naming is clear", "Names explain purpose without vague filler."),
+        waiting("Duplication is justified", "Repeated logic is intentional or refactored where useful."),
+        waiting("Complexity is contained", "Complicated logic has a local reason and a focused test."),
+      ],
+    },
+    {
+      title: "Diff hygiene",
+      rows: [
+        waiting("Line endings are clean", "Whitespace-only or line-ending noise is not committed."),
+        waiting("Generated files match source", "Generated outputs change only because source changed."),
+        waiting("No local paths leak", "Public files do not expose local machine paths."),
+        waiting("No debug leftovers", "Console noise, temp wrappers, and scratch files are removed."),
+        waiting("Commit scope is honest", "The commit contains only the intended product slice."),
+      ],
+    },
+    {
+      title: "Maintainability",
+      rows: [
+        waiting("Tests cover the risk", "Tests match the behavior most likely to regress."),
+        waiting("Failure mode is readable", "The next worker can understand what failed and why."),
+        waiting("Existing patterns are followed", "The implementation matches nearby code style."),
+        waiting("Docs updated when needed", "User-facing or worker-facing behavior changes update docs."),
+        waiting("Slop finding blocks merge", "A real sloppy-risk finding cannot be rubber-stamped green."),
+      ],
+    },
+    improvementLoop("SlopPass"),
+  ],
+  commonsensepass: [
+    {
+      title: "Claim sanity",
+      rows: [
+        waiting("Done means done", "The job is not called done until the requested outcome exists."),
+        waiting("Green means checked", "Green status comes from proof, not optimism or stale comments."),
+        waiting("No false quiet", "A quiet queue is not called healthy when work is still open."),
+        waiting("Scope matches request", "The response answers the user's newest request, not an old one."),
+        waiting("Caveats are plain", "Any limitation is stated simply instead of hidden."),
+      ],
+    },
+    {
+      title: "Proof sanity",
+      rows: [
+        waiting("Proof is current", "Receipts are tied to the current branch, PR, route, or deploy."),
+        waiting("Proof is relevant", "The proof checks the thing being claimed."),
+        waiting("Proof is observable", "A reviewer can click or rerun enough evidence to trust it."),
+        waiting("Fixture is not production proof", "Test fixtures are labeled as tests, not live proof."),
+        waiting("Screenshot proof fits UI work", "UI claims include visual evidence when practical."),
+      ],
+    },
+    {
+      title: "Human comprehension",
+      rows: [
+        waiting("Plain English result", "Anyone can read the report and know what happened."),
+        waiting("No internal-only labels", "Worker jargon is hidden unless technical proof is opened."),
+        waiting("Next action is obvious", "Failed or warning rows say what happens next."),
+        waiting("No contradiction", "Boardroom, PR, docs, and UI tell the same story."),
+        waiting("Common sense failure blocks", "If the claim sounds wrong, the row cannot be green."),
+      ],
+    },
+    improvementLoop("CommonSensePass"),
+  ],
+  seopass: [
+    {
+      title: "Page basics",
+      rows: [
+        waiting("Title tag is useful", "The page title names the product or offer clearly."),
+        waiting("Meta description helps", "The description explains the page in simple search-friendly language."),
+        waiting("Canonical URL is set", "The canonical path is correct and stable."),
+        waiting("Heading order is sensible", "The page uses a clear H1 and logical headings."),
+        waiting("Important words appear", "Product and category terms appear naturally in the visible copy."),
+      ],
+    },
+    {
+      title: "Crawl and index clues",
+      rows: [
+        waiting("Route returns 200", "The public URL returns a successful response."),
+        waiting("No accidental noindex", "The page is not blocked from indexing unless intended."),
+        waiting("Internal links exist", "Relevant pages link to and from this page."),
+        waiting("Images have text alternatives", "Important images have useful alt text or nearby labels."),
+        waiting("Structured clues are stable", "Any structured data or metadata matches the page content."),
+      ],
+    },
+    {
+      title: "Search trust",
+      rows: [
+        waiting("Claims are not spammy", "The copy is useful, not keyword stuffing."),
+        waiting("Brand path is obvious", "The page relationship to UnClick and AutoPilot is clear."),
+        waiting("Duplicate pages are avoided", "Similar pages have distinct jobs or are consolidated."),
+        waiting("Snippet reads well", "The likely search snippet sounds human and accurate."),
+        waiting("SEO issue blocks publish", "A serious search-readability issue becomes FAIL or WARNING."),
+      ],
+    },
+    improvementLoop("SEOPass"),
+  ],
+  geopass: [
+    {
+      title: "AI answer clarity",
+      rows: [
+        waiting("Product can be summarized", "An AI answer can explain what the product is in one sentence."),
+        waiting("Audience is clear", "The answer knows who the page is for."),
+        waiting("Use case is clear", "The answer can name when to use the product."),
+        waiting("Relationship is clear", "The answer understands UnClick, AutoPilot, XPass, and the Pass family."),
+        waiting("No conflicting definitions", "The page does not define the product two different ways."),
+      ],
+    },
+    {
+      title: "Evidence for answer engines",
+      rows: [
+        waiting("Facts are visible", "Important product facts appear in crawlable text."),
+        waiting("Examples are concrete", "The page includes real examples or plain scenarios."),
+        waiting("Internal links support context", "Related UnClick pages connect the concept graph."),
+        waiting("Jargon is explained", "Special names are explained without assuming prior knowledge."),
+        waiting("AI can cite safe proof", "The page points to public proof where appropriate."),
+      ],
+    },
+    {
+      title: "Answer quality",
+      rows: [
+        waiting("No hallucination bait", "The page does not encourage unsupported claims."),
+        waiting("Comparison is honest", "Comparisons avoid vague best-in-class language."),
+        waiting("Freshness is obvious", "Dates, current state, or report status are clear where needed."),
+        waiting("Question coverage exists", "Likely user questions are answered directly."),
+        waiting("GEO gap creates improvement", "Bad AI answers feed back into checklist updates."),
+      ],
+    },
+    improvementLoop("GEOPass"),
+  ],
+  flowpass: [
+    {
+      title: "Journey start",
+      rows: [
+        waiting("Entry point is clear", "The user can see where to start the task."),
+        waiting("Required context is visible", "The screen asks for or shows the information needed to continue."),
+        waiting("Primary path is short", "The main journey avoids unnecessary detours."),
+        waiting("Choice overload is controlled", "Options are grouped or reduced when the user needs a decision."),
+        waiting("Unauthenticated path is handled", "Login or permission gates explain what to do next."),
+      ],
+    },
+    {
+      title: "Journey middle",
+      rows: [
+        waiting("Progress is understandable", "The user knows whether the task is waiting, running, or done."),
+        waiting("Backtracking is safe", "Going back or changing input does not lose important work silently."),
+        waiting("Validation is timely", "Errors appear near the field or step that caused them."),
+        waiting("Handoffs are clear", "Moving between tools, reports, or agents keeps context."),
+        waiting("Interruptions recover", "Refreshes, partial failures, and retries have a recovery path."),
+      ],
+    },
+    {
+      title: "Journey finish",
+      rows: [
+        waiting("Completion is obvious", "The final state says what was completed."),
+        waiting("Receipt is available", "The user can open proof or a report after completion."),
+        waiting("Next action is useful", "The screen suggests a real next step, not generic filler."),
+        waiting("Loop continues when red", "Failed checks route back into work instead of stopping at red."),
+        waiting("Flow failure blocks green", "A journey that cannot be finished is not a PASS."),
+      ],
+    },
+    improvementLoop("FlowPass"),
+  ],
+  rotatepass: [
+    {
+      title: "Credential inventory",
+      rows: [
+        waiting("Credential is identified", "The key, token, or secret type is known without exposing the raw value."),
+        waiting("Owner is known", "The account, service, or team responsible for the credential is clear."),
+        waiting("Environment is known", "Production, preview, local, or CI scope is labeled."),
+        waiting("Consumers are known", "Services that depend on the credential are listed or discoverable."),
+        waiting("Old value is not printed", "Rotation work never logs the raw old secret."),
+      ],
+    },
+    {
+      title: "Rotation path",
+      rows: [
+        waiting("New secret created safely", "New values are generated or copied through approved secret handling."),
+        waiting("Storage is updated", "The correct secret store receives the new value."),
+        waiting("Dependent services redeploy", "Apps or jobs that need the new secret are restarted or redeployed."),
+        waiting("Old secret revoked", "Old values are removed once the new path is proven."),
+        waiting("Rollback plan exists", "If rotation fails, the operator knows the safe recovery step."),
+      ],
+    },
+    {
+      title: "Rotation proof",
+      rows: [
+        waiting("Smoke check proves new value", "A safe check proves the new secret works."),
+        waiting("No secret in receipt", "The proof says what worked without revealing the secret."),
+        waiting("Expiry is tracked", "Expiry, next rotation, or review timing is recorded when known."),
+        waiting("Access is least needed", "The credential has no unnecessary scope where that can be checked."),
+        na("Rotation required", "N/A only when the job does not touch credentials or secret lifecycle."),
+      ],
+    },
+    improvementLoop("RotatePass"),
+  ],
+  wakepass: [
+    {
+      title: "Ownership",
+      rows: [
+        waiting("Owner is assigned", "A job has a real seat, agent, or human owner."),
+        waiting("Owner is fresh", "The owner has checked in recently enough to be trusted."),
+        waiting("Next action is named", "The owner has a concrete next step, not a vague status."),
+        waiting("ETA is present", "The job has a next check-in or completion expectation."),
+        waiting("Fallback is clear", "If the owner goes stale, the handoff path is known."),
+      ],
+    },
+    {
+      title: "Queue health",
+      rows: [
+        waiting("No stale in-progress work", "In-progress jobs are either active, reassigned, or blocked."),
+        waiting("Open backlog is acknowledged", "The system does not claim healthy while work waits unowned."),
+        waiting("QueuePush packets are ACKed", "Direct build packets receive done or blocker replies."),
+        waiting("Blocked jobs say why", "A blocker names the missing input or external state."),
+        waiting("Done jobs have proof", "Jobs are closed only after observable proof exists."),
+      ],
+    },
+    {
+      title: "Wake behavior",
+      rows: [
+        waiting("Wakes are useful", "Wakes ask for action or give proof, not noise."),
+        waiting("No spam loops", "Stale wake loops do not flood the Boardroom."),
+        waiting("Human touch is minimized", "Workers continue when they can without asking the user to babysit."),
+        waiting("Signal reaches right lane", "Alerts go to the owner or routing lane that can act."),
+        waiting("Wake failure blocks quiet", "If wake proof is missing, the system cannot call itself quiet."),
+      ],
+    },
+    improvementLoop("WakePass"),
+  ],
+  compliancepass: [
+    {
+      title: "Readiness scope",
+      rows: [
+        waiting("Framework is named", "The relevant policy, readiness, or compliance framework is identified."),
+        waiting("Scope is bounded", "The report says what product, system, or claim is being checked."),
+        waiting("Evidence standard is clear", "The kind of proof needed for each row is named."),
+        waiting("Certification is not implied", "Readiness checks do not pretend to be formal certification."),
+        waiting("Out-of-scope items are explicit", "N/A rows explain why the check does not apply."),
+      ],
+    },
+    {
+      title: "Evidence readiness",
+      rows: [
+        waiting("Policy evidence exists", "Relevant policies, docs, or controls are linked."),
+        waiting("Operational evidence exists", "Logs, receipts, screenshots, or runs prove behavior where needed."),
+        waiting("Owner evidence exists", "A responsible person or lane is named for ongoing controls."),
+        waiting("Date evidence exists", "Evidence has a useful date or freshness marker."),
+        waiting("Gap evidence is honest", "Missing evidence is marked WARNING or FAIL, not hidden."),
+      ],
+    },
+    {
+      title: "Follow-through",
+      rows: [
+        waiting("Risk is ranked", "Gaps are ranked by severity or release impact."),
+        waiting("Remediation is named", "Each gap has a clear fix or next action."),
+        waiting("Exception is documented", "Accepted risk is recorded with reason and owner."),
+        waiting("Recheck is scheduled", "Readiness work has a future review or trigger."),
+        waiting("Readiness failure blocks claim", "Unproven readiness claims cannot ship as green."),
+      ],
+    },
+    improvementLoop("CompliancePass"),
+  ],
+};
+
+export function countChecklistRows(productId: XPassProductId): number {
+  return XPASS_PRODUCT_CHECKLISTS[productId].reduce((total, group) => total + group.rows.length, 0);
+}
+
+export function countChecklistGroups(productId: XPassProductId): number {
+  return XPASS_PRODUCT_CHECKLISTS[productId].length;
+}


### PR DESCRIPTION
## What changed

This fixes the XPass UI misunderstanding: the Admin XPass pages now show real product-specific QC checklists instead of a tiny generic receipt wrapper.

- Adds a shared XPass checklist catalog with large per-Pass row groups.
- Shows checklist row counts and group counts on product cards.
- Shows PASS, FAIL, Alert, Warning, N/A, and Waiting status states.
- Makes each Pass page display product-specific rows, for example SecurityPass secrets/auth/data-boundary checks and CopyPass message/trust/source-copy checks.
- Updates public XPass copy and docs so the intended model is “large QC checklist that loops until relevant rows are green,” not “roadworthy” as literal UI language.

## Local proof

- `npx vitest run src/pages/admin/AdminXPassHub.test.tsx`
- `npx tsc --noEmit`
- `npm run lint` returned zero errors
- `npm run build`
- Local visual smoke: SecurityPass showed 25 checklist rows with no horizontal overflow; CopyPass mobile showed 26 checklist rows.

## Notes

Vercel connector was not used because the `_vercel_get_env` schema issue can still crash sessions. Cloud proof will come from GitHub checks and direct production verification after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI copy, static checklist data, and tests; no auth or runtime receipt pipeline changes in this diff.
> 
> **Overview**
> Replaces the **roadworthy / tiny receipt** XPass story with a **large per-Pass QC checklist** model in Admin, on the public `/xpass` page, and in PRD/index docs (including post–PR #1219 truth).
> 
> Adds **`xpassChecklistCatalog.ts`**: shared catalog for all 14 Passes (base groups, deep checks, build/evidence/loop groups), row/group/family counts, and statuses **`PASS` / `FAIL` / `ALERT` / `WARNING` / `N/A` / `WAITING`**. **`AdminXPassHub`** merges a small **current run gate** with that catalog, shows counts on cards, a status legend, numbered rows (`data-testid="xpass-check-row"`), and product-specific sections (e.g. SecurityPass secrets/auth, CopyPass message clarity).
> 
> Tests and copy move from *roadworthy inspection* to *quality-control checklist*; **`AdminYou.test`** waits for initial profile/device fetches to reduce flake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10cfcb67efe4a9f99e66fa30e0e34726af48e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->