### PR TITLE
fix(orchestrator): surface operator AI Style into seat handoff prompt

### DIFF
--- a/api/lib/orchestrator-context.ts
+++ b/api/lib/orchestrator-context.ts
@@ -146,6 +146,17 @@ export interface OrchestratorOperatorTimeContext {
   summary: string;
 }
 
+// Operator AI Style preference (set on /admin/you, stored in mc_business_context
+// under category "preference", key "ai_style"). Mirrors the operator_timezone
+// path: read here and woven into the seat handshake prompt so every hosted seat
+// wake carries the operator's standing style directive. directive is the
+// ready-made imperative string built by buildAiStyleDirective (<= 300 chars).
+export interface OrchestratorAiStyleContext {
+  directive: string;
+  updated_at?: string | null;
+  summary: string;
+}
+
 export interface BuildOrchestratorContextInput {
   generatedAt: string;
   continuityLimit?: number;
@@ -382,6 +393,7 @@ export interface OrchestratorContext {
   };
   profile_cards: OrchestratorProfileCard[];
   human_operator_time: OrchestratorOperatorTimeContext | null;
+  operator_ai_style: OrchestratorAiStyleContext | null;
   continuity_events: OrchestratorContinuityEvent[];
   library_snapshots: OrchestratorLibrarySnapshot[];
   rolling_snapshot: OrchestratorRollingSnapshot;
@@ -505,6 +517,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
   const profiles = compact ? allProfiles.slice(0, maxSummaries) : allProfiles;
   const activeSeatCount = allProfiles.filter((profile) => isFresh(profile.last_seen_at, nowMs)).length;
   const humanOperatorTime = buildOperatorTimeContext(input.businessContext, input.generatedAt);
+  const operatorAiStyle = buildAiStyleContext(input.businessContext);
   const zeroTouchScoreboard = buildZeroTouchScoreboard(input.autopilotEvents ?? []);
 
   const activeTodoRows = input.todos
@@ -617,6 +630,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     continuityEvents,
     rollingSnapshot,
     humanOperatorTime,
+    operatorAiStyle,
   });
 
   return {
@@ -679,6 +693,7 @@ export function buildOrchestratorContext(input: BuildOrchestratorContextInput): 
     },
     profile_cards: profiles,
     human_operator_time: humanOperatorTime,
+    operator_ai_style: operatorAiStyle,
     continuity_events: continuityEvents,
     library_snapshots: librarySnapshots,
     rolling_snapshot: rollingSnapshot,
@@ -1105,11 +1120,13 @@ function buildSeatHandshake({
   continuityEvents,
   rollingSnapshot,
   humanOperatorTime,
+  operatorAiStyle,
 }: {
   profiles: OrchestratorProfileCard[];
   continuityEvents: OrchestratorContinuityEvent[];
   rollingSnapshot: OrchestratorRollingSnapshot;
   humanOperatorTime: OrchestratorOperatorTimeContext | null;
+  operatorAiStyle: OrchestratorAiStyleContext | null;
 }): OrchestratorSeatHandshake {
   const usefulEvents = continuityEvents.filter((event) => !isSnapshotNoise(event));
   const recentProof = usefulEvents.find((event) => event.kind === "proof") ?? null;
@@ -1146,6 +1163,17 @@ function buildSeatHandshake({
     ...rollingSnapshot.recent_continuity.slice(0, 4),
   ]);
 
+  // Weave the operator's standing preferences into the seat wake prompt. Both
+  // lines are optional and inert when unset, so the prompt is byte-identical to
+  // before when neither preference exists. operatorAiStyle.directive is the
+  // ready-made imperative string from /admin/you (was previously loaded but
+  // dropped on this path).
+  const operatorTimeLine = humanOperatorTime
+    ? ` Human operator local time is ${humanOperatorTime.summary}.`
+    : "";
+  const aiStyleLine = operatorAiStyle ? ` ${operatorAiStyle.directive}` : "";
+  const nextPrompt = `Use this compact handoff.${operatorTimeLine}${aiStyleLine} Orchestrator continuity writes are authorized: save the wake and final result with save_conversation_turn, unclick_save_conversation_turn, or admin_conversation_turn_ingest if auth is already available. Inspect source pointers only as needed, do one safe useful step, then reply PASS: <progress>; proof: <link/id>; cleanup: done, or BLOCKER: <missing>; progress: <checked>; next: <fix>.`;
+
   return {
     mode: "fresh-seat-pickup",
     summary: compactText(
@@ -1164,9 +1192,7 @@ function buildSeatHandshake({
     recent_proof: recentProof?.summary ?? null,
     active_blocker: blocker?.summary ?? null,
     seat_freshness: seatFreshness,
-    next_prompt: humanOperatorTime
-      ? `Use this compact handoff. Human operator local time is ${humanOperatorTime.summary}. Orchestrator continuity writes are authorized: save the wake and final result with save_conversation_turn, unclick_save_conversation_turn, or admin_conversation_turn_ingest if auth is already available. Inspect source pointers only as needed, do one safe useful step, then reply PASS: <progress>; proof: <link/id>; cleanup: done, or BLOCKER: <missing>; progress: <checked>; next: <fix>.`
-      : "Use this compact handoff. Orchestrator continuity writes are authorized: save the wake and final result with save_conversation_turn, unclick_save_conversation_turn, or admin_conversation_turn_ingest if auth is already available. Inspect source pointers only as needed, do one safe useful step, then reply PASS: <progress>; proof: <link/id>; cleanup: done, or BLOCKER: <missing>; progress: <checked>; next: <fix>.",
+    next_prompt: nextPrompt,
     source_pointers: sourcePointers,
   };
 }
@@ -1208,6 +1234,25 @@ function buildOperatorTimeContext(
     updated_at: row.updated_at ?? (typeof value.updated_at === "string" ? value.updated_at : null),
     privacy: "timezone-only",
     summary,
+  };
+}
+
+// Mirror of buildOperatorTimeContext for the AI Style preference. The row is
+// stored by /admin/you with a ready-made `directive` string; before this it was
+// fetched into businessContext but never surfaced into the seat prompt.
+function buildAiStyleContext(
+  rows: OrchestratorBusinessContextRow[],
+): OrchestratorAiStyleContext | null {
+  const row = rows.find((item) => item.category === "preference" && item.key === "ai_style");
+  if (!row) return null;
+  const value = parseBusinessContextValue(row.value);
+  const directiveRaw = typeof value.directive === "string" ? value.directive.trim() : "";
+  if (!directiveRaw) return null;
+  const directive = compactText(directiveRaw, 300);
+  return {
+    directive,
+    updated_at: row.updated_at ?? (typeof value.updated_at === "string" ? value.updated_at : null),
+    summary: directive,
   };
 }
 

--- a/api/orchestrator-context.test.ts
+++ b/api/orchestrator-context.test.ts
@@ -358,6 +358,59 @@ describe("orchestrator context", () => {
     expect(context.seat_handshake.next_prompt).toContain("Australia/Sydney");
   });
 
+  it("surfaces the operator ai_style directive into the seat handoff prompt", () => {
+    const directive =
+      "Operator AI style, always honor unless overridden in-session: keep answers short; explain simply; use bullet points; no emoji.";
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-10T01:00:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [
+        {
+          id: "bc-ai-style",
+          category: "preference",
+          key: "ai_style",
+          value: {
+            directive,
+            response_length: "short",
+            updated_at: "2026-05-10T00:50:00.000Z",
+          },
+          priority: 99,
+          updated_at: "2026-05-10T00:50:00.000Z",
+        },
+      ],
+      conversationTurns: [],
+    });
+
+    expect(context.operator_ai_style?.directive).toBe(directive);
+    expect(context.seat_handshake.next_prompt).toContain(directive);
+  });
+
+  it("omits the ai_style line from the handoff prompt when no preference is set", () => {
+    const context = buildOrchestratorContext({
+      generatedAt: "2026-05-10T01:00:00.000Z",
+      profiles: [],
+      messages: [],
+      todos: [],
+      comments: [],
+      dispatches: [],
+      signals: [],
+      sessions: [],
+      library: [],
+      businessContext: [],
+      conversationTurns: [],
+    });
+
+    expect(context.operator_ai_style).toBeNull();
+    expect(context.seat_handshake.next_prompt).toContain("Use this compact handoff. Orchestrator");
+  });
+
   it("labels profile-card check-in freshness for AI seats", () => {
     const context = buildOrchestratorContext({
       generatedAt: "2026-05-09T12:00:00.000Z",


### PR DESCRIPTION
## Why

The **AI Style** setting on `/admin/you` was saved and loaded correctly but never reached agent sessions. This fixes the break.

**The chain:**
- The UI (`AdminYou.tsx`) POSTs to `/api/memory-admin?action=ai_style_update`, which upserts into `mc_business_context` under category `preference`, key `ai_style`, including a ready-made imperative `directive` string (built by `buildAiStyleDirective`, capped at 300 chars).
- The hosted orchestrator session builder **does** read `mc_business_context` into `businessContext`, so the `ai_style` row is present.
- But `buildOrchestratorContext` only extracted the sibling `operator_timezone` row (via `buildOperatorTimeContext`) and wove it into the seat prompt. There was **no handler for `ai_style`**, so the directive was fetched and then dropped on the floor. It never entered `seat_handshake.next_prompt`, which is what hosted seats are told to obey.

## What

Mirror the `operator_timezone` path for `ai_style`:
- Add `OrchestratorAiStyleContext` + `buildAiStyleContext(rows)` (finds the `ai_style` preference row, parses it, returns the `directive`).
- Expose a new `operator_ai_style` field on `OrchestratorContext`.
- Weave the directive into `seat_handshake.next_prompt` alongside the existing operator-time line.

No schema change (the row is already stored and already fetched). **Inert and byte-identical to today when no `ai_style` preference is set** (the existing no-preference prompt string is preserved).

## Tests

`api/orchestrator-context.test.ts`:
- Directive is surfaced into `operator_ai_style` and `seat_handshake.next_prompt` when set.
- Prompt is unchanged when no `ai_style` preference exists.

All 55 tests across the orchestrator-context + ai-style suites pass. The edited file is `tsc`-clean (the one pre-existing `COPYROOM_MISSING` readonly-tuple diagnostic on this file is unrelated and also present on `main`; `api/` is bundled by esbuild and not type-checked in CI).

## Follow-up (optional, not in this PR)

On the MCP `load_memory` lite path the `ai_style` value can be truncated to 130 chars by `compactJsonValue`; raising that cap (or special-casing the key) in `packages/mcp-server/src/memory/handlers.ts` would let the full directive survive that surface too.

https://claude.ai/code/session_01SsEGUCd36nJmTjB5ukCeAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsEGUCd36nJmTjB5ukCeAU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only preference plumbing into orchestrator prompts with no schema or auth changes; behavior is unchanged when `ai_style` is unset.
> 
> **Overview**
> Fixes a gap where **AI Style** from `/admin/you` was stored in `mc_business_context` but never reached hosted seats.
> 
> The PR mirrors the existing **operator timezone** path: it adds `OrchestratorAiStyleContext`, `buildAiStyleContext()` (reads `preference` / `ai_style`, compacts the stored `directive` to 300 chars), exposes **`operator_ai_style`** on orchestrator context, and appends that directive to **`seat_handshake.next_prompt`** next to the human local-time line. When no preference is set, the handoff prompt stays the same as before.
> 
> Tests assert the directive appears on `operator_ai_style` and in `next_prompt` when configured, and that the default prompt is unchanged when it is not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d20dd7969ec18626c727992b19abae8d3fab3127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->