### PR TITLE
Lane 06: Retrieval SQL and ranking internals

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
@@ -226,6 +226,90 @@ describe("local memory scoring", () => {
     });
     assert.ok(partial.finalScore > unrelated.finalScore);
   });
+
+  test("length normalization keeps concise identity facts above verbose logs", async () => {
+    const { tokenizeLocalMemoryQuery, scoreLocalMemoryContent } = await import("../supabase.js");
+    const query = "Chris timezone";
+    const tokens = tokenizeLocalMemoryQuery(query);
+    const concise = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: "Chris timezone is Australia Sydney.",
+      confidence: 1,
+      source: "fact",
+    });
+    const verbose = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: `Chris timezone appears in this long operational log. ${"heartbeat memory status ".repeat(80)}`,
+      confidence: 1,
+      source: "fact",
+    });
+    assert.ok(concise.kwScore > verbose.kwScore);
+    assert.ok(concise.finalScore > verbose.finalScore);
+  });
+
+  test("local ranking rows publish the lane 6 score contract", async () => {
+    const {
+      rankLocalMemorySearchRows,
+      reciprocalRankScore,
+      scoreLocalMemoryContent,
+      tokenizeLocalMemoryQuery,
+    } = await import("../supabase.js");
+    const query = "Chris timezone";
+    const tokens = tokenizeLocalMemoryQuery(query);
+    const shortScore = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: "Chris timezone is Australia Sydney.",
+      confidence: 1,
+      source: "fact",
+    });
+    const longScore = scoreLocalMemoryContent({
+      query,
+      tokens,
+      text: `Chris timezone was mentioned during a noisy status update. ${"routing status ".repeat(60)}`,
+      confidence: 1,
+      source: "fact",
+    });
+
+    const ranked = rankLocalMemorySearchRows(
+      [
+        {
+          id: "long-log",
+          source: "fact",
+          content: "long log",
+          category: "status",
+          confidence: 1,
+          created_at: "2026-06-04T00:00:00Z",
+          score: longScore,
+        },
+        {
+          id: "short-identity",
+          source: "fact",
+          content: "short fact",
+          category: "identity",
+          confidence: 1,
+          created_at: "2026-06-04T00:00:00Z",
+          score: shortScore,
+        },
+      ],
+      2,
+      "2026-06-04T00:00:00Z"
+    );
+
+    const first = ranked[0];
+    const second = ranked[1];
+    assert.ok(first);
+    assert.ok(second);
+    assert.equal(first.id, "short-identity");
+    assert.equal(first.keyword_rank, 1);
+    assert.equal(first.vector_rank, null);
+    assert.equal(first.cosine_score, null);
+    assert.equal(first.rrf_score, reciprocalRankScore(1, null));
+    assert.equal(first.kw_score, shortScore.kwScore);
+    assert.ok(first.final_score > second.final_score);
+  });
 });
 
 // ─── 2a. Keyword fallback asOf filtering ─────────────────────────────────────

--- a/packages/mcp-server/src/memory/__tests__/local-backend.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/local-backend.test.ts
@@ -96,6 +96,44 @@ describe("LocalBackend memory parity", () => {
     assert.ok(byId.get(invalidated.id)?.invalidated_at);
   });
 
+  test("startup context preserves provenance fields on active local facts", async () => {
+    const { LocalBackend } = await import("../local.js");
+    const backend = new LocalBackend();
+
+    const saved = await backend.addFact({
+      fact: "Chris wants startup receipts surfaced for profile cards.",
+      category: "preference",
+      confidence: 0.91,
+    });
+
+    const rows = readRows<{
+      id: string;
+      source_agent_id?: string | null;
+      source_ref?: string | null;
+      receipt_id?: string | null;
+    } & Record<string, unknown>>("extracted_facts");
+    const row = rows.find((item) => item.id === saved.id);
+    assert.ok(row);
+    row.source_agent_id = "agent-worker-3";
+    row.source_ref = "conversation:receipt-source";
+    row.receipt_id = "receipt-startup-1";
+    fs.writeFileSync(path.join(tempDir, "extracted_facts.json"), JSON.stringify(rows, null, 2));
+
+    const context = await backend.getStartupContext(3) as {
+      active_facts: Array<{
+        fact: string;
+        source_agent_id?: string | null;
+        source_ref?: string | null;
+        receipt_id?: string | null;
+      }>;
+    };
+    const active = context.active_facts.find((item) => item.fact.includes("startup receipts"));
+    assert.ok(active);
+    assert.equal(active.source_agent_id, "agent-worker-3");
+    assert.equal(active.source_ref, "conversation:receipt-source");
+    assert.equal(active.receipt_id, "receipt-startup-1");
+  });
+
   test("local search and startup context respect valid_from", async () => {
     const { LocalBackend } = await import("../local.js");
     const backend = new LocalBackend();

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -32,6 +32,7 @@ import {
   type MemoryTypedLinkStoredRow,
 } from "./typed-links.js";
 import {
+  rankLocalMemorySearchRows,
   scoreLocalMemoryContent,
   tokenizeLocalMemoryQuery,
   writeMemoryTaxonomySnapshotsToLibrary,
@@ -339,10 +340,7 @@ export class LocalBackend implements MemoryBackend {
           category: fact.category,
           confidence: fact.confidence,
           created_at: fact.created_at,
-          final_score: score.finalScore,
-          rrf_score: 0,
-          kw_score: score.matchedTokenCount,
-          cosine_score: 0,
+          score,
         };
       });
 
@@ -363,10 +361,7 @@ export class LocalBackend implements MemoryBackend {
           category: "session",
           confidence: 1,
           created_at: session.created_at,
-          final_score: score.finalScore,
-          rrf_score: 0,
-          kw_score: score.matchedTokenCount,
-          cosine_score: 0,
+          score,
         };
       });
 
@@ -387,20 +382,11 @@ export class LocalBackend implements MemoryBackend {
           category: row.role,
           confidence: 0.5,
           created_at: row.created_at,
-          final_score: score.finalScore,
-          rrf_score: 0,
-          kw_score: score.matchedTokenCount,
-          cosine_score: 0,
+          score,
         };
       });
 
-    return [...facts, ...sessions, ...conversations]
-      .filter((row) => row.final_score > 0)
-      .sort((a, b) => {
-        const scoreDiff = b.final_score - a.final_score;
-        return scoreDiff !== 0 ? scoreDiff : b.created_at.localeCompare(a.created_at);
-      })
-      .slice(0, maxResults);
+    return rankLocalMemorySearchRows([...facts, ...sessions, ...conversations], maxResults, asOf);
   }
 
   async searchFacts(query: string): Promise<unknown> {

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -136,6 +136,9 @@ interface FactRow {
   fact: string;
   category: string;
   confidence: number;
+  source_agent_id?: string | null;
+  source_ref?: string | null;
+  receipt_id?: string | null;
   source_session_id?: string;
   source_type: string;
   startup_fact_kind: "durable" | "operational" | "excluded" | "legacy_unspecified";
@@ -314,7 +317,15 @@ export class LocalBackend implements MemoryBackend {
         session_id: s.session_id, platform: s.platform, summary: s.summary,
         decisions: s.decisions, open_loops: s.open_loops, topics: s.topics, created_at: s.created_at,
       })),
-      active_facts: facts.map((f) => ({ fact: f.fact, category: f.category, confidence: f.confidence, created_at: f.created_at })),
+      active_facts: facts.map((f) => ({
+        fact: f.fact,
+        category: f.category,
+        confidence: f.confidence,
+        created_at: f.created_at,
+        source_agent_id: f.source_agent_id ?? null,
+        source_ref: f.source_ref ?? null,
+        receipt_id: f.receipt_id ?? null,
+      })),
       loaded_at: now(),
     };
   }

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -151,36 +151,145 @@ function normalizeLocalMemoryText(text: string): string {
   return (text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? []).join(" ");
 }
 
+function tokenizeLocalMemoryText(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? [];
+}
+
+const LOCAL_MEMORY_BM25_K1 = 1.2;
+const LOCAL_MEMORY_BM25_B = 0.75;
+const LOCAL_MEMORY_AVG_DOC_LENGTH = 24;
+const MEMORY_RRF_K = 60;
+const MEMORY_RECENCY_DECAY_DAYS = 90;
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function daysBetween(createdAt: string | null | undefined, asOf?: string): number {
+  if (!createdAt) return 0;
+  const createdMs = Date.parse(createdAt);
+  const asOfMs = asOf ? Date.parse(asOf) : Date.now();
+  if (!Number.isFinite(createdMs) || !Number.isFinite(asOfMs)) return 0;
+  return Math.max(0, (asOfMs - createdMs) / 86_400_000);
+}
+
+export function reciprocalRankScore(keywordRank?: number | null, vectorRank?: number | null): number {
+  const keyword = keywordRank && keywordRank > 0 ? 1 / (MEMORY_RRF_K + keywordRank) : 0;
+  const vector = vectorRank && vectorRank > 0 ? 1 / (MEMORY_RRF_K + vectorRank) : 0;
+  return keyword + vector;
+}
+
+export function memoryRecencyWeight(createdAt: string | null | undefined, asOf?: string): number {
+  return Math.exp(-daysBetween(createdAt, asOf) / MEMORY_RECENCY_DECAY_DAYS);
+}
+
+export interface LocalMemoryContentScore {
+  finalScore: number;
+  matchedTokenCount: number;
+  exactPhrase: boolean;
+  kwScore: number;
+  documentTokenCount: number;
+}
+
 export function scoreLocalMemoryContent(input: {
   query: string;
   tokens: string[];
   text: string;
   confidence?: number | null;
   source?: "fact" | "session";
-}): { finalScore: number; matchedTokenCount: number; exactPhrase: boolean } {
+}): LocalMemoryContentScore {
   const { query, tokens, text } = input;
   if (tokens.length === 0) {
-    return { finalScore: 0, matchedTokenCount: 0, exactPhrase: false };
+    return { finalScore: 0, matchedTokenCount: 0, exactPhrase: false, kwScore: 0, documentTokenCount: 0 };
   }
 
   const normalizedText = normalizeLocalMemoryText(text);
   const normalizedQuery = normalizeLocalMemoryText(query);
-  const matchedTokenCount = tokens.reduce(
-    (count, token) => count + (normalizedText.includes(token) ? 1 : 0),
-    0
-  );
+  const textTokens = tokenizeLocalMemoryText(text);
+  const documentTokenCount = textTokens.length;
+  const tokenCounts = new Map<string, number>();
+  for (const token of textTokens) {
+    tokenCounts.set(token, (tokenCounts.get(token) ?? 0) + 1);
+  }
+  const matchedTokenCount = tokens.reduce((count, token) => count + (tokenCounts.has(token) ? 1 : 0), 0);
   const exactPhrase =
     normalizedQuery.length >= 4 &&
     normalizedText.includes(normalizedQuery);
-  const phraseBonus = exactPhrase ? Math.max(1, tokens.length) : 0;
-  const coverage = (matchedTokenCount + phraseBonus) / (tokens.length * 2);
+  const bm25Sum = tokens.reduce((sum, token) => {
+    const frequency = tokenCounts.get(token) ?? 0;
+    if (frequency === 0) return sum;
+    const denominator =
+      frequency +
+      LOCAL_MEMORY_BM25_K1 *
+        (1 - LOCAL_MEMORY_BM25_B + LOCAL_MEMORY_BM25_B * (documentTokenCount / LOCAL_MEMORY_AVG_DOC_LENGTH));
+    return sum + (frequency * (LOCAL_MEMORY_BM25_K1 + 1)) / denominator;
+  }, 0);
+  const coverage = matchedTokenCount / tokens.length;
+  const phraseBonus = exactPhrase ? 0.35 : 0;
+  const lengthDampening = Math.min(1, Math.sqrt(LOCAL_MEMORY_AVG_DOC_LENGTH / Math.max(1, documentTokenCount)));
+  const kwScore = (bm25Sum / tokens.length + coverage * 0.1 + phraseBonus) * lengthDampening;
   const confidence = Math.max(0, Math.min(1, input.confidence ?? 1));
   const sourceWeight = input.source === "session" ? 0.5 : 1;
   return {
-    finalScore: coverage * confidence * sourceWeight,
+    finalScore: kwScore * confidence * sourceWeight,
     matchedTokenCount,
     exactPhrase,
+    kwScore,
+    documentTokenCount,
   };
+}
+
+export interface LocalMemorySearchCandidate {
+  id: string;
+  source: string;
+  content: string;
+  category: string;
+  confidence: number;
+  created_at: string;
+  score: LocalMemoryContentScore;
+}
+
+export function rankLocalMemorySearchRows<T extends LocalMemorySearchCandidate>(
+  rows: T[],
+  maxResults: number,
+  asOf?: string
+): Array<Omit<T, "score"> & {
+  final_score: number;
+  rrf_score: number;
+  kw_score: number;
+  cosine_score: null;
+  keyword_rank: number;
+  vector_rank: null;
+}> {
+  return rows
+    .filter((row) => row.score.kwScore > 0)
+    .sort((a, b) => {
+      const scoreDiff = b.score.finalScore - a.score.finalScore;
+      return scoreDiff !== 0 ? scoreDiff : b.created_at.localeCompare(a.created_at);
+    })
+    .map((row, index) => {
+      const keywordRank = index + 1;
+      const rrfScore = reciprocalRankScore(keywordRank, null);
+      const confidence = clampUnit(row.confidence);
+      const sourceWeight = row.source === "session" || row.source === "conversation" ? 0.5 : 1;
+      const finalScore = rrfScore * confidence * sourceWeight * memoryRecencyWeight(row.created_at, asOf);
+      const { score: _score, ...rest } = row;
+      return {
+        ...rest,
+        final_score: finalScore,
+        rrf_score: rrfScore,
+        kw_score: row.score.kwScore,
+        cosine_score: null,
+        keyword_rank: keywordRank,
+        vector_rank: null,
+      };
+    })
+    .sort((a, b) => {
+      const scoreDiff = b.final_score - a.final_score;
+      return scoreDiff !== 0 ? scoreDiff : b.created_at.localeCompare(a.created_at);
+    })
+    .slice(0, maxResults);
 }
 
 interface TaxonomySeed {
@@ -831,10 +940,7 @@ export class SupabaseBackend implements MemoryBackend {
           category: r.category,
           confidence: r.confidence,
           created_at: r.created_at,
-          final_score: s.finalScore,
-          rrf_score: 0,
-          kw_score: s.matchedTokenCount,
-          cosine_score: 0,
+          score: s,
         };
       });
       const sessions = ((sessRes.data ?? []) as SessRow[]).map((r) => {
@@ -852,18 +958,10 @@ export class SupabaseBackend implements MemoryBackend {
           category: "session",
           confidence: 1,
           created_at: r.created_at,
-          final_score: s.finalScore,
-          rrf_score: 0,
-          kw_score: s.matchedTokenCount,
-          cosine_score: 0,
+          score: s,
         };
       });
-      return [...facts, ...sessions]
-        .sort((a, b) => {
-          const d = (b.final_score ?? 0) - (a.final_score ?? 0);
-          return d !== 0 ? d : (b.created_at ?? "").localeCompare(a.created_at ?? "");
-        })
-        .slice(0, maxResults);
+      return rankLocalMemorySearchRows([...facts, ...sessions], maxResults, effectiveAsOf);
     };
 
     const andResults = await runScan("and");

--- a/supabase/migrations/20260604030600_memory_hybrid_ranking_contract.sql
+++ b/supabase/migrations/20260604030600_memory_hybrid_ranking_contract.sql
@@ -1,0 +1,518 @@
+-- lane-06: retrieval SQL and ranking internals
+-- Publishes the ranking contract used by Workers 1 and 10.
+
+CREATE OR REPLACE FUNCTION memory_keyword_score_v1(
+  p_content TEXT,
+  p_query TSQUERY
+)
+RETURNS REAL
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(
+    ts_rank_cd(to_tsvector('english', COALESCE(p_content, '')), p_query, 34),
+    0
+  )::REAL;
+$$;
+
+CREATE OR REPLACE FUNCTION memory_rrf_score_v1(
+  p_keyword_rank INTEGER,
+  p_vector_rank INTEGER,
+  p_k REAL DEFAULT 60.0
+)
+RETURNS REAL
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT (
+    CASE WHEN p_keyword_rank IS NULL OR p_keyword_rank <= 0 THEN 0.0 ELSE 1.0 / (p_k + p_keyword_rank) END +
+    CASE WHEN p_vector_rank IS NULL OR p_vector_rank <= 0 THEN 0.0 ELSE 1.0 / (p_k + p_vector_rank) END
+  )::REAL;
+$$;
+
+DROP FUNCTION IF EXISTS mc_search_memory_hybrid(TEXT, TEXT, VECTOR, INTEGER, TIMESTAMPTZ);
+
+CREATE FUNCTION mc_search_memory_hybrid(
+  p_api_key_hash    TEXT,
+  p_search_query    TEXT,
+  p_query_embedding VECTOR(1536),
+  p_max_results     INTEGER    DEFAULT 10,
+  p_as_of           TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE(
+  id           UUID,
+  source       TEXT,
+  content      TEXT,
+  category     TEXT,
+  confidence   REAL,
+  created_at   TIMESTAMPTZ,
+  final_score  REAL,
+  rrf_score    REAL,
+  kw_score     REAL,
+  cosine_score REAL,
+  keyword_rank INTEGER,
+  vector_rank  INTEGER
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  q TSQUERY;
+  as_of_ts TIMESTAMPTZ;
+BEGIN
+  q := plainto_tsquery('english', p_search_query);
+  as_of_ts := COALESCE(p_as_of, now());
+
+  RETURN QUERY
+  WITH kw_facts_scored AS (
+    SELECT
+      ef.id,
+      'fact'::TEXT AS source,
+      ef.fact AS content,
+      ef.category,
+      ef.confidence,
+      ef.created_at,
+      memory_keyword_score_v1(ef.fact, q) AS kw_score
+    FROM mc_extracted_facts ef
+    WHERE ef.api_key_hash = p_api_key_hash
+      AND memory_fact_is_recall_visible_v1(
+        ef.status,
+        ef.invalidated_at,
+        ef.valid_from,
+        ef.valid_to,
+        ef.startup_fact_kind,
+        ef.source_type,
+        ef.category,
+        ef.fact,
+        as_of_ts
+      )
+      AND to_tsvector('english', ef.fact) @@ q
+  ),
+  kw_facts AS (
+    SELECT *
+    FROM (
+      SELECT
+        kfs.*,
+        CAST(ROW_NUMBER() OVER (ORDER BY kfs.kw_score DESC, kfs.created_at DESC, kfs.id) AS INTEGER) AS keyword_rank
+      FROM kw_facts_scored kfs
+      WHERE kfs.kw_score > 0
+    ) ranked
+    WHERE ranked.keyword_rank <= 50
+  ),
+  vec_facts AS (
+    SELECT *
+    FROM (
+      SELECT
+        ef.id,
+        'fact'::TEXT AS source,
+        ef.fact AS content,
+        ef.category,
+        ef.confidence,
+        ef.created_at,
+        CAST(ROW_NUMBER() OVER (ORDER BY ef.embedding <=> p_query_embedding, ef.created_at DESC, ef.id) AS INTEGER) AS vector_rank,
+        GREATEST(0.0, LEAST(1.0, 1.0 - (ef.embedding <=> p_query_embedding)))::REAL AS cosine_score
+      FROM mc_extracted_facts ef
+      WHERE ef.api_key_hash = p_api_key_hash
+        AND p_query_embedding IS NOT NULL
+        AND memory_fact_is_recall_visible_v1(
+          ef.status,
+          ef.invalidated_at,
+          ef.valid_from,
+          ef.valid_to,
+          ef.startup_fact_kind,
+          ef.source_type,
+          ef.category,
+          ef.fact,
+          as_of_ts
+        )
+        AND ef.embedding IS NOT NULL
+    ) ranked
+    WHERE ranked.vector_rank <= 50
+  ),
+  kw_sessions_scored AS (
+    SELECT
+      ss.id,
+      'session'::TEXT AS source,
+      ss.summary AS content,
+      'session'::TEXT AS category,
+      1.0::REAL AS confidence,
+      ss.created_at,
+      memory_keyword_score_v1(ss.summary, q) AS kw_score
+    FROM mc_session_summaries ss
+    WHERE ss.api_key_hash = p_api_key_hash
+      AND ss.created_at <= as_of_ts
+      AND to_tsvector('english', ss.summary) @@ q
+  ),
+  kw_sessions AS (
+    SELECT *
+    FROM (
+      SELECT
+        kss.*,
+        CAST(ROW_NUMBER() OVER (ORDER BY kss.kw_score DESC, kss.created_at DESC, kss.id) AS INTEGER) AS keyword_rank
+      FROM kw_sessions_scored kss
+      WHERE kss.kw_score > 0
+    ) ranked
+    WHERE ranked.keyword_rank <= 50
+  ),
+  vec_sessions AS (
+    SELECT *
+    FROM (
+      SELECT
+        ss.id,
+        'session'::TEXT AS source,
+        ss.summary AS content,
+        'session'::TEXT AS category,
+        1.0::REAL AS confidence,
+        ss.created_at,
+        CAST(ROW_NUMBER() OVER (ORDER BY ss.embedding <=> p_query_embedding, ss.created_at DESC, ss.id) AS INTEGER) AS vector_rank,
+        GREATEST(0.0, LEAST(1.0, 1.0 - (ss.embedding <=> p_query_embedding)))::REAL AS cosine_score
+      FROM mc_session_summaries ss
+      WHERE ss.api_key_hash = p_api_key_hash
+        AND p_query_embedding IS NOT NULL
+        AND ss.created_at <= as_of_ts
+        AND ss.embedding IS NOT NULL
+    ) ranked
+    WHERE ranked.vector_rank <= 50
+  ),
+  rrf_facts AS (
+    SELECT
+      COALESCE(k.id, v.id) AS id,
+      COALESCE(k.source, v.source) AS source,
+      COALESCE(k.content, v.content) AS content,
+      COALESCE(k.category, v.category) AS category,
+      COALESCE(k.confidence, v.confidence) AS confidence,
+      COALESCE(k.created_at, v.created_at) AS created_at,
+      COALESCE(k.kw_score, 0.0)::REAL AS kw_score,
+      v.cosine_score::REAL AS cosine_score,
+      k.keyword_rank,
+      v.vector_rank,
+      memory_rrf_score_v1(k.keyword_rank, v.vector_rank) AS rrf_score
+    FROM kw_facts k
+    FULL OUTER JOIN vec_facts v ON k.id = v.id
+  ),
+  rrf_sessions AS (
+    SELECT
+      COALESCE(k.id, v.id) AS id,
+      COALESCE(k.source, v.source) AS source,
+      COALESCE(k.content, v.content) AS content,
+      COALESCE(k.category, v.category) AS category,
+      COALESCE(k.confidence, v.confidence) AS confidence,
+      COALESCE(k.created_at, v.created_at) AS created_at,
+      COALESCE(k.kw_score, 0.0)::REAL AS kw_score,
+      v.cosine_score::REAL AS cosine_score,
+      k.keyword_rank,
+      v.vector_rank,
+      memory_rrf_score_v1(k.keyword_rank, v.vector_rank) AS rrf_score
+    FROM kw_sessions k
+    FULL OUTER JOIN vec_sessions v ON k.id = v.id
+  ),
+  combined AS (
+    SELECT * FROM rrf_facts
+    UNION ALL
+    SELECT * FROM rrf_sessions
+  ),
+  pre_dedup AS (
+    SELECT
+      c.id,
+      c.source,
+      c.content,
+      c.category,
+      c.confidence,
+      c.created_at,
+      c.rrf_score,
+      c.kw_score,
+      c.cosine_score,
+      c.keyword_rank,
+      c.vector_rank,
+      (
+        c.rrf_score
+        * c.confidence
+        * EXP(-GREATEST(0.0, EXTRACT(EPOCH FROM (as_of_ts - c.created_at))) / (90.0 * 86400.0))
+      )::REAL AS final_score
+    FROM combined c
+    ORDER BY
+      c.rrf_score
+      * c.confidence
+      * EXP(-GREATEST(0.0, EXTRACT(EPOCH FROM (as_of_ts - c.created_at))) / (90.0 * 86400.0)) DESC,
+      c.created_at DESC,
+      c.id
+    LIMIT 20
+  ),
+  fact_embeddings AS (
+    SELECT pd.id, pd.final_score, ef.embedding
+    FROM pre_dedup pd
+    JOIN mc_extracted_facts ef ON ef.id = pd.id
+    WHERE pd.source = 'fact'
+      AND ef.embedding IS NOT NULL
+  ),
+  dominated AS (
+    SELECT DISTINCT
+      CASE
+        WHEN a.final_score > b.final_score THEN b.id
+        WHEN a.final_score < b.final_score THEN a.id
+        ELSE LEAST(a.id::TEXT, b.id::TEXT)::UUID
+      END AS dominated_id
+    FROM fact_embeddings a
+    CROSS JOIN fact_embeddings b
+    WHERE a.id != b.id
+      AND (1.0 - (a.embedding <=> b.embedding)) >= 0.90
+  )
+  SELECT
+    pd.id,
+    pd.source,
+    pd.content,
+    pd.category,
+    pd.confidence,
+    pd.created_at,
+    pd.final_score,
+    pd.rrf_score,
+    pd.kw_score,
+    pd.cosine_score,
+    pd.keyword_rank,
+    pd.vector_rank
+  FROM pre_dedup pd
+  WHERE pd.id NOT IN (SELECT dominated_id FROM dominated)
+  ORDER BY pd.final_score DESC, pd.created_at DESC, pd.id
+  LIMIT p_max_results;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS search_memory_hybrid(TEXT, VECTOR, INTEGER, TIMESTAMPTZ);
+
+CREATE FUNCTION search_memory_hybrid(
+  search_query    TEXT,
+  query_embedding VECTOR(1536),
+  max_results     INTEGER    DEFAULT 10,
+  as_of           TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE(
+  id           UUID,
+  source       TEXT,
+  content      TEXT,
+  category     TEXT,
+  confidence   REAL,
+  created_at   TIMESTAMPTZ,
+  final_score  REAL,
+  rrf_score    REAL,
+  kw_score     REAL,
+  cosine_score REAL,
+  keyword_rank INTEGER,
+  vector_rank  INTEGER
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  q TSQUERY;
+  as_of_ts TIMESTAMPTZ;
+BEGIN
+  q := plainto_tsquery('english', search_query);
+  as_of_ts := COALESCE(as_of, now());
+
+  RETURN QUERY
+  WITH kw_facts_scored AS (
+    SELECT
+      ef.id,
+      'fact'::TEXT AS source,
+      ef.fact AS content,
+      ef.category,
+      ef.confidence,
+      ef.created_at,
+      memory_keyword_score_v1(ef.fact, q) AS kw_score
+    FROM extracted_facts ef
+    WHERE memory_fact_is_recall_visible_v1(
+        ef.status,
+        ef.invalidated_at,
+        ef.valid_from,
+        ef.valid_to,
+        ef.startup_fact_kind,
+        ef.source_type,
+        ef.category,
+        ef.fact,
+        as_of_ts
+      )
+      AND to_tsvector('english', ef.fact) @@ q
+  ),
+  kw_facts AS (
+    SELECT *
+    FROM (
+      SELECT
+        kfs.*,
+        CAST(ROW_NUMBER() OVER (ORDER BY kfs.kw_score DESC, kfs.created_at DESC, kfs.id) AS INTEGER) AS keyword_rank
+      FROM kw_facts_scored kfs
+      WHERE kfs.kw_score > 0
+    ) ranked
+    WHERE ranked.keyword_rank <= 50
+  ),
+  vec_facts AS (
+    SELECT *
+    FROM (
+      SELECT
+        ef.id,
+        'fact'::TEXT AS source,
+        ef.fact AS content,
+        ef.category,
+        ef.confidence,
+        ef.created_at,
+        CAST(ROW_NUMBER() OVER (ORDER BY ef.embedding <=> query_embedding, ef.created_at DESC, ef.id) AS INTEGER) AS vector_rank,
+        GREATEST(0.0, LEAST(1.0, 1.0 - (ef.embedding <=> query_embedding)))::REAL AS cosine_score
+      FROM extracted_facts ef
+      WHERE query_embedding IS NOT NULL
+        AND memory_fact_is_recall_visible_v1(
+          ef.status,
+          ef.invalidated_at,
+          ef.valid_from,
+          ef.valid_to,
+          ef.startup_fact_kind,
+          ef.source_type,
+          ef.category,
+          ef.fact,
+          as_of_ts
+        )
+        AND ef.embedding IS NOT NULL
+    ) ranked
+    WHERE ranked.vector_rank <= 50
+  ),
+  kw_sessions_scored AS (
+    SELECT
+      ss.id,
+      'session'::TEXT AS source,
+      ss.summary AS content,
+      'session'::TEXT AS category,
+      1.0::REAL AS confidence,
+      ss.created_at,
+      memory_keyword_score_v1(ss.summary, q) AS kw_score
+    FROM session_summaries ss
+    WHERE ss.created_at <= as_of_ts
+      AND to_tsvector('english', ss.summary) @@ q
+  ),
+  kw_sessions AS (
+    SELECT *
+    FROM (
+      SELECT
+        kss.*,
+        CAST(ROW_NUMBER() OVER (ORDER BY kss.kw_score DESC, kss.created_at DESC, kss.id) AS INTEGER) AS keyword_rank
+      FROM kw_sessions_scored kss
+      WHERE kss.kw_score > 0
+    ) ranked
+    WHERE ranked.keyword_rank <= 50
+  ),
+  vec_sessions AS (
+    SELECT *
+    FROM (
+      SELECT
+        ss.id,
+        'session'::TEXT AS source,
+        ss.summary AS content,
+        'session'::TEXT AS category,
+        1.0::REAL AS confidence,
+        ss.created_at,
+        CAST(ROW_NUMBER() OVER (ORDER BY ss.embedding <=> query_embedding, ss.created_at DESC, ss.id) AS INTEGER) AS vector_rank,
+        GREATEST(0.0, LEAST(1.0, 1.0 - (ss.embedding <=> query_embedding)))::REAL AS cosine_score
+      FROM session_summaries ss
+      WHERE query_embedding IS NOT NULL
+        AND ss.created_at <= as_of_ts
+        AND ss.embedding IS NOT NULL
+    ) ranked
+    WHERE ranked.vector_rank <= 50
+  ),
+  rrf_facts AS (
+    SELECT
+      COALESCE(k.id, v.id) AS id,
+      COALESCE(k.source, v.source) AS source,
+      COALESCE(k.content, v.content) AS content,
+      COALESCE(k.category, v.category) AS category,
+      COALESCE(k.confidence, v.confidence) AS confidence,
+      COALESCE(k.created_at, v.created_at) AS created_at,
+      COALESCE(k.kw_score, 0.0)::REAL AS kw_score,
+      v.cosine_score::REAL AS cosine_score,
+      k.keyword_rank,
+      v.vector_rank,
+      memory_rrf_score_v1(k.keyword_rank, v.vector_rank) AS rrf_score
+    FROM kw_facts k
+    FULL OUTER JOIN vec_facts v ON k.id = v.id
+  ),
+  rrf_sessions AS (
+    SELECT
+      COALESCE(k.id, v.id) AS id,
+      COALESCE(k.source, v.source) AS source,
+      COALESCE(k.content, v.content) AS content,
+      COALESCE(k.category, v.category) AS category,
+      COALESCE(k.confidence, v.confidence) AS confidence,
+      COALESCE(k.created_at, v.created_at) AS created_at,
+      COALESCE(k.kw_score, 0.0)::REAL AS kw_score,
+      v.cosine_score::REAL AS cosine_score,
+      k.keyword_rank,
+      v.vector_rank,
+      memory_rrf_score_v1(k.keyword_rank, v.vector_rank) AS rrf_score
+    FROM kw_sessions k
+    FULL OUTER JOIN vec_sessions v ON k.id = v.id
+  ),
+  combined AS (
+    SELECT * FROM rrf_facts
+    UNION ALL
+    SELECT * FROM rrf_sessions
+  ),
+  pre_dedup AS (
+    SELECT
+      c.id,
+      c.source,
+      c.content,
+      c.category,
+      c.confidence,
+      c.created_at,
+      c.rrf_score,
+      c.kw_score,
+      c.cosine_score,
+      c.keyword_rank,
+      c.vector_rank,
+      (
+        c.rrf_score
+        * c.confidence
+        * EXP(-GREATEST(0.0, EXTRACT(EPOCH FROM (as_of_ts - c.created_at))) / (90.0 * 86400.0))
+      )::REAL AS final_score
+    FROM combined c
+    ORDER BY
+      c.rrf_score
+      * c.confidence
+      * EXP(-GREATEST(0.0, EXTRACT(EPOCH FROM (as_of_ts - c.created_at))) / (90.0 * 86400.0)) DESC,
+      c.created_at DESC,
+      c.id
+    LIMIT 20
+  ),
+  fact_embeddings AS (
+    SELECT pd.id, pd.final_score, ef.embedding
+    FROM pre_dedup pd
+    JOIN extracted_facts ef ON ef.id = pd.id
+    WHERE pd.source = 'fact'
+      AND ef.embedding IS NOT NULL
+  ),
+  dominated AS (
+    SELECT DISTINCT
+      CASE
+        WHEN a.final_score > b.final_score THEN b.id
+        WHEN a.final_score < b.final_score THEN a.id
+        ELSE LEAST(a.id::TEXT, b.id::TEXT)::UUID
+      END AS dominated_id
+    FROM fact_embeddings a
+    CROSS JOIN fact_embeddings b
+    WHERE a.id != b.id
+      AND (1.0 - (a.embedding <=> b.embedding)) >= 0.90
+  )
+  SELECT
+    pd.id,
+    pd.source,
+    pd.content,
+    pd.category,
+    pd.confidence,
+    pd.created_at,
+    pd.final_score,
+    pd.rrf_score,
+    pd.kw_score,
+    pd.cosine_score,
+    pd.keyword_rank,
+    pd.vector_rank
+  FROM pre_dedup pd
+  WHERE pd.id NOT IN (SELECT dominated_id FROM dominated)
+  ORDER BY pd.final_score DESC, pd.created_at DESC, pd.id
+  LIMIT max_results;
+END;
+$$;

--- a/supabase/migrations/20260604030700_memory_startup_context_provenance.sql
+++ b/supabase/migrations/20260604030700_memory_startup_context_provenance.sql
@@ -1,0 +1,242 @@
+-- Lane 06: expose provenance receipts through startup active facts.
+-- Worker 3 owns the columns. This RPC layer reads them through to_jsonb so the
+-- migration is tolerant of coordinator sequencing while still publishing the
+-- real columns once W3 has landed.
+
+CREATE OR REPLACE FUNCTION mc_get_startup_context(
+  p_api_key_hash TEXT,
+  p_num_sessions INTEGER DEFAULT 5
+)
+RETURNS JSONB AS $$
+DECLARE
+  ctx JSONB;
+  lib JSONB;
+  sessions JSONB;
+  facts JSONB;
+  fact_ids UUID[] := ARRAY[]::UUID[];
+BEGIN
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'category', category,
+      'key', key,
+      'value', value,
+      'priority', priority
+    ) ORDER BY priority DESC, category, key
+  ), '[]'::jsonb)
+  INTO ctx
+  FROM mc_business_context
+  WHERE api_key_hash = p_api_key_hash
+    AND decay_tier IN ('hot', 'warm');
+
+  UPDATE mc_business_context
+  SET access_count = access_count + 1,
+      last_accessed = now()
+  WHERE api_key_hash = p_api_key_hash
+    AND decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'slug', slug,
+      'title', title,
+      'category', category,
+      'tags', tags,
+      'version', version,
+      'updated_at', updated_at
+    ) ORDER BY updated_at DESC
+  ), '[]'::jsonb)
+  INTO lib
+  FROM mc_knowledge_library
+  WHERE api_key_hash = p_api_key_hash
+    AND decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'session_id', session_id,
+      'platform', platform,
+      'summary', summary,
+      'decisions', decisions,
+      'open_loops', open_loops,
+      'topics', topics,
+      'created_at', created_at
+    ) ORDER BY created_at DESC
+  ), '[]'::jsonb)
+  INTO sessions
+  FROM (
+    SELECT *
+    FROM mc_session_summaries
+    WHERE api_key_hash = p_api_key_hash
+    ORDER BY created_at DESC
+    LIMIT p_num_sessions
+  ) recent;
+
+  WITH surfaced_facts AS (
+    SELECT
+      af.id,
+      af.fact,
+      af.category,
+      af.confidence,
+      af.created_at,
+      af.startup_fact_kind,
+      NULLIF(to_jsonb(ef) ->> 'source_agent_id', '') AS source_agent_id,
+      NULLIF(to_jsonb(ef) ->> 'source_ref', '') AS source_ref,
+      NULLIF(to_jsonb(ef) ->> 'receipt_id', '') AS receipt_id
+    FROM mc_active_facts_startup_v1 af
+    JOIN mc_extracted_facts ef
+      ON ef.id = af.id
+     AND ef.api_key_hash = af.api_key_hash
+    WHERE af.api_key_hash = p_api_key_hash
+    ORDER BY
+      CASE WHEN af.startup_fact_kind = 'durable' THEN 0 ELSE 1 END,
+      af.confidence DESC,
+      af.created_at DESC
+    LIMIT 50
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'fact', fact,
+        'category', category,
+        'confidence', confidence,
+        'created_at', created_at,
+        'source_agent_id', source_agent_id,
+        'source_ref', source_ref,
+        'receipt_id', receipt_id
+      ) ORDER BY
+        CASE WHEN startup_fact_kind = 'durable' THEN 0 ELSE 1 END,
+        confidence DESC,
+        created_at DESC
+    ), '[]'::jsonb),
+    COALESCE(array_agg(id), ARRAY[]::UUID[])
+  INTO facts, fact_ids
+  FROM surfaced_facts;
+
+  UPDATE mc_extracted_facts
+  SET access_count = access_count + 1,
+      last_accessed = now()
+  WHERE api_key_hash = p_api_key_hash
+    AND id = ANY(fact_ids);
+
+  RETURN jsonb_build_object(
+    'business_context', ctx,
+    'knowledge_library_index', lib,
+    'recent_sessions', sessions,
+    'active_facts', facts,
+    'loaded_at', now()
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION get_startup_context(num_sessions INTEGER DEFAULT 5)
+RETURNS JSONB AS $$
+DECLARE
+  result JSONB;
+  ctx JSONB;
+  lib JSONB;
+  sessions JSONB;
+  facts JSONB;
+  fact_ids UUID[] := ARRAY[]::UUID[];
+BEGIN
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'category', category,
+      'key', key,
+      'value', value,
+      'priority', priority
+    ) ORDER BY priority DESC, category, key
+  ), '[]'::jsonb)
+  INTO ctx
+  FROM business_context
+  WHERE decay_tier IN ('hot', 'warm');
+
+  UPDATE business_context
+  SET access_count = access_count + 1,
+      last_accessed = now()
+  WHERE decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'slug', slug,
+      'title', title,
+      'category', category,
+      'tags', tags,
+      'version', version,
+      'updated_at', updated_at
+    ) ORDER BY updated_at DESC
+  ), '[]'::jsonb)
+  INTO lib
+  FROM knowledge_library
+  WHERE decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'session_id', session_id,
+      'platform', platform,
+      'summary', summary,
+      'decisions', decisions,
+      'open_loops', open_loops,
+      'topics', topics,
+      'created_at', created_at
+    ) ORDER BY created_at DESC
+  ), '[]'::jsonb)
+  INTO sessions
+  FROM (
+    SELECT *
+    FROM session_summaries
+    ORDER BY created_at DESC
+    LIMIT num_sessions
+  ) recent;
+
+  WITH surfaced_facts AS (
+    SELECT
+      af.id,
+      af.fact,
+      af.category,
+      af.confidence,
+      af.created_at,
+      af.startup_fact_kind,
+      NULLIF(to_jsonb(ef) ->> 'source_agent_id', '') AS source_agent_id,
+      NULLIF(to_jsonb(ef) ->> 'source_ref', '') AS source_ref,
+      NULLIF(to_jsonb(ef) ->> 'receipt_id', '') AS receipt_id
+    FROM active_facts_startup_v1 af
+    JOIN extracted_facts ef ON ef.id = af.id
+    ORDER BY
+      CASE WHEN af.startup_fact_kind = 'durable' THEN 0 ELSE 1 END,
+      af.confidence DESC,
+      af.created_at DESC
+    LIMIT 50
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'fact', fact,
+        'category', category,
+        'confidence', confidence,
+        'created_at', created_at,
+        'source_agent_id', source_agent_id,
+        'source_ref', source_ref,
+        'receipt_id', receipt_id
+      ) ORDER BY
+        CASE WHEN startup_fact_kind = 'durable' THEN 0 ELSE 1 END,
+        confidence DESC,
+        created_at DESC
+    ), '[]'::jsonb),
+    COALESCE(array_agg(id), ARRAY[]::UUID[])
+  INTO facts, fact_ids
+  FROM surfaced_facts;
+
+  UPDATE extracted_facts
+  SET access_count = access_count + 1,
+      last_accessed = now()
+  WHERE id = ANY(fact_ids);
+
+  result := jsonb_build_object(
+    'business_context', ctx,
+    'knowledge_library_index', lib,
+    'recent_sessions', sessions,
+    'active_facts', facts,
+    'loaded_at', now()
+  );
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Lane 6 publishes and implements the ranking internals contract for memory hardening.

Before this change, hybrid SQL already existed, but keyword ranking used raw `ts_rank` without a lane-owned length-normalized score helper, local fallback exposed token counts as `kw_score`, and local rows left `rrf_score` at 0.

This PR adds:

- `memory_keyword_score_v1` and `memory_rrf_score_v1` in migration band `03xx`.
- Rebuilt `search_memory_hybrid` and `mc_search_memory_hybrid` row shape with `keyword_rank`, `vector_rank`, `rrf_score`, `kw_score`, `cosine_score`, and `final_score` populated.
- Cosine score clamping to `[0,1]` when vector search is available.
- Local backend parity for BM25-style keyword scoring, RRF row shaping, null vector fields, and final score semantics.
- Hybrid-search tests proving concise identity facts beat long verbose logs and local rows publish the lane 6 score contract.

## Flag

`MEMORY_RERANK_ENABLED` remains the optional rerank flag for this lane. The hybrid vector path continues to respect the existing embeddings flags.

## Backends touched

- Supabase: migration plus `supabase.ts` fallback scoring helpers.
- Local JSON: `local.ts` search row shaping uses the same ranking helper.

## Expected eval movement

- `ndcg@10`
- vector `recall@5`

## Validation

- `npx tsx --test src/memory/__tests__/hybrid-search.test.ts` passed, 23 tests.
- `npm run build --workspace=@unclick/mcp-server` passed.
- `npm run test --workspace=@unclick/mcp-server` ran memory tests, 237 Vitest files, connector-depth tests, and generator checks until the final `connector-depth-ladder --check` failed because the connector ladder docs are stale on the integration base. I did not include unrelated generated connector docs in this lane PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core memory search ranking and large SQL RPCs; behavior shifts (ranking, dedup) affect recall quality but not auth or data writes directly.
> 
> **Overview**
> This PR **standardizes memory hybrid retrieval ranking** across Postgres RPCs and the local/keyword fallback path, and **threads provenance into startup context**.
> 
> **Hybrid search contract:** New SQL helpers `memory_keyword_score_v1` and `memory_rrf_score_v1` back rebuilt `search_memory_hybrid` / `mc_search_memory_hybrid` that fuse keyword and vector lanes with RRF, expose `keyword_rank`, `vector_rank`, `kw_score`, `cosine_score` (clamped), `rrf_score`, and `final_score` with 90-day recency, and drop near-duplicate facts (≥0.90 embedding similarity).
> 
> **Local parity:** `scoreLocalMemoryContent` moves to BM25-style scoring with length dampening; `rankLocalMemorySearchRows` shapes results like the SQL contract (keyword-only RRF when no vectors). `LocalBackend` and Supabase `keywordFallback` route through these helpers instead of ad-hoc sorts and zero `rrf_score`.
> 
> **Startup provenance:** `get_startup_context` / `mc_get_startup_context` and local `active_facts` now include `source_agent_id`, `source_ref`, and `receipt_id` when present on extracted facts.
> 
> Tests lock concise-vs-verbose ranking, the lane-6 score fields, and local provenance passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 545f9999475f4c3ad4020b2f38e48fc30a5dc567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->