### PR TITLE
XGate Part 9: endpoint + registry + client hooks

### DIFF
--- a/api/lib/xgate/client-hooks.test.ts
+++ b/api/lib/xgate/client-hooks.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildXGateHookNodeScript,
+  generateClaudeCodeHook,
+  generateCursorHook,
+} from "./client-hooks.js";
+
+describe("XGate client hook generators", () => {
+  it("emits a Claude Code PreToolUse config that calls xgate-check", () => {
+    const config = JSON.parse(generateClaudeCodeHook({ endpointUrl: "https://example.test/api/xgate-check" }));
+
+    expect(config.hooks.PreToolUse[0].matcher).toContain("Bash");
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain("https://example.test/api/xgate-check");
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toContain("XGATE_BEARER");
+  });
+
+  it("emits a Cursor delegated hook config with the coverage boundary", () => {
+    const config = JSON.parse(generateCursorHook({ endpointUrl: "https://example.test/api/xgate-check" }));
+
+    expect(config.client).toBe("cursor");
+    expect(config.endpoint).toBe("https://example.test/api/xgate-check");
+    expect(config.boundary).toContain("not a universal hard pre-tool interceptor");
+    expect(config.command).toContain("XGate unavailable");
+  });
+
+  it("maps client tool names into XGate action classes inside the script", () => {
+    const script = buildXGateHookNodeScript("claude-code");
+
+    expect(script).toContain("actionClass");
+    expect(script).toContain("'filesystem'");
+    expect(script).toContain("'git'");
+    expect(script).toContain("'network'");
+  });
+});

--- a/api/lib/xgate/client-hooks.ts
+++ b/api/lib/xgate/client-hooks.ts
@@ -1,0 +1,101 @@
+export interface XGateClientHookOptions {
+  endpointUrl?: string;
+  bearerEnvVar?: string;
+  environmentEnvVar?: string;
+  autonomyEnvVar?: string;
+  defaultEnvironment?: "dev" | "staging" | "prod";
+  defaultAutonomyLevel?: "interactive" | "unattended";
+  timeoutMs?: number;
+}
+
+const DEFAULT_ENDPOINT = "https://unclick.world/api/xgate-check";
+const DEFAULT_BEARER_ENV = "XGATE_BEARER";
+const DEFAULT_ENVIRONMENT_ENV = "XGATE_ENVIRONMENT";
+const DEFAULT_AUTONOMY_ENV = "XGATE_AUTONOMY";
+
+function optionsWithDefaults(options: XGateClientHookOptions = {}) {
+  return {
+    endpointUrl: options.endpointUrl ?? DEFAULT_ENDPOINT,
+    bearerEnvVar: options.bearerEnvVar ?? DEFAULT_BEARER_ENV,
+    environmentEnvVar: options.environmentEnvVar ?? DEFAULT_ENVIRONMENT_ENV,
+    autonomyEnvVar: options.autonomyEnvVar ?? DEFAULT_AUTONOMY_ENV,
+    defaultEnvironment: options.defaultEnvironment ?? "dev",
+    defaultAutonomyLevel: options.defaultAutonomyLevel ?? "interactive",
+    timeoutMs: options.timeoutMs ?? 8000,
+  };
+}
+
+export function buildXGateHookNodeScript(client: "claude-code" | "cursor", options: XGateClientHookOptions = {}) {
+  const cfg = optionsWithDefaults(options);
+  return [
+    "const fs=require('node:fs');",
+    `const endpoint=process.env.XGATE_ENDPOINT||${JSON.stringify(cfg.endpointUrl)};`,
+    `const token=process.env[${JSON.stringify(cfg.bearerEnvVar)}]||'';`,
+    `const environment=process.env[${JSON.stringify(cfg.environmentEnvVar)}]||${JSON.stringify(cfg.defaultEnvironment)};`,
+    `const autonomyLevel=process.env[${JSON.stringify(cfg.autonomyEnvVar)}]||${JSON.stringify(cfg.defaultAutonomyLevel)};`,
+    `const timeoutMs=${JSON.stringify(cfg.timeoutMs)};`,
+    "const inputText=fs.readFileSync(0,'utf8')||'{}';",
+    "let input={};",
+    "try{input=JSON.parse(inputText);}catch{input={raw:inputText};}",
+    "const tool=String(input.tool_name||input.toolName||input.name||input.tool||'client_tool');",
+    "const lower=tool.toLowerCase();",
+    "const actionClass=lower.includes('bash')||lower.includes('shell')||lower.includes('terminal')?'shell':lower.includes('edit')||lower.includes('write')?'filesystem':lower.includes('git')?'git':lower.includes('web')||lower.includes('fetch')?'network':'shell';",
+    "const raw=typeof input.command==='string'?input.command:typeof input.raw==='string'?input.raw:JSON.stringify(input.tool_input||input.input||input);",
+    `const metadata={client:${JSON.stringify(client)}};`,
+    "const payload={action:{class:actionClass,raw,tool},context:{environment,autonomyLevel,now:Date.now()},metadata};",
+    "const controller=new AbortController();",
+    "const timer=setTimeout(()=>controller.abort(),timeoutMs);",
+    "fetch(endpoint,{method:'POST',signal:controller.signal,headers:{'content-type':'application/json',authorization:token?`Bearer ${token}`:''},body:JSON.stringify(payload)})",
+    ".then(async r=>{clearTimeout(timer);const text=await r.text();let data={};try{data=JSON.parse(text);}catch{data={error:text};}if(!r.ok){console.error(data.error||text||'XGate rejected the action');process.exit(2);}if(data.verdict==='allow'){process.exit(0);}console.error(data.reason||data.ruleId||`XGate verdict ${data.verdict}`);process.exit(2);})",
+    ".catch(err=>{clearTimeout(timer);console.error(`XGate unavailable: ${err&&err.message?err.message:String(err)}`);process.exit(2);});",
+  ].join("");
+}
+
+export function buildXGateHookCommand(client: "claude-code" | "cursor", options: XGateClientHookOptions = {}) {
+  return `node -e ${JSON.stringify(buildXGateHookNodeScript(client, options))}`;
+}
+
+export function generateClaudeCodeHook(options: XGateClientHookOptions = {}): string {
+  return JSON.stringify(
+    {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash|Edit|MultiEdit|Write|WebFetch",
+            hooks: [
+              {
+                type: "command",
+                command: buildXGateHookCommand("claude-code", options),
+              },
+            ],
+          },
+        ],
+      },
+    },
+    null,
+    2,
+  );
+}
+
+export function generateCursorHook(options: XGateClientHookOptions = {}): string {
+  const cfg = optionsWithDefaults(options);
+  return JSON.stringify(
+    {
+      version: 1,
+      client: "cursor",
+      endpoint: cfg.endpointUrl,
+      bearerEnvVar: cfg.bearerEnvVar,
+      command: buildXGateHookCommand("cursor", options),
+      boundary:
+        "Cursor rule files are not a universal hard pre-tool interceptor. Use this command where Cursor or a runner supports hooks; otherwise XGate covers UnClick-routed tools only.",
+      ruleFile: ".cursor/rules/xgate.mdc",
+      ruleText: [
+        "Before shell, file-write, git, SQL, network, send, or deploy actions, run the XGate command.",
+        "Continue only when the verdict is allow.",
+        "If the hook is unavailable, stop and ask for a safer route.",
+      ].join("\n"),
+    },
+    null,
+    2,
+  );
+}

--- a/api/lib/xgate/registry.test.ts
+++ b/api/lib/xgate/registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { XGATE_GATE_MANIFEST, loadXGateRegistry, type XGateGateManifestEntry } from "./registry.js";
+
+describe("XGate registry", () => {
+  it("keeps the integration gate order stable", () => {
+    expect(XGATE_GATE_MANIFEST.map((entry) => entry.key)).toEqual([
+      "secret",
+      "command",
+      "git",
+      "data",
+      "ship",
+      "scope",
+      "spend",
+    ]);
+  });
+
+  it("loads available gates and reports missing optional gates", async () => {
+    const gate = () => ({ verdict: "allow" });
+    const manifest: XGateGateManifestEntry[] = [
+      {
+        key: "present",
+        part: 2,
+        gateName: "presentGate",
+        importPath: "./present.js",
+        importModule: async () => ({ presentGate: gate }),
+      },
+      {
+        key: "missing",
+        part: 3,
+        gateName: "missingGate",
+        importPath: "./missing.js",
+        importModule: async () => ({}),
+      },
+    ];
+
+    const registry = await loadXGateRegistry(manifest);
+
+    expect(registry.gates).toEqual([gate]);
+    expect(registry.loaded).toEqual([
+      { key: "present", part: 2, gateName: "presentGate", importPath: "./present.js" },
+    ]);
+    expect(registry.missing).toEqual([
+      expect.objectContaining({
+        key: "missing",
+        gateName: "missingGate",
+        reason: "Missing function export missingGate",
+      }),
+    ]);
+  });
+});

--- a/api/lib/xgate/registry.ts
+++ b/api/lib/xgate/registry.ts
@@ -1,0 +1,154 @@
+export type XGateRuntimeGate = (ctx: unknown) => unknown;
+
+export interface XGateGateManifestEntry {
+  key: string;
+  part: number;
+  gateName: string;
+  importPath: string;
+  importModule: () => Promise<Record<string, unknown>>;
+}
+
+export interface XGateMissingGate {
+  key: string;
+  part: number;
+  gateName: string;
+  importPath: string;
+  reason: string;
+}
+
+export interface XGateRegistryLoad {
+  gates: XGateRuntimeGate[];
+  loaded: Array<Pick<XGateGateManifestEntry, "key" | "part" | "gateName" | "importPath">>;
+  missing: XGateMissingGate[];
+}
+
+function errorReason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isGate(value: unknown): value is XGateRuntimeGate {
+  return typeof value === "function";
+}
+
+export const XGATE_GATE_MANIFEST: XGateGateManifestEntry[] = [
+  {
+    key: "secret",
+    part: 2,
+    gateName: "secretGate",
+    importPath: "./gates/secret-gate.js",
+    importModule: async () => {
+      // TODO XGate Part 2 is optional until the parallel branch lands.
+      const path = "./gates/secret-gate.js";
+      return import(/* @vite-ignore */ path);
+    },
+  },
+  {
+    key: "command",
+    part: 5,
+    gateName: "commandGate",
+    importPath: "./gates/command-gate.js",
+    importModule: async () => {
+      // TODO XGate Part 5 is optional until the parallel branch lands.
+      const path = "./gates/command-gate.js";
+      return import(/* @vite-ignore */ path);
+    },
+  },
+  {
+    key: "git",
+    part: 4,
+    gateName: "gitGate",
+    importPath: "./gates/git-gate.js",
+    importModule: async () => {
+      // TODO XGate Part 4 is optional until the parallel branch lands.
+      const path = "./gates/git-gate.js";
+      return import(/* @vite-ignore */ path);
+    },
+  },
+  {
+    key: "data",
+    part: 3,
+    gateName: "dataGate",
+    importPath: "./gates/data-gate.js",
+    importModule: async () => {
+      // TODO XGate Part 3 is optional until the parallel branch lands.
+      const path = "./gates/data-gate.js";
+      return import(/* @vite-ignore */ path);
+    },
+  },
+  {
+    key: "ship",
+    part: 6,
+    gateName: "shipGate",
+    importPath: "./gates/ship-gate.js",
+    importModule: async () => {
+      // TODO XGate Part 6 is optional until the parallel branch lands.
+      const path = "./gates/ship-gate.js";
+      return import(/* @vite-ignore */ path);
+    },
+  },
+  {
+    key: "scope",
+    part: 7,
+    gateName: "scopeGate",
+    importPath: "./gates/scope-gate.js",
+    importModule: async () => {
+      // TODO XGate Part 7 is optional until the parallel branch lands.
+      const path = "./gates/scope-gate.js";
+      return import(/* @vite-ignore */ path);
+    },
+  },
+  {
+    key: "spend",
+    part: 7,
+    gateName: "spendGate",
+    importPath: "./gates/spend-gate.js",
+    importModule: async () => {
+      // TODO XGate Part 7 is optional until the parallel branch lands.
+      const path = "./gates/spend-gate.js";
+      return import(/* @vite-ignore */ path);
+    },
+  },
+];
+
+export async function loadXGateRegistry(
+  manifest: XGateGateManifestEntry[] = XGATE_GATE_MANIFEST,
+): Promise<XGateRegistryLoad> {
+  const gates: XGateRuntimeGate[] = [];
+  const loaded: XGateRegistryLoad["loaded"] = [];
+  const missing: XGateMissingGate[] = [];
+
+  for (const entry of manifest) {
+    try {
+      const mod = await entry.importModule();
+      const gate = mod[entry.gateName];
+      if (!isGate(gate)) {
+        missing.push({
+          key: entry.key,
+          part: entry.part,
+          gateName: entry.gateName,
+          importPath: entry.importPath,
+          reason: `Missing function export ${entry.gateName}`,
+        });
+        continue;
+      }
+
+      gates.push(gate);
+      loaded.push({
+        key: entry.key,
+        part: entry.part,
+        gateName: entry.gateName,
+        importPath: entry.importPath,
+      });
+    } catch (error) {
+      missing.push({
+        key: entry.key,
+        part: entry.part,
+        gateName: entry.gateName,
+        importPath: entry.importPath,
+        reason: errorReason(error),
+      });
+    }
+  }
+
+  return { gates, loaded, missing };
+}

--- a/api/xgate-check.test.ts
+++ b/api/xgate-check.test.ts
@@ -1,0 +1,109 @@
+import type { VercelRequest } from "@vercel/node";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  coerceDecisionOutcome,
+  parseXGateCheckBody,
+  resolveXGateAuthority,
+  sha256hex,
+} from "./xgate-check.js";
+
+const originalCronSecret = process.env.CRON_SECRET;
+
+afterEach(() => {
+  if (originalCronSecret === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = originalCronSecret;
+});
+
+describe("parseXGateCheckBody", () => {
+  it("builds the frozen gate context from a valid request", () => {
+    const parsed = parseXGateCheckBody(
+      {
+        action: {
+          class: "git",
+          raw: "git push --force origin main",
+          tool: "Bash",
+          targetEnv: "prod",
+          targetFiles: ["README.md"],
+        },
+        context: {
+          autonomyLevel: "unattended",
+          ownedFiles: ["README.md"],
+          tainted: true,
+          now: 42,
+        },
+        metadata: {
+          agent_id: "builder-9",
+          session_id: "XGateChatGPT_9",
+          client: "codex",
+          proof_ref: "xpass_receipt_v1:abc",
+        },
+      },
+      99,
+    );
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.context).toMatchObject({
+      environment: "prod",
+      autonomyLevel: "unattended",
+      ownedFiles: ["README.md"],
+      tainted: true,
+      now: 42,
+    });
+    expect(parsed.value.metadata).toMatchObject({
+      agent_id: "builder-9",
+      session_id: "XGateChatGPT_9",
+      client: "codex",
+      proof_ref: "xpass_receipt_v1:abc",
+    });
+  });
+
+  it("fails closed on invalid action shapes", () => {
+    expect(parseXGateCheckBody({ action: { class: "unknown", raw: "", tool: "Bash" } }).ok).toBe(false);
+    expect(parseXGateCheckBody("{not json").ok).toBe(false);
+    expect(parseXGateCheckBody({ action: { class: "git", raw: "", tool: "" } }).ok).toBe(false);
+  });
+});
+
+describe("resolveXGateAuthority", () => {
+  it("accepts CRON_SECRET bearer auth and hashes the token", async () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    const result = await resolveXGateAuthority(
+      {
+        headers: { authorization: "Bearer cron-secret" },
+      } as unknown as VercelRequest,
+      "https://supabase.example.test",
+      "service-role",
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      authority: "token",
+      apiKeyHash: sha256hex("cron-secret"),
+      actor: "cron",
+    });
+  });
+
+  it("rejects missing bearer auth before admin lookup", async () => {
+    const result = await resolveXGateAuthority(
+      { headers: {} } as unknown as VercelRequest,
+      "https://supabase.example.test",
+      "service-role",
+    );
+
+    expect(result).toEqual({ ok: false, status: 401, error: "Missing Bearer token" });
+  });
+});
+
+describe("coerceDecisionOutcome", () => {
+  it("accepts direct or wrapped decisions", () => {
+    const fallback = { verdict: "ask" as const, deciding: { ruleId: "fallback" } };
+    const direct = { verdict: "deny" as const, halt: true, deciding: { ruleId: "direct" } };
+    const wrapped = { decision: { verdict: "allow" as const, deciding: { ruleId: "wrapped" } }, halt: true };
+
+    expect(coerceDecisionOutcome(direct, fallback)).toEqual({ decision: direct, halt: true });
+    expect(coerceDecisionOutcome(wrapped, fallback)).toEqual({ decision: wrapped.decision, halt: true });
+    expect(coerceDecisionOutcome(null, fallback)).toEqual({ decision: fallback, halt: false });
+  });
+});

--- a/api/xgate-check.ts
+++ b/api/xgate-check.ts
@@ -1,0 +1,452 @@
+import { createHash } from "node:crypto";
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+import { loadXGateRegistry } from "./lib/xgate/registry.js";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST,OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization,Content-Type",
+};
+
+const ACTION_CLASSES = new Set([
+  "filesystem",
+  "git",
+  "sql",
+  "secret",
+  "ship",
+  "spend",
+  "scope",
+  "shell",
+  "network",
+  "send",
+]);
+
+const ENVIRONMENTS = new Set(["dev", "staging", "prod"]);
+const AUTONOMY_LEVELS = new Set(["interactive", "unattended"]);
+
+type GateVerdict = "allow" | "deny" | "ask" | "rewrite";
+type LedgerAuthority = "auto" | "human" | "token" | "kill_switch";
+
+interface XGateActionDescriptor {
+  class: string;
+  raw: string;
+  tool: string;
+  parsed?: unknown;
+  targetEnv?: string;
+  estimatedSpendUsd?: number;
+  targetFiles?: string[];
+}
+
+interface XGateContext {
+  action: XGateActionDescriptor;
+  environment: string;
+  autonomyLevel: string;
+  ownedFiles?: string[];
+  tainted?: boolean;
+  now: number;
+}
+
+interface XGateDecision {
+  verdict: GateVerdict;
+  results?: unknown[];
+  deciding?: unknown;
+}
+
+interface XGateRequestMetadata {
+  agent_id: string | null;
+  session_id: string | null;
+  client: string | null;
+  model: string | null;
+  target: string | null;
+  proof_ref: string | null;
+  reversal: string | null;
+}
+
+interface ParsedXGateCheckBody {
+  action: XGateActionDescriptor;
+  context: XGateContext;
+  metadata: XGateRequestMetadata;
+  budget: unknown;
+}
+
+type ParseResult = { ok: true; value: ParsedXGateCheckBody } | { ok: false; error: string };
+
+interface XGateCore {
+  evaluateGates: (gates: unknown[], ctx: XGateContext) => XGateDecision;
+  applyAutonomy: (decision: XGateDecision, ctx: XGateContext, budget: unknown) => unknown;
+  applyKillSwitch: (decision: XGateDecision, state: unknown) => unknown;
+  buildLedgerEntry: (
+    ctx: XGateContext,
+    decision: XGateDecision,
+    authority: LedgerAuthority,
+    opts: Record<string, unknown>,
+  ) => Record<string, unknown>;
+}
+
+type XGateCoreLoad = { ok: true; core: XGateCore } | { ok: false; missing: Array<{ module: string; reason: string }> };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function stringArrayOrUndefined(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return undefined;
+  const out = value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+  return out.length === value.length ? out : undefined;
+}
+
+function parseMaybeJsonBody(body: unknown): { ok: true; value: unknown } | { ok: false; error: string } {
+  if (typeof body !== "string") return { ok: true, value: body };
+  if (!body.trim()) return { ok: true, value: {} };
+  try {
+    return { ok: true, value: JSON.parse(body) };
+  } catch {
+    return { ok: false, error: "Invalid JSON body" };
+  }
+}
+
+function normalizeSetValue(value: unknown, allowed: Set<string>): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return allowed.has(normalized) ? normalized : null;
+}
+
+export function parseXGateCheckBody(body: unknown, fallbackNow = Date.now()): ParseResult {
+  const parsedBody = parseMaybeJsonBody(body);
+  if (!parsedBody.ok) return parsedBody;
+  if (!isRecord(parsedBody.value)) return { ok: false, error: "Body must be an object" };
+
+  const rawAction = parsedBody.value.action;
+  if (!isRecord(rawAction)) return { ok: false, error: "action is required" };
+
+  const actionClass = normalizeSetValue(rawAction.class, ACTION_CLASSES);
+  if (!actionClass) return { ok: false, error: "action.class is invalid" };
+  if (typeof rawAction.raw !== "string") return { ok: false, error: "action.raw must be a string" };
+  if (typeof rawAction.tool !== "string" || !rawAction.tool.trim()) {
+    return { ok: false, error: "action.tool is required" };
+  }
+
+  const targetEnv =
+    rawAction.targetEnv === undefined ? undefined : normalizeSetValue(rawAction.targetEnv, ENVIRONMENTS);
+  if (rawAction.targetEnv !== undefined && !targetEnv) return { ok: false, error: "action.targetEnv is invalid" };
+
+  const targetFiles = stringArrayOrUndefined(rawAction.targetFiles);
+  if (rawAction.targetFiles !== undefined && !targetFiles) {
+    return { ok: false, error: "action.targetFiles must be strings" };
+  }
+
+  const estimatedSpendUsd = rawAction.estimatedSpendUsd;
+  if (
+    estimatedSpendUsd !== undefined &&
+    (typeof estimatedSpendUsd !== "number" || !Number.isFinite(estimatedSpendUsd))
+  ) {
+    return { ok: false, error: "action.estimatedSpendUsd must be a finite number" };
+  }
+
+  const contextInput = isRecord(parsedBody.value.context) ? parsedBody.value.context : {};
+  const environment =
+    normalizeSetValue(contextInput.environment, ENVIRONMENTS) ?? targetEnv ?? "dev";
+  const autonomyLevel = normalizeSetValue(contextInput.autonomyLevel, AUTONOMY_LEVELS) ?? "interactive";
+  const ownedFiles = stringArrayOrUndefined(contextInput.ownedFiles);
+  if (contextInput.ownedFiles !== undefined && !ownedFiles) {
+    return { ok: false, error: "context.ownedFiles must be strings" };
+  }
+
+  const action: XGateActionDescriptor = {
+    class: actionClass,
+    raw: rawAction.raw,
+    tool: rawAction.tool.trim(),
+  };
+  if (rawAction.parsed !== undefined) action.parsed = rawAction.parsed;
+  if (targetEnv) action.targetEnv = targetEnv;
+  if (estimatedSpendUsd !== undefined) action.estimatedSpendUsd = estimatedSpendUsd;
+  if (targetFiles) action.targetFiles = targetFiles;
+
+  const now = typeof contextInput.now === "number" && Number.isFinite(contextInput.now) ? contextInput.now : fallbackNow;
+  const context: XGateContext = {
+    action,
+    environment,
+    autonomyLevel,
+    now,
+  };
+  if (ownedFiles) context.ownedFiles = ownedFiles;
+  if (typeof contextInput.tainted === "boolean") context.tainted = contextInput.tainted;
+
+  const metadataInput = isRecord(parsedBody.value.metadata) ? parsedBody.value.metadata : {};
+  const metadata: XGateRequestMetadata = {
+    agent_id: stringOrNull(metadataInput.agent_id),
+    session_id: stringOrNull(metadataInput.session_id),
+    client: stringOrNull(metadataInput.client),
+    model: stringOrNull(metadataInput.model),
+    target: stringOrNull(metadataInput.target),
+    proof_ref: stringOrNull(metadataInput.proof_ref),
+    reversal: stringOrNull(metadataInput.reversal),
+  };
+
+  return {
+    ok: true,
+    value: {
+      action,
+      context,
+      metadata,
+      budget: parsedBody.value.budget ?? {},
+    },
+  };
+}
+
+function bearerFrom(req: VercelRequest): string | null {
+  const header = req.headers.authorization;
+  if (!header || typeof header !== "string") return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+export function sha256hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function adminEmails(): string[] {
+  return (process.env.ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+async function resolveAdminEmail(
+  req: VercelRequest,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+): Promise<string | null> {
+  const token = bearerFrom(req);
+  if (!token || token.startsWith("uc_") || token.startsWith("agt_")) return null;
+  try {
+    const scoped = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data, error } = await scoped.auth.getUser(token);
+    if (error || !data?.user?.email) return null;
+    const email = data.user.email.toLowerCase();
+    return adminEmails().includes(email) ? email : null;
+  } catch {
+    return null;
+  }
+}
+
+type AuthorityResult =
+  | { ok: true; authority: LedgerAuthority; apiKeyHash: string; actor: string }
+  | { ok: false; status: 401 | 403; error: string };
+
+export async function resolveXGateAuthority(
+  req: VercelRequest,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+): Promise<AuthorityResult> {
+  const token = bearerFrom(req);
+  if (!token) return { ok: false, status: 401, error: "Missing Bearer token" };
+
+  if (process.env.CRON_SECRET && token === process.env.CRON_SECRET) {
+    return { ok: true, authority: "token", apiKeyHash: sha256hex(token), actor: "cron" };
+  }
+
+  const adminEmail = await resolveAdminEmail(req, supabaseUrl, serviceRoleKey);
+  if (!adminEmail) return { ok: false, status: 403, error: "Admin access required" };
+  return { ok: true, authority: "human", apiKeyHash: sha256hex(token), actor: adminEmail };
+}
+
+async function optionalImport(
+  moduleName: string,
+  importer: () => Promise<Record<string, unknown>>,
+): Promise<{ moduleName: string; mod?: Record<string, unknown>; reason?: string }> {
+  try {
+    return { moduleName, mod: await importer() };
+  } catch (error) {
+    return { moduleName, reason: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function getFunction(mod: Record<string, unknown> | undefined, name: string): unknown {
+  return mod ? mod[name] : undefined;
+}
+
+export async function loadXGateCore(): Promise<XGateCoreLoad> {
+  const imports = await Promise.all([
+    optionalImport("policy-engine", async () => {
+      // TODO XGate Part 1 provides the frozen policy engine.
+      const path = "./lib/xgate/policy-engine.js";
+      return import(/* @vite-ignore */ path);
+    }),
+    optionalImport("autonomy", async () => {
+      // TODO XGate Part 8 provides the autonomy engine.
+      const path = "./lib/xgate/autonomy.js";
+      return import(/* @vite-ignore */ path);
+    }),
+    optionalImport("kill-switch", async () => {
+      // TODO XGate Part 8 provides the kill switch.
+      const path = "./lib/xgate/kill-switch.js";
+      return import(/* @vite-ignore */ path);
+    }),
+    optionalImport("ledger", async () => {
+      // TODO XGate Part 1 provides the control ledger builder.
+      const path = "./lib/xgate/ledger.js";
+      return import(/* @vite-ignore */ path);
+    }),
+  ]);
+
+  const missing: Array<{ module: string; reason: string }> = [];
+  const byName = new Map(imports.map((entry) => [entry.moduleName, entry]));
+  for (const entry of imports) {
+    if (entry.reason) missing.push({ module: entry.moduleName, reason: entry.reason });
+  }
+
+  const evaluateGates = getFunction(byName.get("policy-engine")?.mod, "evaluateGates");
+  const applyAutonomy = getFunction(byName.get("autonomy")?.mod, "applyAutonomy");
+  const applyKillSwitch = getFunction(byName.get("kill-switch")?.mod, "applyKillSwitch");
+  const buildLedgerEntry = getFunction(byName.get("ledger")?.mod, "buildLedgerEntry");
+
+  for (const [module, fn] of [
+    ["policy-engine.evaluateGates", evaluateGates],
+    ["autonomy.applyAutonomy", applyAutonomy],
+    ["kill-switch.applyKillSwitch", applyKillSwitch],
+    ["ledger.buildLedgerEntry", buildLedgerEntry],
+  ] as const) {
+    if (typeof fn !== "function") missing.push({ module, reason: "Missing function export" });
+  }
+
+  if (missing.length) return { ok: false, missing };
+  return {
+    ok: true,
+    core: {
+      evaluateGates: evaluateGates as XGateCore["evaluateGates"],
+      applyAutonomy: applyAutonomy as XGateCore["applyAutonomy"],
+      applyKillSwitch: applyKillSwitch as XGateCore["applyKillSwitch"],
+      buildLedgerEntry: buildLedgerEntry as XGateCore["buildLedgerEntry"],
+    },
+  };
+}
+
+function isDecision(value: unknown): value is XGateDecision {
+  return isRecord(value) && typeof value.verdict === "string";
+}
+
+export function coerceDecisionOutcome(value: unknown, fallback: XGateDecision): { decision: XGateDecision; halt: boolean } {
+  if (isRecord(value)) {
+    if (isDecision(value.decision)) return { decision: value.decision, halt: Boolean(value.halt) };
+    if (isDecision(value)) return { decision: value, halt: Boolean(value.halt) };
+  }
+  return { decision: fallback, halt: false };
+}
+
+function decidingRecord(decision: XGateDecision): Record<string, unknown> {
+  return isRecord(decision.deciding) ? decision.deciding : {};
+}
+
+async function readKillSwitchState(db: ReturnType<typeof createClient>, apiKeyHash: string) {
+  const { data, error } = await db
+    .from("mc_xgate_killswitch")
+    .select("api_key_hash,active,reason,updated_at")
+    .eq("api_key_hash", apiKeyHash)
+    .maybeSingle();
+
+  if (error) {
+    return { ok: false as const, error: error.message };
+  }
+
+  return {
+    ok: true as const,
+    state: data ?? {
+      api_key_hash: apiKeyHash,
+      active: false,
+      reason: null,
+      updated_at: null,
+    },
+  };
+}
+
+function setCors(res: VercelResponse) {
+  for (const [key, value] of Object.entries(CORS_HEADERS)) res.setHeader(key, value);
+}
+
+function json(res: VercelResponse, status: number, body: unknown) {
+  setCors(res);
+  return res.status(status).json(body);
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  setCors(res);
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST") return json(res, 405, { error: "POST required" });
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return json(res, 500, { error: "Database service unavailable" });
+
+  const authority = await resolveXGateAuthority(req, supabaseUrl, serviceRoleKey);
+  if (!authority.ok) return json(res, authority.status, { error: authority.error });
+
+  const parsed = parseXGateCheckBody(req.body);
+  if (!parsed.ok) return json(res, 400, { error: parsed.error });
+
+  const coreLoad = await loadXGateCore();
+  if (!coreLoad.ok) {
+    return json(res, 503, {
+      error: "XGate core dependencies are not ready",
+      missing: coreLoad.missing,
+    });
+  }
+
+  const registry = await loadXGateRegistry();
+  if (registry.gates.length === 0) {
+    return json(res, 503, {
+      error: "XGate gate registry has no loaded gates",
+      missing: registry.missing,
+    });
+  }
+
+  const db = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const killSwitch = await readKillSwitchState(db, authority.apiKeyHash);
+  if (!killSwitch.ok) {
+    return json(res, 503, { error: "XGate kill switch state unavailable", detail: killSwitch.error });
+  }
+
+  const policyDecision = coreLoad.core.evaluateGates(registry.gates, parsed.value.context);
+  const autonomyOutcome = coerceDecisionOutcome(
+    coreLoad.core.applyAutonomy(policyDecision, parsed.value.context, parsed.value.budget),
+    policyDecision,
+  );
+  const killOutcome = coerceDecisionOutcome(
+    coreLoad.core.applyKillSwitch(autonomyOutcome.decision, killSwitch.state),
+    autonomyOutcome.decision,
+  );
+  const finalDecision = killOutcome.decision;
+  const deciding = decidingRecord(finalDecision);
+  const ledgerAuthority: LedgerAuthority = isRecord(killSwitch.state) && killSwitch.state.active ? "kill_switch" : authority.authority;
+  const ledgerEntry = coreLoad.core.buildLedgerEntry(parsed.value.context, finalDecision, ledgerAuthority, {
+    ...parsed.value.metadata,
+    actor: authority.actor,
+    target: parsed.value.metadata.target ?? parsed.value.action.targetEnv ?? parsed.value.context.environment,
+  });
+
+  const { error: ledgerError } = await db.from("mc_xgate_ledger").insert(ledgerEntry);
+  if (ledgerError) return json(res, 503, { error: "XGate ledger unavailable", detail: ledgerError.message });
+
+  return json(res, 200, {
+    verdict: finalDecision.verdict,
+    ruleId: typeof deciding.ruleId === "string" ? deciding.ruleId : null,
+    gate: typeof deciding.gate === "string" ? deciding.gate : null,
+    reason: typeof deciding.reason === "string" ? deciding.reason : null,
+    authority: ledgerAuthority,
+    halt: autonomyOutcome.halt || killOutcome.halt,
+    gatesLoaded: registry.loaded,
+    gatesMissing: registry.missing,
+  });
+}


### PR DESCRIPTION
## Summary

Adds the XGate Part 9 integration surface:

- `api/xgate-check.ts` Vercel endpoint with CRON_SECRET bearer or admin Supabase session auth, XGate core loading, kill-switch read, ledger insert, and verdict response.
- `api/lib/xgate/registry.ts` dynamic gate manifest for the Part 2-7 gates, so the branch compiles while parallel gate branches are still landing.
- `api/lib/xgate/client-hooks.ts` generators for Claude Code PreToolUse config and Cursor-style delegated hook config.
- Focused tests for request parsing, cron auth, decision coercion, registry loading, and hook generation.

## Integration notes

Parts 1-8 are not present on `main` yet. This branch fails closed around that: the endpoint returns `503` when the frozen core modules or all gates are missing instead of silently allowing actions. Once Parts 1-8 land, the dynamic registry loads the available gates and reports any missing gates in the response.

No `vercel.json` change was needed because `api/*.ts` routes are already served as Vercel functions.

## Client-shell boundary

XGate covers actions routed through this endpoint and UnClick-owned tool paths. It cannot see shell commands or file edits a client runs outside UnClick. The generated Claude Code and Cursor configs delegate those client-side actions back to `/api/xgate-check` where the client or runner supports hooks. Clients without a hard hook system still need OS, container, and platform controls.

## Validation

- `npx vitest run api/lib/xgate/registry.test.ts api/lib/xgate/client-hooks.test.ts api/xgate-check.test.ts`
- `npx vitest run api/lib/xgate/ api/xgate-check.test.ts`
- `npm run test:api-lib-esm-extension`
- `npm run build`
- `npm run brainmap:check`
- `rg -n "—|–" api/lib/xgate api/xgate-check.ts api/xgate-check.test.ts` returned no matches
