### PR TITLE
XGate Part 7: ScopeGate + SpendGate

### DIFF
--- a/api/lib/xgate/gates/scope-gate.test.ts
+++ b/api/lib/xgate/gates/scope-gate.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { scopeGate } from "./scope-gate.js";
+import type { GateContext } from "../types.js";
+
+const baseCtx: GateContext = {
+  action: {
+    class: "filesystem",
+    raw: "write file",
+    tool: "test.write",
+    targetFiles: ["api/lib/xgate/gates/scope-gate.ts"],
+  },
+  environment: "dev",
+  autonomyLevel: "interactive",
+  ownedFiles: ["api/lib/xgate/gates/scope-gate.ts"],
+  now: Date.parse("2026-06-02T00:00:00.000Z"),
+};
+
+describe("scopeGate", () => {
+  it("denies an out-of-scope write", () => {
+    const decision = scopeGate({
+      ...baseCtx,
+      action: {
+        ...baseCtx.action,
+        targetFiles: ["api/lib/xgate/gates/scope-gate.ts", "package.json"],
+      },
+    });
+
+    expect(decision.verdict).toBe("deny");
+    expect(decision.ruleId).toBe("scope.out_of_bounds");
+    expect(decision.evidence.join(" ")).toContain("package.json");
+  });
+
+  it("allows an in-scope write", () => {
+    const decision = scopeGate(baseCtx);
+    expect(decision.verdict).toBe("allow");
+    expect(decision.ruleId).toBe("scope.in_bounds");
+  });
+
+  it("allows when no active scope exists", () => {
+    const decision = scopeGate({
+      ...baseCtx,
+      ownedFiles: undefined,
+      action: { ...baseCtx.action, targetFiles: ["package.json"] },
+    });
+
+    expect(decision.verdict).toBe("allow");
+    expect(decision.ruleId).toBe("scope.no_active_scope");
+  });
+
+  it("asks when a write has unknown targets", () => {
+    const decision = scopeGate({
+      ...baseCtx,
+      action: {
+        class: "filesystem",
+        raw: "write file",
+        tool: "test.write",
+      },
+    });
+
+    expect(decision.verdict).toBe("ask");
+    expect(decision.ruleId).toBe("scope.unknown_targets");
+  });
+
+  it("normalizes dot segments, slashes, and trailing separators", () => {
+    const decision = scopeGate({
+      ...baseCtx,
+      ownedFiles: ["./api/lib/xgate/gates/"],
+      action: {
+        ...baseCtx.action,
+        targetFiles: [".\\api\\lib\\xgate\\gates\\..\\gates\\scope-gate.ts"],
+      },
+    });
+
+    expect(decision.verdict).toBe("allow");
+    expect(decision.ruleId).toBe("scope.in_bounds");
+  });
+});
+

--- a/api/lib/xgate/gates/scope-gate.ts
+++ b/api/lib/xgate/gates/scope-gate.ts
@@ -1,0 +1,171 @@
+import { posix as path } from "node:path";
+import type { ActionDescriptor, Gate, GateContext, GateResult } from "../types.js";
+
+const GATE = "ScopeGate";
+
+type OwnedPath = {
+  normalized: string;
+};
+
+function result(
+  verdict: GateResult["verdict"],
+  ruleId: string,
+  reason: string,
+  evidence: string[] = [],
+): GateResult {
+  return { gate: GATE, verdict, ruleId, reason, evidence };
+}
+
+function normalizeRepoPath(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.includes("\0")) return null;
+
+  const slashPath = trimmed.replace(/\\/g, "/");
+  const hadTrailingSlash = slashPath.endsWith("/");
+  const normalized = path.normalize(slashPath).replace(/^\.\/+/, "").replace(/^\/+/, "");
+
+  if (!normalized || normalized === ".") return null;
+
+  const withoutTrailingSlash =
+    normalized.length > 1 && normalized.endsWith("/") ? normalized.slice(0, -1) : normalized;
+
+  if (hadTrailingSlash && withoutTrailingSlash !== ".") {
+    return withoutTrailingSlash;
+  }
+
+  return withoutTrailingSlash;
+}
+
+function normalizeOwnedPaths(ownedFiles: string[]): OwnedPath[] {
+  const seen = new Set<string>();
+  const owned: OwnedPath[] = [];
+
+  for (const raw of ownedFiles) {
+    const normalized = normalizeRepoPath(raw);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    owned.push({ normalized });
+  }
+
+  return owned;
+}
+
+function isWithinOwnedPath(target: string, owned: OwnedPath): boolean {
+  return target === owned.normalized || target.startsWith(`${owned.normalized}/`);
+}
+
+function looksLikeFileWrite(action: ActionDescriptor): boolean {
+  if (action.class === "scope" || action.class === "filesystem") return true;
+
+  const raw = action.raw.toLowerCase();
+
+  if (action.class === "shell") {
+    return (
+      /\b(rm|mv|cp|touch|mkdir|rmdir)\b/.test(raw) ||
+      /\bsed\s+-i\b/.test(raw) ||
+      /\btee\b/.test(raw) ||
+      /(^|[^>])>>?\s*[^&\s]/.test(raw)
+    );
+  }
+
+  if (action.class === "git") {
+    return /\b(commit|merge|checkout|reset|clean)\b/.test(raw);
+  }
+
+  return false;
+}
+
+export const scopeGate: Gate = (ctx: GateContext): GateResult => {
+  try {
+    if (ctx.ownedFiles === undefined) {
+      return result(
+        "allow",
+        "scope.no_active_scope",
+        "No active ScopePack owned files were provided.",
+      );
+    }
+
+    if (!Array.isArray(ctx.ownedFiles)) {
+      return result(
+        "ask",
+        "scope.invalid_owned_files",
+        "ScopePack owned files could not be parsed.",
+      );
+    }
+
+    const targetFiles = ctx.action.targetFiles;
+    if (targetFiles === undefined) {
+      if (looksLikeFileWrite(ctx.action)) {
+        return result(
+          "ask",
+          "scope.unknown_targets",
+          "The action appears to write files but target files are unknown.",
+          [`action_class:${ctx.action.class}`, `tool:${ctx.action.tool}`],
+        );
+      }
+
+      return result("allow", "scope.no_file_targets", "The action has no file targets.");
+    }
+
+    if (!Array.isArray(targetFiles)) {
+      return result(
+        "ask",
+        "scope.invalid_target_files",
+        "Target files could not be parsed.",
+      );
+    }
+
+    if (targetFiles.length === 0) {
+      return result("allow", "scope.empty_targets", "The action reported no file targets.");
+    }
+
+    const owned = normalizeOwnedPaths(ctx.ownedFiles);
+    const normalizedTargets: string[] = [];
+
+    for (const target of targetFiles) {
+      const normalized = normalizeRepoPath(target);
+      if (!normalized) {
+        return result(
+          "ask",
+          "scope.invalid_target_path",
+          "A target path could not be normalized.",
+          [`target:${String(target)}`],
+        );
+      }
+      normalizedTargets.push(normalized);
+    }
+
+    const outOfScope = normalizedTargets.filter(
+      (target) => !owned.some((ownedPath) => isWithinOwnedPath(target, ownedPath)),
+    );
+
+    if (outOfScope.length > 0) {
+      return result(
+        "deny",
+        "scope.out_of_bounds",
+        "The action writes outside the active ScopePack owned files.",
+        [
+          `targets:${normalizedTargets.join(",")}`,
+          `out_of_scope:${outOfScope.join(",")}`,
+          `owned:${owned.map((ownedPath) => ownedPath.normalized).join(",")}`,
+        ],
+      );
+    }
+
+    return result(
+      "allow",
+      "scope.in_bounds",
+      "All target files are inside the active ScopePack owned files.",
+      [`targets:${normalizedTargets.join(",")}`],
+    );
+  } catch (error) {
+    return result(
+      "ask",
+      "scope.parse_error",
+      "ScopeGate could not safely evaluate the action.",
+      [error instanceof Error ? error.message : "unknown error"],
+    );
+  }
+};

--- a/api/lib/xgate/gates/spend-gate.test.ts
+++ b/api/lib/xgate/gates/spend-gate.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { createSpendGate, spendGate } from "./spend-gate.js";
+import type { GateContext } from "../types.js";
+
+const baseCtx: GateContext = {
+  action: {
+    class: "spend",
+    raw: "run paid model batch",
+    tool: "test.spend",
+    estimatedSpendUsd: 0.75,
+  },
+  environment: "dev",
+  autonomyLevel: "interactive",
+  now: Date.parse("2026-06-02T00:00:00.000Z"),
+};
+
+describe("spendGate", () => {
+  it("denies an action over the default budget", () => {
+    const decision = spendGate({
+      ...baseCtx,
+      action: { ...baseCtx.action, estimatedSpendUsd: 1.25 },
+    });
+
+    expect(decision.verdict).toBe("deny");
+    expect(decision.ruleId).toBe("spend.over_budget");
+  });
+
+  it("allows an action within the default budget", () => {
+    const decision = spendGate(baseCtx);
+    expect(decision.verdict).toBe("allow");
+    expect(decision.ruleId).toBe("spend.within_budget");
+  });
+
+  it("uses a configured budget", () => {
+    const gate = createSpendGate({ maxSpendUsd: 2 });
+    const decision = gate({
+      ...baseCtx,
+      action: { ...baseCtx.action, estimatedSpendUsd: 1.5 },
+    });
+
+    expect(decision.verdict).toBe("allow");
+    expect(decision.ruleId).toBe("spend.within_budget");
+  });
+
+  it("asks when a spend action has no estimate", () => {
+    const decision = spendGate({
+      ...baseCtx,
+      action: {
+        class: "spend",
+        raw: "run paid model batch",
+        tool: "test.spend",
+      },
+    });
+
+    expect(decision.verdict).toBe("ask");
+    expect(decision.ruleId).toBe("spend.missing_estimate");
+  });
+
+  it("allows unrelated actions without estimated spend", () => {
+    const decision = spendGate({
+      ...baseCtx,
+      action: {
+        class: "shell",
+        raw: "npm test",
+        tool: "test.shell",
+      },
+    });
+
+    expect(decision.verdict).toBe("allow");
+    expect(decision.ruleId).toBe("spend.no_estimate");
+  });
+});
+

--- a/api/lib/xgate/gates/spend-gate.ts
+++ b/api/lib/xgate/gates/spend-gate.ts
@@ -1,0 +1,88 @@
+import type { Gate, GateContext, GateResult } from "../types.js";
+
+const GATE = "SpendGate";
+const DEFAULT_MAX_SPEND_USD = 1;
+
+export interface SpendGateOptions {
+  maxSpendUsd?: number;
+}
+
+function result(
+  verdict: GateResult["verdict"],
+  ruleId: string,
+  reason: string,
+  evidence: string[] = [],
+): GateResult {
+  return { gate: GATE, verdict, ruleId, reason, evidence };
+}
+
+function formatUsd(value: number): string {
+  return value.toFixed(4).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+export function createSpendGate(options: SpendGateOptions = {}): Gate {
+  return (ctx: GateContext): GateResult => {
+    try {
+      const maxSpendUsd = options.maxSpendUsd ?? DEFAULT_MAX_SPEND_USD;
+
+      if (!Number.isFinite(maxSpendUsd) || maxSpendUsd < 0) {
+        return result(
+          "ask",
+          "spend.invalid_budget",
+          "SpendGate budget could not be parsed.",
+          [`max_usd:${String(maxSpendUsd)}`],
+        );
+      }
+
+      const estimatedSpendUsd = ctx.action.estimatedSpendUsd;
+
+      if (estimatedSpendUsd === undefined) {
+        if (ctx.action.class === "spend") {
+          return result(
+            "ask",
+            "spend.missing_estimate",
+            "Spend action does not include an estimated cost.",
+            [`max_usd:${formatUsd(maxSpendUsd)}`],
+          );
+        }
+
+        return result("allow", "spend.no_estimate", "The action has no estimated spend.");
+      }
+
+      if (!Number.isFinite(estimatedSpendUsd) || estimatedSpendUsd < 0) {
+        return result(
+          "ask",
+          "spend.invalid_estimate",
+          "Estimated spend could not be parsed.",
+          [`estimated_usd:${String(estimatedSpendUsd)}`],
+        );
+      }
+
+      if (estimatedSpendUsd > maxSpendUsd) {
+        return result(
+          "deny",
+          "spend.over_budget",
+          "Estimated spend is above the configured budget.",
+          [`estimated_usd:${formatUsd(estimatedSpendUsd)}`, `max_usd:${formatUsd(maxSpendUsd)}`],
+        );
+      }
+
+      return result(
+        "allow",
+        "spend.within_budget",
+        "Estimated spend is within the configured budget.",
+        [`estimated_usd:${formatUsd(estimatedSpendUsd)}`, `max_usd:${formatUsd(maxSpendUsd)}`],
+      );
+    } catch (error) {
+      return result(
+        "ask",
+        "spend.parse_error",
+        "SpendGate could not safely evaluate the action.",
+        [error instanceof Error ? error.message : "unknown error"],
+      );
+    }
+  };
+}
+
+export const spendGate: Gate = createSpendGate();
+


### PR DESCRIPTION
## Summary

Adds the Builder 7 XGate lane on top of the frozen Part 1 contract:

- `scopeGate` denies file writes outside active `ownedFiles`, asks when write targets are unknown, allows no active scope, and normalizes repo paths.
- `spendGate` adds the default USD budget gate plus `createSpendGate({ maxSpendUsd })` for explicit autonomy budgets.
- Adds focused co-located Vitest coverage for in-scope, out-of-scope, no-scope, unknown target, over-budget, within-budget, and configured-budget cases.

## Scope

Only the four Builder 7 files are included:

- `api/lib/xgate/gates/scope-gate.ts`
- `api/lib/xgate/gates/scope-gate.test.ts`
- `api/lib/xgate/gates/spend-gate.ts`
- `api/lib/xgate/gates/spend-gate.test.ts`

Base branch is Part 1 foundation because `main` does not have the frozen XGate contract yet.

## Validation

- `npx vitest run api/lib/xgate/` - 5 files, 37 tests passed
- `npm run test:api-lib-esm-extension` - passed
- `rg -n "–|—" api/lib/xgate/gates` - no matches
- `git diff --check` - passed

## Notes

Pure gates only. No network, DB, wall-clock, shared contract edits, endpoint wiring, UI changes, or migration changes.