### PR TITLE
Add 8 popular connectors: Todoist, Pipedrive, Confluence, Unsplash, Giphy, Miro, Shortcut, Wikipedia

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 594,
+    "inventory": 602,
     "source_manifest": 190,
     "pages": 82,
-    "tools": 203,
+    "tools": 211,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 203
+      "count": 211
     },
     {
       "id": "rooms",
@@ -4152,6 +4152,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-confluence-packages-mcp-server-src-confluence-tool-ts-no-route",
+      "division": "Tools",
+      "name": "confluence",
+      "kind": "MCP tool",
+      "meaning": "confluence MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/confluence-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-contentful-packages-mcp-server-src-contentful-tool-ts-no-route",
       "division": "Tools",
       "name": "contentful",
@@ -4458,6 +4468,16 @@
       "kind": "MCP tool",
       "meaning": "geopass MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/geopass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-giphy-packages-mcp-server-src-giphy-tool-ts-no-route",
+      "division": "Tools",
+      "name": "giphy",
+      "kind": "MCP tool",
+      "meaning": "giphy MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/giphy-tool.ts",
       "route": "",
       "tags": []
     },
@@ -4802,6 +4822,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-miro-packages-mcp-server-src-miro-tool-ts-no-route",
+      "division": "Tools",
+      "name": "miro",
+      "kind": "MCP tool",
+      "meaning": "miro MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/miro-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-mistral-packages-mcp-server-src-mistral-tool-ts-no-route",
       "division": "Tools",
       "name": "mistral",
@@ -5078,6 +5108,16 @@
       "kind": "MCP tool",
       "meaning": "pinterest MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/pinterest-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-pipedrive-packages-mcp-server-src-pipedrive-tool-ts-no-route",
+      "division": "Tools",
+      "name": "pipedrive",
+      "kind": "MCP tool",
+      "meaning": "pipedrive MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/pipedrive-tool.ts",
       "route": "",
       "tags": []
     },
@@ -5402,6 +5442,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-shortcut-packages-mcp-server-src-shortcut-tool-ts-no-route",
+      "division": "Tools",
+      "name": "shortcut",
+      "kind": "MCP tool",
+      "meaning": "shortcut MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/shortcut-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-slack-packages-mcp-server-src-slack-tool-ts-no-route",
       "division": "Tools",
       "name": "slack",
@@ -5592,6 +5642,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-todoist-packages-mcp-server-src-todoist-tool-ts-no-route",
+      "division": "Tools",
+      "name": "todoist",
+      "kind": "MCP tool",
+      "meaning": "todoist MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/todoist-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-togetherai-packages-mcp-server-src-togetherai-tool-ts-no-route",
       "division": "Tools",
       "name": "togetherai",
@@ -5712,6 +5772,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-unsplash-packages-mcp-server-src-unsplash-tool-ts-no-route",
+      "division": "Tools",
+      "name": "unsplash",
+      "kind": "MCP tool",
+      "meaning": "unsplash MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/unsplash-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-untappd-packages-mcp-server-src-untappd-tool-ts-no-route",
       "division": "Tools",
       "name": "untappd",
@@ -5808,6 +5878,16 @@
       "kind": "MCP tool",
       "meaning": "whatsapp MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/whatsapp-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-wikipedia-packages-mcp-server-src-wikipedia-tool-ts-no-route",
+      "division": "Tools",
+      "name": "wikipedia",
+      "kind": "MCP tool",
+      "meaning": "wikipedia MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/wikipedia-tool.ts",
       "route": "",
       "tags": []
     },
@@ -6738,6 +6818,11 @@
       "packages/mcp-server/src/compliancepass-tool.ts"
     ],
     [
+      "confluence",
+      "confluence MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/confluence-tool.ts"
+    ],
+    [
       "contentful",
       "contentful MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/contentful-tool.ts"
@@ -6891,6 +6976,11 @@
       "geopass",
       "geopass MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/geopass-tool.ts"
+    ],
+    [
+      "giphy",
+      "giphy MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/giphy-tool.ts"
     ],
     [
       "github",
@@ -7063,6 +7153,11 @@
       "packages/mcp-server/src/meal-tool.ts"
     ],
     [
+      "miro",
+      "miro MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/miro-tool.ts"
+    ],
+    [
       "mistral",
       "mistral MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/mistral-tool.ts"
@@ -7201,6 +7296,11 @@
       "pinterest",
       "pinterest MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/pinterest-tool.ts"
+    ],
+    [
+      "pipedrive",
+      "pipedrive MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/pipedrive-tool.ts"
     ],
     [
       "plaid",
@@ -7363,6 +7463,11 @@
       "packages/mcp-server/src/shopify-tool.ts"
     ],
     [
+      "shortcut",
+      "shortcut MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/shortcut-tool.ts"
+    ],
+    [
       "slack",
       "slack MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/slack-tool.ts"
@@ -7458,6 +7563,11 @@
       "packages/mcp-server/src/tmdb-tool.ts"
     ],
     [
+      "todoist",
+      "todoist MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/todoist-tool.ts"
+    ],
+    [
       "togetherai",
       "togetherai MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/togetherai-tool.ts"
@@ -7518,6 +7628,11 @@
       "packages/mcp-server/src/unit-converter-tool.ts"
     ],
     [
+      "unsplash",
+      "unsplash MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/unsplash-tool.ts"
+    ],
+    [
       "untappd",
       "untappd MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/untappd-tool.ts"
@@ -7566,6 +7681,11 @@
       "whatsapp",
       "whatsapp MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/whatsapp-tool.ts"
+    ],
+    [
+      "wikipedia",
+      "wikipedia MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/wikipedia-tool.ts"
     ],
     [
       "willyweather",
@@ -8665,6 +8785,11 @@
       "bytes": 7342
     },
     {
+      "source": "packages/mcp-server/src/confluence-tool.ts",
+      "hash": "f1248450cf5a",
+      "bytes": 4326
+    },
+    {
       "source": "packages/mcp-server/src/contentful-tool.ts",
       "hash": "fe4a6bb32986",
       "bytes": 5202
@@ -8713,11 +8838,6 @@
       "source": "packages/mcp-server/src/digitalocean-tool.ts",
       "hash": "ad80b450a7f7",
       "bytes": 4467
-    },
-    {
-      "source": "packages/mcp-server/src/discogs-tool.ts",
-      "hash": "3e766c100f7c",
-      "bytes": 6462
     },
     {
       "source": ".github/workflows/apply-migrations.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -174,6 +174,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/color-tool.ts | f9aa9c0fec6e | 13643 |
 | packages/mcp-server/src/commonsensepass-tool.ts | bad23b55ea01 | 1995 |
 | packages/mcp-server/src/compliancepass-tool.ts | bedf85b00baa | 7342 |
+| packages/mcp-server/src/confluence-tool.ts | f1248450cf5a | 4326 |
 | packages/mcp-server/src/contentful-tool.ts | fe4a6bb32986 | 5202 |
 | packages/mcp-server/src/convertkit-tool.ts | d6f0f01e6032 | 10595 |
 | packages/mcp-server/src/copypass-tool.ts | 3cbadbc448a0 | 33377 |
@@ -184,7 +185,6 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/deepl-tool.ts | 69dad96b05ec | 8084 |
 | packages/mcp-server/src/deezer-tool.ts | cfbe0c88ce25 | 8390 |
 | packages/mcp-server/src/digitalocean-tool.ts | ad80b450a7f7 | 4467 |
-| packages/mcp-server/src/discogs-tool.ts | 3e766c100f7c | 6462 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
 | .github/workflows/autonomous-runner.yml | a8c83efde889 | 15338 |
@@ -210,7 +210,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 48 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 34 |
-| Tools | MCP and gateway capabilities available to seats. | 203 |
+| Tools | MCP and gateway capabilities available to seats. | 211 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
@@ -367,6 +367,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | color | color MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/color-tool.ts |
 | commonsensepass | commonsensepass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/commonsensepass-tool.ts |
 | compliancepass | compliancepass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/compliancepass-tool.ts |
+| confluence | confluence MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/confluence-tool.ts |
 | contentful | contentful MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/contentful-tool.ts |
 | convertkit | convertkit MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/convertkit-tool.ts |
 | copypass | copypass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/copypass-tool.ts |
@@ -398,6 +399,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gdelt-tool.ts |
 | genius | genius MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/genius-tool.ts |
 | geopass | geopass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/geopass-tool.ts |
+| giphy | giphy MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/giphy-tool.ts |
 | github | github MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/github-tool.ts |
 | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gitlab-tool.ts |
 | groq | groq MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/groq-tool.ts |
@@ -432,6 +434,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | mapbox | mapbox MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mapbox-tool.ts |
 | mastodon | mastodon MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mastodon-tool.ts |
 | meal | meal MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/meal-tool.ts |
+| miro | miro MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/miro-tool.ts |
 | mistral | mistral MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mistral-tool.ts |
 | mixpanel | mixpanel MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mixpanel-tool.ts |
 | monday | monday MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/monday-tool.ts |
@@ -460,6 +463,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | pika | pika MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pika-tool.ts |
 | pinecone | pinecone MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pinecone-tool.ts |
 | pinterest | pinterest MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pinterest-tool.ts |
+| pipedrive | pipedrive MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pipedrive-tool.ts |
 | plaid | plaid MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/plaid-tool.ts |
 | podcastindex | podcastindex MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/podcastindex-tool.ts |
 | posthog | posthog MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/posthog-tool.ts |
@@ -492,6 +496,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | setlistfm | setlistfm MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/setlistfm-tool.ts |
 | shodan | shodan MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/shodan-tool.ts |
 | shopify | shopify MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/shopify-tool.ts |
+| shortcut | shortcut MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/shortcut-tool.ts |
 | slack | slack MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/slack-tool.ts |
 | sleeper | sleeper MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sleeper-tool.ts |
 | sloppass | sloppass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sloppass-tool.ts |
@@ -511,6 +516,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | ticketmaster | ticketmaster MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ticketmaster-tool.ts |
 | tiktok | tiktok MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tiktok-tool.ts |
 | tmdb | tmdb MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tmdb-tool.ts |
+| todoist | todoist MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/todoist-tool.ts |
 | togetherai | togetherai MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/togetherai-tool.ts |
 | toggl | toggl MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/toggl-tool.ts |
 | toilets | toilets MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/toilets-tool.ts |
@@ -523,6 +529,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | twitch | twitch MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/twitch-tool.ts |
 | typeform | typeform MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/typeform-tool.ts |
 | unit converter | unit converter MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/unit-converter-tool.ts |
+| unsplash | unsplash MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/unsplash-tool.ts |
 | untappd | untappd MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/untappd-tool.ts |
 | upstash | upstash MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/upstash-tool.ts |
 | urlscan | urlscan MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/urlscan-tool.ts |
@@ -533,6 +540,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | virustotal | virustotal MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/virustotal-tool.ts |
 | webflow | webflow MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/webflow-tool.ts |
 | whatsapp | whatsapp MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/whatsapp-tool.ts |
+| wikipedia | wikipedia MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wikipedia-tool.ts |
 | willyweather | willyweather MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/willyweather-tool.ts |
 | wise | wise MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wise-tool.ts |
 | woocommerce | woocommerce MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/woocommerce-tool.ts |
@@ -952,6 +960,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | color | color MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/color-tool.ts |
 | Tools | MCP tool | commonsensepass | commonsensepass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/commonsensepass-tool.ts |
 | Tools | MCP tool | compliancepass | compliancepass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/compliancepass-tool.ts |
+| Tools | MCP tool | confluence | confluence MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/confluence-tool.ts |
 | Tools | MCP tool | contentful | contentful MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/contentful-tool.ts |
 | Tools | MCP tool | convertkit | convertkit MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/convertkit-tool.ts |
 | Tools | MCP tool | copypass | copypass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/copypass-tool.ts |
@@ -983,6 +992,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | gdelt | gdelt MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gdelt-tool.ts |
 | Tools | MCP tool | genius | genius MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/genius-tool.ts |
 | Tools | MCP tool | geopass | geopass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/geopass-tool.ts |
+| Tools | MCP tool | giphy | giphy MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/giphy-tool.ts |
 | Tools | MCP tool | github | github MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/github-tool.ts |
 | Tools | MCP tool | gitlab | gitlab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gitlab-tool.ts |
 | Tools | MCP tool | groq | groq MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/groq-tool.ts |
@@ -1017,6 +1027,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | mapbox | mapbox MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mapbox-tool.ts |
 | Tools | MCP tool | mastodon | mastodon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mastodon-tool.ts |
 | Tools | MCP tool | meal | meal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/meal-tool.ts |
+| Tools | MCP tool | miro | miro MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/miro-tool.ts |
 | Tools | MCP tool | mistral | mistral MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mistral-tool.ts |
 | Tools | MCP tool | mixpanel | mixpanel MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mixpanel-tool.ts |
 | Tools | MCP tool | monday | monday MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/monday-tool.ts |
@@ -1045,6 +1056,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | pika | pika MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pika-tool.ts |
 | Tools | MCP tool | pinecone | pinecone MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pinecone-tool.ts |
 | Tools | MCP tool | pinterest | pinterest MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pinterest-tool.ts |
+| Tools | MCP tool | pipedrive | pipedrive MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pipedrive-tool.ts |
 | Tools | MCP tool | plaid | plaid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/plaid-tool.ts |
 | Tools | MCP tool | podcastindex | podcastindex MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/podcastindex-tool.ts |
 | Tools | MCP tool | posthog | posthog MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/posthog-tool.ts |
@@ -1077,6 +1089,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | setlistfm | setlistfm MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/setlistfm-tool.ts |
 | Tools | MCP tool | shodan | shodan MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shodan-tool.ts |
 | Tools | MCP tool | shopify | shopify MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shopify-tool.ts |
+| Tools | MCP tool | shortcut | shortcut MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shortcut-tool.ts |
 | Tools | MCP tool | slack | slack MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/slack-tool.ts |
 | Tools | MCP tool | sleeper | sleeper MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sleeper-tool.ts |
 | Tools | MCP tool | sloppass | sloppass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sloppass-tool.ts |
@@ -1096,6 +1109,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | ticketmaster | ticketmaster MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ticketmaster-tool.ts |
 | Tools | MCP tool | tiktok | tiktok MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tiktok-tool.ts |
 | Tools | MCP tool | tmdb | tmdb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tmdb-tool.ts |
+| Tools | MCP tool | todoist | todoist MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/todoist-tool.ts |
 | Tools | MCP tool | togetherai | togetherai MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/togetherai-tool.ts |
 | Tools | MCP tool | toggl | toggl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/toggl-tool.ts |
 | Tools | MCP tool | toilets | toilets MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/toilets-tool.ts |
@@ -1108,6 +1122,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | twitch | twitch MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/twitch-tool.ts |
 | Tools | MCP tool | typeform | typeform MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/typeform-tool.ts |
 | Tools | MCP tool | unit converter | unit converter MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/unit-converter-tool.ts |
+| Tools | MCP tool | unsplash | unsplash MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/unsplash-tool.ts |
 | Tools | MCP tool | untappd | untappd MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/untappd-tool.ts |
 | Tools | MCP tool | upstash | upstash MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/upstash-tool.ts |
 | Tools | MCP tool | urlscan | urlscan MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/urlscan-tool.ts |
@@ -1118,6 +1133,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | virustotal | virustotal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/virustotal-tool.ts |
 | Tools | MCP tool | webflow | webflow MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/webflow-tool.ts |
 | Tools | MCP tool | whatsapp | whatsapp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/whatsapp-tool.ts |
+| Tools | MCP tool | wikipedia | wikipedia MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wikipedia-tool.ts |
 | Tools | MCP tool | willyweather | willyweather MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/willyweather-tool.ts |
 | Tools | MCP tool | wise | wise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wise-tool.ts |
 | Tools | MCP tool | woocommerce | woocommerce MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/woocommerce-tool.ts |

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -420,6 +420,26 @@
     }
   },
   {
+    "connector": "confluence",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "contentful",
     "level": 5,
     "levelName": "Agentic",
@@ -831,6 +851,26 @@
       "handles429": true,
       "hasRetry": true,
       "readsErrorBody": true,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "giphy",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
@@ -1320,6 +1360,26 @@
     }
   },
   {
+    "connector": "miro",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "mistral",
     "level": 5,
     "levelName": "Agentic",
@@ -1760,6 +1820,26 @@
     }
   },
   {
+    "connector": "pipedrive",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "plaid",
     "level": 5,
     "levelName": "Agentic",
@@ -2100,6 +2180,26 @@
     }
   },
   {
+    "connector": "shortcut",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": true,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "sleeper",
     "level": 5,
     "levelName": "Agentic",
@@ -2320,6 +2420,26 @@
     }
   },
   {
+    "connector": "todoist",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "togetherai",
     "level": 5,
     "levelName": "Agentic",
@@ -2520,6 +2640,26 @@
     }
   },
   {
+    "connector": "unsplash",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "untappd",
     "level": 5,
     "levelName": "Agentic",
@@ -2654,6 +2794,26 @@
       "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": true,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "wikipedia",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": true,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": true,
+      "handles429": true,
+      "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
       "proactive": false,
       "agentic": true,
       "sourceStamped": true

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (177 external connectors)
+## Distribution (185 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 138 | 78% |
+| L5 | Agentic | 146 | 79% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
-| L2 | Reliable | 36 | 20% |
+| L2 | Reliable | 36 | 19% |
 | L1 | Wrapper | 3 | 2% |
 
-**Hardened (reliability bar met): 173 of 177 (98%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 181 of 185 (98%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 138 of 141 (98%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 146 of 149 (98%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -67,6 +67,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `cohere` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `coingecko` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `coinmarketcap` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `confluence` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `contentful` | Yes | Yes | - | Yes | Yes |  |
 | L5 Agentic | `convertkit` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `datadog` | Yes | - | Yes | Yes | Yes | no-memory |
@@ -88,6 +89,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `fpl` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `gdelt` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `genius` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `giphy` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `groq` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `guardian` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `gumroad` | Yes | - | - | Yes | Yes | no-memory |
@@ -112,6 +114,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `mailchimp` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mapbox` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `meal` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `miro` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mistral` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mixpanel` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `monday` | Yes | - | - | Yes | Yes | no-memory |
@@ -134,6 +137,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `pika` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `pinecone` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `pinterest` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `pipedrive` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `plaid` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `podcastindex` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `posthog` | Yes | Yes | - | Yes | Yes |  |
@@ -151,6 +155,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `sendle` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `setlistfm` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `shodan` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `shortcut` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `sleeper` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `speedrun` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `spotify` | Yes | - | - | Yes | Yes | no-memory |
@@ -162,6 +167,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `ticketmaster` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `tiktok` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `tmdb` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `todoist` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `togetherai` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `toggl` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `toilets` | Yes | - | - | Yes | Yes | no-memory |
@@ -172,6 +178,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `twilio` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `twitch` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `typeform` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `unsplash` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `untappd` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `upstash` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `urlscan` | Yes | - | - | Yes | Yes | no-memory |
@@ -179,6 +186,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `vercel` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `virustotal` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `webflow` | Yes | Yes | - | Yes | Yes |  |
+| L5 Agentic | `wikipedia` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `willyweather` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `wise` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `yelp` | Yes | - | - | Yes | Yes | no-memory |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -618,6 +618,24 @@
     ]
   },
   {
+    "app": "confluence",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "confluence_search",
+        "description": "Search Confluence pages by text."
+      },
+      {
+        "name": "confluence_get_page",
+        "description": "Get a Confluence page by id, including its body."
+      },
+      {
+        "name": "confluence_list_spaces",
+        "description": "List Confluence spaces."
+      }
+    ]
+  },
+  {
     "app": "contentful",
     "category": "Marketing / Communication / Data",
     "tools": [
@@ -1376,6 +1394,24 @@
     ]
   },
   {
+    "app": "giphy",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "giphy_search",
+        "description": "Search Giphy for GIFs."
+      },
+      {
+        "name": "giphy_trending",
+        "description": "Get trending GIFs from Giphy."
+      },
+      {
+        "name": "giphy_random",
+        "description": "Get a random GIF from Giphy, optionally by tag."
+      }
+    ]
+  },
+  {
     "app": "github",
     "category": "Developer / Productivity",
     "tools": [
@@ -2110,6 +2146,24 @@
     ]
   },
   {
+    "app": "miro",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "miro_list_boards",
+        "description": "List Miro boards."
+      },
+      {
+        "name": "miro_get_board",
+        "description": "Get a single Miro board by id."
+      },
+      {
+        "name": "miro_list_items",
+        "description": "List the items (notes, shapes, text) on a Miro board."
+      }
+    ]
+  },
+  {
     "app": "mistral",
     "category": "AI Models",
     "tools": [
@@ -2718,6 +2772,28 @@
       {
         "name": "get_pinterest_user",
         "description": "Get the authenticated Pinterest user account info."
+      }
+    ]
+  },
+  {
+    "app": "pipedrive",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "pipedrive_list_deals",
+        "description": "List Pipedrive deals."
+      },
+      {
+        "name": "pipedrive_list_persons",
+        "description": "List Pipedrive persons (contacts)."
+      },
+      {
+        "name": "pipedrive_list_organizations",
+        "description": "List Pipedrive organizations (companies)."
+      },
+      {
+        "name": "pipedrive_search_deals",
+        "description": "Search Pipedrive deals by term."
       }
     ]
   },
@@ -3498,6 +3574,28 @@
     ]
   },
   {
+    "app": "shortcut",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "shortcut_search_stories",
+        "description": "Search Shortcut stories with the search syntax."
+      },
+      {
+        "name": "shortcut_get_story",
+        "description": "Get a single Shortcut story by id."
+      },
+      {
+        "name": "shortcut_list_projects",
+        "description": "List Shortcut projects."
+      },
+      {
+        "name": "shortcut_list_epics",
+        "description": "List Shortcut epics."
+      }
+    ]
+  },
+  {
     "app": "slack",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -3976,6 +4074,28 @@
     ]
   },
   {
+    "app": "todoist",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "todoist_list_projects",
+        "description": "List your Todoist projects."
+      },
+      {
+        "name": "todoist_list_tasks",
+        "description": "List active Todoist tasks, optionally by project or filter."
+      },
+      {
+        "name": "todoist_create_task",
+        "description": "Create a Todoist task."
+      },
+      {
+        "name": "todoist_complete_task",
+        "description": "Complete (close) a Todoist task by id."
+      }
+    ]
+  },
+  {
     "app": "togetherai",
     "category": "Monitoring / CI / CDP / Email / Commerce / Inference",
     "tools": [
@@ -4240,6 +4360,24 @@
     ]
   },
   {
+    "app": "unsplash",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "unsplash_search_photos",
+        "description": "Search Unsplash photos."
+      },
+      {
+        "name": "unsplash_get_photo",
+        "description": "Get a single Unsplash photo by id (URLs + attribution)."
+      },
+      {
+        "name": "unsplash_random_photo",
+        "description": "Get a random Unsplash photo, optionally matching a query."
+      }
+    ]
+  },
+  {
     "app": "untappd",
     "category": "Gaming",
     "tools": [
@@ -4480,6 +4618,24 @@
       {
         "name": "whatsapp_upload_media",
         "description": "Upload a media file to WhatsApp and get a media ID for use in messages."
+      }
+    ]
+  },
+  {
+    "app": "wikipedia",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "wikipedia_search",
+        "description": "Search Wikipedia article titles. No key needed."
+      },
+      {
+        "name": "wikipedia_summary",
+        "description": "Get a short Wikipedia summary for a page title. No key needed."
+      },
+      {
+        "name": "wikipedia_page",
+        "description": "Get the full plain-text Wikipedia article for a title. No key needed."
       }
     ]
   },

--- a/packages/mcp-server/src/confluence-tool.test.ts
+++ b/packages/mcp-server/src/confluence-tool.test.ts
@@ -1,0 +1,12 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { confluenceSearch, confluenceGetPage } from "./confluence-tool.js";
+
+const CREDS = { site: "acme", email: "me@acme.com", api_token: "t" };
+describe("confluence connector (L2/L5)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, json: async () => ({}) }))); await expect(confluenceSearch({ ...CREDS, query: "x" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(confluenceSearch({ ...CREDS, query: "x" })).rejects.toThrow(/timed out/i); });
+  it("not connected", async () => { vi.stubEnv("CONFLUENCE_SITE", ""); vi.stubEnv("CONFLUENCE_EMAIL", ""); vi.stubEnv("CONFLUENCE_API_TOKEN", ""); vi.stubEnv("JIRA_SITE", ""); vi.stubEnv("JIRA_EMAIL", ""); const r = await confluenceSearch({ query: "x" }) as Record<string, unknown>; expect(r.not_connected).toBe(true); });
+  it("validates page_id", async () => { const r = await confluenceGetPage({ ...CREDS }) as Record<string, unknown>; expect(r.error).toMatch(/page_id is required/i); });
+  it("targets the wiki REST API + stamps", async () => { const f = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ results: [] }) })); vi.stubGlobal("fetch", f); const r = await confluenceSearch({ ...CREDS, query: "roadmap" }) as Record<string, any>; expect(String((f.mock.calls[0] as unknown as [string])[0])).toMatch(/^https:\/\/acme\.atlassian\.net\/wiki\/rest\/api\/content\/search/); expect(r.unclick_meta.source).toMatch(/Confluence/); });
+});

--- a/packages/mcp-server/src/confluence-tool.ts
+++ b/packages/mcp-server/src/confluence-tool.ts
@@ -1,0 +1,79 @@
+// Confluence (Atlassian Cloud) integration for the UnClick MCP server.
+// Uses the Confluence Cloud REST API via fetch - no external dependencies.
+// Auth: Basic auth with your Atlassian email + an API token
+// (https://id.atlassian.com/manage-profile/security/api-tokens), plus the site
+// (e.g. "mycompany" or "mycompany.atlassian.net"). Pairs with the Jira connector.
+
+import { notConnectedFor } from "./connector-setup.js";
+import { type NotConnectedResult } from "./connection-help.js";
+import { stampMeta } from "./connector-meta.js";
+
+const CONFLUENCE_SOURCE = "Confluence Cloud REST API";
+
+interface ConfluenceCreds {
+  baseUrl: string;
+  authHeader: string;
+}
+
+function requireCreds(args: Record<string, unknown>): ConfluenceCreds | NotConnectedResult {
+  const rawSite = String(args.site ?? process.env.CONFLUENCE_SITE ?? process.env.JIRA_SITE ?? "").trim();
+  const email = String(args.email ?? process.env.CONFLUENCE_EMAIL ?? process.env.JIRA_EMAIL ?? "").trim();
+  const token = String(args.api_token ?? process.env.CONFLUENCE_API_TOKEN ?? "").trim();
+  if (!rawSite || !email || !token) return notConnectedFor("confluence");
+  const host = rawSite.replace(/^https?:\/\//, "").replace(/\/.*$/, "").replace(/\.atlassian\.net$/, "");
+  return {
+    baseUrl: `https://${host}.atlassian.net/wiki/rest/api`,
+    authHeader: `Basic ${Buffer.from(`${email}:${token}`).toString("base64")}`,
+  };
+}
+
+async function cfFetch<T>(creds: ConfluenceCreds, path: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(`${creds.baseUrl}${path}`);
+  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const CONFLUENCE_TIMEOUT_MS = Number(process.env.CONFLUENCE_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CONFLUENCE_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), { headers: { Authorization: creds.authHeader, Accept: "application/json" }, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Confluence request timed out after ${CONFLUENCE_TIMEOUT_MS}ms.`);
+    throw new Error(`Confluence network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Confluence rate limit reached (HTTP 429). Please wait and retry.");
+  const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+  if (!res.ok) throw new Error(`Confluence error (${res.status}): ${(data.message as string) ?? `status ${res.status}`}`);
+  return data as T;
+}
+
+function stamp(result: unknown, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: CONFLUENCE_SOURCE, fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function confluenceSearch(args: Record<string, unknown>): Promise<unknown> {
+  const creds = requireCreds(args);
+  if ("not_connected" in creds) return creds;
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required (text to search across pages)." };
+  const cql = `text ~ "${query.replace(/"/g, '\\"')}"`;
+  const data = await cfFetch(creds, "/content/search", { cql, limit: String(Math.min(50, Number(args.limit) || 25)) });
+  return stamp(data, ["Use confluence_get_page with a returned id to read the page body."]);
+}
+
+export async function confluenceGetPage(args: Record<string, unknown>): Promise<unknown> {
+  const creds = requireCreds(args);
+  if ("not_connected" in creds) return creds;
+  const id = String(args.page_id ?? "").trim();
+  if (!id) return { error: "page_id is required." };
+  const data = await cfFetch(creds, `/content/${encodeURIComponent(id)}`, { expand: "body.storage,version,space" });
+  return stamp(data, ["Use confluence_search to find related pages, or confluence_list_spaces for the space list."]);
+}
+
+export async function confluenceListSpaces(args: Record<string, unknown>): Promise<unknown> {
+  const creds = requireCreds(args);
+  if ("not_connected" in creds) return creds;
+  const data = await cfFetch(creds, "/space", { limit: String(Math.min(100, Number(args.limit) || 50)) });
+  return stamp(data, ["Use confluence_search to find pages within a space."]);
+}

--- a/packages/mcp-server/src/connector-setup.ts
+++ b/packages/mcp-server/src/connector-setup.ts
@@ -1139,6 +1139,56 @@ export const CONNECTOR_SETUP: Record<string, ConnectorSetup> = {
     setupUrl:    "https://www.klaviyo.com/settings/account/api-keys",
     note:        "Use a private API key (starts with pk_).",
   },
+  todoist: {
+    displayName: "Todoist",
+    credential:  "API token",
+    arg:         "api_token",
+    envVar:      "TODOIST_API_TOKEN",
+    setupUrl:    "https://app.todoist.com/app/settings/integrations/developer",
+  },
+  pipedrive: {
+    displayName: "Pipedrive",
+    credential:  "API token",
+    arg:         "api_token",
+    envVar:      "PIPEDRIVE_API_TOKEN",
+    setupUrl:    "https://app.pipedrive.com/settings/api",
+  },
+  confluence: {
+    displayName: "Confluence",
+    credential:  "API token",
+    arg:         "api_token",
+    envVar:      "CONFLUENCE_API_TOKEN",
+    setupUrl:    "https://id.atlassian.com/manage-profile/security/api-tokens",
+    note:        "Also pass site and email (or set CONFLUENCE_SITE / CONFLUENCE_EMAIL, or reuse JIRA_SITE / JIRA_EMAIL).",
+  },
+  unsplash: {
+    displayName: "Unsplash",
+    credential:  "Access Key",
+    arg:         "access_key",
+    envVar:      "UNSPLASH_ACCESS_KEY",
+    setupUrl:    "https://unsplash.com/oauth/applications",
+  },
+  giphy: {
+    displayName: "Giphy",
+    credential:  "API key",
+    arg:         "api_key",
+    envVar:      "GIPHY_API_KEY",
+    setupUrl:    "https://developers.giphy.com/dashboard/",
+  },
+  miro: {
+    displayName: "Miro",
+    credential:  "access token",
+    arg:         "access_token",
+    envVar:      "MIRO_ACCESS_TOKEN",
+    setupUrl:    "https://developers.miro.com/",
+  },
+  shortcut: {
+    displayName: "Shortcut",
+    credential:  "API token",
+    arg:         "api_token",
+    envVar:      "SHORTCUT_API_TOKEN",
+    setupUrl:    "https://app.shortcut.com/settings/account/api-tokens",
+  },
 };
 
 /**

--- a/packages/mcp-server/src/giphy-tool.test.ts
+++ b/packages/mcp-server/src/giphy-tool.test.ts
@@ -1,0 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { giphySearch, giphyTrending } from "./giphy-tool.js";
+
+describe("giphy connector (L2/L5)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, json: async () => ({}) }))); await expect(giphyTrending({ api_key: "k" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(giphyTrending({ api_key: "k" })).rejects.toThrow(/timed out/i); });
+  it("not connected", async () => { vi.stubEnv("GIPHY_API_KEY", ""); const r = await giphyTrending({}) as Record<string, unknown>; expect(r.not_connected).toBe(true); });
+  it("validates query", async () => { const r = await giphySearch({ api_key: "k" }) as Record<string, unknown>; expect(r.error).toMatch(/query is required/i); });
+  it("passes api_key in query + stamps", async () => { const f = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ data: [] }) })); vi.stubGlobal("fetch", f); const r = await giphyTrending({ api_key: "secret" }) as Record<string, any>; expect(String((f.mock.calls[0] as unknown as [string])[0])).toContain("api_key=secret"); expect(r.unclick_meta.source).toMatch(/Giphy/); });
+});

--- a/packages/mcp-server/src/giphy-tool.ts
+++ b/packages/mcp-server/src/giphy-tool.ts
@@ -1,0 +1,74 @@
+// Giphy integration for the UnClick MCP server.
+// Uses the Giphy REST API v1 via fetch - no external dependencies.
+// Auth: an API key passed as the api_key query parameter from
+// https://developers.giphy.com/dashboard/.
+
+import { requireCredential } from "./connector-setup.js";
+import { type NotConnectedResult } from "./connection-help.js";
+import { stampMeta } from "./connector-meta.js";
+
+const GIPHY_BASE = "https://api.giphy.com/v1";
+const GIPHY_SOURCE = "Giphy API v1";
+
+function requireKey(args: Record<string, unknown>): string | NotConnectedResult {
+  return requireCredential("giphy", args);
+}
+
+async function giphyFetch<T>(key: string, path: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(`${GIPHY_BASE}${path}`);
+  url.searchParams.set("api_key", key);
+  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const GIPHY_TIMEOUT_MS = Number(process.env.GIPHY_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GIPHY_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), { headers: { Accept: "application/json" }, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Giphy request timed out after ${GIPHY_TIMEOUT_MS}ms.`);
+    throw new Error(`Giphy network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Giphy rate limit reached (HTTP 429). Please wait and retry.");
+  const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+  if (!res.ok) {
+    const meta = data.meta as { msg?: string } | undefined;
+    throw new Error(`Giphy error (${res.status}): ${meta?.msg ?? `status ${res.status}`}`);
+  }
+  return data as T;
+}
+
+function stamp(result: unknown, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: GIPHY_SOURCE, fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function giphySearch(args: Record<string, unknown>): Promise<unknown> {
+  const key = requireKey(args);
+  if (typeof key !== "string") return key;
+  const q = String(args.query ?? args.q ?? "").trim();
+  if (!q) return { error: "query is required (what GIF to search for)." };
+  const params: Record<string, string> = { q, limit: String(Math.min(50, Number(args.limit) || 10)) };
+  if (args.rating) params.rating = String(args.rating);
+  const data = await giphyFetch(key, "/gifs/search", params);
+  return stamp(data, ["Use giphy_trending for what is hot now, or giphy_random for a single surprise GIF."]);
+}
+
+export async function giphyTrending(args: Record<string, unknown>): Promise<unknown> {
+  const key = requireKey(args);
+  if (typeof key !== "string") return key;
+  const params: Record<string, string> = { limit: String(Math.min(50, Number(args.limit) || 10)) };
+  if (args.rating) params.rating = String(args.rating);
+  const data = await giphyFetch(key, "/gifs/trending", params);
+  return stamp(data, ["Use giphy_search to find GIFs for a specific term."]);
+}
+
+export async function giphyRandom(args: Record<string, unknown>): Promise<unknown> {
+  const key = requireKey(args);
+  if (typeof key !== "string") return key;
+  const params: Record<string, string> = {};
+  if (args.tag) params.tag = String(args.tag);
+  if (args.rating) params.rating = String(args.rating);
+  const data = await giphyFetch(key, "/gifs/random", params);
+  return stamp(data, ["Use giphy_search to choose from several matching GIFs instead."]);
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -632,6 +632,24 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "confluence",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "confluence_search",
+        "description": "Search Confluence pages by text."
+      },
+      {
+        "name": "confluence_get_page",
+        "description": "Get a Confluence page by id, including its body."
+      },
+      {
+        "name": "confluence_list_spaces",
+        "description": "List Confluence spaces."
+      }
+    ]
+  },
+  {
     "app": "contentful",
     "category": "Marketing / Communication / Data",
     "tools": [
@@ -1390,6 +1408,24 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "giphy",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "giphy_search",
+        "description": "Search Giphy for GIFs."
+      },
+      {
+        "name": "giphy_trending",
+        "description": "Get trending GIFs from Giphy."
+      },
+      {
+        "name": "giphy_random",
+        "description": "Get a random GIF from Giphy, optionally by tag."
+      }
+    ]
+  },
+  {
     "app": "github",
     "category": "Developer / Productivity",
     "tools": [
@@ -2124,6 +2160,24 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "miro",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "miro_list_boards",
+        "description": "List Miro boards."
+      },
+      {
+        "name": "miro_get_board",
+        "description": "Get a single Miro board by id."
+      },
+      {
+        "name": "miro_list_items",
+        "description": "List the items (notes, shapes, text) on a Miro board."
+      }
+    ]
+  },
+  {
     "app": "mistral",
     "category": "AI Models",
     "tools": [
@@ -2732,6 +2786,28 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "get_pinterest_user",
         "description": "Get the authenticated Pinterest user account info."
+      }
+    ]
+  },
+  {
+    "app": "pipedrive",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "pipedrive_list_deals",
+        "description": "List Pipedrive deals."
+      },
+      {
+        "name": "pipedrive_list_persons",
+        "description": "List Pipedrive persons (contacts)."
+      },
+      {
+        "name": "pipedrive_list_organizations",
+        "description": "List Pipedrive organizations (companies)."
+      },
+      {
+        "name": "pipedrive_search_deals",
+        "description": "Search Pipedrive deals by term."
       }
     ]
   },
@@ -3512,6 +3588,28 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "shortcut",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "shortcut_search_stories",
+        "description": "Search Shortcut stories with the search syntax."
+      },
+      {
+        "name": "shortcut_get_story",
+        "description": "Get a single Shortcut story by id."
+      },
+      {
+        "name": "shortcut_list_projects",
+        "description": "List Shortcut projects."
+      },
+      {
+        "name": "shortcut_list_epics",
+        "description": "List Shortcut epics."
+      }
+    ]
+  },
+  {
     "app": "slack",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -3990,6 +4088,28 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "todoist",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "todoist_list_projects",
+        "description": "List your Todoist projects."
+      },
+      {
+        "name": "todoist_list_tasks",
+        "description": "List active Todoist tasks, optionally by project or filter."
+      },
+      {
+        "name": "todoist_create_task",
+        "description": "Create a Todoist task."
+      },
+      {
+        "name": "todoist_complete_task",
+        "description": "Complete (close) a Todoist task by id."
+      }
+    ]
+  },
+  {
     "app": "togetherai",
     "category": "Monitoring / CI / CDP / Email / Commerce / Inference",
     "tools": [
@@ -4254,6 +4374,24 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "unsplash",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "unsplash_search_photos",
+        "description": "Search Unsplash photos."
+      },
+      {
+        "name": "unsplash_get_photo",
+        "description": "Get a single Unsplash photo by id (URLs + attribution)."
+      },
+      {
+        "name": "unsplash_random_photo",
+        "description": "Get a random Unsplash photo, optionally matching a query."
+      }
+    ]
+  },
+  {
     "app": "untappd",
     "category": "Gaming",
     "tools": [
@@ -4494,6 +4632,24 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "whatsapp_upload_media",
         "description": "Upload a media file to WhatsApp and get a media ID for use in messages."
+      }
+    ]
+  },
+  {
+    "app": "wikipedia",
+    "category": "Marketing / Communication / Data",
+    "tools": [
+      {
+        "name": "wikipedia_search",
+        "description": "Search Wikipedia article titles. No key needed."
+      },
+      {
+        "name": "wikipedia_summary",
+        "description": "Get a short Wikipedia summary for a page title. No key needed."
+      },
+      {
+        "name": "wikipedia_page",
+        "description": "Get the full plain-text Wikipedia article for a title. No key needed."
       }
     ]
   },

--- a/packages/mcp-server/src/miro-tool.test.ts
+++ b/packages/mcp-server/src/miro-tool.test.ts
@@ -1,0 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { miroListBoards, miroGetBoard } from "./miro-tool.js";
+
+describe("miro connector (L2/L5)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, json: async () => ({}) }))); await expect(miroListBoards({ access_token: "k" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(miroListBoards({ access_token: "k" })).rejects.toThrow(/timed out/i); });
+  it("not connected", async () => { vi.stubEnv("MIRO_ACCESS_TOKEN", ""); const r = await miroListBoards({}) as Record<string, unknown>; expect(r.not_connected).toBe(true); });
+  it("validates board_id", async () => { const r = await miroGetBoard({ access_token: "k" }) as Record<string, unknown>; expect(r.error).toMatch(/board_id is required/i); });
+  it("stamps", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ data: [] }) }))); const r = await miroListBoards({ access_token: "k" }) as Record<string, any>; expect(r.unclick_meta.source).toMatch(/Miro/); });
+});

--- a/packages/mcp-server/src/miro-tool.ts
+++ b/packages/mcp-server/src/miro-tool.ts
@@ -1,0 +1,69 @@
+// Miro integration for the UnClick MCP server.
+// Uses the Miro REST API v2 via fetch - no external dependencies.
+// Auth: an access token (Authorization: Bearer) from a Miro app
+// (https://developers.miro.com/).
+
+import { requireCredential } from "./connector-setup.js";
+import { type NotConnectedResult } from "./connection-help.js";
+import { stampMeta } from "./connector-meta.js";
+
+const MIRO_BASE = "https://api.miro.com/v2";
+const MIRO_SOURCE = "Miro REST API v2";
+
+function requireToken(args: Record<string, unknown>): string | NotConnectedResult {
+  return requireCredential("miro", args);
+}
+
+async function miroFetch<T>(token: string, path: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(`${MIRO_BASE}${path}`);
+  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const MIRO_TIMEOUT_MS = Number(process.env.MIRO_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MIRO_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), { headers: { Authorization: `Bearer ${token}`, Accept: "application/json" }, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Miro request timed out after ${MIRO_TIMEOUT_MS}ms.`);
+    throw new Error(`Miro network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Miro rate limit reached (HTTP 429). Please wait and retry.");
+  const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+  if (!res.ok) throw new Error(`Miro error (${res.status}): ${(data.message as string) ?? `status ${res.status}`}`);
+  return data as T;
+}
+
+function stamp(result: unknown, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: MIRO_SOURCE, fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function miroListBoards(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const params: Record<string, string> = { limit: String(Math.min(50, Number(args.limit) || 25)) };
+  if (args.query) params.query = String(args.query);
+  const data = await miroFetch(token, "/boards", params);
+  return stamp(data, ["Use miro_get_board with a returned id, or miro_list_items to read what is on a board."]);
+}
+
+export async function miroGetBoard(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const id = String(args.board_id ?? "").trim();
+  if (!id) return { error: "board_id is required." };
+  const data = await miroFetch(token, `/boards/${encodeURIComponent(id)}`);
+  return stamp(data, ["Use miro_list_items to read the sticky notes, shapes, and text on this board."]);
+}
+
+export async function miroListItems(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const id = String(args.board_id ?? "").trim();
+  if (!id) return { error: "board_id is required." };
+  const params: Record<string, string> = { limit: String(Math.min(50, Number(args.limit) || 25)) };
+  if (args.type) params.type = String(args.type);
+  const data = await miroFetch(token, `/boards/${encodeURIComponent(id)}/items`, params);
+  return stamp(data, ["Use miro_get_board for the board's metadata and sharing policy."]);
+}

--- a/packages/mcp-server/src/pipedrive-tool.test.ts
+++ b/packages/mcp-server/src/pipedrive-tool.test.ts
@@ -1,0 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pipedriveListDeals, pipedriveSearchDeals } from "./pipedrive-tool.js";
+
+describe("pipedrive connector (L2/L5)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, json: async () => ({}) }))); await expect(pipedriveListDeals({ api_token: "k" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(pipedriveListDeals({ api_token: "k" })).rejects.toThrow(/timed out/i); });
+  it("not connected", async () => { vi.stubEnv("PIPEDRIVE_API_TOKEN", ""); const r = await pipedriveListDeals({}) as Record<string, unknown>; expect(r.not_connected).toBe(true); });
+  it("validates term", async () => { const r = await pipedriveSearchDeals({ api_token: "k" }) as Record<string, unknown>; expect(r.error).toMatch(/term is required/i); });
+  it("passes api_token in query + stamps", async () => { const f = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ data: [] }) })); vi.stubGlobal("fetch", f); const r = await pipedriveListDeals({ api_token: "secret" }) as Record<string, any>; expect(String((f.mock.calls[0] as unknown as [string])[0])).toContain("api_token=secret"); expect(r.unclick_meta.source).toMatch(/Pipedrive/); });
+});

--- a/packages/mcp-server/src/pipedrive-tool.ts
+++ b/packages/mcp-server/src/pipedrive-tool.ts
@@ -1,0 +1,75 @@
+// Pipedrive CRM integration for the UnClick MCP server.
+// Uses the Pipedrive REST API v1 via fetch - no external dependencies.
+// Auth: an API token passed as the api_token query parameter (Settings >
+// Personal preferences > API in Pipedrive).
+
+import { requireCredential } from "./connector-setup.js";
+import { type NotConnectedResult } from "./connection-help.js";
+import { stampMeta } from "./connector-meta.js";
+
+const PIPEDRIVE_BASE = "https://api.pipedrive.com/v1";
+const PIPEDRIVE_SOURCE = "Pipedrive API v1";
+
+function requireToken(args: Record<string, unknown>): string | NotConnectedResult {
+  return requireCredential("pipedrive", args);
+}
+
+async function pdFetch<T>(token: string, path: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(`${PIPEDRIVE_BASE}${path}`);
+  url.searchParams.set("api_token", token);
+  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const PIPEDRIVE_TIMEOUT_MS = Number(process.env.PIPEDRIVE_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PIPEDRIVE_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), { headers: { Accept: "application/json" }, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Pipedrive request timed out after ${PIPEDRIVE_TIMEOUT_MS}ms.`);
+    throw new Error(`Pipedrive network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Pipedrive rate limit reached (HTTP 429). Please wait and retry.");
+  const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+  if (!res.ok) throw new Error(`Pipedrive error (${res.status}): ${(data.error as string) ?? `status ${res.status}`}`);
+  return data as T;
+}
+
+function stamp(result: unknown, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: PIPEDRIVE_SOURCE, fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function pipedriveListDeals(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const params: Record<string, string> = { limit: String(Math.min(100, Number(args.limit) || 25)) };
+  if (args.status) params.status = String(args.status);
+  const data = await pdFetch(token, "/deals", params);
+  return stamp(data, ["Use pipedrive_list_persons to see the contacts on these deals."]);
+}
+
+export async function pipedriveListPersons(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const params: Record<string, string> = { limit: String(Math.min(100, Number(args.limit) || 25)) };
+  const data = await pdFetch(token, "/persons", params);
+  return stamp(data, ["Use pipedrive_list_organizations for the companies, or pipedrive_search_deals to find a deal."]);
+}
+
+export async function pipedriveListOrganizations(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const params: Record<string, string> = { limit: String(Math.min(100, Number(args.limit) || 25)) };
+  const data = await pdFetch(token, "/organizations", params);
+  return stamp(data, ["Use pipedrive_list_deals to see open deals for these organizations."]);
+}
+
+export async function pipedriveSearchDeals(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const term = String(args.term ?? "").trim();
+  if (!term) return { error: "term is required (the deal title or keyword to search)." };
+  const data = await pdFetch(token, "/deals/search", { term, limit: String(Math.min(100, Number(args.limit) || 25)) });
+  return stamp(data, ["Use pipedrive_list_persons to see who is on a matched deal."]);
+}

--- a/packages/mcp-server/src/shortcut-tool.test.ts
+++ b/packages/mcp-server/src/shortcut-tool.test.ts
@@ -1,0 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { shortcutSearchStories, shortcutListProjects } from "./shortcut-tool.js";
+
+describe("shortcut connector (L2/L5)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, json: async () => ({}) }))); await expect(shortcutListProjects({ api_token: "k" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(shortcutListProjects({ api_token: "k" })).rejects.toThrow(/timed out/i); });
+  it("not connected", async () => { vi.stubEnv("SHORTCUT_API_TOKEN", ""); const r = await shortcutListProjects({}) as Record<string, unknown>; expect(r.not_connected).toBe(true); });
+  it("validates query", async () => { const r = await shortcutSearchStories({ api_token: "k" }) as Record<string, unknown>; expect(r.error).toMatch(/query is required/i); });
+  it("sends Shortcut-Token header + stamps", async () => { const f = vi.fn(async () => ({ ok: true, status: 200, json: async () => ([]) })); vi.stubGlobal("fetch", f); const r = await shortcutListProjects({ api_token: "secret" }) as Record<string, any>; const init = (f.mock.calls[0] as unknown as [string, { headers: Record<string,string> }])[1]; expect(init.headers["Shortcut-Token"]).toBe("secret"); expect(r.unclick_meta.source).toMatch(/Shortcut/); });
+});

--- a/packages/mcp-server/src/shortcut-tool.ts
+++ b/packages/mcp-server/src/shortcut-tool.ts
@@ -1,0 +1,75 @@
+// Shortcut (formerly Clubhouse) integration for the UnClick MCP server.
+// Uses the Shortcut REST API v3 via fetch - no external dependencies.
+// Auth: an API token sent in the "Shortcut-Token" header, from
+// https://app.shortcut.com/settings/account/api-tokens.
+
+import { requireCredential } from "./connector-setup.js";
+import { type NotConnectedResult } from "./connection-help.js";
+import { stampMeta } from "./connector-meta.js";
+
+const SHORTCUT_BASE = "https://api.app.shortcut.com/api/v3";
+const SHORTCUT_SOURCE = "Shortcut REST API v3";
+
+function requireToken(args: Record<string, unknown>): string | NotConnectedResult {
+  return requireCredential("shortcut", args);
+}
+
+async function scFetch<T>(token: string, path: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(`${SHORTCUT_BASE}${path}`);
+  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const SHORTCUT_TIMEOUT_MS = Number(process.env.SHORTCUT_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SHORTCUT_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), { headers: { "Shortcut-Token": token, Accept: "application/json" }, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Shortcut request timed out after ${SHORTCUT_TIMEOUT_MS}ms.`);
+    throw new Error(`Shortcut network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Shortcut rate limit reached (HTTP 429). Please wait and retry.");
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = (data as { message?: string })?.message ?? `status ${res.status}`;
+    throw new Error(`Shortcut error (${res.status}): ${msg}`);
+  }
+  return data as T;
+}
+
+function stamp(result: unknown, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: SHORTCUT_SOURCE, fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function shortcutSearchStories(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required (Shortcut search syntax, e.g. 'state:\"In Progress\"')." };
+  const data = await scFetch(token, "/search/stories", { query, page_size: String(Math.min(25, Number(args.limit) || 25)) });
+  return stamp(data, ["Use shortcut_get_story with a returned id for the full story."]);
+}
+
+export async function shortcutGetStory(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const id = String(args.story_id ?? "").trim();
+  if (!id) return { error: "story_id is required." };
+  const data = await scFetch(token, `/stories/${encodeURIComponent(id)}`);
+  return stamp(data, ["Use shortcut_search_stories to find related work."]);
+}
+
+export async function shortcutListProjects(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const data = await scFetch(token, "/projects");
+  return stamp({ projects: data }, ["Use shortcut_list_epics for higher-level groupings, or shortcut_search_stories to filter work."]);
+}
+
+export async function shortcutListEpics(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const data = await scFetch(token, "/epics");
+  return stamp({ epics: data }, ["Use shortcut_search_stories with 'epic:<id>' to see an epic's stories."]);
+}

--- a/packages/mcp-server/src/todoist-tool.test.ts
+++ b/packages/mcp-server/src/todoist-tool.test.ts
@@ -1,0 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { todoistListProjects, todoistCreateTask } from "./todoist-tool.js";
+
+describe("todoist connector (L2/L5)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, text: async () => "" }))); await expect(todoistListProjects({ api_token: "k" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(todoistListProjects({ api_token: "k" })).rejects.toThrow(/timed out/i); });
+  it("not connected", async () => { vi.stubEnv("TODOIST_API_TOKEN", ""); const r = await todoistListProjects({}) as Record<string, unknown>; expect(r.not_connected).toBe(true); });
+  it("validates content", async () => { const r = await todoistCreateTask({ api_token: "k" }) as Record<string, unknown>; expect(r.error).toMatch(/content is required/i); });
+  it("stamps", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, text: async () => "[]" }))); const r = await todoistListProjects({ api_token: "k" }) as Record<string, any>; expect(r.unclick_meta.source).toMatch(/Todoist/); });
+});

--- a/packages/mcp-server/src/todoist-tool.ts
+++ b/packages/mcp-server/src/todoist-tool.ts
@@ -1,0 +1,84 @@
+// Todoist integration for the UnClick MCP server.
+// Uses the Todoist REST API v2 via fetch - no external dependencies.
+// Auth: an API token (Authorization: Bearer) from Todoist Settings > Integrations.
+
+import { requireCredential } from "./connector-setup.js";
+import { type NotConnectedResult } from "./connection-help.js";
+import { stampMeta } from "./connector-meta.js";
+
+const TODOIST_BASE = "https://api.todoist.com/rest/v2";
+const TODOIST_SOURCE = "Todoist REST API v2";
+
+function requireToken(args: Record<string, unknown>): string | NotConnectedResult {
+  return requireCredential("todoist", args);
+}
+
+async function tdFetch<T>(token: string, method: string, path: string, opts?: { params?: Record<string, string>; body?: unknown }): Promise<T> {
+  const url = new URL(`${TODOIST_BASE}${path}`);
+  if (opts?.params) Object.entries(opts.params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const TODOIST_TIMEOUT_MS = Number(process.env.TODOIST_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TODOIST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), {
+      method,
+      headers: { Authorization: `Bearer ${token}`, ...(opts?.body ? { "Content-Type": "application/json" } : {}) },
+      body: opts?.body ? JSON.stringify(opts.body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Todoist request timed out after ${TODOIST_TIMEOUT_MS}ms.`);
+    throw new Error(`Todoist network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Todoist rate limit reached (HTTP 429). Please wait and retry.");
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : {};
+  if (!res.ok) throw new Error(`Todoist error (${res.status}): ${(data as { error?: string }).error ?? text.slice(0, 200) ?? `status ${res.status}`}`);
+  return data as T;
+}
+
+function stamp(result: unknown, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: TODOIST_SOURCE, fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function todoistListProjects(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const data = await tdFetch(token, "GET", "/projects");
+  return stamp({ projects: data }, ["Use todoist_list_tasks with a project_id to see its tasks."]);
+}
+
+export async function todoistListTasks(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const params: Record<string, string> = {};
+  if (args.project_id) params.project_id = String(args.project_id);
+  if (args.filter) params.filter = String(args.filter);
+  const data = await tdFetch(token, "GET", "/tasks", { params });
+  return stamp({ tasks: data }, ["Use todoist_create_task to add one, or todoist_complete_task to close one."]);
+}
+
+export async function todoistCreateTask(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const content = String(args.content ?? "").trim();
+  if (!content) return { error: "content is required (the task text)." };
+  const body: Record<string, unknown> = { content };
+  if (args.project_id) body.project_id = String(args.project_id);
+  if (args.due_string) body.due_string = String(args.due_string);
+  if (args.priority) body.priority = Number(args.priority);
+  const data = await tdFetch(token, "POST", "/tasks", { body });
+  return stamp(data, ["Use todoist_list_tasks to confirm, or todoist_complete_task to close it."]);
+}
+
+export async function todoistCompleteTask(args: Record<string, unknown>): Promise<unknown> {
+  const token = requireToken(args);
+  if (typeof token !== "string") return token;
+  const id = String(args.task_id ?? "").trim();
+  if (!id) return { error: "task_id is required." };
+  await tdFetch(token, "POST", `/tasks/${encodeURIComponent(id)}/close`);
+  return stamp({ closed: true, task_id: id }, ["Use todoist_list_tasks to see what is left."]);
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -682,6 +682,38 @@ import {
 } from "./klaviyo-tool.js";
 
 import {
+  todoistListProjects, todoistListTasks, todoistCreateTask, todoistCompleteTask,
+} from "./todoist-tool.js";
+
+import {
+  pipedriveListDeals, pipedriveListPersons, pipedriveListOrganizations, pipedriveSearchDeals,
+} from "./pipedrive-tool.js";
+
+import {
+  confluenceSearch, confluenceGetPage, confluenceListSpaces,
+} from "./confluence-tool.js";
+
+import {
+  unsplashSearchPhotos, unsplashGetPhoto, unsplashRandomPhoto,
+} from "./unsplash-tool.js";
+
+import {
+  giphySearch, giphyTrending, giphyRandom,
+} from "./giphy-tool.js";
+
+import {
+  miroListBoards, miroGetBoard, miroListItems,
+} from "./miro-tool.js";
+
+import {
+  shortcutSearchStories, shortcutGetStory, shortcutListProjects, shortcutListEpics,
+} from "./shortcut-tool.js";
+
+import {
+  wikipediaSearch, wikipediaSummary, wikipediaPage,
+} from "./wikipedia-tool.js";
+
+import {
   deeplTranslateText, deeplGetUsage, deeplListLanguages, deeplTranslateDocument,
 } from "./deepl-tool.js";
 
@@ -9901,6 +9933,260 @@ export const ADDITIONAL_TOOLS = [
     },
   },
 
+  // ── todoist-tool.ts ───────────────────────────────────────────────────────────
+  {
+    name: "todoist_list_projects",
+    description: "List your Todoist projects.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Todoist API token" },
+    }, required: ["api_token"] },
+  },
+  {
+    name: "todoist_list_tasks",
+    description: "List active Todoist tasks, optionally by project or filter.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Todoist API token" },
+      project_id: { type: "string", description: "Limit to one project id" },
+      filter: { type: "string", description: "Todoist filter query (e.g. 'today', 'overdue')" },
+    }, required: ["api_token"] },
+  },
+  {
+    name: "todoist_create_task",
+    description: "Create a Todoist task.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Todoist API token" },
+      content: { type: "string", description: "The task text" },
+      project_id: { type: "string", description: "Project id to add the task to" },
+      due_string: { type: "string", description: "Natural-language due date (e.g. 'tomorrow 5pm')" },
+      priority: { type: "number", minimum: 1, maximum: 4, description: "Priority 1 (normal) to 4 (urgent)" },
+    }, required: ["api_token", "content"] },
+  },
+  {
+    name: "todoist_complete_task",
+    description: "Complete (close) a Todoist task by id.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Todoist API token" },
+      task_id: { type: "string", description: "Task id to close" },
+    }, required: ["api_token", "task_id"] },
+  },
+
+  // ── pipedrive-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "pipedrive_list_deals",
+    description: "List Pipedrive deals.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Pipedrive API token" },
+      status: { type: "string", description: "Filter by status (open, won, lost, deleted, all_not_deleted)" },
+      limit: { type: "number", description: "Deals to return (max 100, default 25)" },
+    }, required: ["api_token"] },
+  },
+  {
+    name: "pipedrive_list_persons",
+    description: "List Pipedrive persons (contacts).",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Pipedrive API token" },
+      limit: { type: "number", description: "Persons to return (max 100, default 25)" },
+    }, required: ["api_token"] },
+  },
+  {
+    name: "pipedrive_list_organizations",
+    description: "List Pipedrive organizations (companies).",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Pipedrive API token" },
+      limit: { type: "number", description: "Organizations to return (max 100, default 25)" },
+    }, required: ["api_token"] },
+  },
+  {
+    name: "pipedrive_search_deals",
+    description: "Search Pipedrive deals by term.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Pipedrive API token" },
+      term: { type: "string", description: "Search term (deal title or keyword)" },
+      limit: { type: "number", description: "Results to return (max 100, default 25)" },
+    }, required: ["api_token", "term"] },
+  },
+
+  // ── confluence-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "confluence_search",
+    description: "Search Confluence pages by text.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      site: { type: "string", description: "Atlassian site (e.g. mycompany)" },
+      email: { type: "string", description: "Atlassian account email" },
+      api_token: { type: "string", description: "Atlassian API token" },
+      query: { type: "string", description: "Text to search for" },
+      limit: { type: "number", description: "Results to return (max 50, default 25)" },
+    }, required: ["site", "email", "api_token", "query"] },
+  },
+  {
+    name: "confluence_get_page",
+    description: "Get a Confluence page by id, including its body.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      site: { type: "string", description: "Atlassian site (e.g. mycompany)" },
+      email: { type: "string", description: "Atlassian account email" },
+      api_token: { type: "string", description: "Atlassian API token" },
+      page_id: { type: "string", description: "Confluence content/page id" },
+    }, required: ["site", "email", "api_token", "page_id"] },
+  },
+  {
+    name: "confluence_list_spaces",
+    description: "List Confluence spaces.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      site: { type: "string", description: "Atlassian site (e.g. mycompany)" },
+      email: { type: "string", description: "Atlassian account email" },
+      api_token: { type: "string", description: "Atlassian API token" },
+      limit: { type: "number", description: "Spaces to return (max 100, default 50)" },
+    }, required: ["site", "email", "api_token"] },
+  },
+
+  // ── unsplash-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "unsplash_search_photos",
+    description: "Search Unsplash photos.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      access_key: { type: "string", description: "Unsplash Access Key" },
+      query: { type: "string", description: "What to search for" },
+      per_page: { type: "number", description: "Photos to return (max 30, default 10)" },
+      orientation: { type: "string", enum: ["landscape", "portrait", "squarish"], description: "Filter by orientation" },
+    }, required: ["access_key", "query"] },
+  },
+  {
+    name: "unsplash_get_photo",
+    description: "Get a single Unsplash photo by id (URLs + attribution).",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      access_key: { type: "string", description: "Unsplash Access Key" },
+      photo_id: { type: "string", description: "Unsplash photo id" },
+    }, required: ["access_key", "photo_id"] },
+  },
+  {
+    name: "unsplash_random_photo",
+    description: "Get a random Unsplash photo, optionally matching a query.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      access_key: { type: "string", description: "Unsplash Access Key" },
+      query: { type: "string", description: "Optional topic to match" },
+      orientation: { type: "string", enum: ["landscape", "portrait", "squarish"], description: "Filter by orientation" },
+    }, required: ["access_key"] },
+  },
+
+  // ── giphy-tool.ts ─────────────────────────────────────────────────────────────
+  {
+    name: "giphy_search",
+    description: "Search Giphy for GIFs.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_key: { type: "string", description: "Giphy API key" },
+      query: { type: "string", description: "What GIF to search for" },
+      limit: { type: "number", description: "GIFs to return (max 50, default 10)" },
+      rating: { type: "string", enum: ["g", "pg", "pg-13", "r"], description: "Content rating cap" },
+    }, required: ["api_key", "query"] },
+  },
+  {
+    name: "giphy_trending",
+    description: "Get trending GIFs from Giphy.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_key: { type: "string", description: "Giphy API key" },
+      limit: { type: "number", description: "GIFs to return (max 50, default 10)" },
+      rating: { type: "string", enum: ["g", "pg", "pg-13", "r"], description: "Content rating cap" },
+    }, required: ["api_key"] },
+  },
+  {
+    name: "giphy_random",
+    description: "Get a random GIF from Giphy, optionally by tag.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_key: { type: "string", description: "Giphy API key" },
+      tag: { type: "string", description: "Optional tag to match" },
+      rating: { type: "string", enum: ["g", "pg", "pg-13", "r"], description: "Content rating cap" },
+    }, required: ["api_key"] },
+  },
+
+  // ── miro-tool.ts ──────────────────────────────────────────────────────────────
+  {
+    name: "miro_list_boards",
+    description: "List Miro boards.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      access_token: { type: "string", description: "Miro access token" },
+      query: { type: "string", description: "Filter boards by name" },
+      limit: { type: "number", description: "Boards to return (max 50, default 25)" },
+    }, required: ["access_token"] },
+  },
+  {
+    name: "miro_get_board",
+    description: "Get a single Miro board by id.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      access_token: { type: "string", description: "Miro access token" },
+      board_id: { type: "string", description: "Miro board id" },
+    }, required: ["access_token", "board_id"] },
+  },
+  {
+    name: "miro_list_items",
+    description: "List the items (notes, shapes, text) on a Miro board.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      access_token: { type: "string", description: "Miro access token" },
+      board_id: { type: "string", description: "Miro board id" },
+      type: { type: "string", description: "Filter by item type (e.g. sticky_note, shape, text)" },
+      limit: { type: "number", description: "Items to return (max 50, default 25)" },
+    }, required: ["access_token", "board_id"] },
+  },
+
+  // ── shortcut-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "shortcut_search_stories",
+    description: "Search Shortcut stories with the search syntax.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Shortcut API token" },
+      query: { type: "string", description: "Search query (e.g. 'state:\"In Progress\" owner:me')" },
+      limit: { type: "number", description: "Results to return (max 25, default 25)" },
+    }, required: ["api_token", "query"] },
+  },
+  {
+    name: "shortcut_get_story",
+    description: "Get a single Shortcut story by id.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Shortcut API token" },
+      story_id: { type: "string", description: "Shortcut story id" },
+    }, required: ["api_token", "story_id"] },
+  },
+  {
+    name: "shortcut_list_projects",
+    description: "List Shortcut projects.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Shortcut API token" },
+    }, required: ["api_token"] },
+  },
+  {
+    name: "shortcut_list_epics",
+    description: "List Shortcut epics.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      api_token: { type: "string", description: "Shortcut API token" },
+    }, required: ["api_token"] },
+  },
+
+  // ── wikipedia-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "wikipedia_search",
+    description: "Search Wikipedia article titles. No key needed.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      query: { type: "string", description: "What to search for" },
+      lang: { type: "string", description: "Wikipedia language code (default en)" },
+      limit: { type: "number", description: "Results to return (max 50, default 10)" },
+    }, required: ["query"] },
+  },
+  {
+    name: "wikipedia_summary",
+    description: "Get a short Wikipedia summary for a page title. No key needed.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      title: { type: "string", description: "Exact page title" },
+      lang: { type: "string", description: "Wikipedia language code (default en)" },
+    }, required: ["title"] },
+  },
+  {
+    name: "wikipedia_page",
+    description: "Get the full plain-text Wikipedia article for a title. No key needed.",
+    inputSchema: { type: "object" as const, additionalProperties: false, properties: {
+      title: { type: "string", description: "Exact page title" },
+      lang: { type: "string", description: "Wikipedia language code (default en)" },
+    }, required: ["title"] },
+  },
+
   // ── zendesk-tool.ts ───────────────────────────────────────────────────────────
   {
     name: "zendesk_search",
@@ -15041,6 +15327,50 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   do_list_apps:            (args) => doListApps(args),
   do_list_databases:       (args) => doListDatabases(args),
   do_account:              (args) => doAccount(args),
+
+  // klaviyo-tool.ts
+  // todoist-tool.ts
+  todoist_list_projects:   (args) => todoistListProjects(args),
+  todoist_list_tasks:      (args) => todoistListTasks(args),
+  todoist_create_task:     (args) => todoistCreateTask(args),
+  todoist_complete_task:   (args) => todoistCompleteTask(args),
+
+  // pipedrive-tool.ts
+  pipedrive_list_deals:         (args) => pipedriveListDeals(args),
+  pipedrive_list_persons:       (args) => pipedriveListPersons(args),
+  pipedrive_list_organizations: (args) => pipedriveListOrganizations(args),
+  pipedrive_search_deals:       (args) => pipedriveSearchDeals(args),
+
+  // confluence-tool.ts
+  confluence_search:       (args) => confluenceSearch(args),
+  confluence_get_page:     (args) => confluenceGetPage(args),
+  confluence_list_spaces:  (args) => confluenceListSpaces(args),
+
+  // unsplash-tool.ts
+  unsplash_search_photos:  (args) => unsplashSearchPhotos(args),
+  unsplash_get_photo:      (args) => unsplashGetPhoto(args),
+  unsplash_random_photo:   (args) => unsplashRandomPhoto(args),
+
+  // giphy-tool.ts
+  giphy_search:            (args) => giphySearch(args),
+  giphy_trending:          (args) => giphyTrending(args),
+  giphy_random:            (args) => giphyRandom(args),
+
+  // miro-tool.ts
+  miro_list_boards:        (args) => miroListBoards(args),
+  miro_get_board:          (args) => miroGetBoard(args),
+  miro_list_items:         (args) => miroListItems(args),
+
+  // shortcut-tool.ts
+  shortcut_search_stories: (args) => shortcutSearchStories(args),
+  shortcut_get_story:      (args) => shortcutGetStory(args),
+  shortcut_list_projects:  (args) => shortcutListProjects(args),
+  shortcut_list_epics:     (args) => shortcutListEpics(args),
+
+  // wikipedia-tool.ts
+  wikipedia_search:        (args) => wikipediaSearch(args),
+  wikipedia_summary:       (args) => wikipediaSummary(args),
+  wikipedia_page:          (args) => wikipediaPage(args),
 
   // klaviyo-tool.ts
   klaviyo_list_lists:      (args) => klaviyoListLists(args),

--- a/packages/mcp-server/src/unsplash-tool.test.ts
+++ b/packages/mcp-server/src/unsplash-tool.test.ts
@@ -1,0 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { unsplashSearchPhotos } from "./unsplash-tool.js";
+
+describe("unsplash connector (L2/L5)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, json: async () => ({}) }))); await expect(unsplashSearchPhotos({ access_key: "k", query: "x" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(unsplashSearchPhotos({ access_key: "k", query: "x" })).rejects.toThrow(/timed out/i); });
+  it("not connected", async () => { vi.stubEnv("UNSPLASH_ACCESS_KEY", ""); const r = await unsplashSearchPhotos({ query: "x" }) as Record<string, unknown>; expect(r.not_connected).toBe(true); });
+  it("validates query", async () => { const r = await unsplashSearchPhotos({ access_key: "k" }) as Record<string, unknown>; expect(r.error).toMatch(/query is required/i); });
+  it("sends Client-ID header + stamps", async () => { const f = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ results: [] }) })); vi.stubGlobal("fetch", f); const r = await unsplashSearchPhotos({ access_key: "secret", query: "cats" }) as Record<string, any>; const init = (f.mock.calls[0] as unknown as [string, { headers: Record<string,string> }])[1]; expect(init.headers.Authorization).toBe("Client-ID secret"); expect(r.unclick_meta.source).toMatch(/Unsplash/); });
+});

--- a/packages/mcp-server/src/unsplash-tool.ts
+++ b/packages/mcp-server/src/unsplash-tool.ts
@@ -1,0 +1,73 @@
+// Unsplash integration for the UnClick MCP server.
+// Uses the Unsplash REST API via fetch - no external dependencies.
+// Auth: an Access Key sent as "Authorization: Client-ID <key>" from a registered
+// app at https://unsplash.com/oauth/applications.
+
+import { requireCredential } from "./connector-setup.js";
+import { type NotConnectedResult } from "./connection-help.js";
+import { stampMeta } from "./connector-meta.js";
+
+const UNSPLASH_BASE = "https://api.unsplash.com";
+const UNSPLASH_SOURCE = "Unsplash API";
+
+function requireKey(args: Record<string, unknown>): string | NotConnectedResult {
+  return requireCredential("unsplash", args);
+}
+
+async function usFetch<T>(key: string, path: string, params?: Record<string, string>): Promise<T> {
+  const url = new URL(`${UNSPLASH_BASE}${path}`);
+  if (params) Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  const UNSPLASH_TIMEOUT_MS = Number(process.env.UNSPLASH_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UNSPLASH_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), { headers: { Authorization: `Client-ID ${key}`, "Accept-Version": "v1" }, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Unsplash request timed out after ${UNSPLASH_TIMEOUT_MS}ms.`);
+    throw new Error(`Unsplash network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Unsplash rate limit reached (HTTP 429). Please wait and retry.");
+  const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+  if (!res.ok) {
+    const errs = (data.errors as string[] | undefined)?.join(", ");
+    throw new Error(`Unsplash error (${res.status}): ${errs ?? `status ${res.status}`}`);
+  }
+  return data as T;
+}
+
+function stamp(result: unknown, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: UNSPLASH_SOURCE, fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function unsplashSearchPhotos(args: Record<string, unknown>): Promise<unknown> {
+  const key = requireKey(args);
+  if (typeof key !== "string") return key;
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required (what to search for)." };
+  const params: Record<string, string> = { query, per_page: String(Math.min(30, Number(args.per_page) || 10)) };
+  if (args.orientation) params.orientation = String(args.orientation);
+  const data = await usFetch(key, "/search/photos", params);
+  return stamp(data, ["Use unsplash_get_photo with a returned id for the full-size URLs and attribution."]);
+}
+
+export async function unsplashGetPhoto(args: Record<string, unknown>): Promise<unknown> {
+  const key = requireKey(args);
+  if (typeof key !== "string") return key;
+  const id = String(args.photo_id ?? "").trim();
+  if (!id) return { error: "photo_id is required." };
+  const data = await usFetch(key, `/photos/${encodeURIComponent(id)}`);
+  return stamp(data, ["Credit the photographer using the returned user.name and links.html (Unsplash guideline)."]);
+}
+
+export async function unsplashRandomPhoto(args: Record<string, unknown>): Promise<unknown> {
+  const key = requireKey(args);
+  if (typeof key !== "string") return key;
+  const params: Record<string, string> = {};
+  if (args.query) params.query = String(args.query);
+  if (args.orientation) params.orientation = String(args.orientation);
+  const data = await usFetch(key, "/photos/random", params);
+  return stamp(data, ["Use unsplash_search_photos to pick from a set instead of a random one."]);
+}

--- a/packages/mcp-server/src/wikipedia-tool.test.ts
+++ b/packages/mcp-server/src/wikipedia-tool.test.ts
@@ -1,0 +1,11 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { wikipediaSearch, wikipediaSummary } from "./wikipedia-tool.js";
+
+describe("wikipedia connector (L2/L5, no key)", () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+  it("429", async () => { vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 429, json: async () => ({}) }))); await expect(wikipediaSearch({ query: "x" })).rejects.toThrow(/rate limit/i); });
+  it("timeout", async () => { vi.stubGlobal("fetch", vi.fn(async () => { const e = new Error("x"); e.name = "AbortError"; throw e; })); await expect(wikipediaSearch({ query: "x" })).rejects.toThrow(/timed out/i); });
+  it("validates query", async () => { const r = await wikipediaSearch({}) as Record<string, unknown>; expect(r.error).toMatch(/query is required/i); });
+  it("searches the right lang host + stamps", async () => { const f = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ query: { search: [{ title: "Cat" }] } }) })); vi.stubGlobal("fetch", f); const r = await wikipediaSearch({ query: "cat", lang: "de" }) as Record<string, any>; expect(String((f.mock.calls[0] as unknown as [string])[0])).toMatch(/^https:\/\/de\.wikipedia\.org\/w\/api\.php/); expect((r.results as unknown[]).length).toBe(1); expect(r.unclick_meta.source).toMatch(/Wikipedia/); });
+  it("summary validates title", async () => { const r = await wikipediaSummary({}) as Record<string, unknown>; expect(r.error).toMatch(/title is required/i); });
+});

--- a/packages/mcp-server/src/wikipedia-tool.ts
+++ b/packages/mcp-server/src/wikipedia-tool.ts
@@ -1,0 +1,67 @@
+// Wikipedia integration for the UnClick MCP server.
+// Uses the public MediaWiki + REST APIs via fetch - no key, no dependencies.
+// Defaults to English; pass lang (e.g. "es", "de") to use another Wikipedia.
+
+import { stampMeta } from "./connector-meta.js";
+
+function wikiSource(lang: string): string {
+  return `Wikipedia (${lang})`;
+}
+
+function langOf(args: Record<string, unknown>): string {
+  const l = String(args.lang ?? "en").trim().toLowerCase();
+  return /^[a-z]{2,3}(-[a-z]+)?$/.test(l) ? l : "en";
+}
+
+async function wikiFetch<T>(url: string): Promise<T> {
+  const WIKIPEDIA_TIMEOUT_MS = Number(process.env.WIKIPEDIA_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), WIKIPEDIA_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Accept: "application/json", "User-Agent": "UnClickMCP/1.0 (https://unclick.world)" }, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") throw new Error(`Wikipedia request timed out after ${WIKIPEDIA_TIMEOUT_MS}ms.`);
+    throw new Error(`Wikipedia network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (res.status === 429) throw new Error("Wikipedia rate limit reached (HTTP 429). Please wait and retry.");
+  const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+  if (!res.ok) throw new Error(`Wikipedia error (${res.status}): ${(data as { title?: string }).title ?? `status ${res.status}`}`);
+  return data as T;
+}
+
+function stamp(result: unknown, lang: string, nextSteps: string[]): Record<string, unknown> {
+  return stampMeta(result, { source: wikiSource(lang), fetched_at: new Date().toISOString(), next_steps: nextSteps });
+}
+
+export async function wikipediaSearch(args: Record<string, unknown>): Promise<unknown> {
+  const query = String(args.query ?? "").trim();
+  if (!query) return { error: "query is required (what to search for)." };
+  const lang = langOf(args);
+  const limit = Math.min(50, Number(args.limit) || 10);
+  const url = `https://${lang}.wikipedia.org/w/api.php?action=query&list=search&srsearch=${encodeURIComponent(query)}&srlimit=${limit}&format=json&origin=*`;
+  const data = await wikiFetch<{ query?: { search?: unknown[] } }>(url);
+  return stamp({ results: data.query?.search ?? [] }, lang, ["Use wikipedia_summary with a returned title for a short overview."]);
+}
+
+export async function wikipediaSummary(args: Record<string, unknown>): Promise<unknown> {
+  const title = String(args.title ?? "").trim();
+  if (!title) return { error: "title is required (the exact page title)." };
+  const lang = langOf(args);
+  const url = `https://${lang}.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title.replace(/ /g, "_"))}`;
+  const data = await wikiFetch(url);
+  return stamp(data, lang, ["Use wikipedia_page for the full plain-text article."]);
+}
+
+export async function wikipediaPage(args: Record<string, unknown>): Promise<unknown> {
+  const title = String(args.title ?? "").trim();
+  if (!title) return { error: "title is required (the exact page title)." };
+  const lang = langOf(args);
+  const url = `https://${lang}.wikipedia.org/w/api.php?action=query&prop=extracts&explaintext=1&titles=${encodeURIComponent(title)}&format=json&origin=*`;
+  const data = await wikiFetch<{ query?: { pages?: Record<string, { title?: string; extract?: string }> } }>(url);
+  const pages = data.query?.pages ?? {};
+  const page = Object.values(pages)[0] ?? null;
+  return stamp({ title: page?.title ?? title, extract: page?.extract ?? "" }, lang, ["Use wikipedia_search to find a different article."]);
+}

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -32,8 +32,8 @@ bucket("Money & payments", ["stripe", "paypal", "square", "plaid", "wise", "xero
 bucket("Markets & crypto", ["alphavantage", "coingecko", "coinmarketcap", "exchangerate", "openexchangerates"]);
 bucket("Messaging & email", ["slack", "discord", "telegram", "whatsapp", "line", "twilio", "email", "resend", "sendgrid", "postmark", "mailchimp", "convertkit", "klaviyo", "pushover", "intercom", "zendesk"]);
 bucket("Social", ["reddit", "bluesky", "mastodon", "pinterest", "tiktok", "youtube", "twitch", "hackernews"]);
-bucket("News & reading", ["newsapi", "guardian", "gdelt", "feedly", "instapaper", "readwise", "raindrop", "trove"]);
-bucket("Productivity", ["notion", "asana", "trello", "clickup", "monday", "linear", "jira", "hubspot", "clockify", "toggl", "calendly", "calcom", "airtable", "monica", "figma", "crews", "typeform", "jobsmith"]);
+bucket("News & reading", ["newsapi", "guardian", "gdelt", "feedly", "instapaper", "readwise", "raindrop", "trove", "wikipedia"]);
+bucket("Productivity", ["notion", "asana", "trello", "clickup", "monday", "linear", "jira", "hubspot", "clockify", "toggl", "calendly", "calcom", "airtable", "monica", "figma", "crews", "typeform", "jobsmith", "todoist", "pipedrive", "confluence", "miro", "shortcut"]);
 bucket("Shopping", ["amazon", "ebay", "etsy", "shopify", "woocommerce"]);
 bucket("Music & video", ["spotify", "deezer", "lastfm", "genius", "musicbrainz", "discogs", "setlistfm", "podcastindex", "radiobrowser", "tmdb", "omdb"]);
 bucket("Games & esports", ["steam", "rawg", "igdb", "bgg", "riot", "bungie", "chessdotcom", "lichess", "speedrun", "pandascore", "supercell", "lego", "sleeper", "fpl", "espn", "openf1"]);
@@ -43,6 +43,7 @@ bucket("Security", ["abuseipdb", "haveibeenpwned", "shodan", "urlscan", "virusto
 bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsintown"]);
 bucket("Content & CMS", ["contentful", "webflow"]);
 bucket("Books", ["openlibrary"]);
+bucket("Images", ["unsplash", "giphy"]);
 bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
@@ -87,6 +88,14 @@ const BLURB_OF = {
   openai: "Chat, embeddings, images, and transcription from OpenAI.",
   anthropic: "Chat completions from Claude models.",
   jobsmith: "Check a CV or cover letter against JobSmith's quality rules.",
+  todoist: "List, create, and complete your Todoist tasks.",
+  pipedrive: "Read deals, contacts, and companies in your Pipedrive CRM.",
+  confluence: "Search and read Confluence pages and spaces.",
+  unsplash: "Search and fetch free Unsplash photos.",
+  giphy: "Search trending and random GIFs on Giphy.",
+  miro: "List Miro boards and read what is on them.",
+  shortcut: "Search stories, projects, and epics in Shortcut.",
+  wikipedia: "Search Wikipedia and read article summaries.",
   airtable: "Read and update records across your Airtable bases.",
   bluesky: "Post, read, search, and follow on Bluesky.",
   clickup: "Read and update ClickUp tasks, lists, and spaces.",
@@ -165,6 +174,9 @@ const DOMAIN_OF = {
   shodan: "shodan.io", virustotal: "virustotal.com", openmeteo: "open-meteo.com", tomorrowio: "tomorrow.io",
   guardian: "theguardian.com", monica: "monicahq.com", readwise: "readwise.io", raindrop: "raindrop.io",
   instapaper: "instapaper.com", feedly: "feedly.com",
+  todoist: "todoist.com", pipedrive: "pipedrive.com", confluence: "atlassian.com",
+  unsplash: "unsplash.com", giphy: "giphy.com", miro: "miro.com", shortcut: "shortcut.com",
+  wikipedia: "wikipedia.org",
 };
 
 function titleCase(slug) {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 202,
-  "toolCount": 864,
+  "appCount": 210,
+  "toolCount": 891,
   "categories": [
     "AI",
     "Books",
@@ -9,6 +9,7 @@
     "Developer & infra",
     "Events & tickets",
     "Games & esports",
+    "Images",
     "Markets & crypto",
     "Messaging & email",
     "Money & payments",
@@ -831,6 +832,30 @@
       ],
       "level": null,
       "hardened": false
+    },
+    {
+      "slug": "confluence",
+      "name": "Confluence",
+      "category": "Productivity",
+      "blurb": "Search and read Confluence pages and spaces.",
+      "domain": "atlassian.com",
+      "toolCount": 3,
+      "tools": [
+        {
+          "name": "confluence_search",
+          "description": "Search Confluence pages by text."
+        },
+        {
+          "name": "confluence_get_page",
+          "description": "Get a Confluence page by id, including its body."
+        },
+        {
+          "name": "confluence_list_spaces",
+          "description": "List Confluence spaces."
+        }
+      ],
+      "level": 5,
+      "hardened": true
     },
     {
       "slug": "contentful",
@@ -1759,6 +1784,30 @@
       ],
       "level": 1,
       "hardened": false
+    },
+    {
+      "slug": "giphy",
+      "name": "Giphy",
+      "category": "Images",
+      "blurb": "Search trending and random GIFs on Giphy.",
+      "domain": "giphy.com",
+      "toolCount": 3,
+      "tools": [
+        {
+          "name": "giphy_search",
+          "description": "Search Giphy for GIFs."
+        },
+        {
+          "name": "giphy_trending",
+          "description": "Get trending GIFs from Giphy."
+        },
+        {
+          "name": "giphy_random",
+          "description": "Get a random GIF from Giphy, optionally by tag."
+        }
+      ],
+      "level": 5,
+      "hardened": true
     },
     {
       "slug": "github",
@@ -2693,6 +2742,30 @@
       "hardened": true
     },
     {
+      "slug": "miro",
+      "name": "Miro",
+      "category": "Productivity",
+      "blurb": "List Miro boards and read what is on them.",
+      "domain": "miro.com",
+      "toolCount": 3,
+      "tools": [
+        {
+          "name": "miro_list_boards",
+          "description": "List Miro boards."
+        },
+        {
+          "name": "miro_get_board",
+          "description": "Get a single Miro board by id."
+        },
+        {
+          "name": "miro_list_items",
+          "description": "List the items (notes, shapes, text) on a Miro board."
+        }
+      ],
+      "level": 5,
+      "hardened": true
+    },
+    {
       "slug": "mistral",
       "name": "Mistral",
       "category": "AI",
@@ -3467,6 +3540,34 @@
         {
           "name": "get_pinterest_user",
           "description": "Get the authenticated Pinterest user account info."
+        }
+      ],
+      "level": 5,
+      "hardened": true
+    },
+    {
+      "slug": "pipedrive",
+      "name": "Pipedrive",
+      "category": "Productivity",
+      "blurb": "Read deals, contacts, and companies in your Pipedrive CRM.",
+      "domain": "pipedrive.com",
+      "toolCount": 4,
+      "tools": [
+        {
+          "name": "pipedrive_list_deals",
+          "description": "List Pipedrive deals."
+        },
+        {
+          "name": "pipedrive_list_persons",
+          "description": "List Pipedrive persons (contacts)."
+        },
+        {
+          "name": "pipedrive_list_organizations",
+          "description": "List Pipedrive organizations (companies)."
+        },
+        {
+          "name": "pipedrive_search_deals",
+          "description": "Search Pipedrive deals by term."
         }
       ],
       "level": 5,
@@ -4441,6 +4542,34 @@
       "hardened": true
     },
     {
+      "slug": "shortcut",
+      "name": "Shortcut",
+      "category": "Productivity",
+      "blurb": "Search stories, projects, and epics in Shortcut.",
+      "domain": "shortcut.com",
+      "toolCount": 4,
+      "tools": [
+        {
+          "name": "shortcut_search_stories",
+          "description": "Search Shortcut stories with the search syntax."
+        },
+        {
+          "name": "shortcut_get_story",
+          "description": "Get a single Shortcut story by id."
+        },
+        {
+          "name": "shortcut_list_projects",
+          "description": "List Shortcut projects."
+        },
+        {
+          "name": "shortcut_list_epics",
+          "description": "List Shortcut epics."
+        }
+      ],
+      "level": 5,
+      "hardened": true
+    },
+    {
       "slug": "slack",
       "name": "Slack",
       "category": "Messaging & email",
@@ -5033,6 +5162,34 @@
       "hardened": true
     },
     {
+      "slug": "todoist",
+      "name": "Todoist",
+      "category": "Productivity",
+      "blurb": "List, create, and complete your Todoist tasks.",
+      "domain": "todoist.com",
+      "toolCount": 4,
+      "tools": [
+        {
+          "name": "todoist_list_projects",
+          "description": "List your Todoist projects."
+        },
+        {
+          "name": "todoist_list_tasks",
+          "description": "List active Todoist tasks, optionally by project or filter."
+        },
+        {
+          "name": "todoist_create_task",
+          "description": "Create a Todoist task."
+        },
+        {
+          "name": "todoist_complete_task",
+          "description": "Complete (close) a Todoist task by id."
+        }
+      ],
+      "level": 5,
+      "hardened": true
+    },
+    {
       "slug": "togetherai",
       "name": "Together AI",
       "category": "AI",
@@ -5369,6 +5526,30 @@
       "hardened": false
     },
     {
+      "slug": "unsplash",
+      "name": "Unsplash",
+      "category": "Images",
+      "blurb": "Search and fetch free Unsplash photos.",
+      "domain": "unsplash.com",
+      "toolCount": 3,
+      "tools": [
+        {
+          "name": "unsplash_search_photos",
+          "description": "Search Unsplash photos."
+        },
+        {
+          "name": "unsplash_get_photo",
+          "description": "Get a single Unsplash photo by id (URLs + attribution)."
+        },
+        {
+          "name": "unsplash_random_photo",
+          "description": "Get a random Unsplash photo, optionally matching a query."
+        }
+      ],
+      "level": 5,
+      "hardened": true
+    },
+    {
       "slug": "untappd",
       "name": "Untappd",
       "category": "Weather & science",
@@ -5670,6 +5851,30 @@
         }
       ],
       "level": 2,
+      "hardened": true
+    },
+    {
+      "slug": "wikipedia",
+      "name": "Wikipedia",
+      "category": "News & reading",
+      "blurb": "Search Wikipedia and read article summaries.",
+      "domain": "wikipedia.org",
+      "toolCount": 3,
+      "tools": [
+        {
+          "name": "wikipedia_search",
+          "description": "Search Wikipedia article titles. No key needed."
+        },
+        {
+          "name": "wikipedia_summary",
+          "description": "Get a short Wikipedia summary for a page title. No key needed."
+        },
+        {
+          "name": "wikipedia_page",
+          "description": "Get the full plain-text Wikipedia article for a title. No key needed."
+        }
+      ],
+      "level": 5,
       "hardened": true
     },
     {


### PR DESCRIPTION
Rinse-and-repeat of the connector template, filling popular gaps. Each is built to the L5 house standard (AbortController timeout, clean 429, two-lane errors, source/freshness/next_steps stamp, not-connected card via a `connector-setup` row, colocated test, and `tool-wiring` import + defs + dispatch).

| App | Auth | Tools |
| --- | --- | --- |
| **Todoist** | Bearer token | list projects/tasks, create + complete task |
| **Pipedrive** | `api_token` query | deals, persons, organizations, search |
| **Confluence** | email + token (Basic), site-aware; pairs with Jira | search, get page, list spaces |
| **Unsplash** | `Client-ID` header | search, get, random photo |
| **Giphy** | `api_key` query | search, trending, random |
| **Miro** | Bearer token | list boards, get board, list items |
| **Shortcut** | `Shortcut-Token` header | search stories, get story, list projects/epics |
| **Wikipedia** | none (public) | search, summary, full page; `lang`-aware |

- New **"Images"** category for Unsplash + Giphy.
- Catalog: **202 → 210 apps, ~864 → 891 tools**; depth ladder **177 → 185 connectors** (all 8 grade **L5 Agentic**).
- Regenerated tool-index, depth-ladder, app-catalog, and brainmap.

## Verification
- MCP package: **1070 tests** green; all `--check` gates pass (tool-index, ladder, standalone, brainmap, app-catalog).
- **+40** new connector tests (429, timeout, not-connected/validation, auth-shape, source stamp).
- `tsc --noEmit` clean for the MCP package.

https://claude.ai/code/session_012Ce8oy3qUdBSghDvMFSxjL

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ce8oy3qUdBSghDvMFSxjL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive connector and doc/index changes following the existing template; no auth or core routing changes beyond new optional API credentials.
> 
> **Overview**
> Adds **eight** new MCP integrations—**Todoist**, **Pipedrive**, **Confluence**, **Unsplash**, **Giphy**, **Miro**, **Shortcut**, and **Wikipedia**—each implemented as a dedicated `*-tool.ts` module with timeouts, 429 handling, `not_connected` setup in `connector-setup`, `unclick_meta` stamping, colocated Vitest coverage, and full registration in `tool-wiring`.
> 
> **Todoist** and **Pipedrive** cover tasks/CRM reads (plus Todoist create/complete). **Confluence** uses Atlassian Basic auth and can reuse Jira site/email env vars. **Unsplash** and **Giphy** land in a new **Images** catalog category. **Miro** and **Shortcut** expose board/story workflows. **Wikipedia** is keyless and language-aware.
> 
> Regenerated artifacts bump the public surface (~**210** apps / **891** tools; depth ladder **185** connectors, all eight at **L5**): `tool-index`, `connector-depth-ladder`, `app-catalog`, brainmap, and `generate-app-catalog.mjs` category/blurb/domain mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb82da4f0d5bc0499047fc3eadaf4d27c562dcc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->