### PR TITLE
feat(memory): wire auto-capture into the hosted web-chat ingest path

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -205,7 +205,13 @@ import {
 import {
   isSensitiveMemorySnapshotText,
   writeMemoryTaxonomySnapshotsToLibrary,
+  SupabaseBackend,
 } from "../packages/mcp-server/src/memory/supabase.js";
+import {
+  autoCaptureFromTurn,
+  codeAutoCaptureEnabled,
+  libraryAutoCaptureEnabled,
+} from "../packages/mcp-server/src/memory/auto-capture.js";
 import type {
   LibraryDocInput,
   MemoryTaxonomySnapshotSource,
@@ -6922,6 +6928,35 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .select("id, session_id, role, created_at")
           .single();
         if (error) throw error;
+
+        // Auto-capture (flag-gated, best-effort): mirror the MCP log_conversation
+        // path so hosted web-chat turns also fill the code-dump and library
+        // layers. Wrapped end-to-end so it can never break the turn ingest.
+        // Managed tenants only: BYOD users keep memory in their own Supabase, so
+        // writing to the central mc_* tables would be the wrong store.
+        if (role === "user" && (codeAutoCaptureEnabled() || libraryAutoCaptureEnabled())) {
+          try {
+            const { data: byodConfig } = await supabase
+              .from("memory_configs")
+              .select("api_key_hash")
+              .eq("api_key_hash", apiKeyHash)
+              .maybeSingle();
+            if (!byodConfig) {
+              const captureBackend = new SupabaseBackend({
+                url: supabaseUrl,
+                serviceRoleKey: supabaseKey,
+                tenancy: { mode: "managed", apiKeyHash },
+              });
+              await autoCaptureFromTurn(captureBackend, {
+                session_id: sessionId,
+                role,
+                content: safeContent,
+              });
+            }
+          } catch {
+            // best-effort; never block the turn ingest
+          }
+        }
 
         return res.status(200).json({
           turn_id: data.id,


### PR DESCRIPTION
## Why

The auto-capture hook from #1294 only fired on the **MCP** `log_conversation` path. Hosted **web-chat** turns go through `api/memory-admin.ts` → `admin_conversation_turn_ingest`, which writes `chat_messages` directly and **bypasses** the handler — so web-chat conversations never filled the code-dump / library layers. This closes that gap (the follow-up noted in #1294).

## What

Adds the same flag-gated, best-effort capture to `admin_conversation_turn_ingest`, **reusing the tested `autoCaptureFromTurn` + `SupabaseBackend`** so there's a single capture code path (no duplicated insert logic).

- **Managed tenants only.** BYOD users keep memory in their own Supabase, so writing to the central `mc_*` tables would be the wrong store. Detected via a `memory_configs` row for the `api_key_hash`; BYOD is skipped.
- **User-role turns only** (same as the MCP path).
- **Fully wrapped in `try/catch`** — capture can never break or fail the turn ingest. Worst case it silently no-ops.
- Gated by the existing `MEMORY_CODE_AUTOCAPTURE_ENABLED` / `MEMORY_LIBRARY_AUTOCAPTURE_ENABLED` flags (no new flags).

## Verification

The edited file is `tsc`-clean for these changes (the pre-existing diagnostics in this 11k-line file are unrelated and predate this PR; `api/` is bundled by esbuild and not type-checked in CI). The capture core (`auto-capture.ts`) is already covered by 18 unit tests from #1294.

## Effect

Once merged (flags are already enabled in prod), web-chat user turns containing pasted code or reference docs will start filling the code/library layers, matching the MCP path.

https://claude.ai/code/session_01SsEGUCd36nJmTjB5ukCeAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsEGUCd36nJmTjB5ukCeAU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, flag-gated logic after successful chat insert with swallowed errors; reuses tested capture code and does not change auth or ingest failure modes.
> 
> **Overview**
> **Hosted web-chat** turns that go through `admin_conversation_turn_ingest` now run the same **flag-gated auto-capture** as the MCP `log_conversation` path, so pasted code and reference-style content can fill the **code-dump** and **library** layers without a separate MCP call.
> 
> After a user turn is inserted into `chat_messages`, the handler may call **`autoCaptureFromTurn`** via a managed-tenant **`SupabaseBackend`**, reusing the existing capture module and env flags (`MEMORY_CODE_AUTOCAPTURE_ENABLED` / `MEMORY_LIBRARY_AUTOCAPTURE_ENABLED`). Capture runs only for **user** roles, only when at least one flag is on, and only when the tenant is treated as **managed** (skips tenants that have a **`memory_configs`** row for the key, i.e. BYOD). The block is **best-effort** (`try/catch`) so ingest responses are unchanged if capture fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b6af3e8ce3bc97e6d0f16d32c5e45b65cc6829b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->