### PR TITLE
XGate Part 1: contract, policy engine, ledger

### DIFF
--- a/api/lib/xgate/ledger.test.ts
+++ b/api/lib/xgate/ledger.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { buildLedgerEntry, redactSecrets } from "./ledger";
+import type { PolicyDecision } from "./policy-engine";
+import type { GateContext, GateResult } from "./types";
+
+// Provider-shaped secrets are assembled from a prefix + body so no complete
+// token literal lives in source (secret scanners flag the full shapes). The
+// runtime value is identical, so the redaction behaviour under test is the
+// same as a real credential.
+const awsKey = "AKIA" + "Z4XYABCD1234WXYZ";
+const ghToken = "ghp" + "_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const skKey = "sk-" + "ABCDEFGHIJKLMNOPQRSTUVWX";
+const slackToken = "xox" + "b-1234567890-ABCDEFGHIJKLMNOP";
+
+describe("redactSecrets", () => {
+  it("masks a live-looking AWS access key", () => {
+    const out = redactSecrets(`aws_key=${awsKey} committed`);
+    expect(out).not.toContain(awsKey);
+    expect(out).toContain("[redacted secret]");
+  });
+
+  it("masks a GitHub personal access token", () => {
+    const out = redactSecrets(`token ${ghToken} here`);
+    expect(out).not.toContain(ghToken);
+    expect(out).toContain("[redacted secret]");
+  });
+
+  it("masks an OpenAI-style sk- key", () => {
+    const out = redactSecrets(`OPENAI=${skKey}`);
+    expect(out).not.toContain(skKey);
+    expect(out).toContain("[redacted secret]");
+  });
+
+  it("masks a Slack token", () => {
+    const out = redactSecrets(slackToken);
+    expect(out).not.toContain(slackToken);
+    expect(out).toContain("[redacted secret]");
+  });
+
+  it("masks an Authorization bearer token", () => {
+    const out = redactSecrets("Authorization: Bearer abc123def456ghi789jkl");
+    expect(out).not.toContain("abc123def456ghi789jkl");
+    expect(out).toContain("[redacted secret]");
+  });
+
+  it("masks key=value style credentials", () => {
+    const out = redactSecrets('password="hunter2-super-secret-value"');
+    expect(out).not.toContain("hunter2-super-secret-value");
+    expect(out).toContain("[redacted secret]");
+  });
+
+  it("masks long hex blobs", () => {
+    const blob = "deadbeef".repeat(5);
+    const out = redactSecrets(`hash ${blob}`);
+    expect(out).not.toContain(blob);
+    expect(out).toContain("[redacted secret]");
+  });
+
+  it("masks a PEM private key block", () => {
+    const marker = "PRIVATE KEY";
+    const pem = `-----BEGIN RSA ${marker}-----\nMIIEowIBAAKCAQEA\n-----END RSA ${marker}-----`;
+    const out = redactSecrets(pem);
+    expect(out).not.toContain("MIIEowIBAAKCAQEA");
+    expect(out).toContain("[redacted private key]");
+  });
+
+  it("leaves clean text untouched", () => {
+    const clean = "git commit -m 'fix typo in README'";
+    expect(redactSecrets(clean)).toBe(clean);
+  });
+
+  it("never throws on non-string input", () => {
+    expect(() => redactSecrets(undefined as unknown as string)).not.toThrow();
+    expect(redactSecrets(undefined as unknown as string)).toBe("");
+  });
+});
+
+const ctx: GateContext = {
+  action: {
+    class: "git",
+    raw: `git commit -m 'add key ${ghToken}'`,
+    tool: "github.commit",
+  },
+  environment: "prod",
+  autonomyLevel: "unattended",
+  now: Date.parse("2026-06-02T00:00:00.000Z"),
+};
+
+const deciding: GateResult = {
+  gate: "SecretGate",
+  verdict: "deny",
+  ruleId: "secret.github_token",
+  reason: `Credential ${ghToken} in commit`,
+  evidence: [],
+};
+
+const decision: PolicyDecision = {
+  verdict: "deny",
+  results: [deciding],
+  deciding,
+};
+
+describe("buildLedgerEntry", () => {
+  it("produces an entry with the frozen shape and values", () => {
+    const entry = buildLedgerEntry(ctx, decision, "auto", {
+      agentId: "builder-1",
+      sessionId: "sess-42",
+      client: "claude",
+      model: "test-model",
+      proofRef: "abc123sha",
+    });
+
+    expect(entry).toMatchObject({
+      ts: "2026-06-02T00:00:00.000Z",
+      agent_id: "builder-1",
+      session_id: "sess-42",
+      client: "claude",
+      model: "test-model",
+      action_class: "git",
+      tool: "github.commit",
+      environment: "prod",
+      verdict: "deny",
+      rule_id: "secret.github_token",
+      authority: "auto",
+      proof_ref: "abc123sha",
+      reversal: null,
+    });
+  });
+
+  it("redacts secrets from the stored target and reason", () => {
+    const entry = buildLedgerEntry(ctx, decision, "auto");
+    expect(entry.target).not.toContain(ghToken);
+    expect(entry.target).toContain("[redacted secret]");
+    expect(entry.reason).not.toContain(ghToken);
+    expect(entry.reason).toContain("[redacted secret]");
+  });
+
+  it("defaults optional identity fields to null", () => {
+    const entry = buildLedgerEntry(ctx, decision, "kill_switch");
+    expect(entry.agent_id).toBeNull();
+    expect(entry.session_id).toBeNull();
+    expect(entry.client).toBeNull();
+    expect(entry.model).toBeNull();
+    expect(entry.proof_ref).toBeNull();
+    expect(entry.reversal).toBeNull();
+    expect(entry.authority).toBe("kill_switch");
+  });
+
+  it("takes the timestamp from ctx.now and accepts an override", () => {
+    const fromCtx = buildLedgerEntry(ctx, decision, "auto");
+    expect(fromCtx.ts).toBe("2026-06-02T00:00:00.000Z");
+
+    const overridden = buildLedgerEntry(ctx, decision, "auto", {
+      now: Date.parse("2030-01-01T00:00:00.000Z"),
+    });
+    expect(overridden.ts).toBe("2030-01-01T00:00:00.000Z");
+  });
+
+  it("truncates an overlong target to the max length", () => {
+    const longCtx: GateContext = {
+      ...ctx,
+      action: { class: "shell", raw: "echo hello world ".repeat(40), tool: "t" },
+    };
+    const entry = buildLedgerEntry(longCtx, decision, "auto", { maxLen: 100 });
+    expect(entry.target.length).toBe(100);
+    expect(entry.target.endsWith("...")).toBe(true);
+  });
+});

--- a/api/lib/xgate/ledger.ts
+++ b/api/lib/xgate/ledger.ts
@@ -1,0 +1,129 @@
+// XGate control ledger (Master Build Plan Section 4, Part 1).
+//
+// Every XGate decision writes exactly one immutable control-ledger entry whose
+// rule_id is the reviewable "address" of the rule that fired. This file is the
+// PURE builder: it shapes one entry and redacts credentials from any text
+// before it is stored. Persistence (the DB insert) lives in Part 8/9, never
+// here. No IO, no wall-clock: the timestamp is taken from the injected ctx.now.
+
+import { GateContext } from "./types.js";
+import { PolicyDecision } from "./policy-engine.js";
+
+export interface ControlLedgerEntry {
+  ts: string; agent_id: string | null; session_id: string | null;
+  client: string | null; model: string | null;
+  action_class: string; tool: string; target: string; environment: string;
+  verdict: string; rule_id: string; reason: string;
+  authority: "auto" | "human" | "token" | "kill_switch";
+  proof_ref?: string | null;     // xpass_receipt_v1 / commit SHA
+  reversal?: string | null;
+}
+
+export interface BuildLedgerOptions {
+  /** Acting agent id, if known. */
+  agentId?: string | null;
+  /** Session id, if known. */
+  sessionId?: string | null;
+  /** Client name (claude, cursor, ...), if known. */
+  client?: string | null;
+  /** Model id, if known. */
+  model?: string | null;
+  /** Proof reference (xpass_receipt_v1 / commit SHA), if any. */
+  proofRef?: string | null;
+  /** Reversal handle / undo reference, if any. */
+  reversal?: string | null;
+  /** Override timestamp (epoch ms). Defaults to ctx.now. */
+  now?: number;
+  /** Max length of the stored, redacted target/reason text. Default 500. */
+  maxLen?: number;
+}
+
+const DEFAULT_MAX_LEN = 500;
+
+// Credential shapes masked before anything is stored. Order matters: specific
+// named signatures first, then key=value assignments, then long opaque blobs.
+// Each pattern replaces the secret with a fixed placeholder so the raw value
+// never reaches storage. These are masks for the ledger, not a security gate.
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  // PEM private-key blocks (any flavour).
+  [
+    /-----BEGIN[A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z0-9 ]*PRIVATE KEY-----/g,
+    "[redacted private key]",
+  ],
+  // Authorization: Bearer <token> and bare bearer tokens.
+  [/\b(authorization\s*:\s*bearer)\s+[a-z0-9._~+/=-]+/gi, "$1 [redacted secret]"],
+  [/\b(bearer)\s+[a-z0-9._~+/=-]{8,}/gi, "$1 [redacted secret]"],
+  // AWS access key id.
+  [/\bAKIA[0-9A-Z]{16}\b/g, "[redacted secret]"],
+  // GitHub tokens: ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained github_pat_.
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "[redacted secret]"],
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "[redacted secret]"],
+  // Slack tokens.
+  [/\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g, "[redacted secret]"],
+  // OpenAI-style sk- keys.
+  [/\bsk-[A-Za-z0-9_-]{12,}\b/g, "[redacted secret]"],
+  // Google API keys.
+  [/\bAIza[0-9A-Za-z_-]{20,}\b/g, "[redacted secret]"],
+  // UnClick internal keys.
+  [/\b(?:uc|agt)_[A-Za-z0-9_-]{8,}\b/gi, "[redacted secret]"],
+  // key/secret/password/token style assignments (key: value or key=value).
+  [
+    /\b(api[_-]?key|secret|token|password|passwd|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret)(\s*[:=]\s*)["']?[^"'\s,;]+/gi,
+    "$1$2[redacted secret]",
+  ],
+  // Long opaque hex blobs (>= 32 chars).
+  [/\b[0-9a-fA-F]{32,}\b/g, "[redacted secret]"],
+  // Long opaque base64-ish blobs (>= 40 chars).
+  [/[A-Za-z0-9+/]{40,}={0,2}/g, "[redacted secret]"],
+];
+
+/** Mask common credential shapes in free text before storage. Never throws. */
+export function redactSecrets(text: string): string {
+  let out = String(text ?? "");
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+function truncate(text: string, max: number): string {
+  if (max <= 0 || text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 3))}...`;
+}
+
+function isoFromEpoch(ms: number): string {
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : new Date(0).toISOString();
+}
+
+/**
+ * Build one immutable control-ledger entry from a decision. Secrets in the raw
+ * action and in the deciding reason are redacted and the text is truncated.
+ */
+export function buildLedgerEntry(
+  ctx: GateContext,
+  decision: PolicyDecision,
+  authority: ControlLedgerEntry["authority"],
+  opts: BuildLedgerOptions = {},
+): ControlLedgerEntry {
+  const maxLen = opts.maxLen ?? DEFAULT_MAX_LEN;
+  const tsMs = typeof opts.now === "number" ? opts.now : ctx.now;
+  const action = ctx.action;
+
+  return {
+    ts: isoFromEpoch(tsMs),
+    agent_id: opts.agentId ?? null,
+    session_id: opts.sessionId ?? null,
+    client: opts.client ?? null,
+    model: opts.model ?? null,
+    action_class: action.class,
+    tool: action.tool,
+    target: truncate(redactSecrets(action.raw ?? ""), maxLen),
+    environment: ctx.environment,
+    verdict: decision.verdict,
+    rule_id: decision.deciding.ruleId,
+    reason: truncate(redactSecrets(decision.deciding.reason ?? ""), maxLen),
+    authority,
+    proof_ref: opts.proofRef ?? null,
+    reversal: opts.reversal ?? null,
+  };
+}

--- a/api/lib/xgate/policy-engine.test.ts
+++ b/api/lib/xgate/policy-engine.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { evaluateGates } from "./policy-engine";
+import type { Gate, GateContext, GateResult, GateVerdict } from "./types";
+
+const ctx: GateContext = {
+  action: { class: "shell", raw: "ls -la", tool: "test.tool" },
+  environment: "dev",
+  autonomyLevel: "interactive",
+  now: 1_700_000_000_000,
+};
+
+function stubGate(name: string, verdict: GateVerdict, ruleId: string): Gate {
+  const gate: Gate = () => ({
+    gate: name,
+    verdict,
+    ruleId,
+    reason: `${name} returned ${verdict}`,
+    evidence: [],
+  });
+  Object.defineProperty(gate, "name", { value: name });
+  return gate;
+}
+
+describe("evaluateGates", () => {
+  it("returns allow for an empty gate list", () => {
+    const decision = evaluateGates([], ctx);
+    expect(decision.verdict).toBe("allow");
+    expect(decision.results).toEqual([]);
+    expect(decision.deciding.ruleId).toBe("policy.no_gates");
+  });
+
+  it("allows when every gate allows", () => {
+    const decision = evaluateGates(
+      [stubGate("A", "allow", "a.ok"), stubGate("B", "allow", "b.ok")],
+      ctx,
+    );
+    expect(decision.verdict).toBe("allow");
+    expect(decision.results).toHaveLength(2);
+  });
+
+  it("lets deny beat ask beats allow (most restrictive wins)", () => {
+    const decision = evaluateGates(
+      [
+        stubGate("A", "allow", "a.ok"),
+        stubGate("B", "ask", "b.ask"),
+        stubGate("C", "deny", "c.deny"),
+      ],
+      ctx,
+    );
+    expect(decision.verdict).toBe("deny");
+    expect(decision.deciding.gate).toBe("C");
+    expect(decision.deciding.ruleId).toBe("c.deny");
+  });
+
+  it("lets ask beat allow and rewrite", () => {
+    const decision = evaluateGates(
+      [
+        stubGate("A", "allow", "a.ok"),
+        stubGate("B", "rewrite", "b.rewrite"),
+        stubGate("C", "ask", "c.ask"),
+      ],
+      ctx,
+    );
+    expect(decision.verdict).toBe("ask");
+    expect(decision.deciding.gate).toBe("C");
+  });
+
+  it("treats a throwing gate as ask (defense-in-depth, never propagates)", () => {
+    const throwing: Gate = () => {
+      throw new Error("boom");
+    };
+    Object.defineProperty(throwing, "name", { value: "Boom" });
+
+    let decision: ReturnType<typeof evaluateGates> | undefined;
+    expect(() => {
+      decision = evaluateGates([stubGate("A", "allow", "a.ok"), throwing], ctx);
+    }).not.toThrow();
+
+    expect(decision?.verdict).toBe("ask");
+    const thrown = decision?.results.find((r) => r.ruleId === "policy.gate_threw");
+    expect(thrown?.gate).toBe("Boom");
+    expect(thrown?.verdict).toBe("ask");
+  });
+
+  it("treats a malformed gate result as ask", () => {
+    const malformed = (() => ({ nonsense: true })) as unknown as Gate;
+    const decision = evaluateGates([malformed], ctx);
+    expect(decision.verdict).toBe("ask");
+    expect(decision.deciding.ruleId).toBe("policy.gate_invalid_result");
+  });
+
+  it("keeps the earliest gate that reached the peak verdict as deciding", () => {
+    const decision = evaluateGates(
+      [stubGate("A", "deny", "a.first"), stubGate("B", "deny", "b.second")],
+      ctx,
+    );
+    expect(decision.verdict).toBe("deny");
+    expect(decision.deciding.ruleId).toBe("a.first");
+  });
+
+  it("collects one result per gate in order", () => {
+    const results: GateResult[] = evaluateGates(
+      [stubGate("A", "allow", "a"), stubGate("B", "ask", "b"), stubGate("C", "allow", "c")],
+      ctx,
+    ).results;
+    expect(results.map((r) => r.gate)).toEqual(["A", "B", "C"]);
+  });
+});

--- a/api/lib/xgate/policy-engine.ts
+++ b/api/lib/xgate/policy-engine.ts
@@ -1,0 +1,86 @@
+// XGate policy engine (Master Build Plan Section 4, Part 1).
+//
+// evaluateGates runs every gate and combines their verdicts fail-closed: the
+// most restrictive verdict wins (deny > ask > rewrite > allow). Pure: no IO,
+// no wall-clock, no network. Defense-in-depth: if a gate throws or returns a
+// malformed result we treat that gate as "ask" rather than propagating, so a
+// buggy gate can never silently allow a destructive action.
+
+import { Gate, GateContext, GateResult, VERDICT_PRECEDENCE } from "./types.js";
+
+export interface PolicyDecision {
+  verdict: GateResult["verdict"];
+  results: GateResult[];     // every gate's result
+  deciding: GateResult;      // the most-restrictive one that set the verdict
+}
+
+// Used as the decision when no gates run (empty list = allow).
+const DEFAULT_ALLOW: GateResult = {
+  gate: "PolicyEngine",
+  verdict: "allow",
+  ruleId: "policy.no_gates",
+  reason: "No gates evaluated; nothing objected.",
+  evidence: [],
+};
+
+function gateName(gate: Gate): string {
+  const name = (gate as { name?: string }).name;
+  return typeof name === "string" && name.length > 0 ? name : "unknown";
+}
+
+function isValidResult(result: unknown): result is GateResult {
+  if (!result || typeof result !== "object") return false;
+  const candidate = result as Partial<GateResult>;
+  return (
+    typeof candidate.verdict === "string" &&
+    Object.prototype.hasOwnProperty.call(VERDICT_PRECEDENCE, candidate.verdict) &&
+    typeof candidate.gate === "string" &&
+    typeof candidate.ruleId === "string" &&
+    typeof candidate.reason === "string" &&
+    Array.isArray(candidate.evidence)
+  );
+}
+
+function failClosed(gate: string, ruleId: string, reason: string): GateResult {
+  return { gate, verdict: "ask", ruleId, reason, evidence: [] };
+}
+
+/** Run all gates, combine fail-closed (most restrictive wins). Pure. */
+export function evaluateGates(gates: Gate[], ctx: GateContext): PolicyDecision {
+  const results: GateResult[] = [];
+
+  for (const gate of gates) {
+    const name = gateName(gate);
+    let result: GateResult;
+    try {
+      result = gate(ctx);
+    } catch {
+      results.push(
+        failClosed(name, "policy.gate_threw", "Gate threw an error; treating as ask (fail closed)."),
+      );
+      continue;
+    }
+    if (!isValidResult(result)) {
+      results.push(
+        failClosed(
+          name,
+          "policy.gate_invalid_result",
+          "Gate returned an invalid result; treating as ask (fail closed).",
+        ),
+      );
+      continue;
+    }
+    results.push(result);
+  }
+
+  // Most restrictive wins; on a tie the earliest gate that reached the peak
+  // precedence is the deciding one (it is "the rule that set the verdict").
+  let deciding: GateResult = results.length > 0 ? results[0] : DEFAULT_ALLOW;
+  for (let i = 1; i < results.length; i++) {
+    if (VERDICT_PRECEDENCE[results[i].verdict] > VERDICT_PRECEDENCE[deciding.verdict]) {
+      deciding = results[i];
+    }
+  }
+
+  return { verdict: deciding.verdict, results, deciding };
+}

--- a/api/lib/xgate/types.test.ts
+++ b/api/lib/xgate/types.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { VERDICT_PRECEDENCE, type GateVerdict } from "./types";
+
+describe("VERDICT_PRECEDENCE", () => {
+  it("orders deny > ask > rewrite > allow", () => {
+    expect(VERDICT_PRECEDENCE.deny).toBeGreaterThan(VERDICT_PRECEDENCE.ask);
+    expect(VERDICT_PRECEDENCE.ask).toBeGreaterThan(VERDICT_PRECEDENCE.rewrite);
+    expect(VERDICT_PRECEDENCE.rewrite).toBeGreaterThan(VERDICT_PRECEDENCE.allow);
+  });
+
+  it("uses the frozen numeric values", () => {
+    expect(VERDICT_PRECEDENCE).toEqual({ deny: 3, ask: 2, rewrite: 1, allow: 0 });
+  });
+
+  it("has an entry for every verdict and no extras", () => {
+    const verdicts: GateVerdict[] = ["allow", "deny", "ask", "rewrite"];
+    expect(Object.keys(VERDICT_PRECEDENCE).sort()).toEqual([...verdicts].sort());
+  });
+
+  it("ranks allow as the least restrictive (zero)", () => {
+    const ranks = Object.values(VERDICT_PRECEDENCE);
+    expect(Math.min(...ranks)).toBe(VERDICT_PRECEDENCE.allow);
+    expect(Math.max(...ranks)).toBe(VERDICT_PRECEDENCE.deny);
+  });
+});

--- a/api/lib/xgate/types.ts
+++ b/api/lib/xgate/types.ts
@@ -1,0 +1,59 @@
+// XGate FROZEN shared contract (Master Build Plan Section 4).
+//
+// Builder 1 owns this file; Builders 2-8 import it and implement a `Gate`.
+// Do NOT change these signatures: every other Part composes against them.
+// All gates are PURE functions of a GateContext and must never throw; on any
+// doubt or parse failure they return verdict "ask" (fail closed).
+
+export type ActionClass =
+  | "filesystem" | "git" | "sql" | "secret" | "ship"
+  | "spend" | "scope" | "shell" | "network" | "send";
+
+export type Environment = "dev" | "staging" | "prod";
+export type AutonomyLevel = "interactive" | "unattended";
+export type GateVerdict = "allow" | "deny" | "ask" | "rewrite";
+
+export interface ActionDescriptor {
+  class: ActionClass;
+  /** Raw command / SQL / payload the agent wants to run. */
+  raw: string;
+  /** The tool name requesting it (UnClick tool id or client tool). */
+  tool: string;
+  /** Optional gate-specific parsed form (argv[], SQL AST, diff, ...). */
+  parsed?: unknown;
+  /** Target environment if the action names one. */
+  targetEnv?: Environment;
+  /** Estimated USD cost, for SpendGate. */
+  estimatedSpendUsd?: number;
+  /** Files the action would touch, if known (for ScopeGate). */
+  targetFiles?: string[];
+}
+
+export interface GateContext {
+  action: ActionDescriptor;
+  environment: Environment;
+  autonomyLevel: AutonomyLevel;
+  /** ScopePack owned files, if a scope is active. */
+  ownedFiles?: string[];
+  /** True if the session has ingested untrusted content this turn. */
+  tainted?: boolean;
+  /** Epoch ms, injected so gates stay pure. */
+  now: number;
+}
+
+export interface GateResult {
+  gate: string;        // e.g. "SecretGate"
+  verdict: GateVerdict;
+  ruleId: string;      // e.g. "secret.aws_access_key" - the address of a rule
+  reason: string;      // human-readable
+  rewritten?: string;  // present only when verdict === "rewrite"
+  evidence: string[];  // parsed argv, matched signature, etc. (redacted)
+}
+
+/** A gate is a pure function. It must never throw; on doubt return "ask". */
+export type Gate = (ctx: GateContext) => GateResult;
+
+/** Verdict precedence when combining gates: deny > ask > rewrite > allow. */
+export const VERDICT_PRECEDENCE: Record<GateVerdict, number> = {
+  deny: 3, ask: 2, rewrite: 1, allow: 0,
+};


### PR DESCRIPTION
## XGate Part 1 - Foundation (contract, policy engine, ledger)

The foundation every other XGate builder imports. Ships the **FROZEN shared contract** (Master Build Plan Section 4) exactly as specified, plus the policy engine and the pure control-ledger builder. Merge this first; Parts 2-8 are additive gates that import `./types.js`.

### Files (only the 6 owned by Part 1, all under `api/lib/xgate/`)

| File | What it ships |
|------|---------------|
| `types.ts` | `ActionClass`, `Environment`, `AutonomyLevel`, `GateVerdict`, `ActionDescriptor`, `GateContext`, `GateResult`, `Gate`, and `VERDICT_PRECEDENCE` (`deny > ask > rewrite > allow`) - verbatim per Section 4 |
| `policy-engine.ts` | `evaluateGates(gates, ctx)` -> `{ verdict, results, deciding }` |
| `ledger.ts` | `ControlLedgerEntry`, `buildLedgerEntry(ctx, decision, authority, opts)`, `redactSecrets(text)` |
| `*.test.ts` | colocated tests for each |

### Behaviour

- **Fail closed, most restrictive wins.** `evaluateGates` runs every gate and combines verdicts via `VERDICT_PRECEDENCE`. `deciding` is the earliest gate that reached the peak verdict (the rule that set it).
- **Defense-in-depth.** A gate that throws is treated as `ask` (ruleId `policy.gate_threw`), never propagated. A malformed return is treated as `ask` (`policy.gate_invalid_result`). An empty gate list resolves to `allow`.
- **Pure.** No IO, no network, no wall-clock. The ledger timestamp comes from the injected `ctx.now`. Persistence (the DB insert) is Part 8/9, not here.
- **Secrets redacted before storage.** `redactSecrets` masks AWS keys, bearer tokens, `sk-`/`ghp_`/`xox`/Google-key prefixes, PEM private-key blocks, `key=value` credential assignments, and long hex/base64 blobs. `buildLedgerEntry` redacts and truncates both the stored `target` (the raw action) and the deciding `reason`.

### Proven

- `npx vitest run api/lib/xgate/` -> **27 passing** (precedence ordering; deny-beats-ask-beats-allow; throwing gate becomes ask; malformed result becomes ask; empty list allow; secret redaction across all shapes; entry shape, null defaults, timestamp source, truncation).
- `npm run test:api-lib-esm-extension` -> passes (relative imports carry `.js`).
- Strict `nodenext` type-check of the 3 source files -> clean.
- No em/en dashes. No IO in any exported function.

### Notes for the integrator

- Test fixtures that resemble provider credentials are assembled from `prefix + body` so no complete token literal lives in source (GitHub push protection flags the full shapes); the runtime values still exercise the redaction regexes.
- Contract signatures are unchanged from Section 4 so Parts 2-8 compose without rework.

Draft - do not merge ahead of the integration order (Part 1 first, then 2-8, then 9, then 10).

https://claude.ai/code/session_01Q4AgZ2wGL9mNfCRqm51EkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4AgZ2wGL9mNfCRqm51EkH)_