### PR TITLE
test(worker14): consolidate TestPass regression pack

### DIFF
--- a/api/boardroom-read-bounds.test.ts
+++ b/api/boardroom-read-bounds.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type BoardroomReadBounds,
+  compactBoardroomReadForStrictClients,
+} from "./lib/boardroom-read-bounds";
+
+const message = (
+  id: string,
+  overrides: Partial<{ text: string; created_at: string; tags: string[]; recipients: string[] }> = {},
+) => ({
+  id,
+  author_agent_id: `seat-${id}`,
+  author_emoji: "🤖",
+  author_name: null,
+  recipients: overrides.recipients ?? ["all"],
+  tags: overrides.tags ?? [],
+  thread_id: null,
+  created_at: overrides.created_at ?? `2026-06-02T00:00:${id.padStart(2, "0")}.000Z`,
+  text: overrides.text ?? `body-${id}`,
+  // Field strict clients should not need; bounder must not pass it through.
+  user_agent_hint: "unclick-mcp-server/very-long-client-string",
+});
+
+const agent = (id: string, lastSeen: string) => ({
+  agent_id: id,
+  emoji: "🛰️",
+  display_name: `Agent ${id}`,
+  user_agent_hint: "codex-desktop/gpt-5",
+  created_at: "2026-05-01T00:00:00.000Z",
+  last_seen_at: lastSeen,
+  current_status: null,
+  current_status_updated_at: null,
+  next_checkin_at: null,
+});
+
+const bounds = (result: unknown): BoardroomReadBounds =>
+  (result as { _bounds: BoardroomReadBounds })._bounds;
+
+describe("Boardroom strict-client read bounds", () => {
+  it("caps the feed to the most recent messages in ascending time order", () => {
+    const raw = {
+      messages: Array.from({ length: 50 }, (_, i) =>
+        message(String(i + 1), { created_at: `2026-06-02T00:${String(i).padStart(2, "0")}:00.000Z` }),
+      ),
+      mentions: [],
+    };
+
+    const result = compactBoardroomReadForStrictClients(raw, { maxMessages: 5 }) as {
+      messages: Array<{ id: string }>;
+    };
+
+    expect(result.messages.map((m) => m.id)).toEqual(["46", "47", "48", "49", "50"]);
+    expect(bounds(result)).toMatchObject({
+      compact: true,
+      messages_returned: 5,
+      messages_available: 50,
+    });
+  });
+
+  it("truncates long message bodies and flags it", () => {
+    const raw = {
+      messages: [message("1", { text: "x".repeat(5000) })],
+      mentions: [],
+    };
+
+    const result = compactBoardroomReadForStrictClients(raw, { maxTextChars: 100 }) as {
+      messages: Array<{ text: string }>;
+    };
+
+    expect(result.messages[0].text.length).toBe(100);
+    expect(result.messages[0].text.endsWith("...")).toBe(true);
+    expect(bounds(result).text_truncated).toBe(true);
+  });
+
+  it("preserves the mentions lane even when the feed is heavily trimmed", () => {
+    // The strict-client failure mode is dropping a message addressed to the
+    // caller because the feed overflowed. Mentions must survive that.
+    const raw = {
+      messages: Array.from({ length: 200 }, (_, i) => message(`feed-${i}`)),
+      mentions: [
+        message("mention-1", { text: "ACK needed from you", recipients: ["🧪"] }),
+        message("mention-2", { text: "blocker for worker 14", recipients: ["🧪"] }),
+      ],
+    };
+
+    const result = compactBoardroomReadForStrictClients(raw, { maxMessages: 10 }) as {
+      mentions: Array<{ id: string }>;
+    };
+
+    expect(result.mentions.map((m) => m.id)).toEqual(["mention-1", "mention-2"]);
+    expect(bounds(result)).toMatchObject({ mentions_returned: 2, mentions_available: 2 });
+  });
+
+  it("shapes the agent roster to essential fields and caps it by last_seen", () => {
+    const raw = {
+      messages: [],
+      mentions: [],
+      agents: [
+        agent("old", "2026-05-01T00:00:00.000Z"),
+        agent("newest", "2026-06-02T00:00:00.000Z"),
+        agent("mid", "2026-05-20T00:00:00.000Z"),
+      ],
+    };
+
+    const result = compactBoardroomReadForStrictClients(raw, { maxAgents: 2 }) as {
+      agents: Array<Record<string, unknown>>;
+    };
+
+    expect(result.agents.map((a) => a.agent_id)).toEqual(["newest", "mid"]);
+    // Verbose transport fields must be dropped.
+    expect(result.agents[0]).not.toHaveProperty("user_agent_hint");
+    expect(result.agents[0]).toMatchObject({ agent_id: "newest", display_name: "Agent newest" });
+    expect(bounds(result)).toMatchObject({ agents_returned: 2, agents_available: 3 });
+  });
+
+  it("drops the verbose transport field from shaped messages", () => {
+    const result = compactBoardroomReadForStrictClients({
+      messages: [message("1")],
+      mentions: [],
+    }) as { messages: Array<Record<string, unknown>> };
+
+    expect(result.messages[0]).not.toHaveProperty("user_agent_hint");
+    expect(result.messages[0]).toMatchObject({ id: "1", author_agent_id: "seat-1" });
+  });
+
+  it("shrinks a large room well under the strict-client ceiling", () => {
+    // Mirror the live failure: a busy room serialized to ~100KB and overflowed.
+    const raw = {
+      messages: Array.from({ length: 300 }, (_, i) => message(`m-${i}`, { text: "y".repeat(2000) })),
+      mentions: [],
+      agents: Array.from({ length: 80 }, (_, i) => agent(`a-${i}`, "2026-06-01T00:00:00.000Z")),
+    };
+
+    const rawSize = JSON.stringify(raw).length;
+    const result = compactBoardroomReadForStrictClients(raw);
+    const boundedSize = JSON.stringify(result).length;
+
+    expect(rawSize).toBeGreaterThan(100_000);
+    expect(boundedSize).toBeLessThan(25_000);
+  });
+
+  it("reports a next_steps paging hint only when the feed was trimmed", () => {
+    const trimmed = compactBoardroomReadForStrictClients({
+      messages: Array.from({ length: 30 }, (_, i) => message(`m-${i}`)),
+      mentions: [],
+    });
+    expect(bounds(trimmed).next_steps).toMatch(/Re-read with `since`/);
+
+    const whole = compactBoardroomReadForStrictClients({
+      messages: [message("1")],
+      mentions: [],
+    });
+    expect(bounds(whole).next_steps).toMatch(/within strict-client bounds/);
+  });
+
+  it("passes non-object payloads through untouched", () => {
+    expect(compactBoardroomReadForStrictClients(null)).toBeNull();
+    expect(compactBoardroomReadForStrictClients("not json")).toBe("not json");
+    expect(compactBoardroomReadForStrictClients([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("tolerates a missing mentions/agents lane without inventing one", () => {
+    const result = compactBoardroomReadForStrictClients({ messages: [message("1")] }) as Record<
+      string,
+      unknown
+    >;
+    expect(result).toHaveProperty("mentions");
+    expect(result.mentions).toEqual(expect.any(Array));
+    // agents was absent in the input, so it must stay absent.
+    expect(result).not.toHaveProperty("agents");
+  });
+});

--- a/api/lib/boardroom-read-bounds.ts
+++ b/api/lib/boardroom-read-bounds.ts
@@ -1,0 +1,193 @@
+// Strict-client response bounds for Boardroom read surfaces.
+//
+// The Boardroom read surface returns three lanes: the full `messages` feed,
+// the `mentions` lane (messages addressed to the calling agent), and an
+// `agents` roster. A busy room returns tens of
+// thousands of characters, which overflows the response limit on strict MCP
+// clients and gets dropped or spilled to a file. The memory surfaces already
+// have an equivalent bounder (compactStartupContextForStrictClients /
+// compactSearchMemoryForStrictClients); this is the Boardroom analogue.
+//
+// The function is pure and side-effect free so it can be unit-tested without a
+// network or database, and wired into the read path behind the same compact/
+// lite flag the memory tools already use.
+
+export interface BoardroomReadBoundsOptions {
+  /** Max feed messages to keep (most recent win). Default 20. */
+  maxMessages?: number;
+  /** Max characters of each message body before truncation. Default 600. */
+  maxTextChars?: number;
+  /** Max roster agents to keep (most recently seen win). Default 12. */
+  maxAgents?: number;
+  /** Max mentions to keep. Mentions are preserved ahead of feed. Default 20. */
+  maxMentions?: number;
+}
+
+export interface BoardroomReadBounds {
+  compact: true;
+  messages_returned: number;
+  messages_available: number;
+  mentions_returned: number;
+  mentions_available: number;
+  agents_returned: number;
+  agents_available: number;
+  text_truncated: boolean;
+  next_steps: string;
+}
+
+const DEFAULTS: Required<BoardroomReadBoundsOptions> = {
+  maxMessages: 20,
+  maxTextChars: 600,
+  maxAgents: 12,
+  maxMentions: 20,
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+/** Truncate a string body, flipping `truncated` to true when it had to cut. */
+function capText(value: unknown, max: number, state: { truncated: boolean }): unknown {
+  if (typeof value !== "string") return value;
+  if (value.length <= max) return value;
+  state.truncated = true;
+  return `${value.slice(0, Math.max(0, max - 3))}...`;
+}
+
+function createdAtMs(row: unknown): number {
+  const r = asRecord(row);
+  const raw = r?.created_at;
+  const ms = typeof raw === "string" || typeof raw === "number" ? Date.parse(String(raw)) : NaN;
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+/**
+ * Keep the `n` most recent rows by created_at, returned in ascending time
+ * order (oldest -> newest) so the feed still reads top-to-bottom. Rows without
+ * a parseable created_at sort as oldest, preserving their relative order.
+ */
+function pickRecent<T>(rows: T[], n: number): T[] {
+  if (rows.length <= n) return rows.slice();
+  const indexed = rows.map((row, index) => ({ row, index, ts: createdAtMs(row) }));
+  indexed.sort((a, b) => (b.ts - a.ts) || (b.index - a.index));
+  const kept = indexed.slice(0, n);
+  kept.sort((a, b) => (a.ts - b.ts) || (a.index - b.index));
+  return kept.map((entry) => entry.row);
+}
+
+/** Shape a single message to a known, bounded field set with a truncated body. */
+function shapeMessage(row: unknown, max: number, state: { truncated: boolean }): unknown {
+  const r = asRecord(row);
+  if (!r) return row;
+  return {
+    id: r.id,
+    author_agent_id: r.author_agent_id,
+    author_emoji: r.author_emoji,
+    author_name: r.author_name,
+    recipients: r.recipients,
+    tags: r.tags,
+    thread_id: r.thread_id,
+    created_at: r.created_at,
+    text: capText(r.text, max, state),
+  };
+}
+
+/** Shape a roster agent down to the fields a seat actually needs to route. */
+function shapeAgent(row: unknown): unknown {
+  const r = asRecord(row);
+  if (!r) return row;
+  return {
+    agent_id: r.agent_id,
+    emoji: r.emoji,
+    display_name: r.display_name,
+    last_seen_at: r.last_seen_at,
+    current_status: r.current_status,
+    next_checkin_at: r.next_checkin_at,
+  };
+}
+
+/**
+ * Bound a Boardroom read response for strict MCP clients.
+ *
+ * Guarantees:
+ *  - the `mentions` lane (messages addressed to the caller) is preserved ahead
+ *    of the general feed, capped only to guard against a runaway mention storm;
+ *  - the `messages` feed keeps the most recent `maxMessages` in time order;
+ *  - every message body is truncated to `maxTextChars`;
+ *  - the `agents` roster is shaped to essential fields and capped;
+ *  - a `_bounds` block reports available-vs-returned counts and a next_steps
+ *    hint so the agent knows to narrow with `since` / `limit`.
+ *
+ * Non-object input is returned unchanged so the bounder is safe to drop in
+ * front of error envelopes or already-compact payloads.
+ */
+export function compactBoardroomReadForStrictClients(
+  value: unknown,
+  options: BoardroomReadBoundsOptions = {},
+): unknown {
+  const root = asRecord(value);
+  if (!root) return value;
+
+  const opts = { ...DEFAULTS, ...options };
+  const state = { truncated: false };
+
+  const messages = asArray(root.messages);
+  const mentions = asArray(root.mentions);
+  const agents = asArray(root.agents);
+
+  const keptMentions = pickRecent(mentions, opts.maxMentions).map((row) =>
+    shapeMessage(row, opts.maxTextChars, state),
+  );
+  const keptMessages = pickRecent(messages, opts.maxMessages).map((row) =>
+    shapeMessage(row, opts.maxTextChars, state),
+  );
+  const keptAgents = pickRecentAgents(agents, opts.maxAgents).map(shapeAgent);
+
+  const bounds: BoardroomReadBounds = {
+    compact: true,
+    messages_returned: keptMessages.length,
+    messages_available: messages.length,
+    mentions_returned: keptMentions.length,
+    mentions_available: mentions.length,
+    agents_returned: keptAgents.length,
+    agents_available: agents.length,
+    text_truncated: state.truncated,
+    next_steps:
+      messages.length > keptMessages.length
+        ? "Older feed messages were trimmed for strict clients. Re-read with `since` (last created_at you saw) or a smaller `limit` to page back."
+        : "Full feed within strict-client bounds.",
+  };
+
+  const out: Record<string, unknown> = {};
+  // Mentions first so the most important lane survives JSON truncation.
+  out.mentions = keptMentions;
+  out.messages = keptMessages;
+  if ("agents" in root) out.agents = keptAgents;
+  out._bounds = bounds;
+  for (const [key, val] of Object.entries(root)) {
+    if (!(key in out)) out[key] = val;
+  }
+  return out;
+}
+
+/** Roster equivalent of pickRecent, keyed on last_seen_at instead. */
+function pickRecentAgents<T>(rows: T[], n: number): T[] {
+  if (rows.length <= n) return rows.slice();
+  const lastSeen = (row: unknown): number => {
+    const r = asRecord(row);
+    const raw = r?.last_seen_at;
+    const ms = typeof raw === "string" || typeof raw === "number" ? Date.parse(String(raw)) : NaN;
+    return Number.isFinite(ms) ? ms : 0;
+  };
+  return rows
+    .map((row, index) => ({ row, index, ts: lastSeen(row) }))
+    .sort((a, b) => (b.ts - a.ts) || (b.index - a.index))
+    .slice(0, n)
+    .map((entry) => entry.row);
+}

--- a/api/scope-confusion-replay.test.ts
+++ b/api/scope-confusion-replay.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPrReviewObligation,
+  evaluateAgentObligationState,
+  validateAgentObligationReceipt,
+} from "./lib/agent-obligations";
+import { evaluateLaneClaim, normalizeScopeTokens, normalizeWorkerLane } from "./lib/worker-lanes";
+
+// Cross-lane scope-confusion + signed-ACK replay regression pack.
+//
+// These assert two abuse shapes the fleet must keep blocking:
+//   1. SCOPE CONFUSION  - a claim/token scoped to one lane being honoured by a
+//      different lane, or a denylisted token sneaking in via an allowlist match
+//      or label spoofing.
+//   2. RECEIPT REPLAY   - a signed ACK/PASS receipt minted for one obligation
+//      (one PR / wake / lane) being replayed verbatim against a sibling
+//      obligation, or arriving after the obligation has gone stale.
+//
+// The baseline happy-path coverage lives in worker-lanes.test.ts and
+// agent-obligations.test.ts; this pack locks in the cross-lane guarantees they
+// do not exercise.
+
+const enforceLane = (agentId: string, allow: string[], deny: string[] = []) =>
+  normalizeWorkerLane({
+    apiKeyHash: `hash-${agentId}`,
+    agentId,
+    role: agentId,
+    scopeAllowlist: allow,
+    scopeDenylist: deny,
+    enforceMode: "enforce",
+  });
+
+describe("scope confusion: lane token isolation", () => {
+  it("rejects a denylisted token even when it also appears in the allowlist", () => {
+    // Privileged-token-sneaks-through: allowlist and denylist both name the same
+    // token. Denylist must win, otherwise an allowlist match would launder it.
+    const lane = enforceLane("security-seat", ["security", "deploy"], ["deploy"]);
+
+    expect(evaluateLaneClaim(lane, ["deploy"])).toEqual({
+      decision: "reject",
+      reason: "scope_denylist_match",
+      matched_token: "deploy",
+    });
+  });
+
+  it("blocks denylist evasion through casing and punctuation spoofing", () => {
+    const lane = enforceLane("watcher-seat", ["watch"], ["build"]);
+
+    // All of these normalize to the denylisted "build" token. Note the
+    // normalizer keeps : _ / - so a token like "build/x" stays distinct on
+    // purpose; only punctuation outside that set collapses away.
+    for (const spoof of ["BUILD", "Build!!", "  build  ", "build."]) {
+      expect(evaluateLaneClaim(lane, [spoof])).toMatchObject({
+        decision: "reject",
+        reason: "scope_denylist_match",
+        matched_token: "build",
+      });
+    }
+    expect(normalizeScopeTokens(["BUILD", "Build!!", " build "])).toEqual(["build"]);
+  });
+
+  it("does not let one lane's accepted claim replay onto a foreign lane", () => {
+    // Same todo tokens, two lanes. Lane A owns it; Lane B must not honour the
+    // identical claim just because it was valid somewhere.
+    const claimTokens = ["memory", "recall"];
+    const laneA = enforceLane("memory-seat", ["memory"]);
+    const laneB = enforceLane("seats-seat", ["seats", "routing"]);
+
+    expect(evaluateLaneClaim(laneA, claimTokens)).toMatchObject({
+      decision: "allow",
+      reason: "scope_allowlist_match",
+      matched_token: "memory",
+    });
+    expect(evaluateLaneClaim(laneB, claimTokens)).toEqual({
+      decision: "reject",
+      reason: "scope_allowlist_miss",
+    });
+  });
+});
+
+describe("signed-ACK replay: obligation isolation", () => {
+  const obligationA = buildPrReviewObligation({
+    id: "obligation-pr-695-review",
+    prNumber: 695,
+    prUrl: "https://github.com/malamutemayhem/unclick/pull/695",
+    wakeId: "wake-pull_request-pr-695-aaaa",
+    ownerLane: "Reviewer",
+    nextAction: "ACK wake, review PR #695, post PASS/HOLD/BLOCKER with proof.",
+    createdAt: "2026-06-02T00:00:00.000Z",
+    ttlSeconds: 600,
+    fallbackOwner: "master",
+  });
+
+  const obligationB = buildPrReviewObligation({
+    id: "obligation-pr-696-review",
+    prNumber: 696,
+    prUrl: "https://github.com/malamutemayhem/unclick/pull/696",
+    wakeId: "wake-pull_request-pr-696-bbbb",
+    ownerLane: "Reviewer",
+    nextAction: "ACK wake, review PR #696, post PASS/HOLD/BLOCKER with proof.",
+    createdAt: "2026-06-02T00:00:00.000Z",
+    ttlSeconds: 600,
+    fallbackOwner: "master",
+  });
+
+  // A receipt that legitimately clears obligation A.
+  const receiptForA = {
+    text: "PASS: PR #695 review complete; proof: https://github.com/malamutemayhem/unclick/pull/695#issuecomment-1",
+    author_agent_id: "reviewer-seat",
+    created_at: "2026-06-02T00:05:00.000Z",
+  };
+
+  it("accepts the receipt against its own obligation", () => {
+    expect(validateAgentObligationReceipt(obligationA, receiptForA, new Date("2026-06-02T00:05:00.000Z"))).toMatchObject({
+      accepted: true,
+      status: "accepted",
+      receipt_type: "PASS",
+    });
+  });
+
+  it("rejects that same receipt replayed against a sibling obligation", () => {
+    // Verbatim replay onto PR #696: the proof points at #695, so it must fail.
+    expect(validateAgentObligationReceipt(obligationB, receiptForA, new Date("2026-06-02T00:05:00.000Z"))).toMatchObject({
+      accepted: false,
+      reason: "receipt_does_not_match_obligation",
+      receipt_type: "PASS",
+    });
+  });
+
+  it("rejects an ACK that only cites a foreign lane's wake id", () => {
+    // Proof present and on-repo, but the wake id belongs to obligation A.
+    const crossWakeAck = {
+      text: "ACK wake-pull_request-pr-695-aaaa. proof: https://github.com/malamutemayhem/unclick/pull/695",
+    };
+    expect(validateAgentObligationReceipt(obligationB, crossWakeAck, new Date("2026-06-02T00:05:00.000Z"))).toMatchObject({
+      accepted: false,
+      reason: "receipt_does_not_match_obligation",
+    });
+  });
+
+  it("rejects a receipt type the obligation does not accept (type confusion)", () => {
+    // Obligation that only accepts PASS must reject a matching bare ACK.
+    const passOnly = buildPrReviewObligation({
+      id: "obligation-pr-695-review",
+      prNumber: 695,
+      prUrl: "https://github.com/malamutemayhem/unclick/pull/695",
+      wakeId: "wake-pull_request-pr-695-aaaa",
+      nextAction: "Review and PASS only.",
+      createdAt: "2026-06-02T00:00:00.000Z",
+      ttlSeconds: 600,
+      fallbackOwner: "master",
+      acceptedReceiptTypes: ["PASS"],
+    });
+
+    const bareAck = {
+      text: "ACK wake-pull_request-pr-695-aaaa. proof: https://github.com/malamutemayhem/unclick/pull/695",
+    };
+    expect(validateAgentObligationReceipt(passOnly, bareAck, new Date("2026-06-02T00:05:00.000Z"))).toMatchObject({
+      accepted: false,
+      reason: "receipt_type_not_allowed",
+      receipt_type: "ACK",
+    });
+  });
+
+  it("surfaces stale debt and fallback ownership for a late replayed receipt", () => {
+    const afterTtl = new Date("2026-06-02T00:20:00.000Z"); // 20 min > 10 min TTL
+
+    // The obligation is stale on its own timeline.
+    expect(evaluateAgentObligationState(obligationA, afterTtl)).toMatchObject({
+      accepted: false,
+      status: "stale",
+      reason: "ttl_expired",
+      fallback_owner: "master",
+    });
+
+    // A wrong/replayed receipt arriving after TTL is rejected AND carries the
+    // stale fallback ownership through, so the debt stays visible.
+    const replayWrong = validateAgentObligationReceipt(
+      obligationA,
+      { text: "PASS: PR #696 done; proof: https://github.com/malamutemayhem/unclick/pull/696" },
+      afterTtl,
+    );
+    expect(replayWrong).toMatchObject({
+      accepted: false,
+      status: "stale",
+      reason: "receipt_does_not_match_obligation",
+      fallback_owner: "master",
+    });
+  });
+
+  it("rejects a fake-done receipt that carries no proof or recognised type", () => {
+    expect(
+      validateAgentObligationReceipt(obligationA, { text: "Done, looks good to me." }, new Date("2026-06-02T00:05:00.000Z")),
+    ).toMatchObject({ accepted: false, reason: "unrecognized_receipt" });
+  });
+});

--- a/api/zod-version-policy.test.ts
+++ b/api/zod-version-policy.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+// Dependency migration guard for the planned, NOT-auto-bump zod v3 -> v4 move.
+//
+// The repo intentionally runs a split: packages/mcp-server is on zod v4 (its
+// MCP tool schemas were ported), while every other workspace stays on zod v3.
+// A blind Dependabot bump of any v3 workspace to v4 would change validation
+// semantics under it. This test pins the documented split so such a bump trips
+// CI with a pointer to the migration plan instead of merging silently.
+//
+// When the real migration happens, update docs/zod-v4-migration-decision.md and
+// move the upgraded workspace into V4_WORKSPACES below in the same PR.
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// The one workspace deliberately on zod v4 today.
+const V4_WORKSPACES = new Set(["packages/mcp-server"]);
+
+function majorFromRange(range: string): number | null {
+  const match = String(range).match(/(\d+)\./);
+  return match ? Number(match[1]) : null;
+}
+
+function zodRange(pkg: Record<string, unknown>): string | null {
+  const deps = (pkg.dependencies as Record<string, string> | undefined) ?? {};
+  const dev = (pkg.devDependencies as Record<string, string> | undefined) ?? {};
+  return deps.zod ?? dev.zod ?? null;
+}
+
+/** Workspace package.json locations: root + packages/* + apps/*. */
+function collectWorkspacePackageJsons(): Array<{ rel: string; pkg: Record<string, unknown> }> {
+  const out: Array<{ rel: string; pkg: Record<string, unknown> }> = [];
+  const add = (rel: string) => {
+    const abs = join(REPO_ROOT, rel, "package.json");
+    if (existsSync(abs)) {
+      out.push({ rel, pkg: JSON.parse(readFileSync(abs, "utf8")) });
+    }
+  };
+
+  add(".");
+  for (const group of ["packages", "apps"]) {
+    const groupDir = join(REPO_ROOT, group);
+    if (!existsSync(groupDir)) continue;
+    for (const entry of readdirSync(groupDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) add(`${group}/${entry.name}`);
+    }
+  }
+  return out;
+}
+
+describe("zod version policy (planned v3 -> v4 migration guard)", () => {
+  const workspaces = collectWorkspacePackageJsons().filter(({ pkg }) => zodRange(pkg) !== null);
+
+  it("finds the documented split: at least one v3 island and one v4 island", () => {
+    const majors = new Set(
+      workspaces.map(({ pkg }) => majorFromRange(zodRange(pkg) as string)).filter((m): m is number => m !== null),
+    );
+    expect(majors.has(3)).toBe(true);
+    expect(majors.has(4)).toBe(true);
+  });
+
+  it("keeps packages/mcp-server on zod v4", () => {
+    const mcp = workspaces.find(({ rel }) => rel === "packages/mcp-server");
+    expect(mcp, "packages/mcp-server should declare zod").toBeTruthy();
+    expect(majorFromRange(zodRange(mcp!.pkg) as string)).toBe(4);
+  });
+
+  it("keeps every other workspace on zod v3 until the migration ships", () => {
+    const offenders = workspaces
+      .filter(({ rel }) => !V4_WORKSPACES.has(rel))
+      .map(({ rel, pkg }) => ({ rel, major: majorFromRange(zodRange(pkg) as string) }))
+      .filter(({ major }) => major !== 3);
+
+    expect(
+      offenders,
+      `Unexpected zod major outside the v4 island. If this is the planned migration, update ` +
+        `docs/zod-v4-migration-decision.md and add the workspace to V4_WORKSPACES in the same PR. ` +
+        `Offenders: ${JSON.stringify(offenders)}`,
+    ).toEqual([]);
+  });
+});

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 616,
+    "inventory": 617,
     "source_manifest": 192,
     "pages": 84,
     "tools": 219,
@@ -75,7 +75,7 @@
       "id": "source-of-truth",
       "name": "Source of truth",
       "meaning": "Canonical state, queue, memory, and context surfaces.",
-      "count": 11
+      "count": 12
     },
     {
       "id": "modules-and-apps",
@@ -3848,6 +3848,16 @@
       "kind": "state module",
       "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
       "source": "api/lib/boardroom-compat.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-boardroom-read-bounds-api-lib-boardroom-read-bounds-ts-no-route",
+      "division": "Source of truth",
+      "name": "boardroom read bounds",
+      "kind": "state module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/boardroom-read-bounds.ts",
       "route": "",
       "tags": []
     },

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -219,7 +219,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 121 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 7 |
-| Source of truth | Canonical state, queue, memory, and context surfaces. | 11 |
+| Source of truth | Canonical state, queue, memory, and context surfaces. | 12 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 116 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 5 |
 
@@ -942,6 +942,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Source of truth | memory | Memory Library | Source-linked facts, sessions, context, and generated memory shelves. | /admin/memory | src/pages/admin/AdminMemory.tsx |
 | Source of truth | queue | Boardroom Jobs | Primary work source for open, in-progress, done, and dropped chips. | /admin/jobs | src/pages/admin/AdminJobs.tsx |
 | Source of truth | state module | boardroom compat | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/boardroom-compat.ts |
+| Source of truth | state module | boardroom read bounds | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/boardroom-read-bounds.ts |
 | Source of truth | state module | embed | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory/embed.ts |
 | Source of truth | state module | memory admin | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory-admin.ts |
 | Source of truth | state module | memory Data Island | memory Data Island shared frontend logic. | - | src/lib/memoryDataIsland.ts |

--- a/docs/testpass-eval-harness-decision.md
+++ b/docs/testpass-eval-harness-decision.md
@@ -1,0 +1,91 @@
+# Eval Harness with CI Gates: Minimum Test Pack Decision
+
+Job: `f73dc833-746c-4822-8ffd-d692e996607e` (Worker 14, TestPass and evals lane)
+Status: decision packet / ScopePack. This job's brief is "start with minimum
+test pack decision", so this is the decision, not a full harness build.
+
+## The ask
+
+Stand up an eval harness with a CI gate that runs a ~20-test minimum on prompt
+commits, originally floated as Langfuse or Braintrust.
+
+## What the repo already has (audited 2026-06-02)
+
+- `@unclick/sloppass` ships a vendored `promptfoo-lite` engine:
+  `packages/sloppass/src/vendor/promptfoo-lite/`. README describes it as "a
+  deliberately small promptfoo-derived engine" with a deterministic evaluation
+  runner, a provider abstraction, a test schema, and a report surface. It is
+  already a dependency-light, in-repo eval primitive.
+- `@unclick/testpass` plus `.github/workflows/testpass-pr-check.yml` already run
+  pack-based checks against the MCP server on pull requests, with a token gate
+  and a Vercel-preview wait. That is an existing CI-gated test-pack pattern.
+- Root `ci.yml` already runs `npm test` (vitest over `src/**` and `api/**`) as a
+  blocking gate on every PR.
+
+## Decision
+
+Do NOT adopt Langfuse or Braintrust for the minimum pack. Reasons, ranked:
+
+1. Both are external SaaS. They need an API key in CI and they send prompts and
+   outputs off-platform. The Worker contract requires reversible, secret-free,
+   redacted work, and the fleet already prefers in-house Pass engines over new
+   third-party surfaces.
+2. The repo already owns the primitive (`promptfoo-lite` via sloppass) and an
+   existing CI-gated pack runner (`testpass-pr-check.yml`). Adding a SaaS would
+   duplicate capability and add a network and billing dependency.
+3. Observability tracing (the genuine Langfuse strength) is a separate concern
+   from a blocking pre-merge eval gate, and is already tracked by the Agent
+   Observability job (`4ce58c4f`). Keep them separate.
+
+Recommendation: build the ~20-test minimum as a `promptfoo-lite` / sloppass eval
+pack, run it through a deterministic, mockable provider in `ci.yml` so it gates
+without live model calls, and keep a thin adapter seam so a hosted tracer can be
+attached later if real telemetry is ever needed. Revisit a SaaS only if hosted
+tracing/regression-history across runs becomes a hard requirement.
+
+## Minimum ~20-test pack (first cut)
+
+Scope the first pack to the prompt-bearing surfaces that already exist, so the
+gate protects real behavior. Suggested split:
+
+- Memory protocol prompts (6): load-first ordering honored; save_fact triggers
+  on a preference statement; save_session triggers at wrap-up; no fabricated
+  prior context when memory is empty; Boardroom-only naming in user-facing
+  copy; em-dash-free output.
+- Boardroom / orchestrator prompts (5): receipt-first log-read-decide-reply
+  ordering; ACK carries proof; fake-done rejected; handoff names a fallback
+  owner; "nothing changed" suppression respected.
+- Connector / tool-routing prompts (5): prefers an UnClick tool over web guess
+  for live data; uses `unclick_search` then `unclick_call` for an unknown tool;
+  clean 429 handling copy; two-lane error shape; `stampMeta`
+  source/freshness/next_steps present.
+- Safety prompts (4): refuses secret printing; refuses force-push / hard reset /
+  destructive cleanup; respects human-gated lanes; redacts before posting.
+
+Each is a `promptfoo-lite` test row asserting on a deterministic mocked provider
+response, so the gate is fast and offline.
+
+## CI gate shape
+
+- Trigger: pull requests that touch prompt-bearing paths. Concretely, paths like
+  `packages/mcp-server/src/**`, `.claude/skills/**`, and any
+  `**/prompts/**` / `**/*prompt*` file.
+- Runner: a new workspace script (for example `npm run eval:min`) that runs the
+  pack through the deterministic provider. Wire it as a blocking step alongside
+  the existing `npm test` in `ci.yml`, or as a sibling job mirroring
+  `testpass-pr-check.yml`.
+- Threshold: all ~20 must pass. No live network. No SaaS key.
+
+## Smallest first slice
+
+Land 5 of the 20 (the memory-protocol subset) as a `promptfoo-lite` pack plus a
+`npm run eval:min` script and a path-filtered CI step. Prove it gates on a PR,
+then grow the pack to 20. That keeps the first PR reviewable and avoids standing
+up a harness nobody has exercised yet.
+
+## Not done here (and why)
+
+No harness code was added. The brief asks for the minimum-test-pack decision
+first. The decision is: reuse `promptfoo-lite`/sloppass with a deterministic
+offline provider and an existing-style CI gate, not a new SaaS. The 5-test first
+slice above is the next build chip.

--- a/docs/zod-v4-migration-decision.md
+++ b/docs/zod-v4-migration-decision.md
@@ -1,0 +1,85 @@
+# Zod v3 to v4 Migration Decision
+
+Job: `01896509-17b6-4722-85b9-a7750b079b64` (Worker 14, TestPass and evals lane)
+Status: decision packet. Do NOT auto-bump. No code dependency was changed by this job.
+Guard: `api/zod-version-policy.test.ts` (runs in root CI via `ci.yml`).
+
+## Current truth (audited 2026-06-02)
+
+The repo already runs a deliberate split, not a clean v3 monorepo:
+
+| Workspace | zod range | Major |
+|---|---|---|
+| `packages/mcp-server` | `^4.4.1` | 4 |
+| root `package.json` | `^3.25.76` | 3 |
+| `packages/geopass` | `^3.25.76` | 3 |
+| `packages/compliancepass` | `^3.25.76` | 3 |
+| `packages/seopass` | `^3.25.76` | 3 |
+| `packages/flowpass` | `^3.25.76` | 3 |
+| `packages/securitypass` | `^3.23.8` | 3 |
+| `packages/sloppass` | `^3.23.8` | 3 |
+| `packages/copypass` | `^3.23.8` | 3 |
+| `packages/core` | `^3.23.8` | 3 |
+| `packages/uxpass` | `^3.23.8` | 3 |
+| `apps/api` | `^3.23.8` | 3 |
+| `packages/testpass` | `^3.22.4` | 3 |
+| `packages/legalpass` | `^3.22.4` | 3 |
+| `packages/memory-mcp` | `^3.23.0` | 3 |
+
+`packages/mcp-server` is the only v4 island. Its MCP tool input schemas were
+already ported to v4. Everything else is still v3.
+
+## Why a blind bump is unsafe
+
+Zod v4 is not a drop-in for v3 in the places this repo actually leans on it:
+
+- Error shape changed. Code that reads `error.issues`, `error.format()`, or
+  `.errors` and renders or branches on it can silently change output. The MCP
+  server and the API both surface validation errors to agents and to the admin
+  UI, so a shape change is user-visible, not internal.
+- `.default()` / optional inference and several string formats (for example
+  `z.string().email()` moving toward `z.email()`) changed, so types can compile
+  while runtime acceptance shifts.
+- Mixed versions in one process are a real hazard. If two workspaces import two
+  zod majors and pass schemas or parsed objects across the boundary,
+  `instanceof ZodError` and schema identity checks break. The current split is
+  only safe because the v4 island (`packages/mcp-server`) does not share live
+  zod schema objects across a v3 boundary at runtime.
+
+## Decision
+
+1. Keep the split. Do not let Dependabot or a sweep bump any v3 workspace to v4.
+   The guard test `api/zod-version-policy.test.ts` fails CI if a v3 workspace
+   moves to v4 outside a tracked migration, and the failure message points back
+   to this doc.
+2. Migrate per-workspace, leaf-first, never as one mega-bump. Each workspace is
+   its own PR with its own tests green before and after.
+3. Do the migration in this order (fewest cross-boundary schema handoffs first):
+   `packages/core` -> the standalone Pass packages (`sloppass`, `securitypass`,
+   `copypass`, `uxpass`, `compliancepass`, `seopass`, `geopass`, `flowpass`,
+   `legalpass`, `testpass`) -> `packages/memory-mcp` -> `apps/api` -> root +
+   `api/`. Root and `api/` last because they touch the most surfaces.
+
+## Per-workspace migration checklist
+
+- Bump `zod` to `^4` in that one workspace only.
+- Grep that workspace for `.errors`, `.issues`, `.format(`, `.email(`, `.url(`,
+  `ZodError`, `superRefine`, `.default(` and reconcile each against the v4 API.
+- Run that workspace's own tests, then the root `npm test`.
+- Confirm no error-rendering surface (admin UI, MCP tool error text, API JSON)
+  changed shape. Where it did, update the consumer in the same PR.
+- Update the table above and move the workspace into `V4_WORKSPACES` in
+  `api/zod-version-policy.test.ts` in the same PR.
+
+## Smallest safe first slice
+
+Migrate `packages/core` alone to v4, prove its tests plus root `npm test` stay
+green, update this doc and the guard. That validates the playbook on the lowest
+blast-radius workspace before touching anything agent-facing.
+
+## Not done here (and why)
+
+No dependency was bumped. The job brief says "check if safe now; do not
+auto-bump blindly." The safe answer is: the split is intentional, a blanket bump
+is unsafe, and the migration is a tracked per-workspace sequence guarded by a
+CI test, not a Dependabot merge.


### PR DESCRIPTION
## Summary
- Consolidates the safe Worker 14 pieces from stale PR #1257 onto current main without carrying the old branch's stale diff.
- Adds a pure, unwired Boardroom read bounds helper plus regression coverage.
- Adds signed-ACK scope-confusion replay tests and a zod v3/v4 policy guard.
- Adds decision docs for the eval harness and zod migration.
- Refreshes the generated brainmap.

## Validation
- \\
pm exec vitest -- run api/boardroom-read-bounds.test.ts api/scope-confusion-replay.test.ts api/zod-version-policy.test.ts\\ -> 3 files passed, 21 tests passed.
- \\
pm exec eslint -- api/boardroom-read-bounds.test.ts api/lib/boardroom-read-bounds.ts api/scope-confusion-replay.test.ts api/zod-version-policy.test.ts\\ -> pass.
- \\
pm run brainmap:check\\ -> pass.

## Safety note
This is a replacement for Worker 14 PR #1257 because the original branch cannot be updated cleanly. The helper is pure and not wired into live read behavior in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production wiring; changes are pure helpers, tests, docs, and generated brainmap metadata.
> 
> **Overview**
> Consolidates Worker 14 TestPass work: **regression tests and decision docs**, plus a **pure Boardroom read bounder** that is **not wired** into live reads yet.
> 
> Adds `compactBoardroomReadForStrictClients` in `api/lib/boardroom-read-bounds.ts` (with vitest coverage) to trim feed/mentions/agents, truncate bodies, drop verbose fields like `user_agent_hint`, and attach `_bounds` paging hints for strict MCP clients—mirroring the memory compact helpers.
> 
> Adds `api/scope-confusion-replay.test.ts` to lock cross-lane scope denial (denylist wins, normalization spoofing, foreign-lane claims) and signed receipt replay (sibling PR obligations, wrong wake id, disallowed receipt types, TTL stale debt).
> 
> Adds `api/zod-version-policy.test.ts` so CI fails if a non-`packages/mcp-server` workspace bumps to zod v4 without updating `docs/zod-v4-migration-decision.md`.
> 
> New decision packets: eval harness minimum pack (`docs/testpass-eval-harness-decision.md`) and zod migration (`docs/zod-v4-migration-decision.md`). Regenerated brainmap entries for the new state module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e4b3e64051dff767cbeaf7dc05fc3591568412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->