### PR TITLE
[codex] Polish Boardroom stale signal noise

### DIFF
--- a/api/boardroom-signal-polish.test.ts
+++ b/api/boardroom-signal-polish.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { buildOrchestratorContext } from "./lib/orchestrator-context";
+import {
+  normalizeBoardroomTerminology,
+  polishBoardroomSignal,
+} from "./lib/boardroom-signal-polish";
+
+describe("Boardroom signal polish", () => {
+  it("normalizes retired Boardroom source names in summaries", () => {
+    const summary = normalizeBoardroomTerminology(
+      "fishbowl stale fishbowl-message:abc and fishbowl-checkin:worker-1:2026-06-03",
+    );
+
+    expect(summary).toContain("boardroom stale boardroom-message:abc");
+    expect(summary).toContain("boardroom-checkin:worker-1");
+    expect(summary).not.toMatch(/fishbowl/i);
+  });
+
+  it("marks stale Boardroom dispatches as history noise", () => {
+    const polish = polishBoardroomSignal({
+      sourceKind: "dispatch",
+      source: "fishbowl",
+      status: "stale",
+      summary: 'fishbowl stale fishbowl-message:abc {"kind":"message_handoff"}',
+      tags: ["dispatch", "fishbowl", "stale"],
+    });
+
+    expect(polish).toMatchObject({
+      isNoise: true,
+      reason: "stale-boardroom-source",
+    });
+    expect(polish.summary).not.toMatch(/fishbowl/i);
+    expect(polish.tags).toEqual(expect.arrayContaining(["boardroom", "noise:stale-source"]));
+  });
+
+  it("hides discontinued automation check names from live summaries", () => {
+    const polish = polishBoardroomSignal({
+      sourceKind: "signal",
+      tool: "Cursor Bugbot",
+      action: "review_failed",
+      severity: "critical",
+      summary: "Cursor Bugbot found an issue",
+      tags: ["signal", "Cursor Bugbot", "critical"],
+    });
+
+    expect(polish).toMatchObject({
+      isNoise: true,
+      reason: "retired-automation-check",
+      summary: "Discontinued automation check ignored as non-operational noise.",
+    });
+    expect(JSON.stringify(polish)).not.toMatch(/bugbot/i);
+  });
+
+  it("keeps real action-needed signals visible", () => {
+    const polish = polishBoardroomSignal({
+      sourceKind: "signal",
+      tool: "github_action",
+      action: "deploy_failed",
+      severity: "critical",
+      summary: "Vercel deploy failed on production build",
+      tags: ["signal", "github_action", "critical"],
+    });
+
+    expect(polish.isNoise).toBe(false);
+    expect(polish.summary).toContain("Vercel deploy failed");
+    expect(polish.tags).not.toContain("noise:stale-source");
+  });
+
+  it("does not emit em dashes in polished text", () => {
+    const outputs = [
+      normalizeBoardroomTerminology("Fishbowl handoff"),
+      polishBoardroomSignal({
+        sourceKind: "signal",
+        tool: "Cursor Bugbot",
+        action: "review_failed",
+        severity: "critical",
+        summary: "Cursor Bugbot found an issue",
+      }).summary,
+    ];
+
+    expect(outputs.join(" ")).not.toContain("—");
+  });
+
+  it("prevents stale source and discontinued check noise from becoming active blockers", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-06-04T03:50:00.000Z",
+      profiles: [
+        {
+          agent_id: "worker-live",
+          display_name: "Worker Live",
+          user_agent_hint: "codex-desktop",
+          last_seen_at: "2026-06-04T03:45:00.000Z",
+        },
+      ],
+      messages: [],
+      todos: [
+        {
+          id: "todo-active",
+          title: "Current active work",
+          description: "Fresh owned work should stay visible.",
+          status: "in_progress",
+          priority: "urgent",
+          created_by_agent_id: "router",
+          assigned_to_agent_id: "worker-live",
+          created_at: "2026-06-04T03:00:00.000Z",
+          updated_at: "2026-06-04T03:40:00.000Z",
+        },
+      ],
+      comments: [],
+      dispatches: [
+        {
+          dispatch_id: "dispatch-old-message",
+          source: "fishbowl",
+          target_agent_id: "worker-old",
+          task_ref: null,
+          status: "stale",
+          payload: {
+            kind: "message_handoff",
+            source_ref: "fishbowl-message:abc",
+            tags: ["blocker", "fyi"],
+          },
+          created_at: "2026-06-03T19:30:01.000Z",
+          updated_at: "2026-06-03T19:30:01.000Z",
+        },
+        {
+          dispatch_id: "dispatch-old-checkin",
+          source: "wakepass",
+          target_agent_id: "worker-old",
+          task_ref: null,
+          status: "stale",
+          payload: {
+            source_ref: "fishbowl-checkin:worker-old:2026-06-03T03:04:50.834+00:00",
+          },
+          created_at: "2026-06-03T03:30:39.000Z",
+          updated_at: "2026-06-03T03:30:39.000Z",
+        },
+      ],
+      signals: [
+        {
+          id: "signal-retired-check",
+          tool: "Cursor Bugbot",
+          action: "review_failed",
+          severity: "critical",
+          summary: "Cursor Bugbot review failed",
+          created_at: "2026-06-04T03:35:00.000Z",
+        },
+      ],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.current_state_card.blocker_count).toBe(0);
+    expect(context.current_state_card.blockers).toHaveLength(0);
+    expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
+    expect(context.seat_handshake.active_blocker).toBeNull();
+
+    const publicContext = JSON.stringify({
+      state: context.current_state_card,
+      continuity: context.continuity_events,
+      rolling: context.rolling_snapshot,
+      handshake: context.seat_handshake,
+    });
+    expect(publicContext).not.toMatch(/fishbowl/i);
+    expect(publicContext).not.toMatch(/bugbot/i);
+  });
+});

--- a/api/lib/boardroom-signal-polish.ts
+++ b/api/lib/boardroom-signal-polish.ts
@@ -1,0 +1,147 @@
+export type BoardroomSignalPolishReason =
+  | "retired-automation-check"
+  | "stale-boardroom-source"
+  | null;
+
+export interface BoardroomSignalPolishInput {
+  sourceKind?: string | null;
+  source?: string | null;
+  status?: string | null;
+  summary?: unknown;
+  tags?: string[] | null;
+  actorAgentId?: string | null;
+  tool?: string | null;
+  action?: string | null;
+  severity?: string | null;
+  payload?: unknown;
+}
+
+export interface BoardroomSignalPolishResult {
+  summary: string;
+  tags: string[];
+  isNoise: boolean;
+  reason: BoardroomSignalPolishReason;
+}
+
+const LEGACY_BOARDROOM_SOURCE_PATTERN = /\bfishbowl(?:-(?:message|checkin))?\b/gi;
+const LEGACY_BOARDROOM_CHECKIN_PATTERN = /\bfishbowl-checkin:/gi;
+const LEGACY_BOARDROOM_MESSAGE_PATTERN = /\bfishbowl-message:/gi;
+const BOARDROOM_SOURCE_PATTERN = /\b(?:fishbowl|boardroom)(?:-(?:message|checkin))?\b/i;
+const RETIRED_AUTOMATION_PATTERN = /\b(?:cursor[\s_-]*)?bugbot\b/i;
+
+export function normalizeBoardroomTerminology(input: unknown): string {
+  return stringify(input)
+    .replace(LEGACY_BOARDROOM_CHECKIN_PATTERN, "boardroom-checkin:")
+    .replace(LEGACY_BOARDROOM_MESSAGE_PATTERN, "boardroom-message:")
+    .replace(LEGACY_BOARDROOM_SOURCE_PATTERN, (match) => {
+      if (match === match.toUpperCase()) return "BOARDROOM";
+      if (match[0] === match[0].toUpperCase()) return "Boardroom";
+      return "boardroom";
+    });
+}
+
+export function polishBoardroomSignal(input: BoardroomSignalPolishInput): BoardroomSignalPolishResult {
+  if (isRetiredAutomationCheck(input)) {
+    return {
+      summary: "Discontinued automation check ignored as non-operational noise.",
+      tags: uniqueTags([...normalizeBoardroomTags(input.tags), "noise:retired-automation"]),
+      isNoise: true,
+      reason: "retired-automation-check",
+    };
+  }
+
+  const summary = normalizeBoardroomTerminology(input.summary);
+  if (isStaleBoardroomSource(input)) {
+    return {
+      summary,
+      tags: uniqueTags([...normalizeBoardroomTags(input.tags), "noise:stale-source"]),
+      isNoise: true,
+      reason: "stale-boardroom-source",
+    };
+  }
+
+  return {
+    summary,
+    tags: normalizeBoardroomTags(input.tags),
+    isNoise: false,
+    reason: null,
+  };
+}
+
+export function isRetiredBoardroomSignalNoise(input: BoardroomSignalPolishInput): boolean {
+  return hasNoiseTag(input.tags) || isRetiredAutomationCheck(input) || isStaleBoardroomSource(input);
+}
+
+function isRetiredAutomationCheck(input: BoardroomSignalPolishInput): boolean {
+  return RETIRED_AUTOMATION_PATTERN.test(evidenceText(input));
+}
+
+function hasNoiseTag(tags?: string[] | null): boolean {
+  return (tags ?? []).some((tag) => typeof tag === "string" && tag.toLowerCase().startsWith("noise:"));
+}
+
+function isStaleBoardroomSource(input: BoardroomSignalPolishInput): boolean {
+  if ((input.sourceKind ?? "").toLowerCase() !== "dispatch") return false;
+
+  const status = (input.status ?? "").toLowerCase();
+  const tags = normalizeBoardroomTags(input.tags).map((tag) => tag.toLowerCase());
+  const isStale = status === "stale" || tags.includes("stale");
+  if (!isStale) return false;
+
+  const text = evidenceText(input);
+  if (BOARDROOM_SOURCE_PATTERN.test(text)) return true;
+
+  return /\bwakepass\b/i.test(text) && isRoutineWakeNoise(text);
+}
+
+function isRoutineWakeNoise(text: string): boolean {
+  return (
+    /\b(?:fishbowl|boardroom)-checkin:/.test(text) ||
+    /\bmissed_next_checkin\b/.test(text) ||
+    /\bissue_comment\b/.test(text) ||
+    /\bsuperseded_status_comment\b/.test(text) ||
+    (/\bbridge_status\b/.test(text) && /\bsuppress\b/.test(text)) ||
+    (/\bduplicate\b/.test(text) && /\b(?:ack|wake)\b/.test(text))
+  );
+}
+
+function normalizeBoardroomTags(tags?: string[] | null): string[] {
+  return uniqueTags(
+    (tags ?? [])
+      .filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+      .map((tag) => normalizeBoardroomTerminology(tag).trim())
+      .map((tag) => (RETIRED_AUTOMATION_PATTERN.test(tag) ? "retired-automation" : tag)),
+  );
+}
+
+function evidenceText(input: BoardroomSignalPolishInput): string {
+  return [
+    input.sourceKind,
+    input.source,
+    input.status,
+    input.summary,
+    input.actorAgentId,
+    input.tool,
+    input.action,
+    input.severity,
+    input.payload,
+    ...(input.tags ?? []),
+  ]
+    .map((value) => normalizeBoardroomTerminology(value))
+    .join(" ")
+    .toLowerCase();
+}
+
+function uniqueTags(tags: string[]): string[] {
+  return Array.from(new Set(tags.filter((tag) => tag.trim().length > 0)));
+}
+
+function stringify(input: unknown): string {
+  if (input == null) return "";
+  if (typeof input === "string") return input;
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return String(input);
+  }
+}

--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -5,6 +5,10 @@ import {
   createAutopilotZeroTouchMetrics,
   type AutopilotTouchMetricsRow,
 } from "./autopilot-control-ledger.js";
+import {
+  isRetiredBoardroomSignalNoise,
+  polishBoardroomSignal,
+} from "./boardroom-signal-polish.js";
 import type { CommonSensePassResult } from "../../packages/commonsensepass/src/index.js";
 
 export interface OrchestratorProfileRow {
@@ -1301,6 +1305,7 @@ function isActiveBlockerEvent(
   profileLastSeenByAgent: Map<string, string | null>,
 ): boolean {
   if (event.kind !== "blocker") return false;
+  if (isPolishedSignalNoiseEvent(event)) return false;
   if (isWakeIssueCommentStale(event, activeTodos)) return false;
   if (isSuppressedWakePassStatusDispatch(event)) return false;
   if (isSupersededMissedCheckinDispatch(event, profileLastSeenByAgent, nowMs)) return false;
@@ -1319,7 +1324,7 @@ function isSupersededMissedCheckinDispatch(
   const summary = event.summary.toLowerCase();
   const text = `${summary} ${tags.join(" ")}`;
   const isStale = tags.includes("stale") || /\bstale\b/.test(text);
-  if (!isStale || !text.includes("fishbowl-checkin:")) return false;
+  if (!isStale || !/\b(?:fishbowl|boardroom)-checkin:/.test(text)) return false;
 
   const agentId = extractMissedCheckinAgentId(event);
   if (!agentId) return false;
@@ -1334,7 +1339,7 @@ function isSupersededMissedCheckinDispatch(
 }
 
 function extractMissedCheckinAgentId(event: OrchestratorContinuityEvent): string | null {
-  const match = event.summary.match(/\bfishbowl-checkin:([^:\s{]+):/i);
+  const match = event.summary.match(/\b(?:fishbowl|boardroom)-checkin:([^:\s{]+):/i);
   if (match?.[1]) return match[1];
   return event.actor_agent_id && !/^\p{Emoji_Presentation}$/u.test(event.actor_agent_id)
     ? event.actor_agent_id
@@ -1555,6 +1560,9 @@ function uniqueSourcePointers(items: OrchestratorRollingSnapshotItem[]): Orchest
 }
 
 function isSnapshotNoise(event: OrchestratorContinuityEvent): boolean {
+  if (isPolishedSignalNoiseEvent(event)) {
+    return true;
+  }
   const summary = event.summary.toLowerCase();
   const tags = (event.tags ?? []).map((tag) => tag.toLowerCase());
   if (event.kind === "decision" && !tags.includes("heartbeat")) {
@@ -1565,6 +1573,20 @@ function isSnapshotNoise(event: OrchestratorContinuityEvent): boolean {
   }
   const text = `${summary} ${tags.join(" ")}`;
   return isHeartbeatAutomationText(text) || /heartbeat|quiet-status|dont_notify|don't notify|no user action needed|unchanged ack|raw transcript/.test(text);
+}
+
+function isPolishedSignalNoiseEvent(event: OrchestratorContinuityEvent): boolean {
+  return isRetiredBoardroomSignalNoise({
+    sourceKind: event.source_kind,
+    status:
+      event.tags?.find((tag) => {
+        const lower = tag.toLowerCase();
+        return lower === "stale" || lower === "failed" || lower === "leased";
+      }) ?? null,
+    summary: event.summary,
+    tags: event.tags,
+    actorAgentId: event.actor_agent_id,
+  });
 }
 
 function buildProfileCard(profile: OrchestratorProfileRow, nowMs: number): OrchestratorProfileCard {
@@ -1681,6 +1703,8 @@ function commentToEvent(comment: OrchestratorCommentRow): OrchestratorContinuity
 
 function dispatchToEvent(dispatch: OrchestratorDispatchRow): OrchestratorContinuityEvent {
   const payloadTags = dispatchPayloadEvidenceTags(dispatch.payload);
+  const actorAgentId = dispatch.lease_owner ?? dispatch.target_agent_id;
+  const tags = ["dispatch", dispatch.source, dispatch.status, ...payloadTags];
   const detail = [
     dispatch.source,
     dispatch.status,
@@ -1689,15 +1713,30 @@ function dispatchToEvent(dispatch: OrchestratorDispatchRow): OrchestratorContinu
   ]
     .filter(Boolean)
     .join(" ");
+  const polish = polishBoardroomSignal({
+    sourceKind: "dispatch",
+    source: dispatch.source,
+    status: dispatch.status,
+    summary: detail,
+    tags,
+    actorAgentId,
+    payload: dispatch.payload,
+  });
+  const baseKind =
+    dispatch.status === "leased"
+      ? "handoff"
+      : dispatch.status === "failed" || dispatch.status === "stale"
+        ? "blocker"
+        : "status";
   return {
     source_kind: "dispatch",
     source_id: dispatch.dispatch_id,
     deep_link: dispatch.task_ref?.startsWith("todo:") ? `/admin/jobs#${dispatch.task_ref}` : null,
     created_at: dispatch.updated_at ?? dispatch.created_at,
-    kind: dispatch.status === "leased" ? "handoff" : dispatch.status === "failed" || dispatch.status === "stale" ? "blocker" : "status",
-    actor_agent_id: dispatch.lease_owner ?? dispatch.target_agent_id,
-    summary: compactText(detail, 240),
-    tags: ["dispatch", dispatch.source, dispatch.status, ...payloadTags],
+    kind: polish.isNoise ? "status" : baseKind,
+    actor_agent_id: actorAgentId,
+    summary: compactText(polish.summary, 240),
+    tags: polish.tags,
   };
 }
 
@@ -1713,14 +1752,29 @@ function dispatchPayloadEvidenceTags(payload: OrchestratorDispatchRow["payload"]
 }
 
 function signalToEvent(signal: OrchestratorSignalRow): OrchestratorContinuityEvent {
+  const tags = ["signal", signal.tool, signal.action, signal.severity];
+  const summary = `${signal.tool} ${signal.action}: ${signal.summary}`;
+  const polish = polishBoardroomSignal({
+    sourceKind: "signal",
+    tool: signal.tool,
+    action: signal.action,
+    severity: signal.severity,
+    summary,
+    tags,
+    payload: signal.payload,
+  });
   return {
     source_kind: "signal",
     source_id: signal.id,
     deep_link: signal.deep_link ?? null,
     created_at: signal.created_at,
-    kind: signal.severity === "critical" || signal.severity === "action_needed" ? "blocker" : classify([signal.action, signal.severity], signal.summary),
-    summary: compactText(`${signal.tool} ${signal.action}: ${signal.summary}`, 240),
-    tags: ["signal", signal.tool, signal.action, signal.severity],
+    kind: polish.isNoise
+      ? "status"
+      : signal.severity === "critical" || signal.severity === "action_needed"
+        ? "blocker"
+        : classify([signal.action, signal.severity], signal.summary),
+    summary: compactText(polish.summary, 240),
+    tags: polish.tags,
   };
 }
 

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -497,7 +497,13 @@ describe("orchestrator context", () => {
       conversationTurns: [],
     });
 
-    expect(context.continuity_events.filter((event) => event.kind === "blocker")).toHaveLength(2);
+    const staleEvents = context.continuity_events.filter((event) => event.source_id.startsWith("dispatch-stale-"));
+    expect(staleEvents).toHaveLength(2);
+    expect(staleEvents.find((event) => event.source_id === "dispatch-stale-wakepass")?.kind).toBe("blocker");
+    expect(staleEvents.find((event) => event.source_id === "dispatch-stale-fishbowl")?.kind).toBe("status");
+    expect(staleEvents.find((event) => event.source_id === "dispatch-stale-fishbowl")?.tags).toContain(
+      "noise:stale-source",
+    );
     expect(context.current_state_card.active_todo_count).toBe(0);
     expect(context.current_state_card.blocker_count).toBe(0);
     expect(context.current_state_card.blockers).toHaveLength(0);
@@ -535,7 +541,11 @@ describe("orchestrator context", () => {
       conversationTurns: [],
     });
 
-    expect(context.continuity_events.filter((event) => event.kind === "blocker")).toHaveLength(1);
+    const staleWake = context.continuity_events.find(
+      (event) => event.source_id === "dispatch-fresh-issue-comment-wake",
+    );
+    expect(staleWake?.kind).toBe("status");
+    expect(staleWake?.tags).toContain("noise:stale-source");
     expect(context.current_state_card.blocker_count).toBe(0);
     expect(context.current_state_card.blockers).toHaveLength(0);
     expect(context.rolling_snapshot.active_blockers).toHaveLength(0);
@@ -604,8 +614,9 @@ describe("orchestrator context", () => {
     const blockerEvents = context.continuity_events.filter((event) => event.kind === "blocker");
     const activeBlockerIds = context.rolling_snapshot.active_blockers.map((event) => event.source_id);
 
-    expect(blockerEvents.map((event) => event.source_id)).toEqual(
-      expect.arrayContaining(["dispatch-superseded-wakepass", "dispatch-real-wakepass"]),
+    expect(blockerEvents.map((event) => event.source_id)).toEqual(["dispatch-real-wakepass"]);
+    expect(context.continuity_events.find((event) => event.source_id === "dispatch-superseded-wakepass")?.kind).toBe(
+      "status",
     );
     expect(context.current_state_card.active_todo_count).toBe(1);
     expect(context.current_state_card.blocker_count).toBe(1);
@@ -660,8 +671,9 @@ describe("orchestrator context", () => {
       conversationTurns: [],
     });
 
-    expect(context.continuity_events.find((event) => event.source_id === "dispatch-old-checkin")?.kind).toBe(
-      "blocker",
+    expect(context.continuity_events.find((event) => event.source_id === "dispatch-old-checkin")?.kind).toBe("status");
+    expect(context.continuity_events.find((event) => event.source_id === "dispatch-old-checkin")?.tags).toContain(
+      "noise:stale-source",
     );
     expect(context.current_state_card.active_todo_count).toBe(1);
     expect(context.current_state_card.blocker_count).toBe(0);

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 618,
+    "inventory": 619,
     "source_manifest": 192,
     "pages": 84,
     "tools": 219,
@@ -75,7 +75,7 @@
       "id": "source-of-truth",
       "name": "Source of truth",
       "meaning": "Canonical state, queue, memory, and context surfaces.",
-      "count": 12
+      "count": 13
     },
     {
       "id": "modules-and-apps",
@@ -3868,6 +3868,16 @@
       "kind": "state module",
       "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
       "source": "api/lib/boardroom-read-bounds.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "source-of-truth-state-module-boardroom-signal-polish-api-lib-boardroom-signal-polish-ts-no-route",
+      "division": "Source of truth",
+      "name": "boardroom signal polish",
+      "kind": "state module",
+      "meaning": "Server endpoint or helper used by UnClick admin, memory, workers, or tools.",
+      "source": "api/lib/boardroom-signal-polish.ts",
       "route": "",
       "tags": []
     },
@@ -8166,6 +8176,10 @@
       "node --test scripts/api-lib-esm-extension-guard.test.mjs"
     ],
     [
+      "test:boardroom-signal-polish",
+      "vitest run api/boardroom-signal-polish.test.ts"
+    ],
+    [
       "test:brainmap",
       "node --test scripts/UnClick-brainmap.test.mjs"
     ],
@@ -8290,8 +8304,8 @@
     },
     {
       "source": "package.json",
-      "hash": "82714e796f84",
-      "bytes": 6974
+      "hash": "475c10903425",
+      "bytes": 7060
     },
     {
       "source": "seed/skills/agent-handoff-packet-writer.skill.md",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -30,7 +30,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/ci.yml | ab3e717a4ae9 | 1663 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | .github/workflows/continuous-improvement-watch.yml | d121a434a464 | 2358 |
-| package.json | 82714e796f84 | 6974 |
+| package.json | 475c10903425 | 7060 |
 | seed/skills/agent-handoff-packet-writer.skill.md | f9c498e48796 | 938 |
 | seed/skills/browser-qa-tester.skill.md | b57ce8b2e63a | 1115 |
 | seed/skills/builder-implementation-packet.skill.md | 1fcda17af905 | 1276 |
@@ -219,7 +219,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 121 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 8 |
-| Source of truth | Canonical state, queue, memory, and context surfaces. | 12 |
+| Source of truth | Canonical state, queue, memory, and context surfaces. | 13 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 116 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 5 |
 
@@ -944,6 +944,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Source of truth | queue | Boardroom Jobs | Primary work source for open, in-progress, done, and dropped chips. | /admin/jobs | src/pages/admin/AdminJobs.tsx |
 | Source of truth | state module | boardroom compat | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/boardroom-compat.ts |
 | Source of truth | state module | boardroom read bounds | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/boardroom-read-bounds.ts |
+| Source of truth | state module | boardroom signal polish | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/lib/boardroom-signal-polish.ts |
 | Source of truth | state module | embed | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory/embed.ts |
 | Source of truth | state module | memory admin | Server endpoint or helper used by UnClick admin, memory, workers, or tools. | - | api/memory-admin.ts |
 | Source of truth | state module | memory Data Island | memory Data Island shared frontend logic. | - | src/lib/memoryDataIsland.ts |
@@ -1275,6 +1276,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | test | npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && vitest run && npm run test:api-lib-esm-extension |
 | test:api | npm run test --workspace=apps/api |
 | test:api-lib-esm-extension | node --test scripts/api-lib-esm-extension-guard.test.mjs |
+| test:boardroom-signal-polish | vitest run api/boardroom-signal-polish.test.ts |
 | test:brainmap | node --test scripts/UnClick-brainmap.test.mjs |
 | test:compliancepass-receipt | node --test scripts/enterprisepass-receipt-guard.test.mjs |
 | test:continuous-improvement-watch | node --test scripts/pinballwake-continuous-improvement-watch.test.mjs |

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "compliancepass:report": "npm run build --workspace=@unclick/compliancepass && node scripts/build-compliancepass-report.mjs",
     "memory:eval": "node scripts/memory-retrieval-eval.mjs",
     "test:memory-eval": "node --test scripts/memory-retrieval-eval.test.mjs",
+    "test:boardroom-signal-polish": "vitest run api/boardroom-signal-polish.test.ts",
     "test:compliancepass-receipt": "node --test scripts/enterprisepass-receipt-guard.test.mjs",
     "test:continuous-improvement-watch": "node --test scripts/pinballwake-continuous-improvement-watch.test.mjs",
     "test:enterprisepass-receipt": "node --test scripts/enterprisepass-receipt-guard.test.mjs",


### PR DESCRIPTION
## What changed

- Adds a pure Boardroom signal polish helper for stale source naming and retired automation noise.
- Routes orchestrator dispatch and signal events through the helper before blocker counting.
- Downgrades routine stale source noise to status/history while preserving real action-needed blockers.
- Refreshes the UnClick brainmap for the new helper and focused test.

## Why

Some stale dispatch sources still exposed retired Boardroom naming and routine wake noise as apparent blockers. This made the context card look noisier than the actual work state.

## Validation

- `npm run test:boardroom-signal-polish`
- `npm exec vitest -- run api/orchestrator-context.test.ts api/boardroom-signal-polish.test.ts`
- `npm exec eslint -- api/lib/boardroom-signal-polish.ts api/lib/orchestrator-context.ts api/boardroom-signal-polish.test.ts api/orchestrator-context.test.ts`
- `npm run brainmap:check`