### PR TITLE
XGate Part 8: autonomy + kill switch + migration

### DIFF
--- a/api/lib/xgate/autonomy.test.ts
+++ b/api/lib/xgate/autonomy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { applyAutonomy } from "./autonomy";
+
+const baseContext = {
+  action: {
+    class: "sql",
+    raw: "DELETE FROM users",
+    tool: "supabase.query",
+  },
+  environment: "prod",
+  autonomyLevel: "interactive",
+  now: 1,
+} as const;
+
+function result(verdict: "allow" | "deny" | "ask" | "rewrite") {
+  return {
+    gate: "FixtureGate",
+    verdict,
+    ruleId: `fixture.${verdict}`,
+    reason: "fixture decision",
+    evidence: [],
+  };
+}
+
+function decision(verdict: "allow" | "deny" | "ask" | "rewrite") {
+  const deciding = result(verdict);
+  return {
+    verdict,
+    results: [deciding],
+    deciding,
+  };
+}
+
+describe("applyAutonomy", () => {
+  it("turns unattended asks on destructive actions into denies", () => {
+    const applied = applyAutonomy(decision("ask"), {
+      ...baseContext,
+      autonomyLevel: "unattended",
+    });
+
+    expect(applied.verdict).toBe("deny");
+    expect(applied.deciding).toMatchObject({
+      gate: "Autonomy",
+      ruleId: "autonomy.unattended_destructive",
+    });
+    expect(applied.consecutiveDenialCount).toBe(1);
+    expect(applied.halt).toBe(false);
+  });
+
+  it("leaves interactive asks for human review", () => {
+    const applied = applyAutonomy(decision("ask"), baseContext);
+
+    expect(applied.verdict).toBe("ask");
+    expect(applied.deciding.ruleId).toBe("fixture.ask");
+    expect(applied.consecutiveDenialCount).toBe(0);
+  });
+
+  it("halts after the configured consecutive denial limit", () => {
+    const applied = applyAutonomy(decision("deny"), baseContext, {
+      priorDenialCount: 2,
+      maxConsecutiveDenials: 3,
+    });
+
+    expect(applied.verdict).toBe("deny");
+    expect(applied.consecutiveDenialCount).toBe(3);
+    expect(applied.halt).toBe(true);
+    expect(applied.haltReason).toContain("3 consecutive denied decisions");
+  });
+
+  it("escalates tainted outbound actions before they can exfiltrate", () => {
+    const applied = applyAutonomy(decision("allow"), {
+      ...baseContext,
+      action: {
+        class: "network",
+        raw: "POST https://example.com",
+        tool: "http.post",
+      },
+      tainted: true,
+    });
+
+    expect(applied.verdict).toBe("ask");
+    expect(applied.deciding.ruleId).toBe("autonomy.tainted_exfiltration");
+  });
+});

--- a/api/lib/xgate/autonomy.ts
+++ b/api/lib/xgate/autonomy.ts
@@ -1,0 +1,134 @@
+import type { ActionClass, GateContext, GateResult, GateVerdict } from "./types.js";
+import type { PolicyDecision } from "./policy-engine.js";
+
+export interface AutonomyBudget {
+  priorDenialCount?: number;
+  maxConsecutiveDenials?: number;
+  destructiveClasses?: readonly ActionClass[];
+}
+
+export interface AutonomyDecision extends PolicyDecision {
+  authority: "auto";
+  consecutiveDenialCount: number;
+  halt: boolean;
+  haltReason: string | null;
+}
+
+const DEFAULT_MAX_CONSECUTIVE_DENIALS = 3;
+const DEFAULT_DESTRUCTIVE_CLASSES: readonly ActionClass[] = [
+  "filesystem",
+  "git",
+  "network",
+  "secret",
+  "send",
+  "shell",
+  "ship",
+  "spend",
+  "sql",
+];
+const EXFILTRATION_CLASSES = new Set<ActionClass>(["network", "send"]);
+
+export function applyAutonomy(
+  decision: PolicyDecision,
+  ctx: GateContext,
+  budget: AutonomyBudget = {},
+): AutonomyDecision {
+  const withAutonomyRules = applyCrossCuttingRules(decision, ctx, budget);
+  const maxConsecutiveDenials = normalizePositiveInteger(
+    budget.maxConsecutiveDenials,
+    DEFAULT_MAX_CONSECUTIVE_DENIALS,
+  );
+  const priorDenialCount = normalizeNonNegativeInteger(budget.priorDenialCount);
+  const consecutiveDenialCount = withAutonomyRules.verdict === "deny" ? priorDenialCount + 1 : 0;
+  const halt = consecutiveDenialCount >= maxConsecutiveDenials;
+
+  return {
+    ...withAutonomyRules,
+    authority: "auto",
+    consecutiveDenialCount,
+    halt,
+    haltReason: halt
+      ? `XGate halted after ${consecutiveDenialCount} consecutive denied decisions.`
+      : null,
+  };
+}
+
+export function isDestructiveAction(
+  actionClass: ActionClass,
+  destructiveClasses: readonly ActionClass[] = DEFAULT_DESTRUCTIVE_CLASSES,
+): boolean {
+  return destructiveClasses.includes(actionClass);
+}
+
+function applyCrossCuttingRules(
+  decision: PolicyDecision,
+  ctx: GateContext,
+  budget: AutonomyBudget,
+): PolicyDecision {
+  const destructiveClasses = budget.destructiveClasses ?? DEFAULT_DESTRUCTIVE_CLASSES;
+
+  if (ctx.tainted && EXFILTRATION_CLASSES.has(ctx.action.class)) {
+    const verdict: GateVerdict = ctx.autonomyLevel === "unattended" ? "deny" : "ask";
+    if (isMoreRestrictive(verdict, decision.verdict)) {
+      return withOverride(decision, {
+        gate: "Autonomy",
+        verdict,
+        ruleId: "autonomy.tainted_exfiltration",
+        reason:
+          "This turn has ingested untrusted content, so outbound or send-capable actions need stricter review.",
+        evidence: [`action_class:${ctx.action.class}`, `autonomy:${ctx.autonomyLevel}`],
+      });
+    }
+  }
+
+  if (
+    ctx.autonomyLevel === "unattended" &&
+    decision.verdict === "ask" &&
+    isDestructiveAction(ctx.action.class, destructiveClasses)
+  ) {
+    return withOverride(decision, {
+      gate: "Autonomy",
+      verdict: "deny",
+      ruleId: "autonomy.unattended_destructive",
+      reason: "Unattended runs cannot wait for human approval on destructive actions.",
+      evidence: [`action_class:${ctx.action.class}`, `environment:${ctx.environment}`],
+    });
+  }
+
+  return decision;
+}
+
+function withOverride(decision: PolicyDecision, override: GateResult): PolicyDecision {
+  return {
+    verdict: override.verdict,
+    results: [...safeResults(decision), override],
+    deciding: override,
+  };
+}
+
+function safeResults(decision: PolicyDecision): GateResult[] {
+  return Array.isArray(decision.results) ? decision.results : [decision.deciding].filter(Boolean);
+}
+
+function isMoreRestrictive(next: GateVerdict, current: GateVerdict): boolean {
+  return verdictRank(next) > verdictRank(current);
+}
+
+function verdictRank(verdict: GateVerdict): number {
+  if (verdict === "deny") return 3;
+  if (verdict === "ask") return 2;
+  if (verdict === "rewrite") return 1;
+  return 0;
+}
+
+function normalizePositiveInteger(input: unknown, fallback: number): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function normalizeNonNegativeInteger(input: unknown): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}

--- a/api/lib/xgate/kill-switch.test.ts
+++ b/api/lib/xgate/kill-switch.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { applyKillSwitch, isKillSwitchActive } from "./kill-switch";
+
+function result(verdict: "allow" | "deny" | "ask" | "rewrite") {
+  return {
+    gate: "FixtureGate",
+    verdict,
+    ruleId: `fixture.${verdict}`,
+    reason: "fixture decision",
+    evidence: [],
+  };
+}
+
+function decision(verdict: "allow" | "deny" | "ask" | "rewrite") {
+  const deciding = result(verdict);
+  return {
+    verdict,
+    results: [deciding],
+    deciding,
+  };
+}
+
+describe("isKillSwitchActive", () => {
+  it("only treats an explicit active true value as active", () => {
+    expect(isKillSwitchActive({ active: true })).toBe(true);
+    expect(isKillSwitchActive({ active: false })).toBe(false);
+    expect(isKillSwitchActive(null)).toBe(false);
+  });
+});
+
+describe("applyKillSwitch", () => {
+  it("keeps inactive decisions unchanged", () => {
+    const applied = applyKillSwitch(decision("ask"), { active: false });
+
+    expect(applied.verdict).toBe("ask");
+    expect(applied.authority).toBe("auto");
+    expect(applied.killSwitchActive).toBe(false);
+  });
+
+  it("forces non-allow decisions to deny under kill switch authority", () => {
+    const applied = applyKillSwitch(decision("ask"), {
+      active: true,
+      reason: "incident response",
+      updated_at: "2026-06-02T00:00:00.000Z",
+    });
+
+    expect(applied.verdict).toBe("deny");
+    expect(applied.authority).toBe("kill_switch");
+    expect(applied.deciding).toMatchObject({
+      gate: "KillSwitch",
+      ruleId: "kill_switch.active",
+      verdict: "deny",
+    });
+    expect(applied.results).toHaveLength(2);
+  });
+
+  it("leaves allow decisions frictionless when only non-allow decisions are stopped", () => {
+    const applied = applyKillSwitch(decision("allow"), { active: true });
+
+    expect(applied.verdict).toBe("allow");
+    expect(applied.authority).toBe("auto");
+    expect(applied.killSwitchActive).toBe(true);
+  });
+});

--- a/api/lib/xgate/kill-switch.ts
+++ b/api/lib/xgate/kill-switch.ts
@@ -1,0 +1,53 @@
+import type { GateResult } from "./types.js";
+import type { PolicyDecision } from "./policy-engine.js";
+
+export interface KillSwitchState {
+  api_key_hash?: string | null;
+  active?: boolean | null;
+  reason?: string | null;
+  updated_at?: string | null;
+}
+
+export interface KillSwitchDecision extends PolicyDecision {
+  authority: "auto" | "kill_switch";
+  killSwitchActive: boolean;
+}
+
+export function isKillSwitchActive(state: KillSwitchState | null | undefined): boolean {
+  return state?.active === true;
+}
+
+export function applyKillSwitch(
+  decision: PolicyDecision,
+  state: KillSwitchState | null | undefined,
+): KillSwitchDecision {
+  const killSwitchActive = isKillSwitchActive(state);
+
+  if (!killSwitchActive || decision.verdict === "allow") {
+    return {
+      ...decision,
+      authority: "auto",
+      killSwitchActive,
+    };
+  }
+
+  const override: GateResult = {
+    gate: "KillSwitch",
+    verdict: "deny",
+    ruleId: "kill_switch.active",
+    reason: state?.reason ? `Global XGate kill switch active: ${state.reason}` : "Global XGate kill switch active.",
+    evidence: state?.updated_at ? [`updated_at:${state.updated_at}`] : [],
+  };
+
+  return {
+    verdict: "deny",
+    results: [...safeResults(decision), override],
+    deciding: override,
+    authority: "kill_switch",
+    killSwitchActive: true,
+  };
+}
+
+function safeResults(decision: PolicyDecision): GateResult[] {
+  return Array.isArray(decision.results) ? decision.results : [decision.deciding].filter(Boolean);
+}

--- a/supabase/migrations/20260602083000_xgate.sql
+++ b/supabase/migrations/20260602083000_xgate.sql
@@ -1,0 +1,85 @@
+-- XGate control ledger and kill switch state.
+-- Service-role storage for pre-execution decisions.
+
+CREATE TABLE IF NOT EXISTS mc_xgate_ledger (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  ts timestamptz NOT NULL DEFAULT now(),
+  api_key_hash text,
+  agent_id text,
+  session_id text,
+  client text,
+  model text,
+  action_class text NOT NULL,
+  tool text NOT NULL,
+  target text NOT NULL DEFAULT '',
+  environment text NOT NULL CHECK (environment IN ('dev', 'staging', 'prod')),
+  verdict text NOT NULL CHECK (verdict IN ('allow', 'deny', 'ask', 'rewrite')),
+  rule_id text NOT NULL,
+  reason text NOT NULL,
+  authority text NOT NULL CHECK (authority IN ('auto', 'human', 'token', 'kill_switch')),
+  proof_ref text,
+  reversal text
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_xgate_ledger_api_key_ts
+  ON mc_xgate_ledger(api_key_hash, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_xgate_ledger_session
+  ON mc_xgate_ledger(session_id, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_xgate_ledger_rule
+  ON mc_xgate_ledger(rule_id, ts DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mc_xgate_ledger_verdict
+  ON mc_xgate_ledger(verdict, ts DESC);
+
+ALTER TABLE mc_xgate_ledger ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE mc_xgate_ledger FROM anon, authenticated;
+GRANT ALL ON TABLE mc_xgate_ledger TO service_role;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'mc_xgate_ledger'
+      AND policyname = 'mc_xgate_ledger_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_xgate_ledger_service_role_all"
+      ON mc_xgate_ledger FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS mc_xgate_killswitch (
+  api_key_hash text PRIMARY KEY,
+  active boolean NOT NULL DEFAULT false,
+  reason text,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_xgate_killswitch_active
+  ON mc_xgate_killswitch(active)
+  WHERE active = true;
+
+ALTER TABLE mc_xgate_killswitch ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE mc_xgate_killswitch FROM anon, authenticated;
+GRANT ALL ON TABLE mc_xgate_killswitch TO service_role;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'mc_xgate_killswitch'
+      AND policyname = 'mc_xgate_killswitch_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_xgate_killswitch_service_role_all"
+      ON mc_xgate_killswitch FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## What changed

- Added `api/lib/xgate/autonomy.ts` with pure autonomy post-processing for PolicyDecision-shaped inputs.
- Added `api/lib/xgate/kill-switch.ts` with pure kill switch helpers and kill-switch authority metadata.
- Added co-located tests for unattended destructive escalation, denial circuit breaker halting, tainted outbound escalation, and kill switch behavior.
- Added additive Supabase migration `20260602083000_xgate.sql` for `mc_xgate_ledger` and `mc_xgate_killswitch` with RLS enabled and service-role-only grants.

## Scope and boundaries

This is Builder 8 scope only. It creates the Part 8 files from the XGate plan and does not wire an endpoint, registry, UI, or client hooks. The pure helpers use Part 1 contract import paths with `.js` extensions and are intended to compose with the frozen Part 1 contract when the XGate slices are integrated.

## Proof

- `npx vitest run api/lib/xgate/` passed: 2 files, 8 tests.
- `npm run test:api-lib-esm-extension` passed.
- Owned-file Unicode dash scan passed for `api/lib/xgate` and `supabase/migrations/20260602083000_xgate.sql`.
- `git diff --cached --check` passed before commit.

## Notes

The worktree had an unrelated line-ending marker on `packages/channel-plugin/index.js`; it was not staged or committed. The commit contains only the five Builder 8 files.