### PR TITLE
feat: XGate shadow observability + admin dial (off/watch/block)

### DIFF
--- a/api/lib/xgate/preflight.test.ts
+++ b/api/lib/xgate/preflight.test.ts
@@ -25,6 +25,9 @@ describe("classifyEndpoint", () => {
   it("classifies send endpoints", () => {
     expect(classifyEndpoint("email.send", { to: "x" })?.class).toBe("send");
   });
+  it("classifies the email_send direct tool name (not just dot form)", () => {
+    expect(classifyEndpoint("email_send", { to: "x" })?.class).toBe("send");
+  });
   it("returns null for ordinary reads (not gated)", () => {
     expect(classifyEndpoint("weather.current", { city: "x" })).toBeNull();
   });
@@ -79,5 +82,21 @@ describe("runPreflight", () => {
     expect(() =>
       runPreflight("neon.execute_sql", { sql: { not: "a string" } as unknown as string }, { mode: "block" }),
     ).not.toThrow();
+  });
+
+  it("marks classified actions with their action class (so the ledger can log them)", () => {
+    const out = runPreflight(
+      "neon.execute_sql",
+      { sql: "SELECT id FROM users WHERE id = 1" },
+      { mode: "shadow", environment: "prod" },
+    );
+    expect(out.classified).toBe(true);
+    expect(out.actionClass).toBe("sql");
+  });
+
+  it("does not mark benign reads as classified (so they are never logged)", () => {
+    const out = runPreflight("weather.current", { city: "x" }, { enforce: true });
+    expect(out.classified).toBeFalsy();
+    expect(out.actionClass).toBeUndefined();
   });
 });

--- a/api/lib/xgate/preflight.ts
+++ b/api/lib/xgate/preflight.ts
@@ -53,6 +53,10 @@ export interface PreflightOutcome {
   reason?: string;
   /** True when a non-allow verdict was observed but mode let it through. */
   shadowed?: boolean;
+  /** True when the endpoint mapped to a real action class and was evaluated. */
+  classified?: boolean;
+  /** The action class evaluated, when classified (for the ledger). */
+  actionClass?: ActionClass;
 }
 
 /** Resolve the active mode from explicit opts then env. Default off. */
@@ -98,7 +102,7 @@ export function classifyEndpoint(
     return { class: "ship", raw: endpointId };
   }
   // Outbound send endpoints (email, sms, message) -> secret/exfil relevant.
-  if (/(send_email|send_sms|send_message|email\.send|whatsapp|telegram_send|slack)/.test(id)) {
+  if (/(send_email|email_send|send_sms|send_message|email\.send|whatsapp|telegram_send|slack)/.test(id)) {
     return { class: "send", raw: JSON.stringify(params) };
   }
   return null;
@@ -159,12 +163,14 @@ export function runPreflight(
       verdict: "ask",
       reason: "xgate preflight engine error; failing " + (mode === "block" ? "closed" : "open"),
       shadowed: mode !== "block",
+      classified: true,
+      actionClass: classified.class,
     };
   }
 
   const blocking = decision.verdict === "deny" || decision.verdict === "ask";
   if (!blocking) {
-    return { proceed: true, mode, verdict: decision.verdict };
+    return { proceed: true, mode, verdict: decision.verdict, classified: true, actionClass: classified.class };
   }
 
   if (mode === "shadow") {
@@ -176,6 +182,8 @@ export function runPreflight(
       ruleId: decision.deciding.ruleId,
       reason: decision.deciding.reason,
       shadowed: true,
+      classified: true,
+      actionClass: classified.class,
     };
   }
 
@@ -187,5 +195,7 @@ export function runPreflight(
     gate: decision.deciding.gate,
     ruleId: decision.deciding.ruleId,
     reason: decision.deciding.reason,
+    classified: true,
+    actionClass: classified.class,
   };
 }

--- a/api/xgate-check.test.ts
+++ b/api/xgate-check.test.ts
@@ -2,10 +2,28 @@ import type { VercelRequest } from "@vercel/node";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   coerceDecisionOutcome,
+  normalizeMode,
   parseXGateCheckBody,
   resolveXGateAuthority,
   sha256hex,
 } from "./xgate-check.js";
+
+describe("normalizeMode (the 3-state dial)", () => {
+  it("accepts the three valid modes", () => {
+    expect(normalizeMode("off")).toBe("off");
+    expect(normalizeMode("shadow")).toBe("shadow");
+    expect(normalizeMode("block")).toBe("block");
+  });
+  it("falls back to shadow for anything unknown", () => {
+    expect(normalizeMode("")).toBe("shadow");
+    expect(normalizeMode("BLOCK")).toBe("shadow");
+    expect(normalizeMode(undefined)).toBe("shadow");
+    expect(normalizeMode(42)).toBe("shadow");
+  });
+  it("honors an explicit fallback", () => {
+    expect(normalizeMode(undefined, "off")).toBe("off");
+  });
+});
 
 const originalCronSecret = process.env.CRON_SECRET;
 

--- a/api/xgate-check.ts
+++ b/api/xgate-check.ts
@@ -401,6 +401,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const endpointId = typeof body.endpointId === "string" ? body.endpointId : "";
       const params = (body.params && typeof body.params === "object" ? body.params : {}) as Record<string, unknown>;
       const outcome = runPreflight(endpointId, params, { enforce: true });
+
+      // Observability: record evaluated (risk-classified) decisions to the
+      // control ledger so shadow mode is visible. Benign/unclassified calls are
+      // not logged -- they carry no gate-relevant risk. Best-effort: a logging
+      // failure must never block the tool path.
+      if (outcome.classified) {
+        try {
+          const db = createClient(supabaseUrl, serviceRoleKey, {
+            auth: { persistSession: false, autoRefreshToken: false },
+          });
+          const env = (process.env.UNCLICK_XGATE_ENV ?? "prod").toLowerCase();
+          await db.from("mc_xgate_ledger").insert({
+            api_key_hash: authority.apiKeyHash,
+            action_class: outcome.actionClass ?? "scope",
+            tool: endpointId || "unknown",
+            target: typeof params.target === "string" ? params.target : "",
+            environment: ENVIRONMENTS.has(env) ? env : "prod",
+            verdict: outcome.verdict,
+            rule_id: outcome.ruleId ?? "preflight",
+            reason: outcome.reason ?? `preflight ${outcome.verdict} (${outcome.mode})`,
+            authority: authority.authority,
+          });
+        } catch {
+          // swallow: never block the hot path on a ledger write
+        }
+      }
+
       return json(res, 200, outcome);
     } catch (error) {
       // Fail open: a preflight transport error must not block the tool path.

--- a/api/xgate-check.ts
+++ b/api/xgate-check.ts
@@ -25,6 +25,14 @@ const ACTION_CLASSES = new Set([
 const ENVIRONMENTS = new Set(["dev", "staging", "prod"]);
 const AUTONOMY_LEVELS = new Set(["interactive", "unattended"]);
 
+export type XGateMode = "off" | "shadow" | "block";
+const XGATE_SETTINGS_KEY = "global";
+
+/** Clamp any input to a valid 3-state dial value, falling back when unknown. */
+export function normalizeMode(value: unknown, fallback: XGateMode = "shadow"): XGateMode {
+  return value === "off" || value === "shadow" || value === "block" ? value : fallback;
+}
+
 type GateVerdict = "allow" | "deny" | "ask" | "rewrite";
 type LedgerAuthority = "auto" | "human" | "token" | "kill_switch";
 
@@ -369,6 +377,33 @@ async function readKillSwitchState(db: ReturnType<typeof createClient>, apiKeyHa
   };
 }
 
+let modeCache: { mode: XGateMode; at: number } | null = null;
+
+/**
+ * The live dial value (off/shadow/block) from mc_xgate_settings, cached briefly
+ * so the hot path does not read the DB on every call. Falls back to the
+ * UNCLICK_XGATE_MODE env (then shadow) when no row exists, so behaviour is
+ * unchanged until the dial is first used. Never throws.
+ */
+async function readXGateMode(db: ReturnType<typeof createClient>): Promise<XGateMode> {
+  if (modeCache && Date.now() - modeCache.at < 15000) return modeCache.mode;
+  const envFallback = normalizeMode(process.env.UNCLICK_XGATE_MODE, "shadow");
+  let mode: XGateMode = envFallback;
+  try {
+    const { data } = await db
+      .from("mc_xgate_settings")
+      .select("mode")
+      .eq("api_key_hash", XGATE_SETTINGS_KEY)
+      .maybeSingle();
+    const raw = isRecord(data) ? data.mode : undefined;
+    mode = typeof raw === "string" ? normalizeMode(raw, envFallback) : envFallback;
+  } catch {
+    mode = envFallback;
+  }
+  modeCache = { mode, at: Date.now() };
+  return mode;
+}
+
 function setCors(res: VercelResponse) {
   for (const [key, value] of Object.entries(CORS_HEADERS)) res.setHeader(key, value);
 }
@@ -381,7 +416,6 @@ function json(res: VercelResponse, status: number, body: unknown) {
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCors(res);
   if (req.method === "OPTIONS") return res.status(204).end();
-  if (req.method !== "POST") return json(res, 405, { error: "POST required" });
 
   const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -390,17 +424,65 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const authority = await resolveXGateAuthority(req, supabaseUrl, serviceRoleKey);
   if (!authority.ok) return json(res, authority.status, { error: authority.error });
 
+  const action = typeof req.query.action === "string" ? req.query.action : "";
+
+  // Dashboard read (admin session): recent control-ledger rows + the live dial
+  // value. Read-only; the service role is used only to query.
+  if (req.method === "GET") {
+    if (action === "recent") {
+      const db = createClient(supabaseUrl, serviceRoleKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+      const { data: rows } = await db
+        .from("mc_xgate_ledger")
+        .select("id,ts,verdict,rule_id,action_class,environment,tool,reason")
+        .order("ts", { ascending: false })
+        .limit(50);
+      const mode = await readXGateMode(db);
+      return json(res, 200, { decisions: rows ?? [], mode });
+    }
+    return json(res, 400, { error: "Unknown GET action" });
+  }
+
+  if (req.method !== "POST") return json(res, 405, { error: "POST required" });
+
+  // The dial: set the live XGate posture (off / shadow / block). Admin session
+  // only -- the cron token may evaluate but may not change posture.
+  if (action === "set_mode") {
+    if (authority.authority !== "human") {
+      return json(res, 403, { error: "Admin session required to change XGate mode" });
+    }
+    const parsed = parseMaybeJsonBody(req.body);
+    const bodyObj = parsed.ok && isRecord(parsed.value) ? parsed.value : {};
+    const mode = normalizeMode(bodyObj.mode);
+    const db = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { error } = await db
+      .from("mc_xgate_settings")
+      .upsert(
+        { api_key_hash: XGATE_SETTINGS_KEY, mode, updated_at: new Date().toISOString() },
+        { onConflict: "api_key_hash" },
+      );
+    if (error) return json(res, 503, { error: "Could not save XGate mode", detail: error.message });
+    modeCache = { mode, at: Date.now() };
+    return json(res, 200, { mode });
+  }
+
   // Preflight mode: the MCP tool hot path posts { endpointId, params } and gets
-  // a simple proceed/block decision via the pure preflight helper. Off-by-
-  // default and shadow/block behaviour are decided inside runPreflight from the
-  // UNCLICK_XGATE_* env, so this path is safe to expose.
+  // a simple proceed/block decision. The active mode (off/shadow/block) now
+  // comes from the live dial (mc_xgate_settings), falling back to env.
   if (req.query.mode === "preflight") {
     try {
       const { runPreflight } = await import(/* @vite-ignore */ "./lib/xgate/preflight.js");
       const body = (req.body ?? {}) as { endpointId?: unknown; params?: unknown };
       const endpointId = typeof body.endpointId === "string" ? body.endpointId : "";
       const params = (body.params && typeof body.params === "object" ? body.params : {}) as Record<string, unknown>;
-      const outcome = runPreflight(endpointId, params, { enforce: true });
+      const db = createClient(supabaseUrl, serviceRoleKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+      const mode = await readXGateMode(db);
+      const outcome = runPreflight(endpointId, params, { mode });
 
       // Observability: record evaluated (risk-classified) decisions to the
       // control ledger so shadow mode is visible. Benign/unclassified calls are
@@ -408,9 +490,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // failure must never block the tool path.
       if (outcome.classified) {
         try {
-          const db = createClient(supabaseUrl, serviceRoleKey, {
-            auth: { persistSession: false, autoRefreshToken: false },
-          });
           const env = (process.env.UNCLICK_XGATE_ENV ?? "prod").toLowerCase();
           await db.from("mc_xgate_ledger").insert({
             api_key_hash: authority.apiKeyHash,

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8538,8 +8538,8 @@
     },
     {
       "source": "src/pages/admin/AdminXGate.tsx",
-      "hash": "d9be13cafb44",
-      "bytes": 12478
+      "hash": "e5c445d83634",
+      "bytes": 14917
     },
     {
       "source": "src/pages/admin/AdminYou.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -90,7 +90,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/testpass/TestPassCatalog.tsx | 8fc76ddd8d3f | 21847 |
 | src/pages/admin/AdminTruthRate.tsx | 115c5cce9b90 | 8868 |
 | src/pages/admin/AdminUsers.tsx | 701e7da2f201 | 863 |
-| src/pages/admin/AdminXGate.tsx | d9be13cafb44 | 12478 |
+| src/pages/admin/AdminXGate.tsx | e5c445d83634 | 14917 |
 | src/pages/admin/AdminYou.tsx | 3d0240411971 | 51024 |
 | src/pages/AppDetail.tsx | 0cf7c397e1b5 | 5401 |
 | src/pages/Apps.tsx | 1ccab2a4ccad | 2647 |

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1943,6 +1943,34 @@ export function createServer(): Server {
     trackToolCall(name);
 
     try {
+      // ── XGate preflight (defense in depth): EVERY UnClick tool call is
+      // evaluated before it runs, not just unclick_call. Off by default; only
+      // when UNCLICK_XGATE_ENFORCE=1. A cheap name-based prefilter in
+      // xgatePreflight skips the network hop for ordinary benign reads, so tool
+      // latency is unaffected. Shadow mode (default when enabled) records a
+      // verdict to the ledger but never blocks; only "block" mode stops the
+      // call. Never throws (fails open). The gate logic is single-sourced in the
+      // API (api/lib/xgate); this hook calls it over HTTP.
+      {
+        const gateEndpointId =
+          name === "unclick_call" ? String(args.endpoint_id ?? "") : name;
+        const gateParams = (
+          name === "unclick_call" ? (args.params ?? {}) : args
+        ) as Record<string, unknown>;
+        const xgate = await xgatePreflight(gateEndpointId, gateParams);
+        if (xgate && !xgate.proceed) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `XGate blocked this action (${xgate.gate ?? "xgate"}: ${xgate.ruleId ?? "rule"}). ${xgate.reason ?? ""}`.trim(),
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
       // ── Heartbeat protocol: static, read-only AI Seat tether contract ──
       if (name === "heartbeat_protocol") {
         return {
@@ -2393,26 +2421,6 @@ export function createServer(): Server {
       if (name === "unclick_call") {
         const endpointId = String(args.endpoint_id ?? "");
         const params = (args.params ?? {}) as Record<string, unknown>;
-
-        // XGate preflight: pre-execution guardrails. Off by default; only
-        // evaluates when UNCLICK_XGATE_ENFORCE=1, and only blocks in "block"
-        // mode. Shadow mode (default when enabled) reports without blocking.
-        // The gate logic is single-sourced in the API (api/lib/xgate); this
-        // hot-path hook calls it over HTTP, matching how the package already
-        // reaches the API. Never throws; on any error it proceeds (fail open
-        // in shadow, the operator opts into block explicitly).
-        const xgate = await xgatePreflight(endpointId, params);
-        if (xgate && !xgate.proceed) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `XGate blocked this action (${xgate.gate ?? "xgate"}: ${xgate.ruleId ?? "rule"}). ${xgate.reason ?? ""}`.trim(),
-              },
-            ],
-            isError: true,
-          };
-        }
 
         // Memory endpoints: "memory.add_fact", "memory.store_code", etc.
         if (endpointId.startsWith("memory.")) {

--- a/packages/mcp-server/src/xgate-preflight.test.ts
+++ b/packages/mcp-server/src/xgate-preflight.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mightBeGated, isXGateEnforceEnabled, xgatePreflight } from "./xgate-preflight.js";
+
+describe("mightBeGated (cheap name-based prefilter)", () => {
+  it("skips ordinary benign tools so they never pay the network hop", () => {
+    expect(mightBeGated("datetime_current_time")).toBe(false);
+    expect(mightBeGated("weather_current")).toBe(false);
+    expect(mightBeGated("crypto_price")).toBe(false);
+    expect(mightBeGated("load_memory")).toBe(false);
+  });
+
+  it("flags risk-relevant tools so the API makes the authoritative call", () => {
+    expect(mightBeGated("email_send")).toBe(true);
+    expect(mightBeGated("neon_execute_sql")).toBe(true);
+    expect(mightBeGated("github_action")).toBe(true);
+    expect(mightBeGated("telegram_send")).toBe(true);
+    expect(mightBeGated("deploy_to_vercel")).toBe(true);
+    expect(mightBeGated("slack_action")).toBe(true);
+  });
+});
+
+describe("xgatePreflight gating", () => {
+  const original = process.env.UNCLICK_XGATE_ENFORCE;
+  afterEach(() => {
+    if (original === undefined) delete process.env.UNCLICK_XGATE_ENFORCE;
+    else process.env.UNCLICK_XGATE_ENFORCE = original;
+  });
+
+  it("returns null (proceed) when enforcement is off", async () => {
+    delete process.env.UNCLICK_XGATE_ENFORCE;
+    expect(isXGateEnforceEnabled()).toBe(false);
+    expect(await xgatePreflight("email_send", {})).toBeNull();
+  });
+
+  it("short-circuits benign tools without a network call even when enforcing", async () => {
+    process.env.UNCLICK_XGATE_ENFORCE = "1";
+    // The benign prefilter returns null before any fetch is attempted.
+    expect(await xgatePreflight("datetime_current_time", {})).toBeNull();
+  });
+});

--- a/packages/mcp-server/src/xgate-preflight.ts
+++ b/packages/mcp-server/src/xgate-preflight.ts
@@ -29,6 +29,20 @@ export function isXGateEnforceEnabled(): boolean {
   return process.env.UNCLICK_XGATE_ENFORCE === "1";
 }
 
+// Cheap, name-based prefilter so the common benign tools (datetime, weather,
+// search reads, memory) skip the network hop entirely. This is a SUPERSET of the
+// API's classifyEndpoint risk patterns: a false positive only costs one extra
+// preflight call (the API then returns allow), while a false negative would
+// silently skip the gate, so this errs toward true. The authoritative
+// classification stays single-sourced in the API; this only decides whether to
+// ask it at all.
+const GATE_HINT =
+  /(sql|query|exec|shell|command|bash|github|gitlab|push|merge|reset|force|deploy|publish|release|rollback|send|email|sms|message|whatsapp|telegram|slack)/i;
+
+export function mightBeGated(endpointId: string): boolean {
+  return GATE_HINT.test(endpointId);
+}
+
 /**
  * Ask the API to evaluate an endpoint call against the gates. Returns null when
  * disabled or on any failure (caller should proceed). Only a definitive block
@@ -39,6 +53,7 @@ export async function xgatePreflight(
   params: Record<string, unknown>,
 ): Promise<XGatePreflightOutcome | null> {
   if (!isXGateEnforceEnabled()) return null;
+  if (!mightBeGated(endpointId)) return null; // benign tool; skip the network hop
 
   const secret = process.env.CRON_SECRET;
   if (!secret) return null; // cannot authorize; do not block real work

--- a/src/pages/admin/AdminXGate.tsx
+++ b/src/pages/admin/AdminXGate.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { AlertTriangle, CircleDot, Loader2, Lock, RefreshCw, ShieldCheck, ShieldHalf } from "lucide-react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { CircleDot, Loader2, Lock, RefreshCw, ShieldHalf } from "lucide-react";
 import { useSession } from "@/lib/auth";
 
 type XGateVerdict = "allow" | "deny" | "ask" | "rewrite";
+type XGateMode = "off" | "shadow" | "block";
 
 interface XGateDecision {
   id: string;
@@ -17,18 +18,31 @@ interface XGateDecision {
   reason: string;
 }
 
-interface KillSwitchState {
-  active: boolean;
-  reason: string | null;
-  updatedAt: string | null;
-}
-
 const VERDICT_STYLE: Record<XGateVerdict, { label: string; className: string }> = {
   allow: { label: "Allow", className: "bg-emerald-400 text-black" },
   ask: { label: "Ask", className: "bg-[#E2B93B] text-black" },
   deny: { label: "Deny", className: "bg-red-500 text-white" },
   rewrite: { label: "Rewrite", className: "bg-[#61C1C4] text-black" },
 };
+
+// The 3-state dial. One control: Off (dormant) -> Watch (logs, never blocks)
+// -> Block (actually stops flagged actions).
+const MODES: { value: XGateMode; label: string; blurb: string }[] = [
+  { value: "off", label: "Off", blurb: "Dormant. No checks, no warnings, no notes. Agents behave as if XGate isn't here." },
+  { value: "shadow", label: "Watch", blurb: "Watches everything and writes notes, but never blocks. Pure awareness." },
+  { value: "block", label: "Block", blurb: "Actually stops flagged actions. Real teeth." },
+];
+
+// Each gate, in plain english. The sidebar sub-links anchor to these sections.
+const GATES: { id: string; name: string; what: string }[] = [
+  { id: "commandgate", name: "CommandGate", what: "Watches terminal commands. Stops the scary, can't-undo ones (like deleting everything or wiping a disk) before they run." },
+  { id: "gitgate", name: "GitGate", what: "Watches Git. Stops moves that erase work, like force-pushing, deleting a branch, or rewriting history." },
+  { id: "datagate", name: "DataGate", what: "Watches database commands. It reads the SQL and stops the ones that wipe or delete data, like dropping a table or a DELETE with no filter." },
+  { id: "secretgate", name: "SecretGate", what: "Watches for passwords, API keys, and tokens. Stops them from being saved into code or sent out, where a leak is forever." },
+  { id: "shipgate", name: "ShipGate", what: "Watches deploys and releases. Makes sure pushing to live (or changing servers and DNS) isn't done carelessly or without proof." },
+  { id: "scopegate", name: "ScopeGate", what: "Watches which files get touched. Keeps the agent in its own lane, so it doesn't edit things it doesn't own." },
+  { id: "spendgate", name: "SpendGate", what: "Watches spending. Pauses anything that would cost more than your set limit before real money goes out." },
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -40,25 +54,19 @@ function readString(value: unknown): string {
   return "";
 }
 
-function readBool(value: unknown): boolean | null {
-  if (typeof value === "boolean") return value;
-  return null;
-}
-
 function normalizeVerdict(value: unknown): XGateVerdict {
   if (value === "deny" || value === "ask" || value === "rewrite" || value === "allow") return value;
   return "ask";
 }
 
+function normalizeMode(value: unknown): XGateMode {
+  return value === "off" || value === "shadow" || value === "block" ? value : "shadow";
+}
+
 function formatDate(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value || "Unknown";
-  return date.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
 }
 
 function pickRows(body: Record<string, unknown>): unknown[] {
@@ -89,21 +97,6 @@ function normalizeDecision(row: unknown, index: number): XGateDecision {
   };
 }
 
-function normalizeKillSwitch(body: Record<string, unknown>): KillSwitchState | null {
-  const source = isRecord(body.killSwitch)
-    ? body.killSwitch
-    : isRecord(body.kill_switch)
-      ? body.kill_switch
-      : null;
-  if (!source) return null;
-  const active = readBool(source.active);
-  return {
-    active: active ?? false,
-    reason: readString(source.reason) || null,
-    updatedAt: readString(source.updated_at) || readString(source.updatedAt) || null,
-  };
-}
-
 function VerdictPill({ verdict }: { verdict: XGateVerdict }) {
   const style = VERDICT_STYLE[verdict];
   return (
@@ -113,45 +106,52 @@ function VerdictPill({ verdict }: { verdict: XGateVerdict }) {
   );
 }
 
-function StatCard({ label, value, detail }: { label: string; value: string; detail: string }) {
+function ModeDial({
+  mode,
+  saving,
+  onChange,
+}: {
+  mode: XGateMode;
+  saving: boolean;
+  onChange: (next: XGateMode) => void;
+}) {
+  const active = MODES.find((m) => m.value === mode) ?? MODES[1];
   return (
-    <div className="rounded-xl border border-white/[0.06] bg-[#111] p-4">
-      <p className="text-[11px] font-medium uppercase tracking-wide text-white/40">{label}</p>
-      <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
-      <p className="mt-1 text-xs leading-5 text-white/45">{detail}</p>
-    </div>
-  );
-}
-
-function KillSwitchPanel({ state }: { state: KillSwitchState | null }) {
-  const active = state?.active ?? false;
-
-  return (
-    <section className="rounded-xl border border-white/[0.06] bg-[#111] p-4">
-      <div className="flex items-start gap-3">
-        <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${active ? "bg-red-500/15 text-red-300" : "bg-emerald-400/10 text-emerald-300"}`}>
-          {active ? <AlertTriangle className="h-4 w-4" /> : <ShieldCheck className="h-4 w-4" />}
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <h2 className="text-sm font-semibold text-white">Kill switch</h2>
-            <span className={`rounded px-2 py-0.5 text-[10px] font-bold ${active ? "bg-red-500 text-white" : "bg-emerald-400 text-black"}`}>
-              {active ? "Active" : "Inactive"}
-            </span>
-            {!state && (
-              <span className="rounded bg-white/[0.06] px-2 py-0.5 text-[10px] font-medium text-white/45">
-                Waiting for endpoint
-              </span>
-            )}
-          </div>
-          <p className="mt-2 text-xs leading-5 text-white/55">
-            {state?.reason || "No stop reason is recorded."}
-          </p>
-          <p className="mt-2 text-[11px] text-white/35">
-            Last update: {state?.updatedAt ? formatDate(state.updatedAt) : "Not reported"}
-          </p>
+    <section className="rounded-xl border border-white/[0.06] bg-[#111] p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-white">Mode</h2>
+          <p className="mt-1 text-xs text-white/50">One switch for your whole account. Choose how strict XGate is.</p>
+        </div>
+        <div className="inline-flex rounded-lg border border-white/[0.08] bg-black/30 p-1">
+          {MODES.map((m) => {
+            const selected = m.value === mode;
+            return (
+              <button
+                key={m.value}
+                type="button"
+                disabled={saving}
+                onClick={() => onChange(m.value)}
+                className={`relative min-w-[78px] rounded-md px-3 py-1.5 text-xs font-semibold transition-colors disabled:opacity-60 ${
+                  selected
+                    ? m.value === "block"
+                      ? "bg-red-500 text-white"
+                      : m.value === "off"
+                        ? "bg-white/80 text-black"
+                        : "bg-[#61C1C4] text-black"
+                    : "text-white/55 hover:text-white"
+                }`}
+              >
+                {m.label}
+              </button>
+            );
+          })}
         </div>
       </div>
+      <p className="mt-3 flex items-center gap-2 text-xs leading-5 text-white/55">
+        {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+        {active.blurb}
+      </p>
     </section>
   );
 }
@@ -192,12 +192,14 @@ function DecisionTable({ decisions }: { decisions: XGateDecision[] }) {
 export default function AdminXGate() {
   const { session } = useSession();
   const navigate = useNavigate();
+  const location = useLocation();
   const [adminVerified, setAdminVerified] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
   const [endpointReady, setEndpointReady] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [decisions, setDecisions] = useState<XGateDecision[]>([]);
-  const [killSwitch, setKillSwitch] = useState<KillSwitchState | null>(null);
+  const [mode, setMode] = useState<XGateMode>("shadow");
+  const [savingMode, setSavingMode] = useState(false);
 
   const load = useCallback(async () => {
     if (!session) return;
@@ -216,7 +218,6 @@ export default function AdminXGate() {
       if (response.status === 404 || response.status === 405) {
         setEndpointReady(false);
         setDecisions([]);
-        setKillSwitch(null);
         return;
       }
       const body = await response.json();
@@ -224,7 +225,7 @@ export default function AdminXGate() {
       const record = isRecord(body) ? body : {};
       setEndpointReady(true);
       setDecisions(pickRows(record).map(normalizeDecision));
-      setKillSwitch(normalizeKillSwitch(record));
+      setMode(normalizeMode(record.mode));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
@@ -235,6 +236,37 @@ export default function AdminXGate() {
   useEffect(() => {
     load();
   }, [load]);
+
+  // Scroll to the gate section named in the URL hash (the sidebar sub-links).
+  useEffect(() => {
+    if (loading || !location.hash) return;
+    const el = document.getElementById(location.hash.slice(1));
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [loading, location.hash]);
+
+  const changeMode = useCallback(
+    async (next: XGateMode) => {
+      if (!session || next === mode || savingMode) return;
+      if (next === "block" && !window.confirm("Switch XGate to Block? This will actually stop flagged agent actions.")) return;
+      setSavingMode(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/xgate-check?action=set_mode", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${session.access_token}`, "Content-Type": "application/json" },
+          body: JSON.stringify({ mode: next }),
+        });
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.error ?? "Could not change mode");
+        setMode(normalizeMode(body.mode));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Could not change mode");
+      } finally {
+        setSavingMode(false);
+      }
+    },
+    [session, mode, savingMode],
+  );
 
   if (adminVerified === false) {
     return (
@@ -254,9 +286,6 @@ export default function AdminXGate() {
     );
   }
 
-  const strictCount = decisions.filter((decision) => decision.verdict === "deny" || decision.verdict === "ask").length;
-  const latest = decisions[0];
-
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4">
@@ -266,7 +295,7 @@ export default function AdminXGate() {
             <h1 className="text-2xl font-semibold text-white">XGate</h1>
           </div>
           <p className="mt-1 max-w-2xl text-sm leading-6 text-white/55">
-            Pre-action guardrail decisions for UnClick tool calls and delegated client hooks.
+            The guardrail that decides what an agent is allowed to do, before it does it. Each gate below watches one kind of risky action.
           </p>
         </div>
         <button
@@ -278,35 +307,46 @@ export default function AdminXGate() {
         </button>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-3">
-        <StatCard label="Decisions" value={String(decisions.length)} detail={endpointReady ? "Recent control ledger rows." : "Endpoint is waiting for Part 9."} />
-        <StatCard label="Strict results" value={String(strictCount)} detail="Deny and ask verdicts that slowed an action." />
-        <StatCard label="Latest" value={latest ? VERDICT_STYLE[latest.verdict].label : "None"} detail={latest ? `${latest.ruleId} in ${latest.environment}` : "No recent decision reported."} />
-      </div>
-
-      <KillSwitchPanel state={killSwitch} />
+      <ModeDial mode={mode} saving={savingMode} onChange={changeMode} />
 
       {error && (
-        <div className="rounded-xl border border-red-400/20 bg-red-400/5 p-4 text-xs text-red-300">
-          {error}
-        </div>
+        <div className="rounded-xl border border-red-400/20 bg-red-400/5 p-4 text-xs text-red-300">{error}</div>
       )}
 
       {!endpointReady && (
         <div className="rounded-xl border border-[#E2B93B]/20 bg-[#E2B93B]/[0.05] p-4 text-xs leading-5 text-[#E2B93B]">
-          XGate history is waiting for the Part 9 endpoint. The dashboard route and read-only surface are ready.
+          XGate history endpoint is not responding yet. The dial and gate guide below still work.
         </div>
       )}
 
-      {decisions.length > 0 ? (
-        <DecisionTable decisions={decisions} />
-      ) : (
-        <div className="rounded-xl border border-white/[0.06] bg-[#111] p-8 text-center">
-          <CircleDot className="mx-auto h-6 w-6 text-white/25" />
-          <p className="mt-3 text-sm text-white/60">No XGate decisions recorded yet.</p>
-          <p className="mt-1 text-xs text-white/35">The ledger will fill once `/api/xgate-check?action=recent` returns rows.</p>
+      <div>
+        <h2 className="mb-3 text-sm font-semibold text-white">Recent decisions</h2>
+        {decisions.length > 0 ? (
+          <DecisionTable decisions={decisions} />
+        ) : (
+          <div className="rounded-xl border border-white/[0.06] bg-[#111] p-8 text-center">
+            <CircleDot className="mx-auto h-6 w-6 text-white/25" />
+            <p className="mt-3 text-sm text-white/60">No XGate decisions recorded yet.</p>
+            <p className="mt-1 text-xs text-white/35">In Watch or Block mode, flagged actions show up here.</p>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <h2 className="mb-3 text-sm font-semibold text-white">The gates</h2>
+        <div className="space-y-3">
+          {GATES.map((gate) => (
+            <section
+              key={gate.id}
+              id={gate.id}
+              className="scroll-mt-24 rounded-xl border border-white/[0.06] bg-[#111] p-4"
+            >
+              <h3 className="text-sm font-semibold text-white">{gate.name}</h3>
+              <p className="mt-1 text-xs leading-6 text-white/60">{gate.what}</p>
+            </section>
+          ))}
         </div>
-      )}
+      </div>
 
       <div className="flex flex-wrap gap-3 text-[11px] text-white/40">
         <Link to="/admin/checks" className="hover:text-[#61C1C4]">XPass checks</Link>

--- a/supabase/migrations/20260603100000_xgate_settings.sql
+++ b/supabase/migrations/20260603100000_xgate_settings.sql
@@ -1,0 +1,33 @@
+-- XGate mode setting: the live 3-state dial (off / shadow / block).
+-- One shared row keyed 'global' (this deployment shares one XGate posture,
+-- mirroring the routing scorecard's 'global' scope). The admin dashboard writes
+-- it; the preflight hot path reads it (with a short cache) so the dial controls
+-- behaviour live, replacing the UNCLICK_XGATE_MODE env + redeploy. When no row
+-- exists the hot path falls back to the env default (shadow), so this is safe
+-- to apply before the UI ships.
+
+CREATE TABLE IF NOT EXISTS mc_xgate_settings (
+  api_key_hash text PRIMARY KEY,
+  mode text NOT NULL DEFAULT 'shadow' CHECK (mode IN ('off', 'shadow', 'block')),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE mc_xgate_settings ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE mc_xgate_settings FROM anon, authenticated;
+GRANT ALL ON TABLE mc_xgate_settings TO service_role;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'mc_xgate_settings'
+      AND policyname = 'mc_xgate_settings_service_role_all'
+  ) THEN
+    CREATE POLICY "mc_xgate_settings_service_role_all"
+      ON mc_xgate_settings FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Makes XGate observable and controllable, end to end.

## 1. Gate every tool call + log shadow verdicts
- `server.ts`: the XGate preflight now runs on **every** UnClick tool call, not just `unclick_call`. For direct tools the tool name is the endpoint id.
- `xgate-preflight.ts`: a cheap name-based prefilter (`mightBeGated`) so benign reads (datetime, weather, memory) skip the network hop; only possibly-risky tools call the API.
- `preflight.ts`: marks classified outcomes (`classified` + `actionClass`) and catches the `email_send` direct tool name.
- `xgate-check.ts`: logs classified decisions to `mc_xgate_ledger` (best-effort, never blocks).

## 2. Admin dial + finished gate landing page
- **3-state dial (Off / Watch / Block)** stored live in a new `mc_xgate_settings` row (`global`). The preflight hot path reads it (cached ~15s, env fallback), so the dial controls posture **without a redeploy**. Block asks for confirmation; admin session required to change.
- `GET /api/xgate-check?action=recent` returns recent ledger rows + the current mode, so the decisions table actually fills (was "waiting for Part 9").
- Each of the 7 gates gets a **plain-english explainer section** with an id anchor; the sidebar sub-links scroll to them.
- Kill switch dropped from the UI in favour of the dial.
- New migration `mc_xgate_settings` (additive, idempotent, service-role only).

## Safety
- **Off by default.** No behavior change unless `UNCLICK_XGATE_ENFORCE=1`.
- When the settings row is absent, the hot path falls back to the env default (**shadow**) — unchanged until the dial is first used.
- Fail-open everywhere; logging/transport errors never break a tool call.

## Note
The `mc_xgate_settings` migration must be applied to prod for the dial to persist (reads fall back to env until then).

## Tests
- `xgate-preflight.test.ts` (prefilter), `preflight.test.ts` (classified flag, `email_send`), `xgate-check.test.ts` (`normalizeMode`). MCP package + API suites green.

https://claude.ai/code/session_01MHugYais5RyFLm9FX54kov

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-action enforcement and logging on the MCP hot path when enforcement is enabled; misconfiguration or dial/cache issues could affect blocking vs. observability, though defaults and fail-open paths limit blast radius.
> 
> **Overview**
> **XGate** now runs on **every** MCP tool call (not only `unclick_call`), with a client-side `mightBeGated` name filter so benign tools skip the preflight HTTP call. Preflight outcomes expose **`classified`** / **`actionClass`** (and `email_send` is classified as send); the API preflight path loads **off / shadow / block** from **`mc_xgate_settings`** (short cache, env fallback) and **best-effort** writes classified decisions to **`mc_xgate_ledger`**.
> 
> Admins get a **live mode dial** (Off / Watch / Block) via `GET ?action=recent` and `POST ?action=set_mode` (human session only), backed by a new **`mc_xgate_settings`** migration. **AdminXGate** drops the kill-switch UI in favor of the dial, gate explainers with hash anchors, and a decisions table fed by the new GET endpoint.
> 
> Behavior stays **off unless `UNCLICK_XGATE_ENFORCE=1`**; transport and ledger failures remain **fail-open** on the tool path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eb0bcd7040485afbc4ec3ea904db40f9f2e7f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->