### PR TITLE
Tidy up the Boardroom: working filters, idea freshness, view-more

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8336,8 +8336,8 @@
     },
     {
       "source": "src/pages/admin/Fishbowl.tsx",
-      "hash": "525cfc33fcdc",
-      "bytes": 33809
+      "hash": "ec3c5b4f4b4f",
+      "bytes": 37557
     },
     {
       "source": "src/pages/admin/AdminBrainmap.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -60,7 +60,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminExpressBuild.tsx | 4dadebd9c4aa | 22681 |
 | src/pages/admin/AdminEcosystemPages.tsx | 13bc51cceb52 | 12105 |
 | src/pages/admin/AdminBenchmarks.tsx | 69eb15aaf438 | 25684 |
-| src/pages/admin/Fishbowl.tsx | 525cfc33fcdc | 33809 |
+| src/pages/admin/Fishbowl.tsx | ec3c5b4f4b4f | 37557 |
 | src/pages/admin/AdminBrainmap.tsx | c764ced96836 | 26511 |
 | src/pages/admin/AdminCodebase.tsx | ff33937fdf7b | 8044 |
 | src/pages/admin/copypass/CopyPassCatalog.tsx | a7d741e75c78 | 7306 |

--- a/src/pages/admin/Fishbowl.tsx
+++ b/src/pages/admin/Fishbowl.tsx
@@ -10,6 +10,11 @@ import {
   getMainFeedMessages,
   isHandoffMessage,
 } from "./fishbowl/messageLanes";
+import {
+  filterFeedByPrefs,
+  filterProfilesByPrefs,
+  useFishbowlViewPrefs,
+} from "./fishbowl/prefs";
 
 interface FishbowlMessage {
   id: string;
@@ -42,6 +47,10 @@ interface FishbowlProfile {
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 const STALE_IDLE_VISIBILITY_MS = 24 * 60 * 60 * 1000;
+
+// How many feed threads / agents to show before a "show more" control.
+const FEED_PAGE_SIZE = 20;
+const AGENT_PAGE_SIZE = 6;
 
 interface FishbowlResponse {
   room: { id: string; slug: string; name: string } | null;
@@ -88,16 +97,12 @@ function formatUtcTime(iso: string): string {
   return `${hh}:${mm} UTC`;
 }
 
-function ExplainerPanel({
-  profiles,
-  clusters,
-}: {
-  profiles: FishbowlProfile[];
-  clusters: ProfileCluster<FishbowlProfile>[];
-}) {
+function ExplainerPanel() {
+  // Reference material, so it defaults to collapsed. Once a viewer expands it
+  // we remember that with the "0" sentinel.
   const [collapsed, setCollapsed] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(EXPLAINER_STORAGE_KEY) === "1";
+    if (typeof window === "undefined") return true;
+    return window.localStorage.getItem(EXPLAINER_STORAGE_KEY) !== "0";
   });
 
   const toggle = () => {
@@ -172,59 +177,10 @@ function ExplainerPanel({
               Note: agents connect via the UnClick MCP connector, not git. Git is for
               separate code-running workers, not chat agents. Do not confuse the two.
             </p>
-          </div>
-
-          <div className="space-y-2">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-[#888]">
-              Who is already in your pack?
-            </h3>
-            {profiles.length === 0 ? (
-              <p className="text-[#888]">
-                No agents claimed yet. Connect your first AI chat to UnClick and it will
-                appear here once it joins.
-              </p>
-            ) : (
-              <ul className="flex flex-wrap gap-2">
-                {clusters.map((c) => (
-                  <Fragment key={c.key}>
-                    {c.primaries.map((p) => (
-                      <li
-                        key={p.agent_id}
-                        className="flex items-center gap-2 rounded-full border border-white/[0.06] bg-white/[0.02] px-3 py-1 text-xs"
-                      >
-                        <span aria-hidden className="text-base leading-none">{p.emoji}</span>
-                        <span className="text-[#ccc]">{p.display_name ?? p.agent_id}</span>
-                        {c.primaries.length > 1 && (
-                          <span
-                            className="rounded bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-[#888]"
-                            title={p.agent_id}
-                          >
-                            {p.agent_id.slice(0, 8)}
-                          </span>
-                        )}
-                        {isHumanAgentId(p.agent_id) && (
-                          <span className="rounded bg-[#E2B93B]/15 px-1.5 py-0.5 text-[10px] font-medium text-[#E2B93B]">
-                            you
-                          </span>
-                        )}
-                        <span className="text-[#666]" title="recently seen">
-                          {relativeTime(p.last_seen_at)}
-                        </span>
-                      </li>
-                    ))}
-                    {c.staleAliasCount > 0 && (
-                      <li
-                        key={`${c.key}-stale`}
-                        className="flex items-center gap-1 rounded-full border border-white/[0.04] bg-white/[0.01] px-3 py-1 text-[11px] italic text-[#666]"
-                        title="Older agent_ids that share this emoji and name but have not been seen recently."
-                      >
-                        +{c.staleAliasCount} stale alias{c.staleAliasCount === 1 ? "" : "es"}
-                      </li>
-                    )}
-                  </Fragment>
-                ))}
-              </ul>
-            )}
+            <p className="text-[#888]">
+              Your connected agents are listed under Now Playing and in the agents
+              panel on the right.
+            </p>
           </div>
         </div>
       )}
@@ -252,12 +208,23 @@ function hasVisibleNowPlayingState(profile: FishbowlProfile, nowMs: number): boo
   return isMia && nowMs - checkinMs <= STALE_IDLE_VISIBILITY_MS;
 }
 
+function isIdleOnly(profile: FishbowlProfile, nowMs: number): boolean {
+  if (profile.current_status?.trim()) return false;
+  const checkinMs = profile.next_checkin_at ? new Date(profile.next_checkin_at).getTime() : null;
+  const seenMs = profile.last_seen_at ? new Date(profile.last_seen_at).getTime() : 0;
+  const isMia = checkinMs !== null && checkinMs < nowMs && seenMs < checkinMs;
+  const isComingBack = checkinMs !== null && checkinMs >= nowMs;
+  return !isMia && !isComingBack;
+}
+
 function NowPlayingStrip({
   profiles,
   clusters,
+  hideIdle = false,
 }: {
   profiles: FishbowlProfile[];
   clusters: ProfileCluster<FishbowlProfile>[];
+  hideIdle?: boolean;
 }) {
   // Re-render every 30s so the relative timestamps and stale state stay fresh
   // even if no new poll has come back from the server.
@@ -274,7 +241,10 @@ function NowPlayingStrip({
   const visibleClusters = clusters
     .map((c) => ({
       ...c,
-      primaries: c.primaries.filter((p) => hasVisibleNowPlayingState(p, nowMs)),
+      primaries: c.primaries.filter(
+        (p) =>
+          hasVisibleNowPlayingState(p, nowMs) && (!hideIdle || !isIdleOnly(p, nowMs)),
+      ),
     }))
     .filter((c) => c.primaries.length > 0);
 
@@ -290,7 +260,7 @@ function NowPlayingStrip({
           <span aria-hidden>🎧</span>
           <span>Now Playing</span>
         </h2>
-        <span className="text-[10px] text-[#555]">Live, polled every 5s</span>
+        <span className="text-[10px] text-[#555]">Updates live</span>
       </div>
       <div className="overflow-x-auto">
         <ul className="flex gap-2 px-3 py-3">
@@ -504,12 +474,14 @@ function MessageLane({
   title,
   icon,
   messages,
+  defaultExpanded = false,
 }: {
   title: string;
   icon: string;
   messages: FishbowlMessage[];
+  defaultExpanded?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
 
   return (
     <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
@@ -589,6 +561,11 @@ export default function Fishbowl() {
   const [error, setError] = useState<string | null>(null);
   const [humanAgentId, setHumanAgentId] = useState<string | null>(null);
   const [expandedThreads, setExpandedThreads] = useState<Set<string>>(new Set());
+  const [feedShown, setFeedShown] = useState(FEED_PAGE_SIZE);
+  const [agentsExpanded, setAgentsExpanded] = useState(false);
+  const [settingsCollapsed, setSettingsCollapsed] = useState(true);
+
+  const { prefs, update, toggleTag, toggleMute } = useFishbowlViewPrefs();
 
   const heartbeatMessages = useMemo(
     () => getLaneMessages(messages, "heartbeat"),
@@ -600,18 +577,27 @@ export default function Fishbowl() {
   );
   const actionQueueMessages = useMemo(() => getActionQueueMessages(messages), [messages]);
   const mainFeedMessages = useMemo(() => getMainFeedMessages(messages), [messages]);
+
+  // The viewer's filters (muted agents, tag focus) narrow the feed before we
+  // group it into threads.
+  const filteredFeed = useMemo(
+    () => filterFeedByPrefs(mainFeedMessages, prefs),
+    [mainFeedMessages, prefs],
+  );
   const groupedMessages = useMemo(
-    () => groupMessagesByThread(mainFeedMessages),
-    [mainFeedMessages],
+    () => groupMessagesByThread(filteredFeed),
+    [filteredFeed],
   );
 
-  // Cluster profiles by (emoji, display_name) once per profile update so all
-  // three render sites (ExplainerPanel, NowPlayingStrip, sidebar) share the
-  // same view-model. Re-runs every 5s poll because setProfiles installs a
-  // fresh array reference.
+  // Presence surfaces (Now Playing + the agents panel) hide muted agents. The
+  // full profile list is kept for the mute control itself in View settings.
+  const visibleProfiles = useMemo(
+    () => filterProfilesByPrefs(profiles, prefs),
+    [profiles, prefs],
+  );
   const profileClusters = useMemo(
-    () => clusterProfiles(profiles, Date.now()),
-    [profiles],
+    () => clusterProfiles(visibleProfiles, Date.now()),
+    [visibleProfiles],
   );
 
   const toggleThread = useCallback((parentId: string) => {
@@ -688,18 +674,57 @@ export default function Fishbowl() {
     return () => clearInterval(id);
   }, [token, fetchFeed]);
 
-  const showEmptyState = firstLoadDone && !error && profiles.length === 0 && messages.length === 0;
+  const showEmptyState =
+    firstLoadDone && !error && profiles.length === 0 && messages.length === 0;
+  const filtersHideEverything =
+    mainFeedMessages.length > 0 && filteredFeed.length === 0;
+
+  const nowForCounts = Date.now();
+  const connectedCount = profileClusters.reduce((n, c) => n + c.primaries.length, 0);
+  const liveCount = profileClusters.reduce(
+    (n, c) =>
+      n +
+      c.primaries.filter(
+        (p) =>
+          p.last_seen_at &&
+          nowForCounts - new Date(p.last_seen_at).getTime() < STALE_THRESHOLD_MS,
+      ).length,
+    0,
+  );
+  const sidebarClusters = agentsExpanded
+    ? profileClusters
+    : profileClusters.slice(0, AGENT_PAGE_SIZE);
+  const visibleGroups = groupedMessages.slice(0, feedShown);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <header>
         <h1 className="flex items-center gap-2 text-2xl font-semibold text-[#ccc]">
           <span aria-hidden>🐠</span>
-        <span>Boardroom</span>
+          <span>Boardroom</span>
         </h1>
         <p className="mt-1 text-sm text-[#888]">
-          Your AI agents talking to each other. You are welcome to listen in, and to chime in.
+          Where your AI agents post updates to each other. Listen in, or chime in.
         </p>
+        {!showEmptyState && (
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[#888]">
+            <span className="flex items-center gap-1.5">
+              <span
+                className={`h-2 w-2 rounded-full ${liveCount > 0 ? "bg-green-400" : "bg-[#555]"}`}
+                aria-hidden
+              />
+              {liveCount} live now
+            </span>
+            <span>{connectedCount} connected</span>
+            {actionQueueMessages.length > 0 ? (
+              <span className="text-[#E2B93B]">
+                {actionQueueMessages.length} need attention
+              </span>
+            ) : (
+              <span className="text-[#666]">nothing needs attention</span>
+            )}
+          </div>
+        )}
       </header>
 
       {error && (
@@ -709,28 +734,26 @@ export default function Fishbowl() {
         </div>
       )}
 
-      <ExplainerPanel profiles={profiles} clusters={profileClusters} />
+      <NowPlayingStrip
+        profiles={visibleProfiles}
+        clusters={profileClusters}
+        hideIdle={prefs.hideIdleAgents}
+      />
 
-      <NowPlayingStrip profiles={profiles} clusters={profileClusters} />
-
-      <FishbowlSettings profiles={profiles} />
-
-      <FishbowlIdeas authHeader={authHeader} humanAgentId={humanAgentId} />
+      {actionQueueMessages.length > 0 && (
+        <MessageLane
+          title="Needs attention"
+          icon="🟡"
+          messages={actionQueueMessages}
+          defaultExpanded
+        />
+      )}
 
       <PostBox disabled={!humanAgentId} onPost={postMessage} />
 
-      <MessageLane title="Action queue" icon="🟡" messages={actionQueueMessages} />
-
-      <div className="grid gap-3 md:grid-cols-2">
-        <MessageLane title="Heartbeats" icon="💓" messages={heartbeatMessages} />
-        <MessageLane title="Events" icon="🧭" messages={eventMessages} />
-      </div>
-
       {showEmptyState ? (
         <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-8 text-center">
-          <p className="text-base text-[#ccc]">
-            No agents posting yet.
-          </p>
+          <p className="text-base text-[#ccc]">No agents posting yet.</p>
           <p className="mt-2 text-sm text-[#888]">
             Once an AI agent like Claude or ChatGPT connects to UnClick, it claims an
             emoji here and starts posting updates. Your own posts will appear here too.
@@ -741,114 +764,193 @@ export default function Fishbowl() {
           {/* Feed */}
           <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
             <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
-              <h2 className="text-sm font-semibold text-[#ccc]">Recent messages</h2>
+              <h2 className="text-sm font-semibold text-[#ccc]">
+                Recent messages
+                {groupedMessages.length > 0 && (
+                  <span className="ml-2 text-xs font-normal text-[#666]">
+                    {groupedMessages.length}
+                  </span>
+                )}
+              </h2>
               {loading && <Loader2 className="h-3.5 w-3.5 animate-spin text-[#888]" />}
             </div>
-            <div className="max-h-[70vh] overflow-y-auto">
-              {mainFeedMessages.length === 0 ? (
+            <div>
+              {groupedMessages.length === 0 ? (
                 <p className="px-4 py-6 text-center text-sm text-[#666]">
-                  No action messages yet. Routine heartbeat and event chatter is grouped above.
+                  {filtersHideEverything
+                    ? "Your view settings are hiding every message. Clear them below to see the feed."
+                    : "No messages yet. Routine heartbeat and event chatter is grouped lower down."}
                 </p>
               ) : (
-                <ul className="divide-y divide-white/[0.04]">
-                  {groupedMessages.map(({ parent, replies }) => {
-                    const isExpanded = expandedThreads.has(parent.id);
-                    const parentHuman = isHumanAgentId(parent.author_agent_id);
-                    return (
-                      <li
-                        key={parent.id}
-                        className={`px-4 py-3 text-sm ${parentHuman ? "bg-[#E2B93B]/[0.04]" : ""}`}
-                      >
-                        <MessageBody m={parent} />
-                        {replies.length > 0 && (
-                          <div className="mt-2">
-                            <button
-                              type="button"
-                              onClick={() => toggleThread(parent.id)}
-                              className="rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-2 py-0.5 text-[11px] font-medium text-[#E2B93B] transition hover:bg-[#E2B93B]/20"
-                              aria-expanded={isExpanded}
-                            >
-                              {isExpanded ? "Hide" : "Show"} {replies.length}{" "}
-                              {replies.length === 1 ? "reply" : "replies"}
-                            </button>
-                            {isExpanded && (
-                              <ul className="mt-2 space-y-3 border-l-2 border-white/[0.08] pl-4 opacity-80">
-                                {replies.map((r) => {
-                                  const replyHuman = isHumanAgentId(r.author_agent_id);
-                                  return (
-                                    <li
-                                      key={r.id}
-                                      className={replyHuman ? "rounded-md bg-[#E2B93B]/[0.04] px-2 py-1" : ""}
-                                    >
-                                      <MessageBody m={r} />
-                                    </li>
-                                  );
-                                })}
-                              </ul>
-                            )}
-                          </div>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ul>
+                <>
+                  <ul className="divide-y divide-white/[0.04]">
+                    {visibleGroups.map(({ parent, replies }) => {
+                      const isExpanded = expandedThreads.has(parent.id);
+                      const parentHuman = isHumanAgentId(parent.author_agent_id);
+                      return (
+                        <li
+                          key={parent.id}
+                          className={`px-4 py-3 text-sm ${parentHuman ? "bg-[#E2B93B]/[0.04]" : ""}`}
+                        >
+                          <MessageBody m={parent} />
+                          {replies.length > 0 && (
+                            <div className="mt-2">
+                              <button
+                                type="button"
+                                onClick={() => toggleThread(parent.id)}
+                                className="rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-2 py-0.5 text-[11px] font-medium text-[#E2B93B] transition hover:bg-[#E2B93B]/20"
+                                aria-expanded={isExpanded}
+                              >
+                                {isExpanded ? "Hide" : "Show"} {replies.length}{" "}
+                                {replies.length === 1 ? "reply" : "replies"}
+                              </button>
+                              {isExpanded && (
+                                <ul className="mt-2 space-y-3 border-l-2 border-white/[0.08] pl-4 opacity-80">
+                                  {replies.map((r) => {
+                                    const replyHuman = isHumanAgentId(r.author_agent_id);
+                                    return (
+                                      <li
+                                        key={r.id}
+                                        className={replyHuman ? "rounded-md bg-[#E2B93B]/[0.04] px-2 py-1" : ""}
+                                      >
+                                        <MessageBody m={r} />
+                                      </li>
+                                    );
+                                  })}
+                                </ul>
+                              )}
+                            </div>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                  {groupedMessages.length > FEED_PAGE_SIZE && (
+                    <div className="flex items-center justify-center gap-3 border-t border-white/[0.04] px-4 py-3">
+                      {feedShown < groupedMessages.length && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setFeedShown((n) =>
+                              Math.min(n + FEED_PAGE_SIZE, groupedMessages.length),
+                            )
+                          }
+                          className="rounded-md border border-white/[0.08] px-3 py-1 text-xs font-medium text-[#aaa] hover:bg-white/[0.05]"
+                        >
+                          Show {Math.min(FEED_PAGE_SIZE, groupedMessages.length - feedShown)} more
+                        </button>
+                      )}
+                      {feedShown > FEED_PAGE_SIZE && (
+                        <button
+                          type="button"
+                          onClick={() => setFeedShown(FEED_PAGE_SIZE)}
+                          className="text-xs text-[#666] hover:text-[#aaa]"
+                        >
+                          Show fewer
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </section>
 
           {/* Sidebar: connected agents */}
           <aside className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
-            <div className="border-b border-white/[0.06] px-4 py-3">
-              <h2 className="text-sm font-semibold text-[#ccc]">Connected agents</h2>
+            <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
+              <h2 className="text-sm font-semibold text-[#ccc]">Agents</h2>
+              {connectedCount > 0 && (
+                <span className="text-xs text-[#666]">{connectedCount}</span>
+              )}
             </div>
-            {profiles.length === 0 ? (
+            {profileClusters.length === 0 ? (
               <p className="px-4 py-6 text-xs text-[#666]">No agents yet.</p>
             ) : (
-              <ul className="divide-y divide-white/[0.04]">
-                {profileClusters.map((c) => (
-                  <Fragment key={c.key}>
-                    {c.primaries.map((p) => (
-                      <li key={p.agent_id} className="flex items-start gap-3 px-4 py-3">
-                        <span className="text-xl leading-none">{p.emoji}</span>
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm font-medium text-[#ccc]">
-                            {p.display_name ?? "(unnamed)"}
-                            {c.primaries.length > 1 && (
-                              <span
-                                className="ml-1.5 rounded bg-white/[0.06] px-1 py-0.5 font-mono text-[9px] text-[#888]"
-                                title={p.agent_id}
-                              >
-                                {p.agent_id.slice(0, 8)}
-                              </span>
-                            )}
-                            {isHumanAgentId(p.agent_id) && (
-                              <span className="ml-1.5 rounded bg-[#E2B93B]/15 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide text-[#E2B93B]">
-                                you
-                              </span>
-                            )}
-                          </p>
-                          <p className="truncate text-xs text-[#666]" title="recently seen">
-                            Last seen {relativeTime(p.last_seen_at)}
-                          </p>
-                        </div>
-                      </li>
-                    ))}
-                    {c.staleAliasCount > 0 && (
-                      <li
-                        key={`${c.key}-stale`}
-                        className="px-4 py-2 text-xs italic text-[#666]"
-                        title="Older agent_ids that share this emoji and name but have not been seen recently."
-                      >
-                        +{c.staleAliasCount} stale alias{c.staleAliasCount === 1 ? "" : "es"}
-                      </li>
-                    )}
-                  </Fragment>
-                ))}
-              </ul>
+              <>
+                <ul className="divide-y divide-white/[0.04]">
+                  {sidebarClusters.map((c) => (
+                    <Fragment key={c.key}>
+                      {c.primaries.map((p) => (
+                        <li key={p.agent_id} className="flex items-start gap-3 px-4 py-3">
+                          <span className="text-xl leading-none">{p.emoji}</span>
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-[#ccc]">
+                              {p.display_name ?? "(unnamed)"}
+                              {c.primaries.length > 1 && (
+                                <span
+                                  className="ml-1.5 rounded bg-white/[0.06] px-1 py-0.5 font-mono text-[9px] text-[#888]"
+                                  title={p.agent_id}
+                                >
+                                  {p.agent_id.slice(0, 8)}
+                                </span>
+                              )}
+                              {isHumanAgentId(p.agent_id) && (
+                                <span className="ml-1.5 rounded bg-[#E2B93B]/15 px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide text-[#E2B93B]">
+                                  you
+                                </span>
+                              )}
+                            </p>
+                            <p className="truncate text-xs text-[#666]" title="recently seen">
+                              Last seen {relativeTime(p.last_seen_at)}
+                            </p>
+                          </div>
+                        </li>
+                      ))}
+                      {c.staleAliasCount > 0 && (
+                        <li
+                          key={`${c.key}-stale`}
+                          className="px-4 py-2 text-xs italic text-[#666]"
+                          title="Older agent_ids that share this emoji and name but have not been seen recently."
+                        >
+                          +{c.staleAliasCount} stale alias{c.staleAliasCount === 1 ? "" : "es"}
+                        </li>
+                      )}
+                    </Fragment>
+                  ))}
+                </ul>
+                {profileClusters.length > AGENT_PAGE_SIZE && (
+                  <div className="border-t border-white/[0.04] px-4 py-2 text-center">
+                    <button
+                      type="button"
+                      onClick={() => setAgentsExpanded((v) => !v)}
+                      className="text-xs text-[#888] hover:text-[#ccc]"
+                    >
+                      {agentsExpanded ? "Show fewer" : `Show all ${profileClusters.length}`}
+                    </button>
+                  </div>
+                )}
+              </>
             )}
           </aside>
         </div>
       )}
+
+      <FishbowlIdeas authHeader={authHeader} humanAgentId={humanAgentId} />
+
+      {/* Routine chatter: agent housekeeping, de-emphasised and collapsed. */}
+      <div className="space-y-2">
+        <h2 className="px-1 text-xs font-semibold uppercase tracking-wide text-[#666]">
+          Routine chatter
+        </h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          <MessageLane title="Heartbeats" icon="💓" messages={heartbeatMessages} />
+          <MessageLane title="Events" icon="🧭" messages={eventMessages} />
+        </div>
+      </div>
+
+      <FishbowlSettings
+        profiles={profiles}
+        prefs={prefs}
+        collapsed={settingsCollapsed}
+        onToggleCollapsed={() => setSettingsCollapsed((v) => !v)}
+        onToggleHideIdle={(value) => update("hideIdleAgents", value)}
+        onToggleTag={toggleTag}
+        onToggleMute={toggleMute}
+        onClearTags={() => update("tagFilters", [])}
+      />
+
+      <ExplainerPanel />
     </div>
   );
 }

--- a/src/pages/admin/fishbowl/Ideas.tsx
+++ b/src/pages/admin/fishbowl/Ideas.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { ChevronDown, ChevronRight, Loader2, Plus, ThumbsDown, ThumbsUp } from "lucide-react";
 import Comments from "./Comments";
+import { ageLabel, partitionIdeas } from "./ideaActivity";
 
 interface Idea {
   id: string;
@@ -150,6 +151,7 @@ function IdeaRow({
   humanAgentId,
   pollSeq,
   onMutated,
+  nowMs,
 }: {
   idea: Idea;
   expanded: boolean;
@@ -158,6 +160,7 @@ function IdeaRow({
   humanAgentId: string | null;
   pollSeq: number;
   onMutated: () => void;
+  nowMs: number;
 }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -232,6 +235,9 @@ function IdeaRow({
             <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-[#666]">
               {statusPill(idea.status)}
               <span>by {idea.created_by_agent_id}</span>
+              <span title={new Date(idea.updated_at).toLocaleString()}>
+                updated {ageLabel(idea.updated_at, nowMs)}
+              </span>
               {(idea.comment_count ?? 0) > 0 && (
                 <span className="text-[#888]">💬 {idea.comment_count}</span>
               )}
@@ -298,6 +304,8 @@ export default function FishbowlIdeas({ authHeader, humanAgentId }: IdeasProps) 
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [pollSeq, setPollSeq] = useState(0);
+  const [showStale, setShowStale] = useState(false);
+  const [showResolved, setShowResolved] = useState(false);
 
   const toggleCollapsed = () => {
     setCollapsed((prev) => {
@@ -331,10 +339,12 @@ export default function FishbowlIdeas({ authHeader, humanAgentId }: IdeasProps) 
     }
   }, [authHeader, humanAgentId]);
 
+  // Fetch once as soon as we have an identity (even while collapsed) so the
+  // header badge can show an accurate active-idea count without opening the
+  // panel. Polling below stays gated on the panel being open.
   useEffect(() => {
-    if (collapsed) return;
     void fetchIdeas();
-  }, [collapsed, fetchIdeas]);
+  }, [fetchIdeas]);
 
   useEffect(() => {
     if (collapsed) return;
@@ -359,7 +369,23 @@ export default function FishbowlIdeas({ authHeader, humanAgentId }: IdeasProps) 
     });
   };
 
-  const activeCount = ideas.filter((i) => i.status === "proposed" || i.status === "voting").length;
+  const nowMs = Date.now();
+  const { active, stale, resolved } = partitionIdeas(ideas, nowMs);
+
+  const renderIdea = (i: Idea) => (
+    <li key={i.id}>
+      <IdeaRow
+        idea={i}
+        expanded={expanded.has(i.id)}
+        onToggle={() => toggleRow(i.id)}
+        authHeader={authHeader}
+        humanAgentId={humanAgentId}
+        pollSeq={pollSeq}
+        onMutated={onMutated}
+        nowMs={nowMs}
+      />
+    </li>
+  );
 
   return (
     <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
@@ -372,9 +398,9 @@ export default function FishbowlIdeas({ authHeader, humanAgentId }: IdeasProps) 
         <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
           <span aria-hidden>💡</span>
           <span>Ideas</span>
-          {activeCount > 0 && (
+          {active.length > 0 && (
             <span className="rounded-full bg-[#E2B93B]/15 px-2 py-0.5 text-[10px] font-medium text-[#E2B93B]">
-              {activeCount} open
+              {active.length} active
             </span>
           )}
         </span>
@@ -404,24 +430,68 @@ export default function FishbowlIdeas({ authHeader, humanAgentId }: IdeasProps) 
 
           {ideas.length === 0 ? (
             <p className="rounded-md border border-white/[0.04] bg-black/20 px-3 py-4 text-center text-xs text-[#666]">
-              No ideas yet. Propose one above.
+              No ideas yet. Propose one above. Ideas are quick proposals you or
+              your agents can vote on and promote to a TODO.
             </p>
           ) : (
-            <ul className="space-y-2">
-              {ideas.map((i) => (
-                <li key={i.id}>
-                  <IdeaRow
-                    idea={i}
-                    expanded={expanded.has(i.id)}
-                    onToggle={() => toggleRow(i.id)}
-                    authHeader={authHeader}
-                    humanAgentId={humanAgentId}
-                    pollSeq={pollSeq}
-                    onMutated={onMutated}
-                  />
-                </li>
-              ))}
-            </ul>
+            <div className="space-y-3">
+              {active.length > 0 ? (
+                <ul className="space-y-2">{active.map(renderIdea)}</ul>
+              ) : (
+                <p className="rounded-md border border-white/[0.04] bg-black/20 px-3 py-3 text-center text-xs text-[#666]">
+                  No active ideas. Everything below has either gone quiet or been
+                  decided.
+                </p>
+              )}
+
+              {stale.length > 0 && (
+                <div className="space-y-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowStale((s) => !s)}
+                    className="flex w-full items-center gap-1.5 text-left text-xs font-medium text-[#888] hover:text-[#ccc]"
+                    aria-expanded={showStale}
+                  >
+                    {showStale ? (
+                      <ChevronDown className="h-3.5 w-3.5" />
+                    ) : (
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    )}
+                    Stale ideas ({stale.length})
+                    <span className="font-normal text-[#555]">
+                      no activity in 3+ weeks
+                    </span>
+                  </button>
+                  {showStale && (
+                    <ul className="space-y-2 opacity-70">{stale.map(renderIdea)}</ul>
+                  )}
+                </div>
+              )}
+
+              {resolved.length > 0 && (
+                <div className="space-y-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowResolved((s) => !s)}
+                    className="flex w-full items-center gap-1.5 text-left text-xs font-medium text-[#888] hover:text-[#ccc]"
+                    aria-expanded={showResolved}
+                  >
+                    {showResolved ? (
+                      <ChevronDown className="h-3.5 w-3.5" />
+                    ) : (
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    )}
+                    Resolved ideas ({resolved.length})
+                    <span className="font-normal text-[#555]">
+                      locked, parked, or rejected
+                    </span>
+                  </button>
+                  {showResolved && (
+                    <ul className="space-y-2 opacity-70">{resolved.map(renderIdea)}</ul>
+                  )}
+                </div>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/src/pages/admin/fishbowl/Settings.tsx
+++ b/src/pages/admin/fishbowl/Settings.tsx
@@ -1,114 +1,50 @@
 // src/pages/admin/fishbowl/Settings.tsx
 //
-// Fishbowl heartbeat Settings panel - collapsible, dark theme, localStorage prefs.
-// Slot: after <NowPlayingStrip /> in Fishbowl.tsx main component.
-// Import: import FishbowlSettings from "./fishbowl/Settings";
-// Usage: <FishbowlSettings profiles={profiles} />
+// Boardroom "View settings" panel - collapsible, dark theme.
 //
-// This is frontend-only MVP. Prefs stored in localStorage.
-// Phase 2: persist to mc_fishbowl_settings table via API.
+// This used to be a placebo: it wrote prefs to localStorage that nothing read.
+// It is now fully controlled by the parent page via the useFishbowlViewPrefs
+// hook, and every control here actually changes what the viewer sees (the feed
+// and the agent presence surfaces). Controls that the viewer could not
+// influence (pulse cadence, an unbuilt events bot) were removed.
+//
+// "Fishbowl" is the load-bearing internal name; the user-facing surface is the
+// Boardroom.
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { ChevronDown, ChevronRight, Settings as SettingsIcon } from "lucide-react";
 import { findDuplicateProfileAgentIds } from "./clusterProfiles";
+import { CANONICAL_TAGS, type FishbowlViewPrefs } from "./prefs";
 
-/* -- types -- */
 interface FishbowlProfile {
   agent_id: string;
   emoji: string;
   display_name: string | null;
-  user_agent_hint: string | null;
-  created_at: string;
   last_seen_at: string | null;
-  current_status: string | null;
-  current_status_updated_at: string | null;
-  next_checkin_at: string | null;
 }
 
-interface HeartbeatPrefs {
-  pulseIntervalMin: 15 | 30 | 60;
-  staleThresholdMin: 5 | 10 | 15 | 30;
-  hideIdleAgents: boolean;
-  tagFilters: string[];           // empty = show all
-  mutedAgentIds: string[];        // agent_ids to hide from feed
-  eventsBotEnabled: boolean;      // placeholder for future events bot
+interface SettingsProps {
+  profiles: FishbowlProfile[];
+  prefs: FishbowlViewPrefs;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  onToggleHideIdle: (value: boolean) => void;
+  onToggleTag: (tag: string) => void;
+  onToggleMute: (agentId: string) => void;
+  onClearTags: () => void;
 }
 
-const DEFAULT_PREFS: HeartbeatPrefs = {
-  pulseIntervalMin: 15,
-  staleThresholdMin: 5,
-  hideIdleAgents: false,
-  tagFilters: [],
-  mutedAgentIds: [],
-  eventsBotEnabled: false,
-};
-
-const STORAGE_KEY = "unclick.fishbowl.heartbeat.settings";
-const CANONICAL_TAGS = [
-  "heartbeat", "qc", "pr", "decision", "question",
-  "answer", "handoff", "blocker", "done", "fyi",
-];
-
-/* -- helpers -- */
-function loadPrefs(): HeartbeatPrefs {
-  if (typeof window === "undefined") return DEFAULT_PREFS;
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return DEFAULT_PREFS;
-    return { ...DEFAULT_PREFS, ...JSON.parse(raw) };
-  } catch {
-    return DEFAULT_PREFS;
-  }
-}
-
-function savePrefs(prefs: HeartbeatPrefs): void {
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
-  } catch {
-    // localStorage may be unavailable; ignore.
-  }
-}
-
-/* -- component -- */
 export default function FishbowlSettings({
   profiles,
-}: {
-  profiles: FishbowlProfile[];
-}) {
-  const [collapsed, setCollapsed] = useState(true); // default-collapsed
-  const [prefs, setPrefs] = useState<HeartbeatPrefs>(loadPrefs);
-
-  // Persist on change
-  useEffect(() => {
-    savePrefs(prefs);
-  }, [prefs]);
-
-  const update = useCallback(
-    <K extends keyof HeartbeatPrefs>(key: K, value: HeartbeatPrefs[K]) => {
-      setPrefs((prev) => ({ ...prev, [key]: value }));
-    },
-    [],
-  );
-
-  const toggleTag = useCallback((tag: string) => {
-    setPrefs((prev) => {
-      const next = prev.tagFilters.includes(tag)
-        ? prev.tagFilters.filter((t) => t !== tag)
-        : [...prev.tagFilters, tag];
-      return { ...prev, tagFilters: next };
-    });
-  }, []);
-
-  const toggleMute = useCallback((agentId: string) => {
-    setPrefs((prev) => {
-      const next = prev.mutedAgentIds.includes(agentId)
-        ? prev.mutedAgentIds.filter((id) => id !== agentId)
-        : [...prev.mutedAgentIds, agentId];
-      return { ...prev, mutedAgentIds: next };
-    });
-  }, []);
-
-  // Only show non-human agents in mute list
+  prefs,
+  collapsed,
+  onToggleCollapsed,
+  onToggleHideIdle,
+  onToggleTag,
+  onToggleMute,
+  onClearTags,
+}: SettingsProps) {
+  // Only real (non-human) agents can be muted.
   const agentProfiles = useMemo(
     () => profiles.filter((p) => !p.agent_id.startsWith("human-")),
     [profiles],
@@ -118,17 +54,25 @@ export default function FishbowlSettings({
     [agentProfiles],
   );
 
+  const activeFilterCount =
+    prefs.tagFilters.length + prefs.mutedAgentIds.length + (prefs.hideIdleAgents ? 1 : 0);
+
   return (
     <section className="rounded-xl border border-white/[0.06] bg-white/[0.02]">
       <button
         type="button"
-        onClick={() => setCollapsed((p) => !p)}
+        onClick={onToggleCollapsed}
         className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"
         aria-expanded={!collapsed}
       >
         <span className="flex items-center gap-2 text-sm font-semibold text-[#ccc]">
           <SettingsIcon className="h-3.5 w-3.5 text-[#888]" />
-          <span>Heartbeat Settings</span>
+          <span>View settings</span>
+          {activeFilterCount > 0 && (
+            <span className="rounded-full bg-[#E2B93B]/15 px-2 py-0.5 text-[10px] font-medium text-[#E2B93B]">
+              {activeFilterCount} active
+            </span>
+          )}
         </span>
         {collapsed ? (
           <ChevronRight className="h-4 w-4 text-[#555]" />
@@ -139,85 +83,30 @@ export default function FishbowlSettings({
 
       {!collapsed && (
         <div className="space-y-5 border-t border-white/[0.06] px-4 py-4">
-          {/* -- Pulse interval -- */}
+          <p className="text-xs text-[#888]">
+            These filters only change what you see here. Your agents still post
+            everything; nothing is deleted.
+          </p>
+
+          {/* Hide idle agents */}
+          <label className="flex cursor-pointer items-center gap-2 text-xs text-[#ccc]">
+            <input
+              type="checkbox"
+              checked={prefs.hideIdleAgents}
+              onChange={(e) => onToggleHideIdle(e.target.checked)}
+              className="accent-[#E2B93B]"
+            />
+            Hide idle agents from Now Playing
+          </label>
+
+          {/* Tag filters */}
           <fieldset>
             <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
-              Pulse interval
-            </legend>
-            <div className="flex gap-2">
-              {([15, 30, 60] as const).map((v) => (
-                <button
-                  key={v}
-                  type="button"
-                  onClick={() => update("pulseIntervalMin", v)}
-                  className={`rounded-md border px-3 py-1 text-xs font-medium transition ${
-                    prefs.pulseIntervalMin === v
-                      ? "border-[#E2B93B]/40 bg-[#E2B93B]/15 text-[#E2B93B]"
-                      : "border-white/[0.08] bg-white/[0.03] text-[#888] hover:text-[#ccc]"
-                  }`}
-                >
-                  {v}m
-                </button>
-              ))}
-            </div>
-          </fieldset>
-
-          {/* -- Stale threshold -- */}
-          <fieldset>
-            <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
-              Stale threshold
-            </legend>
-            <div className="flex gap-2">
-              {([5, 10, 15, 30] as const).map((v) => (
-                <button
-                  key={v}
-                  type="button"
-                  onClick={() => update("staleThresholdMin", v)}
-                  className={`rounded-md border px-3 py-1 text-xs font-medium transition ${
-                    prefs.staleThresholdMin === v
-                      ? "border-[#E2B93B]/40 bg-[#E2B93B]/15 text-[#E2B93B]"
-                      : "border-white/[0.08] bg-white/[0.03] text-[#888] hover:text-[#ccc]"
-                  }`}
-                >
-                  {v}m
-                </button>
-              ))}
-            </div>
-          </fieldset>
-
-          {/* -- Toggles row -- */}
-          <div className="flex flex-wrap gap-x-6 gap-y-2">
-            <label className="flex cursor-pointer items-center gap-2 text-xs text-[#888]">
-              <input
-                type="checkbox"
-                checked={prefs.hideIdleAgents}
-                onChange={(e) => update("hideIdleAgents", e.target.checked)}
-                className="accent-[#E2B93B]"
-              />
-              Hide idle agents on strip
-            </label>
-            <label className="flex cursor-pointer items-center gap-2 text-xs text-[#888]">
-              <input
-                type="checkbox"
-                checked={prefs.eventsBotEnabled}
-                onChange={(e) => update("eventsBotEnabled", e.target.checked)}
-                className="accent-[#E2B93B]"
-              />
-              Events bot
-              <span className="rounded bg-white/[0.06] px-1 py-0.5 text-[9px] uppercase text-[#555]">
-                soon
-              </span>
-            </label>
-          </div>
-
-          {/* -- Tag filters -- */}
-          <fieldset>
-            <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
-              Tag filters
+              Only show these tags
               {prefs.tagFilters.length > 0 && (
                 <button
                   type="button"
-                  onClick={() => update("tagFilters", [])}
+                  onClick={onClearTags}
                   className="ml-2 text-[10px] text-[#E2B93B] hover:underline"
                 >
                   clear
@@ -231,7 +120,7 @@ export default function FishbowlSettings({
                   <button
                     key={tag}
                     type="button"
-                    onClick={() => toggleTag(tag)}
+                    onClick={() => onToggleTag(tag)}
                     className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition ${
                       active
                         ? "border-[#E2B93B]/40 bg-[#E2B93B]/15 text-[#E2B93B]"
@@ -245,12 +134,12 @@ export default function FishbowlSettings({
             </div>
             <p className="mt-1 text-[10px] text-[#555]">
               {prefs.tagFilters.length === 0
-                ? "Showing all tags"
-                : `Showing: ${prefs.tagFilters.join(", ")}`}
+                ? "Showing every message."
+                : `Showing only: ${prefs.tagFilters.join(", ")}.`}
             </p>
           </fieldset>
 
-          {/* -- Mute per agent -- */}
+          {/* Mute agents */}
           {agentProfiles.length > 0 && (
             <fieldset>
               <legend className="mb-1.5 text-xs font-medium uppercase tracking-wide text-[#888]">
@@ -264,7 +153,7 @@ export default function FishbowlSettings({
                     <button
                       key={p.agent_id}
                       type="button"
-                      onClick={() => toggleMute(p.agent_id)}
+                      onClick={() => onToggleMute(p.agent_id)}
                       className={`flex items-center gap-1 rounded-md border px-2 py-1 text-xs transition ${
                         muted
                           ? "border-red-400/30 bg-red-400/10 text-red-300 line-through"
@@ -287,6 +176,10 @@ export default function FishbowlSettings({
                   );
                 })}
               </div>
+              <p className="mt-1 text-[10px] text-[#555]">
+                Muted agents are hidden from Now Playing, the feed, and the
+                roster.
+              </p>
             </fieldset>
           )}
         </div>

--- a/src/pages/admin/fishbowl/ideaActivity.test.ts
+++ b/src/pages/admin/fishbowl/ideaActivity.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  IDEA_STALE_AFTER_MS,
+  ageLabel,
+  ideaBucket,
+  partitionIdeas,
+  type IdeaActivity,
+  type IdeaStatus,
+} from "./ideaActivity";
+
+const NOW = Date.parse("2026-06-02T00:00:00Z");
+
+const daysAgo = (n: number) => new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString();
+
+const idea = (status: IdeaStatus, updatedDaysAgo: number): IdeaActivity => ({
+  status,
+  created_at: daysAgo(updatedDaysAgo + 1),
+  updated_at: daysAgo(updatedDaysAgo),
+});
+
+describe("idea activity buckets", () => {
+  it("keeps recently touched open ideas active", () => {
+    expect(ideaBucket(idea("proposed", 1), NOW)).toBe("active");
+    expect(ideaBucket(idea("voting", 5), NOW)).toBe("active");
+  });
+
+  it("marks open ideas that have gone quiet as stale", () => {
+    expect(ideaBucket(idea("proposed", 22), NOW)).toBe("stale");
+    expect(ideaBucket(idea("voting", 60), NOW)).toBe("stale");
+  });
+
+  it("treats locked, parked, and rejected ideas as resolved regardless of age", () => {
+    expect(ideaBucket(idea("locked", 1), NOW)).toBe("resolved");
+    expect(ideaBucket(idea("parked", 100), NOW)).toBe("resolved");
+    expect(ideaBucket(idea("rejected", 0), NOW)).toBe("resolved");
+  });
+
+  it("uses a three-week staleness boundary", () => {
+    const justInside = new Date(NOW - IDEA_STALE_AFTER_MS + 1000).toISOString();
+    const justOutside = new Date(NOW - IDEA_STALE_AFTER_MS - 1000).toISOString();
+    expect(ideaBucket({ status: "voting", created_at: justInside, updated_at: justInside }, NOW)).toBe(
+      "active",
+    );
+    expect(
+      ideaBucket({ status: "voting", created_at: justOutside, updated_at: justOutside }, NOW),
+    ).toBe("stale");
+  });
+
+  it("partitions a mixed list into the three buckets", () => {
+    const ideas = [
+      idea("voting", 2), // active
+      idea("proposed", 40), // stale
+      idea("locked", 3), // resolved
+      idea("rejected", 90), // resolved
+    ];
+    const parts = partitionIdeas(ideas, NOW);
+    expect(parts.active).toHaveLength(1);
+    expect(parts.stale).toHaveLength(1);
+    expect(parts.resolved).toHaveLength(2);
+  });
+});
+
+describe("ageLabel", () => {
+  it("renders plain-English relative ages", () => {
+    expect(ageLabel(daysAgo(0), NOW)).toBe("just now");
+    expect(ageLabel(new Date(NOW - 5 * 60 * 1000).toISOString(), NOW)).toBe("5m ago");
+    expect(ageLabel(new Date(NOW - 3 * 60 * 60 * 1000).toISOString(), NOW)).toBe("3h ago");
+    expect(ageLabel(daysAgo(4), NOW)).toBe("4d ago");
+    expect(ageLabel(daysAgo(45), NOW)).toBe("1mo ago");
+    expect(ageLabel(daysAgo(800), NOW)).toBe("2y ago");
+  });
+
+  it("returns an empty string for missing or invalid input", () => {
+    expect(ageLabel(null, NOW)).toBe("");
+    expect(ageLabel("not-a-date", NOW)).toBe("");
+  });
+});

--- a/src/pages/admin/fishbowl/ideaActivity.ts
+++ b/src/pages/admin/fishbowl/ideaActivity.ts
@@ -1,0 +1,72 @@
+// Freshness + bucketing helpers for Boardroom ideas.
+//
+// Ideas pile up and go quiet. To keep the panel honest, we split them into:
+//   - active:   still open (proposed/voting) and touched recently
+//   - stale:    still open but nothing has happened for a long time
+//   - resolved: locked, parked, or rejected (the decision is made)
+//
+// The page shows "active" up front and tucks "stale" and "resolved" behind
+// view-more toggles so dead ideas stop crowding the live ones.
+
+export type IdeaStatus = "proposed" | "voting" | "locked" | "parked" | "rejected";
+
+export interface IdeaActivity {
+  status: IdeaStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export type IdeaBucket = "active" | "stale" | "resolved";
+
+// An open idea with no movement for three weeks is treated as stale.
+export const IDEA_STALE_AFTER_MS = 21 * 24 * 60 * 60 * 1000;
+
+const RESOLVED_STATUSES: ReadonlySet<IdeaStatus> = new Set<IdeaStatus>([
+  "locked",
+  "parked",
+  "rejected",
+]);
+
+export function ideaBucket(idea: IdeaActivity, nowMs: number): IdeaBucket {
+  if (RESOLVED_STATUSES.has(idea.status)) return "resolved";
+  const updated = new Date(idea.updated_at).getTime();
+  if (Number.isFinite(updated) && nowMs - updated > IDEA_STALE_AFTER_MS) {
+    return "stale";
+  }
+  return "active";
+}
+
+export interface PartitionedIdeas<T extends IdeaActivity> {
+  active: T[];
+  stale: T[];
+  resolved: T[];
+}
+
+export function partitionIdeas<T extends IdeaActivity>(
+  ideas: T[],
+  nowMs: number,
+): PartitionedIdeas<T> {
+  const out: PartitionedIdeas<T> = { active: [], stale: [], resolved: [] };
+  for (const idea of ideas) {
+    out[ideaBucket(idea, nowMs)].push(idea);
+  }
+  return out;
+}
+
+/** Short, plain-English age label, e.g. "3d ago" or "just now". */
+export function ageLabel(iso: string | null | undefined, nowMs: number): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return "";
+  const diffSec = Math.max(1, Math.floor((nowMs - then) / 1000));
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMonth = Math.floor(diffDay / 30);
+  if (diffMonth < 12) return `${diffMonth}mo ago`;
+  return `${Math.floor(diffMonth / 12)}y ago`;
+}

--- a/src/pages/admin/fishbowl/prefs.test.ts
+++ b/src/pages/admin/fishbowl/prefs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_VIEW_PREFS,
+  filterFeedByPrefs,
+  filterProfilesByPrefs,
+  isAgentMuted,
+} from "./prefs";
+
+const msg = (author_agent_id: string | null, tags: string[] | null) => ({
+  author_agent_id,
+  tags,
+});
+
+describe("Boardroom view prefs", () => {
+  it("treats the default prefs as a pass-through", () => {
+    const messages = [msg("a", ["pr"]), msg("b", null), msg(null, ["fyi"])];
+    expect(filterFeedByPrefs(messages, DEFAULT_VIEW_PREFS)).toEqual(messages);
+  });
+
+  it("drops posts from muted agents", () => {
+    const prefs = { ...DEFAULT_VIEW_PREFS, mutedAgentIds: ["noisy"] };
+    const messages = [msg("noisy", ["pr"]), msg("quiet", ["pr"])];
+    expect(filterFeedByPrefs(messages, prefs).map((m) => m.author_agent_id)).toEqual([
+      "quiet",
+    ]);
+  });
+
+  it("keeps only messages matching an active tag filter", () => {
+    const prefs = { ...DEFAULT_VIEW_PREFS, tagFilters: ["decision"] };
+    const messages = [
+      msg("a", ["decision"]),
+      msg("b", ["fyi"]),
+      msg("c", ["pr", "decision"]),
+      msg("d", null),
+    ];
+    expect(filterFeedByPrefs(messages, prefs).map((m) => m.author_agent_id)).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+
+  it("combines mute and tag filters", () => {
+    const prefs = {
+      ...DEFAULT_VIEW_PREFS,
+      mutedAgentIds: ["a"],
+      tagFilters: ["pr"],
+    };
+    const messages = [msg("a", ["pr"]), msg("b", ["pr"]), msg("b", ["fyi"])];
+    expect(filterFeedByPrefs(messages, prefs)).toEqual([msg("b", ["pr"])]);
+  });
+
+  it("removes muted agents from presence lists without copying when unmuted", () => {
+    const profiles = [{ agent_id: "a" }, { agent_id: "b" }];
+    expect(filterProfilesByPrefs(profiles, DEFAULT_VIEW_PREFS)).toBe(profiles);
+
+    const prefs = { ...DEFAULT_VIEW_PREFS, mutedAgentIds: ["a"] };
+    expect(filterProfilesByPrefs(profiles, prefs)).toEqual([{ agent_id: "b" }]);
+  });
+
+  it("guards isAgentMuted against null ids", () => {
+    const prefs = { ...DEFAULT_VIEW_PREFS, mutedAgentIds: ["a"] };
+    expect(isAgentMuted(prefs, null)).toBe(false);
+    expect(isAgentMuted(prefs, "a")).toBe(true);
+  });
+});

--- a/src/pages/admin/fishbowl/prefs.ts
+++ b/src/pages/admin/fishbowl/prefs.ts
@@ -1,0 +1,148 @@
+// Shared view preferences for the Boardroom page.
+//
+// These are the human viewer's filters (mute an agent, focus on certain tags,
+// hide idle agents). They are persisted in localStorage so they survive a
+// reload, and applied to the live surfaces (Now Playing strip, message feed,
+// connected agents). The pure helpers below are unit-tested in prefs.test.ts.
+//
+// Note: "Fishbowl" is the load-bearing internal name (storage key, file paths).
+// The user-facing surface is always called the Boardroom.
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface FishbowlViewPrefs {
+  /** Hide agents that have no current status and have gone quiet. */
+  hideIdleAgents: boolean;
+  /** When non-empty, the feed only shows messages carrying one of these tags. */
+  tagFilters: string[];
+  /** agent_ids whose posts and presence are hidden from the viewer. */
+  mutedAgentIds: string[];
+}
+
+export const DEFAULT_VIEW_PREFS: FishbowlViewPrefs = {
+  hideIdleAgents: false,
+  tagFilters: [],
+  mutedAgentIds: [],
+};
+
+// Kept identical to the original Settings key so existing saved prefs migrate
+// cleanly. Older payloads also carried pulse/stale/eventsBot fields; we simply
+// ignore the ones the viewer can no longer control.
+export const VIEW_PREFS_STORAGE_KEY = "unclick.fishbowl.heartbeat.settings";
+
+export const CANONICAL_TAGS = [
+  "heartbeat",
+  "qc",
+  "pr",
+  "decision",
+  "question",
+  "answer",
+  "handoff",
+  "blocker",
+  "done",
+  "fyi",
+] as const;
+
+export function loadViewPrefs(): FishbowlViewPrefs {
+  if (typeof window === "undefined") return DEFAULT_VIEW_PREFS;
+  try {
+    const raw = window.localStorage.getItem(VIEW_PREFS_STORAGE_KEY);
+    if (!raw) return DEFAULT_VIEW_PREFS;
+    const parsed = JSON.parse(raw) as Partial<FishbowlViewPrefs>;
+    return {
+      hideIdleAgents: Boolean(parsed.hideIdleAgents),
+      tagFilters: Array.isArray(parsed.tagFilters) ? parsed.tagFilters : [],
+      mutedAgentIds: Array.isArray(parsed.mutedAgentIds) ? parsed.mutedAgentIds : [],
+    };
+  } catch {
+    return DEFAULT_VIEW_PREFS;
+  }
+}
+
+export function saveViewPrefs(prefs: FishbowlViewPrefs): void {
+  try {
+    window.localStorage.setItem(VIEW_PREFS_STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // localStorage may be unavailable (private mode, quota); ignore.
+  }
+}
+
+export interface FeedFilterMessage {
+  author_agent_id: string | null;
+  tags: string[] | null;
+}
+
+export function isAgentMuted(
+  prefs: FishbowlViewPrefs,
+  agentId: string | null | undefined,
+): boolean {
+  if (!agentId) return false;
+  return prefs.mutedAgentIds.includes(agentId);
+}
+
+/**
+ * Apply the viewer's filters to a list of feed messages: drop muted authors,
+ * and (when tag filters are active) keep only messages carrying a matching tag.
+ */
+export function filterFeedByPrefs<T extends FeedFilterMessage>(
+  messages: T[],
+  prefs: FishbowlViewPrefs,
+): T[] {
+  return messages.filter((m) => {
+    if (isAgentMuted(prefs, m.author_agent_id)) return false;
+    if (prefs.tagFilters.length > 0) {
+      const tags = m.tags ?? [];
+      if (!tags.some((t) => prefs.tagFilters.includes(t))) return false;
+    }
+    return true;
+  });
+}
+
+export interface MutableProfile {
+  agent_id: string;
+}
+
+/** Remove muted agents from a list of profiles (used for presence surfaces). */
+export function filterProfilesByPrefs<T extends MutableProfile>(
+  profiles: T[],
+  prefs: FishbowlViewPrefs,
+): T[] {
+  if (prefs.mutedAgentIds.length === 0) return profiles;
+  return profiles.filter((p) => !isAgentMuted(prefs, p.agent_id));
+}
+
+/** React hook that loads, exposes, and persists the viewer's Boardroom prefs. */
+export function useFishbowlViewPrefs() {
+  const [prefs, setPrefs] = useState<FishbowlViewPrefs>(loadViewPrefs);
+
+  useEffect(() => {
+    saveViewPrefs(prefs);
+  }, [prefs]);
+
+  const update = useCallback(
+    <K extends keyof FishbowlViewPrefs>(key: K, value: FishbowlViewPrefs[K]) => {
+      setPrefs((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const toggleTag = useCallback((tag: string) => {
+    setPrefs((prev) => ({
+      ...prev,
+      tagFilters: prev.tagFilters.includes(tag)
+        ? prev.tagFilters.filter((t) => t !== tag)
+        : [...prev.tagFilters, tag],
+    }));
+  }, []);
+
+  const toggleMute = useCallback((agentId: string) => {
+    setPrefs((prev) => ({
+      ...prev,
+      mutedAgentIds: prev.mutedAgentIds.includes(agentId)
+        ? prev.mutedAgentIds.filter((id) => id !== agentId)
+        : [...prev.mutedAgentIds, agentId],
+    }));
+  }, []);
+
+  return { prefs, update, toggleTag, toggleMute };
+}


### PR DESCRIPTION
## What this is

A UI/UX tidy-up of the Boardroom page (`src/pages/admin/Fishbowl.tsx` + `src/pages/admin/fishbowl/*`). Goal: clean, scannable data for humans and tidy structure for agents. User-facing copy stays **Boardroom**; the load-bearing internal **Fishbowl** identifiers (DB tables, routes, file/component names, API actions) are untouched.

## Review first: what was working vs not

**Working well (kept):**
- Now Playing live status strip, with MIA / "back in" / idle states.
- Lane separation that keeps routine heartbeat/event chatter out of the main feed.
- Thread grouping in the feed; profile clustering that dedupes emoji+name aliases.

**Not working / messy (fixed):**
1. **"Heartbeat Settings" was a placebo.** It wrote `mutedAgentIds` / `tagFilters` / `hideIdleAgents` / pulse interval to localStorage and **nothing read them**. Every control was inert.
2. **Agents were listed three times** (explainer "your pack" + Now Playing + sidebar).
3. **No pagination.** The feed rendered every message in an inner scroll box; the agents list was uncapped.
4. **Ideas had no freshness signal** and the panel defaulted closed, so stale ideas rotted invisibly (the reported "nobody uses ideas").
5. **Eight stacked full-width panels** before any real content, with no priority order.

(Also noted, not touched: `fishbowl/Todos.tsx` / `FishbowlTodos` is dead code, never imported. The gold `#E2B93B` accent is the established admin convention across 38 files, so it was deliberately kept.)

## Changes

- **View settings panel is now real.** A shared `useFishbowlViewPrefs` hook drives the page: muting an agent hides it from Now Playing, the feed, and the roster; tag filters narrow the feed; "hide idle" trims Now Playing. Controls a viewer can't influence (pulse cadence, the unbuilt events bot) were removed. Copy makes clear filters only change *your* view and delete nothing.
- **Ideas show freshness.** Each row shows "updated Xd ago". Ideas split into **active / stale (no activity 3+ weeks) / resolved (locked, parked, rejected)**; stale + resolved sit behind view-more toggles. The header badge shows the active count without opening the panel.
- **View-more everywhere.** Feed paginates (20 threads, show more / show fewer); agents panel caps at 6 with "show all N".
- **Clearer hierarchy.** Live signal up top (Now Playing, a "Needs attention" queue that only appears when non-empty and opens by default, post box, feed + agents). Reference/controls (Ideas, routine chatter, view settings, "What is the Boardroom?") move below. Header gains a live / connected / needs-attention summary line.

## New tested helpers

- `fishbowl/prefs.ts` - feed + profile filtering from view prefs.
- `fishbowl/ideaActivity.ts` - staleness buckets + plain-English age labels.
- 13 new unit tests (`prefs.test.ts`, `ideaActivity.test.ts`).

## Verification

- `npx vitest run src/pages/admin/fishbowl/` - 26 passed.
- `npx vitest run src/pages/admin` - 153 passed.
- `npx tsc --noEmit` - no new errors in Boardroom files.
- `npx eslint --quiet` on changed files - clean.
- `npx vite build` - clean.

Could not capture a live screenshot (the page needs an authenticated admin session + backend), so this is verified via build + tests + review. Happy to wire up a render harness if you want pixels.

https://claude.ai/code/session_012FA7kHyQ23yoT1EQPisGUc

---
_Generated by [Claude Code](https://claude.ai/code/session_012FA7kHyQ23yoT1EQPisGUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only UI and localStorage view filters; no auth, API, or data-model changes beyond generated brainmap metadata.
> 
> **Overview**
> **Boardroom (Fishbowl admin)** gets a layout and behavior pass so view settings actually affect the UI, ideas are easier to scan, and long lists don’t dominate the page.
> 
> **View settings** move to a shared `useFishbowlViewPrefs` hook (`fishbowl/prefs.ts`): mute agents, tag filters, and hide-idle now apply to Now Playing, the message feed, and the agents roster (client-only; same localStorage key). The old “Heartbeat Settings” placebo controls (pulse interval, events bot, etc.) are removed; the panel is renamed **View settings** and is parent-controlled.
> 
> **Page structure** prioritizes live signal: header stats (live / connected / needs attention), Now Playing, an auto-expanded **Needs attention** lane when non-empty, post box, then feed + sidebar. Ideas, routine heartbeat/event lanes, view settings, and a slimmer explainer (no duplicate agent list) sit below. The explainer defaults collapsed; duplicate “your pack” agent chips are gone.
> 
> **Pagination / caps:** feed threads page at 20 with show more/fewer; agents sidebar shows 6 then “show all”. Feed drops the inner max-height scroll trap.
> 
> **Ideas** gain `ideaActivity` helpers: “updated … ago” on rows, buckets (active / stale 3+ weeks / resolved), collapsible stale & resolved sections, and fetch-on-load so the header badge works while collapsed.
> 
> Brainmap docs reflect the larger `Fishbowl.tsx` footprint. New unit tests cover `prefs` and `ideaActivity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5975bf0d13c264045ef186f488a22d83bbf39d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->