### PR TITLE
Run MCP wiring prep before Vercel build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run prepare:wiring --workspace=@unclick/mcp-server && npm run build",
   "outputDirectory": "dist",
   "installCommand": "npm install",
   "framework": "vite",


### PR DESCRIPTION
## Summary
- Run the MCP server wiring prep before the root Vercel build.
- Ensures `/api/mcp` bundles the patched Reddit tool wiring from PR #1229.

## Why
`/api/mcp` imports `packages/mcp-server/src/server.ts` directly during the root app build, so the MCP package-level `prepare:wiring` step was not running for production.

## Tests
- Not run locally; change is Vercel build-command wiring only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-pipeline change in `vercel.json`; no runtime auth or data-path changes, only ensures codegen/patch steps run before bundle.
> 
> **Overview**
> Updates the Vercel **`buildCommand`** so production runs **`@unclick/mcp-server`**’s **`prepare:wiring`** (Reddit public wiring patch + tool index generation) **before** the root **`npm run build`**.
> 
> That closes a gap where **`/api/mcp`** pulls in **`packages/mcp-server/src/server.ts`** during the app build without ever running the MCP package’s prep scripts, so deployed MCP could miss the intended tool wiring (e.g. from PR #1229).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5935fdfe9f7ad61f66343a3a07a0b1c4693d44b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->