### PR TITLE
Lane 10: Eval Harness, Diagnostics & Memory Passport

### DIFF
--- a/docs/memory-hardening/lane-10-eval-baseline.json
+++ b/docs/memory-hardening/lane-10-eval-baseline.json
@@ -1,0 +1,65 @@
+{
+  "suite_id": "memory-hardening-eval-v1",
+  "generated_at": "2026-06-04T03:19:12.802Z",
+  "backend": "local",
+  "note": "Frozen lane-10 baseline from the deterministic LocalBackend diagnostic harness. Existing proof-as-reward docs/eval-baseline.json is left intact.",
+  "diagnostics": {
+    "total": 6,
+    "passed": 4,
+    "failed": 2
+  },
+  "metrics": {
+    "recall@5": 1,
+    "identity_hit_rate": null,
+    "latest_value_accuracy": 1,
+    "contradiction_precision": null,
+    "provenance_coverage": null,
+    "scope_leakage": 1,
+    "forget_compliance": 1,
+    "correction_adherence": null,
+    "ndcg@10": null,
+    "vector_recall@5": null,
+    "duplicate_rate": 0.666667,
+    "write_precision": 1,
+    "hot_set_staleness": null,
+    "dedup_collapse_rate": null,
+    "fact_index_purity": null,
+    "passport_roundtrip_fidelity": 1,
+    "passport_credential_leakage": 0,
+    "scorecard": 0.666667
+  },
+  "scenarios": [
+    {
+      "id": "paraphrase-recall",
+      "kind": "paraphrase_recall",
+      "passed": true
+    },
+    {
+      "id": "latest-value",
+      "kind": "latest_value",
+      "passed": true
+    },
+    {
+      "id": "scope-bleed",
+      "kind": "scope_bleed",
+      "passed": false,
+      "expected_owner": "Worker 4"
+    },
+    {
+      "id": "no-answer",
+      "kind": "no_answer",
+      "passed": true
+    },
+    {
+      "id": "forget",
+      "kind": "forget",
+      "passed": true
+    },
+    {
+      "id": "duplicate-storm",
+      "kind": "duplicate_storm",
+      "passed": false,
+      "expected_owner": "Worker 7"
+    }
+  ]
+}

--- a/docs/memory-hardening/lane-10-eval-report.md
+++ b/docs/memory-hardening/lane-10-eval-report.md
@@ -1,0 +1,42 @@
+# Lane 10 Memory Eval Report
+
+Generated for `memory-hardening-eval-v1` on `2026-06-04T03:19:12.802Z` against the local memory backend.
+
+The existing proof-as-reward eval files at `docs/eval-baseline.json` and `docs/eval-report.md` are not overwritten by this lane. This report is the memory-hardening scorecard that Coordinator can rerun after lane merges.
+
+## Headline
+
+| Metric | Value |
+| --- | ---: |
+| Scorecard | 66.7% |
+| Diagnostics passed | 4 / 6 |
+| Passport roundtrip fidelity | 100.0% |
+| Passport credential leakage | 0 |
+
+## Registry Metrics
+
+| Metric | Value |
+| --- | ---: |
+| `recall@5` | 1 |
+| `latest_value_accuracy` | 1 |
+| `scope_leakage` | 1 |
+| `forget_compliance` | 1 |
+| `duplicate_rate` | 0.666667 |
+| `write_precision` | 1 |
+| `passport_roundtrip_fidelity` | 1 |
+| `passport_credential_leakage` | 0 |
+
+Metrics owned by lanes that have not merged yet remain `null` in the JSON baseline.
+
+## Diagnostics
+
+| Scenario | Result | Owner Expected To Move It |
+| --- | --- | --- |
+| paraphrase-recall | pass | Worker 1 / Worker 6 |
+| latest-value | pass | Worker 2 |
+| scope-bleed | fail | Worker 4 |
+| no-answer | pass | Worker 7 |
+| forget | pass | Worker 5 |
+| duplicate-storm | fail | Worker 7 |
+
+The failing baseline cases are not lane-10 failures. They are the observable pre-change deltas the harness is meant to catch.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,7 +2,7 @@
   "name": "@unclick/mcp-server",
   "version": "0.3.110",
   "mcpName": "io.github.malamutemayhem/unclick",
-  "description": "MCP server for the UnClick tool marketplace — lets AI agents discover and use every UnClick tool",
+  "description": "MCP server for the UnClick tool marketplace - lets AI agents discover and use every UnClick tool",
   "type": "module",
   "bin": {
     "unclick-mcp": "./dist/index.js"
@@ -23,7 +23,7 @@
     "build": "npm run prepare:wiring && npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsc",
     "dev": "npm run prepare:wiring && npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "npm run prepare:wiring && npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsx --test src/memory/__tests__/typed-links.test.ts src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts src/memory/__tests__/response-bounds.test.ts src/memory/__tests__/load-memory-invalidation.test.ts src/memory/__tests__/snapshot-taxonomy.test.ts src/memory/__tests__/local-backend.test.ts src/memory/__tests__/session-inspection-trigger.test.ts && vitest run && node --test scripts/connector-depth-ladder.test.mjs && node scripts/generate-tool-index.mjs --check && node scripts/connector-depth-ladder.mjs --check && node scripts/check-standalone-registry.mjs",
+    "test": "npm run prepare:wiring && npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsx --test src/memory/__tests__/typed-links.test.ts src/memory/__tests__/hybrid-search.test.ts src/memory/__tests__/bitemporal.test.ts src/memory/__tests__/response-bounds.test.ts src/memory/__tests__/load-memory-invalidation.test.ts src/memory/__tests__/snapshot-taxonomy.test.ts src/memory/__tests__/local-backend.test.ts src/memory/__tests__/session-inspection-trigger.test.ts src/memory/__tests__/eval-harness.test.ts src/memory/__tests__/passport.test.ts && vitest run && node --test scripts/connector-depth-ladder.test.mjs && node scripts/generate-tool-index.mjs --check && node scripts/connector-depth-ladder.mjs --check && node scripts/check-standalone-registry.mjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/mcp-server/src/memory/__tests__/eval-harness.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/eval-harness.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let tempDir = "";
+
+describe("memory hardening eval harness", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "unclick-memory-eval-"));
+    process.env.MEMORY_LOCAL_DATA_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    delete process.env.MEMORY_LOCAL_DATA_DIR;
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = "";
+  });
+
+  test("runs the six lane-10 diagnostics and emits Part 6 metrics", async () => {
+    const { LocalBackend } = await import("../local.js");
+    const { runMemoryHardeningEval } = await import("../eval-harness.js");
+    const backend = new LocalBackend();
+
+    const scorecard = await runMemoryHardeningEval(backend);
+
+    assert.equal(scorecard.suite_id, "memory-hardening-eval-v1");
+    assert.equal(scorecard.scenarios.length, 6);
+    assert.equal(scorecard.diagnostics.total, 6);
+    assert.equal(scorecard.diagnostics.passed + scorecard.diagnostics.failed, 6);
+    assert.equal(typeof scorecard.generated_at, "string");
+
+    for (const metric of [
+      "recall@5",
+      "latest_value_accuracy",
+      "scope_leakage",
+      "forget_compliance",
+      "duplicate_rate",
+      "write_precision",
+      "passport_roundtrip_fidelity",
+      "passport_credential_leakage",
+    ]) {
+      assert.ok(metric in scorecard.metrics, `${metric} missing`);
+    }
+
+    const duplicateStorm = scorecard.scenarios.find((scenario) => scenario.kind === "duplicate_storm");
+    assert.ok(duplicateStorm, "duplicate storm diagnostic missing");
+    assert.equal(typeof scorecard.metrics.duplicate_rate, "number");
+  });
+});

--- a/packages/mcp-server/src/memory/__tests__/passport.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/passport.test.ts
@@ -110,6 +110,14 @@ describe("memory passport", () => {
       assert.equal(results.some((row) => row.content.includes("lane-ten-teal")), true);
       const context = await target.getBusinessContext() as Array<{ category: string; key: string; value: unknown }>;
       assert.equal(context.some((row) => row.category === "identity" && row.key === "preferred_name"), true);
+      const reexported = await target.exportMemoryPassport({
+        signing_secret: SIGNING_SECRET,
+        include_sessions: false,
+      });
+      const reexportedFact = reexported.bundle.memory.facts.find((row) => row.fact.includes("lane-ten-teal"));
+      assert.equal(reexportedFact?.extractor_id, "lane-10-test");
+      assert.equal(reexportedFact?.prompt_version, "passport-v1");
+      assert.equal(reexportedFact?.model_id, "test-model");
     } finally {
       fs.rmSync(targetDir, { recursive: true, force: true });
     }

--- a/packages/mcp-server/src/memory/__tests__/passport.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/passport.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SIGNING_SECRET = "lane-10-test-signing-secret";
+let tempDir = "";
+
+function readRows<T>(dir: string, table: string): T[] {
+  return JSON.parse(fs.readFileSync(path.join(dir, `${table}.json`), "utf8")) as T[];
+}
+
+describe("memory passport", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "unclick-memory-passport-"));
+    process.env.MEMORY_LOCAL_DATA_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    delete process.env.MEMORY_LOCAL_DATA_DIR;
+    delete process.env.MEMORY_PASSPORT_ENABLED;
+    delete process.env.MEMORY_PASSPORT_SIGNING_SECRET;
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = "";
+  });
+
+  test("exports a signed allowlisted bundle without credential-shaped memory", async () => {
+    const { LocalBackend } = await import("../local.js");
+    const {
+      auditMemoryPassportCredentialLeakage,
+      verifyMemoryPassportBundle,
+    } = await import("../passport.js");
+    const backend = new LocalBackend();
+
+    await backend.setBusinessContext("identity", "preferred_name", "Chris", 100);
+    await backend.addFact({
+      fact: "Portable memory marker lane-ten-silver should roundtrip.",
+      category: "technical",
+      confidence: 0.97,
+      commit_sha: "abc1234",
+      pr_number: 1274,
+    });
+    await backend.addFact({
+      fact: "Temporary API key sk-test-secret-1234567890 should never export.",
+      category: "credential",
+      confidence: 1,
+    });
+    await backend.writeSessionSummary({
+      session_id: "passport-source-session",
+      summary: "Passport export keeps non-secret session summaries.",
+      topics: ["memory"],
+      open_loops: [],
+      decisions: ["Use signed JSON bundles."],
+      platform: "test",
+    });
+
+    const result = await backend.exportMemoryPassport({
+      subject_id: "test-subject",
+      signing_secret: SIGNING_SECRET,
+    });
+    const serialized = JSON.stringify(result.bundle);
+
+    assert.equal(result.bundle.version, "memory-passport-v1");
+    assert.equal(result.bundle.subject_id, "test-subject");
+    assert.equal(result.metrics.passport_credential_leakage, 0);
+    assert.equal(serialized.includes("sk-test-secret"), false);
+    assert.equal(serialized.includes("lane-ten-silver"), true);
+    assert.equal(result.bundle.summary.redacted_records, 1);
+    assert.deepEqual(auditMemoryPassportCredentialLeakage(result.bundle).leak_paths, []);
+    assert.deepEqual(verifyMemoryPassportBundle(result.bundle, SIGNING_SECRET), { verified: true });
+
+    const auditRows = readRows<{ operation: string; credential_leakage: number }>(tempDir, "memory_passport_audit");
+    assert.equal(auditRows.length, 1);
+    assert.equal(auditRows[0].operation, "export");
+    assert.equal(auditRows[0].credential_leakage, 0);
+  });
+
+  test("imports a verified bundle and preserves searchable memory", async () => {
+    const { LocalBackend } = await import("../local.js");
+    const source = new LocalBackend();
+    await source.setBusinessContext("identity", "preferred_name", "Chris", 100);
+    await source.addFact({
+      fact: "Passport import marker lane-ten-teal should be searchable.",
+      category: "technical",
+      confidence: 0.91,
+      extractor_id: "lane-10-test",
+      prompt_version: "passport-v1",
+      model_id: "test-model",
+    });
+    const exported = await source.exportMemoryPassport({
+      signing_secret: SIGNING_SECRET,
+      include_sessions: false,
+    });
+
+    const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), "unclick-memory-passport-target-"));
+    try {
+      process.env.MEMORY_LOCAL_DATA_DIR = targetDir;
+      const target = new LocalBackend();
+      const imported = await target.importMemoryPassport({
+        bundle: exported.bundle,
+        signing_secret: SIGNING_SECRET,
+      });
+
+      assert.equal(imported.imported, true);
+      assert.equal(imported.metrics.passport_credential_leakage, 0);
+      assert.equal(imported.metrics.passport_roundtrip_fidelity, 1);
+
+      const results = await target.searchMemory("lane-ten-teal", 5) as Array<{ content: string }>;
+      assert.equal(results.some((row) => row.content.includes("lane-ten-teal")), true);
+      const context = await target.getBusinessContext() as Array<{ category: string; key: string; value: unknown }>;
+      assert.equal(context.some((row) => row.category === "identity" && row.key === "preferred_name"), true);
+    } finally {
+      fs.rmSync(targetDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects tampered bundles and handlers are default-off", async () => {
+    const { LocalBackend } = await import("../local.js");
+    const { MEMORY_HANDLERS } = await import("../handlers.js");
+    const backend = new LocalBackend();
+    await backend.addFact({
+      fact: "Passport tamper marker lane-ten-gold.",
+      category: "technical",
+      confidence: 1,
+    });
+    const exported = await backend.exportMemoryPassport({ signing_secret: SIGNING_SECRET });
+    exported.bundle.memory.facts[0].fact = "Tampered passport payload.";
+
+    await assert.rejects(
+      () => backend.importMemoryPassport({ bundle: exported.bundle, signing_secret: SIGNING_SECRET }),
+      /signature_mismatch/
+    );
+
+    delete process.env.MEMORY_PASSPORT_ENABLED;
+    const disabled = await MEMORY_HANDLERS.export_memory_passport({});
+    assert.deepEqual(disabled, { enabled: false, flag: "MEMORY_PASSPORT_ENABLED" });
+  });
+});

--- a/packages/mcp-server/src/memory/eval-harness.ts
+++ b/packages/mcp-server/src/memory/eval-harness.ts
@@ -1,0 +1,258 @@
+import type { FactInput, InvalidateFactInput, MemoryBackend } from "./types.js";
+
+export type MemoryEvalScenarioKind =
+  | "paraphrase_recall"
+  | "latest_value"
+  | "scope_bleed"
+  | "no_answer"
+  | "forget"
+  | "duplicate_storm";
+
+export interface MemoryEvalScenarioResult {
+  id: string;
+  kind: MemoryEvalScenarioKind;
+  passed: boolean;
+  details: Record<string, unknown>;
+}
+export interface MemoryHardeningScorecard {
+  suite_id: "memory-hardening-eval-v1";
+  generated_at: string;
+  scenarios: MemoryEvalScenarioResult[];
+  metrics: Record<string, number | null>;
+  diagnostics: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+}
+
+interface SearchRow {
+  id?: string;
+  source?: string;
+  content: string;
+  category?: string;
+  confidence?: number;
+}
+
+type EvalBackend = Pick<MemoryBackend, "addFact" | "searchMemory" | "invalidateFact">;
+
+const EMPTY_REGISTRY_METRICS: Record<string, number | null> = {
+  "recall@5": null,
+  identity_hit_rate: null,
+  latest_value_accuracy: null,
+  contradiction_precision: null,
+  provenance_coverage: null,
+  scope_leakage: null,
+  forget_compliance: null,
+  correction_adherence: null,
+  "ndcg@10": null,
+  "vector_recall@5": null,
+  duplicate_rate: null,
+  write_precision: null,
+  hot_set_staleness: null,
+  dedup_collapse_rate: null,
+  fact_index_purity: null,
+  passport_roundtrip_fidelity: null,
+  passport_credential_leakage: null,
+};
+
+function asText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  return JSON.stringify(value);
+}
+
+function normalizeRows(value: unknown): SearchRow[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((row) => {
+    const record = row && typeof row === "object" ? row as Record<string, unknown> : {};
+    return {
+      id: typeof record.id === "string" ? record.id : undefined,
+      source: typeof record.source === "string" ? record.source : undefined,
+      content: asText(record.content ?? record.fact ?? record.summary ?? ""),
+      category: typeof record.category === "string" ? record.category : undefined,
+      confidence: typeof record.confidence === "number" ? record.confidence : undefined,
+    };
+  }).filter((row) => row.content.length > 0);
+}
+
+function containsText(rows: SearchRow[], needle: string): boolean {
+  const lowerNeedle = needle.toLowerCase();
+  return rows.some((row) => row.content.toLowerCase().includes(lowerNeedle));
+}
+
+async function addFact(backend: EvalBackend, input: Omit<FactInput, "confidence"> & { confidence?: number }) {
+  return backend.addFact({
+    confidence: 0.95,
+    ...input,
+  });
+}
+
+async function runParaphraseRecall(backend: EvalBackend): Promise<MemoryEvalScenarioResult> {
+  await addFact(backend, {
+    fact: "The project codename for the memory passport work is Silver Ledger.",
+    category: "project",
+  });
+  const rows = normalizeRows(await backend.searchMemory("What is the portable memory bundle called?", 5));
+  const passed = containsText(rows, "Silver Ledger");
+  return {
+    id: "paraphrase-recall",
+    kind: "paraphrase_recall",
+    passed,
+    details: {
+      expected: "Silver Ledger",
+      returned: rows.map((row) => row.content),
+    },
+  };
+}
+
+async function runLatestValue(backend: EvalBackend): Promise<MemoryEvalScenarioResult> {
+  await addFact(backend, {
+    fact: "The current memory-hardening release channel is alpha.",
+    category: "project",
+    valid_from: "2026-06-01T00:00:00.000Z",
+  });
+  await addFact(backend, {
+    fact: "The current memory-hardening release channel is beta.",
+    category: "project",
+    valid_from: "2026-06-04T00:00:00.000Z",
+  });
+  const rows = normalizeRows(await backend.searchMemory("current memory-hardening release channel", 5));
+  const top = rows[0]?.content ?? "";
+  const passed = top.toLowerCase().includes("beta");
+  return {
+    id: "latest-value",
+    kind: "latest_value",
+    passed,
+    details: {
+      expected: "beta",
+      top,
+    },
+  };
+}
+
+async function runScopeBleed(backend: EvalBackend): Promise<MemoryEvalScenarioResult> {
+  await addFact(backend, {
+    fact: "Boardroom private scope marker lane-ten-red must stay isolated.",
+    category: "private",
+  });
+  await addFact(backend, {
+    fact: "Shared scope marker lane-ten-blue can be recalled.",
+    category: "shared",
+  });
+  const rows = normalizeRows(await backend.searchMemory("scope marker lane-ten", 5));
+  const leaked = rows.filter((row) => row.content.includes("lane-ten-red")).length;
+  return {
+    id: "scope-bleed",
+    kind: "scope_bleed",
+    passed: leaked === 0,
+    details: {
+      leaked,
+      returned: rows.map((row) => row.content),
+    },
+  };
+}
+
+async function runNoAnswer(backend: EvalBackend): Promise<MemoryEvalScenarioResult> {
+  await addFact(backend, {
+    fact: "The harness knows the memory passport uses signed JSON.",
+    category: "technical",
+  });
+  const rows = normalizeRows(await backend.searchMemory("unrelated orbital banana schedule", 5));
+  return {
+    id: "no-answer",
+    kind: "no_answer",
+    passed: rows.length === 0,
+    details: {
+      returned_count: rows.length,
+      returned: rows.map((row) => row.content),
+    },
+  };
+}
+
+async function runForget(backend: EvalBackend): Promise<MemoryEvalScenarioResult> {
+  const fact = await addFact(backend, {
+    fact: "Forget diagnostic marker lane-ten-purple should disappear after invalidation.",
+    category: "technical",
+  });
+  const input: InvalidateFactInput = {
+    fact_id: fact.id,
+    reason: "lane-10 forget diagnostic",
+    session_id: "memory-hardening-eval-v1",
+  };
+  await backend.invalidateFact(input);
+  const rows = normalizeRows(await backend.searchMemory("lane-ten-purple", 5));
+  const present = containsText(rows, "lane-ten-purple");
+  return {
+    id: "forget",
+    kind: "forget",
+    passed: !present,
+    details: {
+      invalidated_fact_id: fact.id,
+      returned: rows.map((row) => row.content),
+    },
+  };
+}
+
+async function runDuplicateStorm(backend: EvalBackend): Promise<MemoryEvalScenarioResult> {
+  const duplicateFact = "Duplicate storm marker lane-ten-orange should collapse to one active fact.";
+  await addFact(backend, { fact: duplicateFact, category: "technical" });
+  await addFact(backend, { fact: duplicateFact, category: "technical" });
+  await addFact(backend, { fact: duplicateFact, category: "technical" });
+  const rows = normalizeRows(await backend.searchMemory("lane-ten-orange", 10));
+  const duplicateHits = rows.filter((row) => row.content === duplicateFact).length;
+  return {
+    id: "duplicate-storm",
+    kind: "duplicate_storm",
+    passed: duplicateHits <= 1,
+    details: {
+      duplicate_hits: duplicateHits,
+      returned_count: rows.length,
+    },
+  };
+}
+
+function passRatio(result: MemoryEvalScenarioResult): number {
+  return result.passed ? 1 : 0;
+}
+
+export async function runMemoryHardeningEval(backend: EvalBackend): Promise<MemoryHardeningScorecard> {
+  const scenarios = [
+    await runParaphraseRecall(backend),
+    await runLatestValue(backend),
+    await runScopeBleed(backend),
+    await runNoAnswer(backend),
+    await runForget(backend),
+    await runDuplicateStorm(backend),
+  ];
+  const byKind = new Map(scenarios.map((scenario) => [scenario.kind, scenario]));
+  const duplicateDetails = byKind.get("duplicate_storm")?.details ?? {};
+  const duplicateHits = typeof duplicateDetails.duplicate_hits === "number"
+    ? duplicateDetails.duplicate_hits
+    : 0;
+  const duplicateRate = duplicateHits <= 1 ? 0 : (duplicateHits - 1) / duplicateHits;
+  const scopeDetails = byKind.get("scope_bleed")?.details ?? {};
+  const scopeLeakage = typeof scopeDetails.leaked === "number" ? scopeDetails.leaked : null;
+  const passed = scenarios.filter((scenario) => scenario.passed).length;
+
+  return {
+    suite_id: "memory-hardening-eval-v1",
+    generated_at: new Date().toISOString(),
+    scenarios,
+    metrics: {
+      ...EMPTY_REGISTRY_METRICS,
+      "recall@5": passRatio(byKind.get("paraphrase_recall") as MemoryEvalScenarioResult),
+      latest_value_accuracy: passRatio(byKind.get("latest_value") as MemoryEvalScenarioResult),
+      scope_leakage: scopeLeakage,
+      forget_compliance: passRatio(byKind.get("forget") as MemoryEvalScenarioResult),
+      duplicate_rate: duplicateRate,
+      write_precision: passRatio(byKind.get("no_answer") as MemoryEvalScenarioResult),
+      scorecard: passed / scenarios.length,
+    },
+    diagnostics: {
+      total: scenarios.length,
+      passed,
+      failed: scenarios.length - passed,
+    },
+  };
+}

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -18,8 +18,10 @@ import { triggerSessionInspection } from "./session-inspection-trigger.js";
 import { emitSignal } from "../signals/emit.js";
 import { buildSearchMemoryCard } from "../cards/search-memory-card.js";
 import { extractMemoryTypedLinkCandidates } from "./typed-links.js";
+import { isMemoryPassportEnabled, MEMORY_PASSPORT_FLAG } from "./passport.js";
 import type {
   MemoryBackend,
+  MemoryPassportBundle,
   MemoryProfileCard,
   MemoryProfileCardReceipt,
   MemoryProfileCardSourceKind,
@@ -49,6 +51,10 @@ function arr(v: unknown): string[] {
 
 function bool(v: unknown, fallback = false): boolean {
   return typeof v === "boolean" ? v : fallback;
+}
+
+function memoryPassportSigningSecret(): string | undefined {
+  return process.env.MEMORY_PASSPORT_SIGNING_SECRET;
 }
 
 function capText(text: string, max: number): string {
@@ -810,4 +816,43 @@ export const MEMORY_HANDLERS: Record<string, (args: Args) => Promise<unknown>> =
       session_id: typeof args.session_id === "string" ? args.session_id : undefined,
     });
   },
+
+  // --- lane-10: eval harness and memory passport ---
+  async export_memory_passport(args) {
+    if (!isMemoryPassportEnabled()) {
+      return { enabled: false, flag: MEMORY_PASSPORT_FLAG };
+    }
+    const signingSecret = memoryPassportSigningSecret();
+    if (!signingSecret) {
+      throw new Error("MEMORY_PASSPORT_SIGNING_SECRET is required when MEMORY_PASSPORT_ENABLED is on");
+    }
+    const db = await getBackend();
+    return db.exportMemoryPassport({
+      subject_id: typeof args.subject_id === "string" ? args.subject_id : undefined,
+      include_sessions: bool(args.include_sessions, true),
+      signing_secret: signingSecret,
+    });
+  },
+
+  async import_memory_passport(args) {
+    if (!isMemoryPassportEnabled()) {
+      return { enabled: false, flag: MEMORY_PASSPORT_FLAG };
+    }
+    const signingSecret = memoryPassportSigningSecret();
+    if (!signingSecret) {
+      throw new Error("MEMORY_PASSPORT_SIGNING_SECRET is required when MEMORY_PASSPORT_ENABLED is on");
+    }
+    const bundle = args.bundle as MemoryPassportBundle | undefined;
+    if (!bundle || typeof bundle !== "object") {
+      throw new Error("bundle is required for import_memory_passport");
+    }
+    const db = await getBackend();
+    return db.importMemoryPassport({
+      bundle,
+      dry_run: bool(args.dry_run, false),
+      signing_secret: signingSecret,
+      source_session_id: typeof args.source_session_id === "string" ? args.source_session_id : undefined,
+    });
+  },
+  // --- end lane-10 ---
 };

--- a/packages/mcp-server/src/memory/instrumentation.ts
+++ b/packages/mcp-server/src/memory/instrumentation.ts
@@ -32,6 +32,7 @@ import {
 
 const DATA_DIR = path.join(os.homedir(), ".unclick", "memory");
 const TABLE = "memory_load_events";
+const EVAL_SCORECARD_TABLE = "memory_eval_scorecards";
 
 export interface MemoryLoadEvent {
   tool_name: string;
@@ -88,6 +89,65 @@ export function logMemoryLoadEvent(event: Omit<MemoryLoadEvent, "created_at">): 
     appendLocal(row);
   }
 }
+
+// --- lane-10: eval scorecard instrumentation ---
+export interface MemoryEvalScorecardEvent {
+  suite_id: string;
+  scorecard: Record<string, unknown>;
+  metrics: Record<string, unknown>;
+}
+
+function appendLocalEvalScorecard(row: MemoryEvalScorecardEvent & { id: string; created_at: string }): void {
+  try {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    const file = path.join(DATA_DIR, `${EVAL_SCORECARD_TABLE}.json`);
+    let rows: unknown[] = [];
+    if (fs.existsSync(file)) {
+      try {
+        rows = JSON.parse(fs.readFileSync(file, "utf8"));
+        if (!Array.isArray(rows)) rows = [];
+      } catch {
+        rows = [];
+      }
+    }
+    rows.push(row);
+    const tmp = file + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(rows, null, 2));
+    fs.renameSync(tmp, file);
+  } catch {
+    // instrumentation must never crash the caller
+  }
+}
+
+async function insertSupabaseEvalScorecard(row: MemoryEvalScorecardEvent & { created_at: string }): Promise<void> {
+  try {
+    const { createClient } = await import("@supabase/supabase-js");
+    const url = process.env.SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY;
+    if (!url || !key) return;
+    const sb = createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
+    const apiKeyHash = process.env.UNCLICK_API_KEY_HASH;
+    const table = apiKeyHash ? "mc_memory_eval_scorecards" : EVAL_SCORECARD_TABLE;
+    const payload = apiKeyHash ? { api_key_hash: apiKeyHash, ...row } : row;
+    await sb.from(table).insert(payload);
+  } catch {
+    // table may not exist until the lane-10 migration is applied
+  }
+}
+
+export function logMemoryEvalScorecard(event: MemoryEvalScorecardEvent): void {
+  const row = {
+    id: crypto.randomUUID(),
+    created_at: new Date().toISOString(),
+    ...event,
+  };
+  if (process.env.SUPABASE_URL) {
+    void insertSupabaseEvalScorecard(row);
+  } else {
+    appendLocalEvalScorecard(row);
+  }
+}
+// --- end lane-10 ---
 
 /** Called from the Initialize handler. */
 export function trackInitialize(

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -24,7 +24,17 @@ import type {
   MemoryTaxonomySnapshotWriteOptions,
   MemoryTaxonomySnapshotWriteResult,
   SaveTypedLinkCandidatesResult,
+  MemoryPassportAuditRecord,
+  MemoryPassportExportInput,
+  MemoryPassportExportResult,
+  MemoryPassportImportInput,
+  MemoryPassportImportResult,
 } from "./types.js";
+import {
+  buildMemoryPassportBundle,
+  buildMemoryPassportImportResult,
+  verifyMemoryPassportBundle,
+} from "./passport.js";
 import {
   filterAndRankMemoryTypedLinks,
   type MemoryTypedLinkCandidate,
@@ -150,8 +160,14 @@ interface FactRow {
   valid_to?: string;
   created_at: string;
   updated_at: string;
+  extractor_id?: string;
+  prompt_version?: string;
+  model_id?: string;
   commit_sha?: string;
   pr_number?: number;
+  source_agent_id?: string;
+  source_ref?: string;
+  receipt_id?: string;
 }
 
 interface ConversationRow {
@@ -175,6 +191,11 @@ interface TypedLinkRow extends MemoryTypedLinkStoredRow {
   evidence_end: number;
   evidence_text: string;
   redaction_state: MemoryTypedLinkStoredRow["redaction_state"];
+  created_at: string;
+}
+
+interface PassportAuditRow extends MemoryPassportAuditRecord {
+  id: string;
   created_at: string;
 }
 
@@ -481,6 +502,9 @@ export class LocalBackend implements MemoryBackend {
       valid_to: undefined,
       created_at: now(),
       updated_at: now(),
+      extractor_id: data.extractor_id,
+      prompt_version: data.prompt_version,
+      model_id: data.model_id,
       commit_sha: data.commit_sha,
       pr_number: data.pr_number,
     });
@@ -802,6 +826,114 @@ export class LocalBackend implements MemoryBackend {
     writeTable("extracted_facts", rows);
     return { invalidated_at: invalidatedAt };
   }
+
+  // --- lane-10: eval harness and memory passport ---
+  async exportMemoryPassport(input: MemoryPassportExportInput = {}): Promise<MemoryPassportExportResult> {
+    const result = buildMemoryPassportBundle({
+      ...input,
+      source_backend: "local",
+      business_context: readTable<Record<string, unknown>>("business_context"),
+      facts: readTable<Record<string, unknown>>("extracted_facts"),
+      session_summaries: readTable<Record<string, unknown>>("session_summaries"),
+    });
+    this.recordPassportAudit(result.audit);
+    return result;
+  }
+
+  async importMemoryPassport(input: MemoryPassportImportInput): Promise<MemoryPassportImportResult> {
+    const verification = verifyMemoryPassportBundle(input.bundle, input.signing_secret);
+    if (!verification.verified) {
+      throw new Error(`Memory passport verification failed: ${verification.reason ?? "unknown"}`);
+    }
+
+    const dryRun = input.dry_run === true;
+    let insertedBusinessContext = 0;
+    let insertedFacts = 0;
+    let insertedSessions = 0;
+    let skippedExisting = 0;
+
+    const existingFacts = new Set(
+      readTable<FactRow>("extracted_facts").map((row) => row.fact.toLowerCase().trim())
+    );
+    const existingSessions = new Set(
+      readTable<SessionRow>("session_summaries").map((row) => `${row.session_id}\n${row.summary}`)
+    );
+
+    for (const row of input.bundle.identity.business_context) {
+      if (!dryRun) {
+        await this.setBusinessContext(row.category, row.key, row.value, row.priority);
+      }
+      insertedBusinessContext++;
+    }
+
+    for (const row of input.bundle.memory.facts) {
+      const key = row.fact.toLowerCase().trim();
+      if (existingFacts.has(key)) {
+        skippedExisting++;
+        continue;
+      }
+      if (!dryRun) {
+        await this.addFact({
+          fact: row.fact,
+          category: row.category,
+          confidence: row.confidence,
+          source_session_id: row.source_session_id ?? input.source_session_id,
+          startup_fact_kind: row.startup_fact_kind ?? "durable",
+          valid_from: row.valid_from ?? undefined,
+          extractor_id: row.extractor_id ?? undefined,
+          prompt_version: row.prompt_version ?? undefined,
+          model_id: row.model_id ?? undefined,
+          commit_sha: row.commit_sha ?? undefined,
+          pr_number: row.pr_number,
+        });
+        existingFacts.add(key);
+      }
+      insertedFacts++;
+    }
+
+    for (const row of input.bundle.memory.session_summaries) {
+      const key = `${row.session_id}\n${row.summary}`;
+      if (existingSessions.has(key)) {
+        skippedExisting++;
+        continue;
+      }
+      if (!dryRun) {
+        await this.writeSessionSummary({
+          session_id: row.session_id,
+          summary: row.summary,
+          topics: row.topics,
+          open_loops: row.open_loops,
+          decisions: row.decisions,
+          platform: row.platform,
+          duration_minutes: row.duration_minutes,
+        });
+        existingSessions.add(key);
+      }
+      insertedSessions++;
+    }
+
+    const result = buildMemoryPassportImportResult({
+      bundle: input.bundle,
+      inserted_facts: insertedFacts,
+      inserted_business_context: insertedBusinessContext,
+      inserted_sessions: insertedSessions,
+      skipped_existing: skippedExisting,
+      dry_run: dryRun,
+    });
+    this.recordPassportAudit(result.audit);
+    return result;
+  }
+
+  private recordPassportAudit(audit: MemoryPassportAuditRecord): void {
+    const rows = readTable<PassportAuditRow>("memory_passport_audit");
+    rows.push({
+      id: uuid(),
+      created_at: now(),
+      ...audit,
+    });
+    writeTable("memory_passport_audit", rows);
+  }
+  // --- end lane-10 ---
 }
 
 function typedLinkKey(row: Pick<TypedLinkRow, "source_kind" | "source_id" | "relation" | "target_kind" | "target_text">): string {

--- a/packages/mcp-server/src/memory/passport.ts
+++ b/packages/mcp-server/src/memory/passport.ts
@@ -1,0 +1,320 @@
+import { createHmac, createHash } from "node:crypto";
+import type {
+  MemoryPassportBundle,
+  MemoryPassportBusinessContextRecord,
+  MemoryPassportExportInput,
+  MemoryPassportExportResult,
+  MemoryPassportFactRecord,
+  MemoryPassportImportResult,
+  MemoryPassportSessionRecord,
+  MemoryPassportSignature,
+} from "./types.js";
+
+export const MEMORY_PASSPORT_FLAG = "MEMORY_PASSPORT_ENABLED";
+export const MEMORY_PASSPORT_VERSION = "memory-passport-v1";
+
+const SECRET_FIELD_PATTERN =
+  /(api[_-]?key|authorization|bearer|credential|password|private[_-]?key|service[_-]?role|secret|token)/i;
+const SECRET_VALUE_PATTERN =
+  /(sk-[a-z0-9_-]{12,}|gh[oprsu]_[a-z0-9_]{20,}|xox[baprs]-[a-z0-9-]{10,}|Bearer\s+[a-z0-9._-]{12,}|eyJ[a-z0-9_-]{10,}\.[a-z0-9_-]{10,}\.[a-z0-9_-]{10,})/i;
+
+export function isMemoryPassportEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[MEMORY_PASSPORT_FLAG] ?? "";
+  return raw === "1" || raw.toLowerCase() === "true";
+}
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (isPlainObject(value)) {
+    const body = Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",");
+    return `{${body}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function payloadForSigning(bundle: MemoryPassportBundle): Omit<MemoryPassportBundle, "signature"> {
+  const { signature: _signature, ...payload } = bundle;
+  return payload;
+}
+
+function signPayload(payload: Omit<MemoryPassportBundle, "signature">, signingSecret: string): MemoryPassportSignature {
+  const value = createHmac("sha256", signingSecret)
+    .update(stableStringify(payload), "utf8")
+    .digest("hex");
+  return {
+    algorithm: "hmac-sha256",
+    key_id: "memory-passport-v1",
+    value,
+  };
+}
+
+function signatureDigest(signature: MemoryPassportSignature): string {
+  return createHash("sha256").update(signature.value, "utf8").digest("hex");
+}
+
+function textHasSecret(value: string): boolean {
+  return SECRET_VALUE_PATTERN.test(value);
+}
+
+function valueHasSecret(value: unknown): boolean {
+  if (typeof value === "string") return textHasSecret(value);
+  if (Array.isArray(value)) return value.some(valueHasSecret);
+  if (isPlainObject(value)) return Object.values(value).some(valueHasSecret);
+  return false;
+}
+
+function rowHasSecretShape(row: Record<string, unknown>): boolean {
+  return Object.entries(row).some(([key, value]) => SECRET_FIELD_PATTERN.test(key) || valueHasSecret(value));
+}
+
+function stringValue(row: Record<string, unknown>, key: string): string | undefined {
+  const value = row[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberValue(row: Record<string, unknown>, key: string): number | undefined {
+  const value = row[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function nullableStringValue(row: Record<string, unknown>, key: string): string | null | undefined {
+  const value = row[key];
+  if (value === null) return null;
+  return typeof value === "string" ? value : undefined;
+}
+
+function businessContextRecord(row: Record<string, unknown>): MemoryPassportBusinessContextRecord | null {
+  if (rowHasSecretShape(row)) return null;
+  const category = stringValue(row, "category");
+  const key = stringValue(row, "key");
+  if (!category || !key) return null;
+  return {
+    category,
+    key,
+    value: row.value,
+    priority: numberValue(row, "priority") ?? 0,
+    created_at: stringValue(row, "created_at"),
+    updated_at: stringValue(row, "updated_at"),
+  };
+}
+
+function factRecord(row: Record<string, unknown>): MemoryPassportFactRecord | null {
+  if (rowHasSecretShape(row)) return null;
+  const fact = stringValue(row, "fact");
+  const category = stringValue(row, "category");
+  if (!fact || !category) return null;
+  return {
+    id: stringValue(row, "id"),
+    fact,
+    category,
+    confidence: numberValue(row, "confidence") ?? 0.9,
+    source_session_id: nullableStringValue(row, "source_session_id"),
+    source_type: stringValue(row, "source_type"),
+    startup_fact_kind: stringValue(row, "startup_fact_kind") as MemoryPassportFactRecord["startup_fact_kind"],
+    status: stringValue(row, "status"),
+    superseded_by: nullableStringValue(row, "superseded_by"),
+    invalidated_at: nullableStringValue(row, "invalidated_at"),
+    invalidation_reason: nullableStringValue(row, "invalidation_reason"),
+    invalidated_by_session_id: nullableStringValue(row, "invalidated_by_session_id"),
+    valid_from: nullableStringValue(row, "valid_from"),
+    valid_to: nullableStringValue(row, "valid_to"),
+    created_at: stringValue(row, "created_at"),
+    updated_at: stringValue(row, "updated_at"),
+    extractor_id: nullableStringValue(row, "extractor_id"),
+    prompt_version: nullableStringValue(row, "prompt_version"),
+    model_id: nullableStringValue(row, "model_id"),
+    commit_sha: nullableStringValue(row, "commit_sha"),
+    pr_number: numberValue(row, "pr_number"),
+    source_agent_id: nullableStringValue(row, "source_agent_id"),
+    source_ref: nullableStringValue(row, "source_ref"),
+    receipt_id: nullableStringValue(row, "receipt_id"),
+  };
+}
+
+function sessionRecord(row: Record<string, unknown>): MemoryPassportSessionRecord | null {
+  if (rowHasSecretShape(row)) return null;
+  const sessionId = stringValue(row, "session_id");
+  const summary = stringValue(row, "summary");
+  if (!sessionId || !summary) return null;
+  return {
+    session_id: sessionId,
+    summary,
+    topics: Array.isArray(row.topics) ? row.topics.map(String) : [],
+    open_loops: Array.isArray(row.open_loops) ? row.open_loops.map(String) : [],
+    decisions: Array.isArray(row.decisions) ? row.decisions.map(String) : [],
+    platform: stringValue(row, "platform") ?? "unknown",
+    duration_minutes: numberValue(row, "duration_minutes"),
+    created_at: stringValue(row, "created_at"),
+  };
+}
+
+function sortedByKeys<T>(rows: T[], keys: Array<keyof T>): T[] {
+  return [...rows].sort((a, b) => {
+    for (const key of keys) {
+      const left = String(a[key] ?? "");
+      const right = String(b[key] ?? "");
+      const diff = left.localeCompare(right);
+      if (diff !== 0) return diff;
+    }
+    return 0;
+  });
+}
+
+export function auditMemoryPassportCredentialLeakage(bundle: MemoryPassportBundle): {
+  passport_credential_leakage: number;
+  leak_paths: string[];
+} {
+  const paths: string[] = [];
+  const visit = (value: unknown, path: string): void => {
+    if (typeof value === "string") {
+      if (textHasSecret(value)) paths.push(path);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => visit(item, `${path}[${index}]`));
+      return;
+    }
+    if (isPlainObject(value)) {
+      for (const [key, nested] of Object.entries(value)) {
+        visit(nested, path ? `${path}.${key}` : key);
+      }
+    }
+  };
+  visit(bundle, "");
+  return {
+    passport_credential_leakage: paths.length,
+    leak_paths: paths,
+  };
+}
+
+export function buildMemoryPassportBundle(input: MemoryPassportExportInput & {
+  source_backend: "local" | "supabase";
+  business_context: Array<Record<string, unknown>>;
+  facts: Array<Record<string, unknown>>;
+  session_summaries: Array<Record<string, unknown>>;
+}): MemoryPassportExportResult {
+  if (!input.signing_secret) {
+    throw new Error("MEMORY_PASSPORT_SIGNING_SECRET is required to export a memory passport");
+  }
+
+  const businessContext = input.business_context
+    .map(businessContextRecord)
+    .filter((row): row is MemoryPassportBusinessContextRecord => row !== null);
+  const facts = input.facts
+    .map(factRecord)
+    .filter((row): row is MemoryPassportFactRecord => row !== null);
+  const sessions = input.include_sessions === false
+    ? []
+    : input.session_summaries
+        .map(sessionRecord)
+        .filter((row): row is MemoryPassportSessionRecord => row !== null);
+
+  const redactedRecords =
+    input.business_context.length - businessContext.length +
+    input.facts.length - facts.length +
+    (input.include_sessions === false ? 0 : input.session_summaries.length - sessions.length);
+
+  const payload: Omit<MemoryPassportBundle, "signature"> = {
+    version: MEMORY_PASSPORT_VERSION,
+    exported_at: new Date().toISOString(),
+    subject_id: input.subject_id,
+    source_backend: input.source_backend,
+    identity: {
+      business_context: sortedByKeys(businessContext, ["category", "key"]),
+    },
+    memory: {
+      facts: sortedByKeys(facts, ["category", "fact"]),
+      session_summaries: sortedByKeys(sessions, ["session_id", "summary"]),
+    },
+    summary: {
+      exported_records: businessContext.length + facts.length + sessions.length,
+      redacted_records: redactedRecords,
+    },
+  };
+  const bundle: MemoryPassportBundle = {
+    ...payload,
+    signature: signPayload(payload, input.signing_secret),
+  };
+  const leakage = auditMemoryPassportCredentialLeakage(bundle);
+  return {
+    bundle,
+    metrics: {
+      passport_roundtrip_fidelity: null,
+      passport_credential_leakage: leakage.passport_credential_leakage,
+    },
+    audit: {
+      operation: "export",
+      bundle_version: bundle.version,
+      signature_digest: signatureDigest(bundle.signature),
+      exported_records: bundle.summary.exported_records,
+      imported_records: 0,
+      redacted_records: bundle.summary.redacted_records,
+      credential_leakage: leakage.passport_credential_leakage,
+    },
+  };
+}
+
+export function verifyMemoryPassportBundle(bundle: MemoryPassportBundle, signingSecret?: string): {
+  verified: boolean;
+  reason?: string;
+} {
+  if (bundle.version !== MEMORY_PASSPORT_VERSION) {
+    return { verified: false, reason: "unsupported_version" };
+  }
+  if (!signingSecret) {
+    return { verified: false, reason: "missing_signing_secret" };
+  }
+  const expected = signPayload(payloadForSigning(bundle), signingSecret);
+  if (bundle.signature.algorithm !== expected.algorithm || bundle.signature.value !== expected.value) {
+    return { verified: false, reason: "signature_mismatch" };
+  }
+  const leakage = auditMemoryPassportCredentialLeakage(bundle);
+  if (leakage.passport_credential_leakage > 0) {
+    return { verified: false, reason: "credential_leakage" };
+  }
+  return { verified: true };
+}
+
+export function buildMemoryPassportImportResult(input: {
+  bundle: MemoryPassportBundle;
+  inserted_facts: number;
+  inserted_business_context: number;
+  inserted_sessions: number;
+  skipped_existing: number;
+  dry_run: boolean;
+}): MemoryPassportImportResult {
+  const importedRecords =
+    input.inserted_facts + input.inserted_business_context + input.inserted_sessions + input.skipped_existing;
+  const exportedRecords = Math.max(input.bundle.summary.exported_records, 1);
+  const fidelity = importedRecords / exportedRecords;
+  const leakage = auditMemoryPassportCredentialLeakage(input.bundle);
+  return {
+    imported: !input.dry_run,
+    dry_run: input.dry_run,
+    inserted_facts: input.inserted_facts,
+    inserted_business_context: input.inserted_business_context,
+    inserted_sessions: input.inserted_sessions,
+    skipped_existing: input.skipped_existing,
+    metrics: {
+      passport_roundtrip_fidelity: fidelity,
+      passport_credential_leakage: leakage.passport_credential_leakage,
+    },
+    audit: {
+      operation: "import",
+      bundle_version: input.bundle.version,
+      signature_digest: signatureDigest(input.bundle.signature),
+      exported_records: input.bundle.summary.exported_records,
+      imported_records: importedRecords,
+      redacted_records: input.bundle.summary.redacted_records,
+      credential_leakage: leakage.passport_credential_leakage,
+    },
+  };
+}

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -32,7 +32,17 @@ import type {
   MemoryTaxonomySnapshotWriteResult,
   MemoryTaxonomySnapshotSource,
   SaveTypedLinkCandidatesResult,
+  MemoryPassportAuditRecord,
+  MemoryPassportExportInput,
+  MemoryPassportExportResult,
+  MemoryPassportImportInput,
+  MemoryPassportImportResult,
 } from "./types.js";
+import {
+  buildMemoryPassportBundle,
+  buildMemoryPassportImportResult,
+  verifyMemoryPassportBundle,
+} from "./passport.js";
 import {
   filterAndRankMemoryTypedLinks,
   type MemoryTypedLinkCandidate,
@@ -1507,6 +1517,190 @@ export class SupabaseBackend implements MemoryBackend {
   async manageDecay(): Promise<unknown> {
     return this.rpc("manage_decay", {}, "mc_manage_decay", {});
   }
+
+  // --- lane-10: eval harness and memory passport ---
+  async exportMemoryPassport(input: MemoryPassportExportInput = {}): Promise<MemoryPassportExportResult> {
+    const [businessContext, facts, sessions] = await Promise.all([
+      this.readPassportRows(
+        this.tables.business_context,
+        "category,key,value,priority,created_at,updated_at",
+        "category"
+      ),
+      this.readPassportRows(
+        this.tables.extracted_facts,
+        [
+          "id",
+          "fact",
+          "category",
+          "confidence",
+          "source_session_id",
+          "source_type",
+          "startup_fact_kind",
+          "status",
+          "superseded_by",
+          "invalidated_at",
+          "invalidation_reason",
+          "invalidated_by_session_id",
+          "valid_from",
+          "valid_to",
+          "created_at",
+          "updated_at",
+          "extractor_id",
+          "prompt_version",
+          "model_id",
+          "commit_sha",
+          "pr_number",
+        ].join(","),
+        "created_at"
+      ),
+      input.include_sessions === false
+        ? Promise.resolve([])
+        : this.readPassportRows(
+            this.tables.session_summaries,
+            "session_id,summary,topics,open_loops,decisions,platform,duration_minutes,created_at",
+            "created_at"
+          ),
+    ]);
+    const result = buildMemoryPassportBundle({
+      ...input,
+      source_backend: "supabase",
+      business_context: businessContext,
+      facts,
+      session_summaries: sessions,
+    });
+    await this.recordPassportAudit(result.audit);
+    return result;
+  }
+
+  async importMemoryPassport(input: MemoryPassportImportInput): Promise<MemoryPassportImportResult> {
+    const verification = verifyMemoryPassportBundle(input.bundle, input.signing_secret);
+    if (!verification.verified) {
+      throw new Error(`Memory passport verification failed: ${verification.reason ?? "unknown"}`);
+    }
+
+    const dryRun = input.dry_run === true;
+    let insertedBusinessContext = 0;
+    let insertedFacts = 0;
+    let insertedSessions = 0;
+    let skippedExisting = 0;
+
+    for (const row of input.bundle.identity.business_context) {
+      if (!dryRun) {
+        await this.setBusinessContext(row.category, row.key, row.value, row.priority);
+      }
+      insertedBusinessContext++;
+    }
+
+    for (const row of input.bundle.memory.facts) {
+      if (await this.passportFactExists(row.fact)) {
+        skippedExisting++;
+        continue;
+      }
+      if (!dryRun) {
+        await this.addFact({
+          fact: row.fact,
+          category: row.category,
+          confidence: row.confidence,
+          source_session_id: row.source_session_id ?? input.source_session_id,
+          startup_fact_kind: row.startup_fact_kind ?? "durable",
+          valid_from: row.valid_from ?? undefined,
+          extractor_id: row.extractor_id ?? undefined,
+          prompt_version: row.prompt_version ?? undefined,
+          model_id: row.model_id ?? undefined,
+          commit_sha: row.commit_sha ?? undefined,
+          pr_number: row.pr_number,
+        });
+      }
+      insertedFacts++;
+    }
+
+    for (const row of input.bundle.memory.session_summaries) {
+      if (await this.passportSessionExists(row.session_id, row.summary)) {
+        skippedExisting++;
+        continue;
+      }
+      if (!dryRun) {
+        await this.writeSessionSummary({
+          session_id: row.session_id,
+          summary: row.summary,
+          topics: row.topics,
+          open_loops: row.open_loops,
+          decisions: row.decisions,
+          platform: row.platform,
+          duration_minutes: row.duration_minutes,
+        });
+      }
+      insertedSessions++;
+    }
+
+    const result = buildMemoryPassportImportResult({
+      bundle: input.bundle,
+      inserted_facts: insertedFacts,
+      inserted_business_context: insertedBusinessContext,
+      inserted_sessions: insertedSessions,
+      skipped_existing: skippedExisting,
+      dry_run: dryRun,
+    });
+    await this.recordPassportAudit(result.audit);
+    return result;
+  }
+
+  private async readPassportRows(table: string, columns: string, orderBy: string): Promise<Array<Record<string, unknown>>> {
+    let query = this.client.from(table).select(columns).order(orderBy);
+    if (this.tenancy.mode === "managed") {
+      query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
+    }
+    const { data, error } = await query;
+    if (error) throw pgError(`passport select ${table}`, error);
+    return (data ?? []) as unknown as Array<Record<string, unknown>>;
+  }
+
+  private async passportFactExists(fact: string): Promise<boolean> {
+    let query = this.client
+      .from(this.tables.extracted_facts)
+      .select("id")
+      .eq("fact", fact)
+      .limit(1);
+    if (this.tenancy.mode === "managed") {
+      query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
+    }
+    const { data, error } = await query.maybeSingle();
+    if (error) throw pgError("passport fact exists", error);
+    return Boolean(data);
+  }
+
+  private async passportSessionExists(sessionId: string, summary: string): Promise<boolean> {
+    let query = this.client
+      .from(this.tables.session_summaries)
+      .select("id")
+      .eq("session_id", sessionId)
+      .eq("summary", summary)
+      .limit(1);
+    if (this.tenancy.mode === "managed") {
+      query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
+    }
+    const { data, error } = await query.maybeSingle();
+    if (error) throw pgError("passport session exists", error);
+    return Boolean(data);
+  }
+
+  private async recordPassportAudit(audit: MemoryPassportAuditRecord): Promise<void> {
+    const table = this.tenancy.mode === "managed" ? "mc_memory_passport_audit" : "memory_passport_audit";
+    try {
+      await this.client.from(table).insert(this.withTenancy({
+        operation: audit.operation,
+        bundle_version: audit.bundle_version,
+        signature_digest: audit.signature_digest,
+        exported_records: audit.exported_records,
+        imported_records: audit.imported_records,
+        redacted_records: audit.redacted_records,
+        credential_leakage: audit.credential_leakage,
+      }));
+    } catch {
+      // Passport audit must not block an otherwise valid export/import.
+    }
+  }
+  // --- end lane-10 ---
 
   async getMemoryStatus(): Promise<unknown> {
     const tableKeys: Array<keyof TableNames> = [

--- a/packages/mcp-server/src/memory/types.ts
+++ b/packages/mcp-server/src/memory/types.ts
@@ -174,6 +174,125 @@ export interface MemoryTaxonomySnapshotWriteResult {
   }>;
 }
 
+export type MemoryPassportStartupFactKind = "durable" | "operational" | "excluded" | "legacy_unspecified";
+
+export interface MemoryPassportBusinessContextRecord {
+  category: string;
+  key: string;
+  value: unknown;
+  priority: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface MemoryPassportFactRecord {
+  id?: string;
+  fact: string;
+  category: string;
+  confidence: number;
+  source_session_id?: string | null;
+  source_type?: string;
+  startup_fact_kind?: MemoryPassportStartupFactKind;
+  status?: string;
+  superseded_by?: string | null;
+  invalidated_at?: string | null;
+  invalidation_reason?: string | null;
+  invalidated_by_session_id?: string | null;
+  valid_from?: string | null;
+  valid_to?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  extractor_id?: string | null;
+  prompt_version?: string | null;
+  model_id?: string | null;
+  commit_sha?: string | null;
+  pr_number?: number;
+  source_agent_id?: string | null;
+  source_ref?: string | null;
+  receipt_id?: string | null;
+}
+
+export interface MemoryPassportSessionRecord {
+  session_id: string;
+  summary: string;
+  topics: string[];
+  open_loops: string[];
+  decisions: string[];
+  platform: string;
+  duration_minutes?: number;
+  created_at?: string;
+}
+
+export interface MemoryPassportSignature {
+  algorithm: "hmac-sha256";
+  key_id: string;
+  value: string;
+}
+
+export interface MemoryPassportBundle {
+  version: "memory-passport-v1";
+  exported_at: string;
+  subject_id?: string;
+  source_backend: "local" | "supabase";
+  identity: {
+    business_context: MemoryPassportBusinessContextRecord[];
+  };
+  memory: {
+    facts: MemoryPassportFactRecord[];
+    session_summaries: MemoryPassportSessionRecord[];
+  };
+  summary: {
+    exported_records: number;
+    redacted_records: number;
+  };
+  signature: MemoryPassportSignature;
+}
+
+export interface MemoryPassportMetrics {
+  passport_roundtrip_fidelity: number | null;
+  passport_credential_leakage: number;
+}
+
+export interface MemoryPassportAuditRecord {
+  operation: "export" | "import";
+  bundle_version: string;
+  signature_digest: string;
+  exported_records: number;
+  imported_records: number;
+  redacted_records: number;
+  credential_leakage: number;
+}
+
+export interface MemoryPassportExportInput {
+  subject_id?: string;
+  include_sessions?: boolean;
+  signing_secret?: string;
+}
+
+export interface MemoryPassportExportResult {
+  bundle: MemoryPassportBundle;
+  metrics: MemoryPassportMetrics;
+  audit: MemoryPassportAuditRecord;
+}
+
+export interface MemoryPassportImportInput {
+  bundle: MemoryPassportBundle;
+  dry_run?: boolean;
+  signing_secret?: string;
+  source_session_id?: string;
+}
+
+export interface MemoryPassportImportResult {
+  imported: boolean;
+  dry_run: boolean;
+  inserted_facts: number;
+  inserted_business_context: number;
+  inserted_sessions: number;
+  skipped_existing: number;
+  metrics: MemoryPassportMetrics;
+  audit: MemoryPassportAuditRecord;
+}
+
 export interface MemoryBackend {
   /** Load startup context (business context + recent sessions + hot facts). */
   getStartupContext(numSessions: number): Promise<unknown>;
@@ -237,4 +356,9 @@ export interface MemoryBackend {
 
   /** Mark a fact as invalidated (does not delete it). Writes an audit row. */
   invalidateFact(input: InvalidateFactInput): Promise<{ invalidated_at: string }>;
+
+  // --- lane-10: eval harness and memory passport ---
+  exportMemoryPassport(input?: MemoryPassportExportInput): Promise<MemoryPassportExportResult>;
+  importMemoryPassport(input: MemoryPassportImportInput): Promise<MemoryPassportImportResult>;
+  // --- end lane-10 ---
 }

--- a/supabase/migrations/20260604090000_mem_harden_lane10_eval_passport.sql
+++ b/supabase/migrations/20260604090000_mem_harden_lane10_eval_passport.sql
@@ -1,0 +1,55 @@
+-- lane-10: eval scorecard storage and memory passport audit
+
+create table if not exists memory_eval_scorecards (
+  id uuid primary key default gen_random_uuid(),
+  suite_id text not null,
+  scorecard jsonb not null,
+  metrics jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists memory_eval_scorecards_suite_created_idx
+  on memory_eval_scorecards (suite_id, created_at desc);
+
+create table if not exists memory_passport_audit (
+  id uuid primary key default gen_random_uuid(),
+  operation text not null check (operation in ('export', 'import')),
+  bundle_version text not null,
+  signature_digest text not null,
+  exported_records integer not null default 0,
+  imported_records integer not null default 0,
+  redacted_records integer not null default 0,
+  credential_leakage integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists memory_passport_audit_created_idx
+  on memory_passport_audit (created_at desc);
+
+create table if not exists mc_memory_eval_scorecards (
+  id uuid primary key default gen_random_uuid(),
+  api_key_hash text not null,
+  suite_id text not null,
+  scorecard jsonb not null,
+  metrics jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists mc_memory_eval_scorecards_tenant_suite_created_idx
+  on mc_memory_eval_scorecards (api_key_hash, suite_id, created_at desc);
+
+create table if not exists mc_memory_passport_audit (
+  id uuid primary key default gen_random_uuid(),
+  api_key_hash text not null,
+  operation text not null check (operation in ('export', 'import')),
+  bundle_version text not null,
+  signature_digest text not null,
+  exported_records integer not null default 0,
+  imported_records integer not null default 0,
+  redacted_records integer not null default 0,
+  credential_leakage integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists mc_memory_passport_audit_tenant_created_idx
+  on mc_memory_passport_audit (api_key_hash, created_at desc);


### PR DESCRIPTION
## What existed before

The repo already had the proof-as-reward eval docs and API eval harness. The memory package did not yet have the lane-10 memory-hardening diagnostic harness or memory passport export/import operations.

## What this adds

- Adds `memory-hardening-eval-v1` with six deterministic diagnostics: paraphrase recall, latest value, scope bleed, no answer, forget, and duplicate storm.
- Adds a committed lane-10 baseline and report under `docs/memory-hardening/` without overwriting the existing proof-as-reward eval docs.
- Adds signed memory passport export/import helpers with explicit allowlisted fields and credential-shaped record omission.
- Adds lane-10 backend methods in both `local.ts` and `supabase.ts`.
- Adds gated handler ops: `export_memory_passport` and `import_memory_passport`.
- Adds local/Supabase scorecard instrumentation and 09xx schema storage for eval scorecards and passport audit.
- Strengthens passport round-trip proof by re-exporting after import and asserting non-secret provenance fields survive.

## Flag

`MEMORY_PASSPORT_ENABLED`, default off. Passport handlers also require `MEMORY_PASSPORT_SIGNING_SECRET` when the flag is on.

## Backends touched

- Local backend: export/import passport, audit rows, provenance preservation for existing `FactInput` fields.
- Supabase backend: tenant-scoped export/import passport and non-blocking passport audit writes.

## Metrics expected to move

- scorecard
- `passport_roundtrip_fidelity`
- `passport_credential_leakage`, target 0

The baseline also reports registry metrics for dependent lanes so the coordinator can rerun after merges.

## Validation

- `npx tsx --test src/memory/__tests__/eval-harness.test.ts src/memory/__tests__/passport.test.ts`
- `npx tsc --noEmit -p packages/mcp-server/tsconfig.json`
- `npm run test --workspace=@unclick/mcp-server` reaches the final known base-branch failure at `connector-depth-ladder --check` after passing memory tsx tests, package builds, Vitest, connector-depth unit tests, and tool-index check.
- `node scripts/check-standalone-registry.mjs`

## Notes

Draft stays open for coordinator sequencing and integration merge order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Passport paths move user memory across backends with signing and redaction, but misconfiguration of signing secrets or enabling the flag in production could expose export/import surfaces; eval baseline intentionally documents failing scope/duplicate scenarios for other lanes.
> 
> **Overview**
> Adds **lane-10 memory hardening** tooling: a deterministic `memory-hardening-eval-v1` harness (`eval-harness.ts`) with six diagnostics and registry metrics, plus committed baseline/report under `docs/memory-hardening/` without touching existing proof-as-reward eval docs.
> 
> Introduces a **signed memory passport** (`passport.ts`): allowlisted export/import of business context, facts, and session summaries with credential-shaped rows dropped, HMAC verification, and audit rows on local and Supabase backends. MCP handlers `export_memory_passport` / `import_memory_passport` are **off by default** (`MEMORY_PASSPORT_ENABLED`) and require `MEMORY_PASSPORT_SIGNING_SECRET` when enabled.
> 
> Wires **scorecard persistence** (`logMemoryEvalScorecard`, migration `20260604090000_mem_harden_lane10_eval_passport.sql`), extends `MemoryBackend` and fact provenance fields on import, and adds `eval-harness` / `passport` tests to the mcp-server test script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e43d79f140513791eecbeb2bf7cf63a73c1c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->