### PR TITLE
fix(worker11): remove duplicate auth tracking calls

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8600,8 +8600,8 @@
     },
     {
       "source": "src/pages/AuthCallback.tsx",
-      "hash": "41644ade9f97",
-      "bytes": 5284
+      "hash": "c7dba82923b5",
+      "bytes": 4875
     },
     {
       "source": "src/pages/VerifyMfa.tsx",
@@ -8670,8 +8670,8 @@
     },
     {
       "source": "src/pages/Login.tsx",
-      "hash": "0cfc79660be5",
-      "bytes": 8862
+      "hash": "86f887990094",
+      "bytes": 8440
     },
     {
       "source": "src/pages/MemoryConnect.tsx",
@@ -8710,8 +8710,8 @@
     },
     {
       "source": "src/pages/Signup.tsx",
-      "hash": "8eee366a8e3f",
-      "bytes": 9045
+      "hash": "bb69e5123b4b",
+      "bytes": 8623
     },
     {
       "source": "src/pages/SmartHome.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -94,7 +94,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminYou.tsx | 89ed912e326b | 59397 |
 | src/pages/AppDetail.tsx | 0cf7c397e1b5 | 5401 |
 | src/pages/Apps.tsx | 1ccab2a4ccad | 2647 |
-| src/pages/AuthCallback.tsx | 41644ade9f97 | 5284 |
+| src/pages/AuthCallback.tsx | c7dba82923b5 | 4875 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
 | src/pages/Connect.tsx | ebf2c68ad6c3 | 29590 |
 | src/pages/Crews.tsx | 672df3eeb92b | 18792 |
@@ -108,7 +108,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/FAQPage.tsx | 507e1ed5789c | 712 |
 | src/pages/InstallRecover.tsx | 56c822e69817 | 6971 |
 | src/pages/Jobsmith.tsx | 08e9c9874c22 | 61541 |
-| src/pages/Login.tsx | 0cfc79660be5 | 8862 |
+| src/pages/Login.tsx | 86f887990094 | 8440 |
 | src/pages/MemoryConnect.tsx | c760d37398d5 | 18534 |
 | src/pages/MemorySetup.tsx | c46cb67d413e | 19854 |
 | src/pages/Memory.tsx | cf7f06bacc89 | 18641 |
@@ -116,7 +116,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Organiser.tsx | a439fcf2092f | 16578 |
 | src/pages/Pricing.tsx | 0830c034b4a3 | 8753 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
-| src/pages/Signup.tsx | 8eee366a8e3f | 9045 |
+| src/pages/Signup.tsx | bb69e5123b4b | 8623 |
 | src/pages/SmartHome.tsx | 3671f5d143b1 | 20733 |
 | src/pages/Terms.tsx | 4613736d1aa8 | 9327 |
 | src/pages/tools/LinkInBio.tsx | 4f20852d63d4 | 7831 |

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -51,15 +51,9 @@ export default function AuthCallbackPage() {
         provider,
         created_at: user.created_at,
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const umamiTrack = (window as any).umami?.track;
       if (isNewUser) {
-        // TODO(posthog-migration): remove umami call once PostHog validated
-        umamiTrack?.("new_user_signup", { method, email: user.email });
         posthog.capture("signup_completed", { method, email: user.email });
       } else {
-        // TODO(posthog-migration): remove umami call once PostHog validated
-        umamiTrack?.("returning_user_signin", { method });
         posthog.capture("signin_completed", { method });
       }
       // Check if MFA is required before entering the admin shell

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -50,9 +50,6 @@ export default function LoginPage() {
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
-      // TODO(posthog-migration): remove umami call once PostHog validated
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).umami?.track("signin", { method: "magic_link" });
       posthog.capture("signin_started", { method: "magic_link" });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong. Try again.");
@@ -65,9 +62,6 @@ export default function LoginPage() {
     setError("");
     setBusy(provider);
     track("login_started", { method: provider });
-    // TODO(posthog-migration): remove umami call once PostHog validated
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).umami?.track("signin", { method: provider });
     posthog.capture("signin_started", { method: provider });
     try {
       await signInWithOAuth(provider);

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -54,9 +54,6 @@ export default function SignupPage() {
     try {
       await signInWithMagicLink(trimmed);
       setSent(true);
-      // TODO(posthog-migration): remove umami call once PostHog validated
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).umami?.track("signup", { method: "magic_link" });
       posthog.capture("signup_started", { method: "magic_link" });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong. Try again.");
@@ -69,9 +66,6 @@ export default function SignupPage() {
     setError("");
     setBusy(provider);
     track("signup_started", { method: provider });
-    // TODO(posthog-migration): remove umami call once PostHog validated
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).umami?.track("signup", { method: provider });
     posthog.capture("signup_started", { method: provider });
     try {
       await signInWithOAuth(provider);


### PR DESCRIPTION
## Summary
- Takes only the safe Worker 11 auth analytics cleanup from draft PR #1261.
- Removes duplicate direct window.umami calls and old migration TODOs from Login, Signup, and AuthCallback.
- Keeps the existing track(...) analytics helper calls and PostHog capture calls intact.
- Refreshes the generated brainmap.

## Safety decisions
- Did not take the larger Boardroom UI polish from #1261: author texture, My team default, or playback panel stay held for visual/UX proof.
- No new UI, no API changes, no auth flow behavior change beyond removing duplicate dead tracking calls.

## Validation
- npm exec vitest -- run src/lib/analytics.test.ts -> 1 file passed, 3 tests passed.
- npm exec eslint -- src/pages/Login.tsx src/pages/Signup.tsx src/pages/AuthCallback.tsx -> pass.
- npm run brainmap:check -> pass.
- Search for direct umami/TODO markers in the three auth pages -> no matches.

## Replaces in part
This safely lands the auth cleanup part of Worker 11 PR #1261. The bigger UI changes remain held.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only cleanup on auth pages with no auth, API, or UI behavior changes.
> 
> **Overview**
> Removes leftover **Umami** `window.umami?.track` calls and PostHog-migration TODO comments from `Login`, `Signup`, and `AuthCallback` so auth analytics are not double-fired alongside the existing `track(...)` helper and **PostHog** `capture` events.
> 
> Auth UX and Supabase flows are unchanged; generated brainmap metadata is refreshed for the touched page files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa57d665a174a607058f6451e03670897801c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->