### PR TITLE
feat(uipass): add curated UI toolbox gates

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 619,
+    "inventory": 620,
     "source_manifest": 192,
     "pages": 84,
     "tools": 219,
@@ -51,7 +51,7 @@
       "id": "passes-and-gates",
       "name": "Passes and gates",
       "meaning": "Quality, proof, safety, and fidelity checks.",
-      "count": 16
+      "count": 17
     },
     {
       "id": "wrappers-and-protocols",
@@ -442,6 +442,16 @@
       "tags": []
     },
     {
+      "id": "admin-surfaces-admin-page-boardroom-src-pages-admin-fishbowl-tsx-admin-boardroom",
+      "division": "Admin surfaces",
+      "name": "Boardroom",
+      "kind": "admin page",
+      "meaning": "Boardroom discussion surface for worker coordination.",
+      "source": "src/pages/admin/Fishbowl.tsx",
+      "route": "/admin/boardroom",
+      "tags": []
+    },
+    {
       "id": "admin-surfaces-admin-page-copy-pass-catalog-src-pages-admin-copypass-copypasscatalog-tsx-admin-copypass",
       "division": "Admin surfaces",
       "name": "Copy Pass Catalog",
@@ -509,16 +519,6 @@
       "meaning": "Crews admin page for Crews Settings.",
       "source": "src/pages/admin/crews/CrewsSettings.tsx",
       "route": "/admin/crews/settings",
-      "tags": []
-    },
-    {
-      "id": "admin-surfaces-admin-page-fishbowl-src-pages-admin-fishbowl-tsx-admin-boardroom",
-      "division": "Admin surfaces",
-      "name": "Fishbowl",
-      "kind": "admin page",
-      "meaning": "Boardroom discussion surface for worker coordination.",
-      "source": "src/pages/admin/Fishbowl.tsx",
-      "route": "/admin/boardroom",
       "tags": []
     },
     {
@@ -3089,6 +3089,16 @@
       "meaning": "Agent Skills-compatible starter package with provenance, safety, and native-mode metadata.",
       "source": "seed/skills/write-tests-for-changed-code.skill.md",
       "route": "/admin/skills",
+      "tags": []
+    },
+    {
+      "id": "passes-and-gates-component-source-gate-uipass-toolbox-packages-uxpass-src-ui-toolbox-ts-no-route",
+      "division": "Passes and gates",
+      "name": "UIPass Toolbox",
+      "kind": "component source gate",
+      "meaning": "Curated UI source registry and proof scoreboard for shadcn, Radix, React Aria, Base UI, Floating UI, Motion, 21st.dev, Magic UI, Aceternity, Origin UI, and advisory design intelligence.",
+      "source": "packages/uxpass/src/ui-toolbox.ts",
+      "route": "",
       "tags": []
     },
     {
@@ -6351,7 +6361,7 @@
     ],
     [
       "/admin/boardroom",
-      "Fishbowl",
+      "Boardroom",
       "Boardroom discussion surface for worker coordination.",
       "src/pages/admin/Fishbowl.tsx"
     ],
@@ -8225,8 +8235,8 @@
     },
     {
       "source": "docs/unclick-context-boot-packet.md",
-      "hash": "259a136f762b",
-      "bytes": 6132
+      "hash": "8af9b8fedfc4",
+      "bytes": 11213
     },
     {
       "source": "docs/agent-observability.md",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -15,7 +15,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | AUTOPILOT.md | 790b43137907 | 17556 |
 | FLEET_SYNC.md | 83bbf1598b48 | 14705 |
-| docs/unclick-context-boot-packet.md | 259a136f762b | 6132 |
+| docs/unclick-context-boot-packet.md | 8af9b8fedfc4 | 11213 |
 | docs/agent-observability.md | bffd9f890c75 | 4629 |
 | docs/pinballwake-nudgeonly-api.md | e056b727ce53 | 7559 |
 | docs/pinballwake-igniteonly-api.md | bea4d9c8fa21 | 7919 |
@@ -215,7 +215,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Tools | MCP and gateway capabilities available to seats. | 219 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
-| Passes and gates | Quality, proof, safety, and fidelity checks. | 16 |
+| Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 121 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 8 |
@@ -264,7 +264,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /admin/autopilot | Admin Autopilot | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
 | /admin/benchmarks | Admin Benchmarks | Admin surface for Admin Benchmarks. | src/pages/admin/AdminBenchmarks.tsx |
 | /admin/billing | Admin Billing | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
-| /admin/boardroom | Fishbowl | Boardroom discussion surface for worker coordination. | src/pages/admin/Fishbowl.tsx |
+| /admin/boardroom | Boardroom | Boardroom discussion surface for worker coordination. | src/pages/admin/Fishbowl.tsx |
 | /admin/brainmap | Admin Brainmap | Generated ecosystem map that teaches seats what UnClick is. | src/pages/admin/AdminBrainmap.tsx |
 | /admin/checks/:productId | Admin Checks | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
 | /admin/checks | Admin Checks | Admin surface for Admin Ecosystem Pages. | src/pages/admin/AdminEcosystemPages.tsx |
@@ -601,6 +601,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Admin Workers | Admin surface for Admin Ecosystem Pages. | /admin/workers | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin XGate | Admin surface for Admin XGate. | /admin/xgate | src/pages/admin/AdminXGate.tsx |
 | Admin surfaces | admin page | Admin You | Personal account, identity, and access panel. | /admin/you | src/pages/admin/AdminYou.tsx |
+| Admin surfaces | admin page | Boardroom | Boardroom discussion surface for worker coordination. | /admin/boardroom | src/pages/admin/Fishbowl.tsx |
 | Admin surfaces | admin page | Copy Pass Catalog | Admin surface for Copy Pass Catalog. | /admin/copypass | src/pages/admin/copypass/CopyPassCatalog.tsx |
 | Admin surfaces | admin page | Crew Composer | Crews admin page for Crew Composer. | /admin/crews/:id/edit | src/pages/admin/crews/CrewComposer.tsx |
 | Admin surfaces | admin page | Crew Composer | Crews admin page for Crew Composer. | /admin/crews/new | src/pages/admin/crews/CrewComposer.tsx |
@@ -608,7 +609,6 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Crews Catalog | Crews admin page for Crews Catalog. | /admin/crews | src/pages/admin/crews/CrewsCatalog.tsx |
 | Admin surfaces | admin page | Crews Runs | Crews admin page for Crews Runs. | /admin/crews/runs | src/pages/admin/crews/CrewsRuns.tsx |
 | Admin surfaces | admin page | Crews Settings | Crews admin page for Crews Settings. | /admin/crews/settings | src/pages/admin/crews/CrewsSettings.tsx |
-| Admin surfaces | admin page | Fishbowl | Boardroom discussion surface for worker coordination. | /admin/boardroom | src/pages/admin/Fishbowl.tsx |
 | Admin surfaces | admin page | Memory Setup Guide | User-facing page for Memory Setup Guide. | /admin/setup-guide | src/pages/MemorySetupGuide.tsx |
 | Admin surfaces | admin page | New Run Wizard | Admin surface for New Run Wizard. | /admin/testpass/new | src/pages/admin/testpass/NewRunWizard.tsx |
 | Admin surfaces | admin page | Report Detail | Admin surface for Report Detail. | /admin/testpass/reports/:id | src/pages/admin/testpass/ReportDetail.tsx |
@@ -866,6 +866,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | skill package | tester proof plan | Agent Skills-compatible starter package with provenance, safety, and native-mode metadata. | /admin/skills | seed/skills/tester-proof-plan.skill.md |
 | Modules and apps | skill package | watcher heartbeat tether | Agent Skills-compatible starter package with provenance, safety, and native-mode metadata. | /admin/skills | seed/skills/watcher-heartbeat-tether.skill.md |
 | Modules and apps | skill package | write tests for changed code | Agent Skills-compatible starter package with provenance, safety, and native-mode metadata. | /admin/skills | seed/skills/write-tests-for-changed-code.skill.md |
+| Passes and gates | component source gate | UIPass Toolbox | Curated UI source registry and proof scoreboard for shadcn, Radix, React Aria, Base UI, Floating UI, Motion, 21st.dev, Magic UI, Aceternity, Origin UI, and advisory design intelligence. | - | packages/uxpass/src/ui-toolbox.ts |
 | Passes and gates | fidelity gate | CopyRoom | Exact-copy room for code, docs, tables, notes, and source text so seats do not retype drift-prone material. | - | docs/UnClick-brainmap.generated.md |
 | Passes and gates | fidelity gate | FidelityPass | Checks exactness and invariant preservation when copying, refactoring, or translating content. | - | scripts/fidelitycopy.test.mjs |
 | Passes and gates | judgment gate | CommonSensePass | Plain-reasoning gate used before healthy, done, merge-ready, or PASS claims. | - | api/commonsensepass-bridge.test.ts |

--- a/docs/prd/xpass.md
+++ b/docs/prd/xpass.md
@@ -300,6 +300,13 @@ Use an individual Pass when:
 - the check is still being built or validated
 - credentials or target setup only exist for one Pass
 
+Use UIPass when:
+
+- an app, landing page, component, or admin surface needs interface polish rather than journey-only UX review
+- an AI seat wants to use shadcn/ui, Radix, React Aria, Base UI, Floating UI, Motion, 21st.dev, Magic UI, Aceternity UI, Origin UI, cmdk, Sonner, Embla, Vaul, or UI UX Pro Max style intelligence
+- the work needs a source-and-proof scoreboard before implementation: provenance, licence fit, accessibility primitive, design-system fit, mobile proof, reduced-motion proof, performance budget, brand fit, and screenshot proof
+- repeated missing UI proof should become a continuous-improvement job rather than another manual reminder
+
 Use CopyRoom when:
 
 - the user asks to copy, duplicate, mirror, transcribe, preserve, or move source content exactly

--- a/docs/unclick-context-boot-packet.md
+++ b/docs/unclick-context-boot-packet.md
@@ -14,17 +14,18 @@ Read this before summarizing UnClick, routing UnClick work, or correcting anothe
 - **Rooms** are the specialized stages inside Autopilot.
 - **XPass** is the product line beneath or alongside the broader platform, not the top-level automation system.
 - **PinballWake** is internal wake, queue, ACK, lease, reclaim, and routing heritage. It is not the public top-level name.
-- **Fishbowl** is coordination and work visibility.
+- **Boardroom** is coordination, work visibility, jobs, proof, and worker discussion.
 - **Memory** is persistent context, identity, active facts, and recall.
+- **Tool Index** is the compact capability map for fresh chats. Use it after Memory so a seat can route work proactively instead of waiting for exact tool names.
+- **Crews** are the hats-around-the-table council layer. Use them when a decision needs dissent, evidence, specialist review, or a final synthesis instead of one agreeable answer.
 - **Event Ledger** is the audit trail for actions and state.
 - **Worker Registry** is verified worker identity and signed ACK authority.
 - **ACK Ledger** is trusted PASS, BLOCKER, and HOLD evidence.
-- **CopyRoom** is the exact-copy office copier for 1:1 copying, transcription, mirroring, and source preservation.
-- **FidelityPass** is the XPass/QC wrapper over CopyRoom receipts. It does not duplicate CopyRoom.
-- **CopyPass** checks wording quality, claims, tone, and clarity.
-- **CommonSensePass** is the sanity gate for false healthy, false done, false quiet, stale proof, and rubber-stamp claims.
-- **CompliancePass** is the official compliance and enterprise-readiness Pass. EnterprisePass is historical wording only.
-- **SlopPass** is the official AI-quality and slop-signal Pass. QualityPass is historical wording only.
+- **CopyRoom** is the exact-copy room. Use it like the office photocopier: whenever a worker is asked to copy anything 1:1, it must preserve the source exactly and return a CopyRoom receipt.
+- **FidelityPass** is the XPass/QC wrapper for exact-copy proof. It should verify or wrap CopyRoom receipts rather than rebuilding a second exact-copy engine.
+- **CommonSensePass** is the XPass sanity gate for claims that sound complete but may contradict the evidence. Use it before trusted healthy, quiet, PASS, no-work, done, merge-ready, or duplicate-wake claims.
+- **CompliancePass** is the official compliance/readiness product name. EnterprisePass is historical wording only.
+- **SlopPass** is the official code-quality and AI-output roughness product name. QualityPass is historical wording only.
 
 ## Visibility Warning
 
@@ -65,12 +66,14 @@ UnClick
   XPass products
     TestPass
     UXPass
+    UIPass
+    AnswerPass
     SecurityPass
     LegalPass
-    CopyPass
-    FidelityPass
     SEOPass
     GEOPass
+    CopyPass
+    FidelityPass
     CompliancePass
     CommonSensePass
     SlopPass
@@ -78,12 +81,50 @@ UnClick
   Core platform
     MCP tools
     Memory
-    Fishbowl
+    Crews
     CopyRoom
+    Boardroom
     Keychain
     Connectors
     Admin
 ```
+
+## AI Feature Discovery Shortcuts
+
+Use this as UnClick's internal SEO map when routing work:
+
+| If the worker says or needs | Use | Proof or output to expect |
+| --- | --- | --- |
+| first chat, fresh chat, what tools exist, route this, do the right thing, vague work request | **Memory** then **Tool Index** | loaded context, recommended routes, boot completeness gate, no catalog dump unless asked |
+| what is true right now, stale queue, no active owner, current blocker | **Orchestrator** and **Boardroom Jobs** | compact state, source pointers, next action, blocker reason |
+| score, health, throughput, proof debt, zero-touch rate, human-touch leak | **Scoreboards and Readiness Audits** | counts, leak reason, next action, trend-ready evidence, improvement packet seed |
+| worker discussion, todo state, scoped job, proof comment, stale owner | **Boardroom** | Boardroom receipt, job update, ScopePack, PASS or BLOCKER |
+| decision review, expert hats, council, challenge my plan, avoid agreeable AI | **Crews** | council policy score, dissent, evidence, peer review, synthesis, action |
+| continuous improvement, repeated friction, stale handoff, better policy | **Continuous Improvement Room** | one scoped improvement job with owned files and expected proof |
+| deep research, product notes, observed seat friction, reusable learning | **Continuous Research Improvements** | updated boot packet, Brainmap row, PRD note, or scoped Boardroom job |
+| wake, retry, stale ACK, queue push, dormant worker | **WakePass**, **QueuePush**, and **PinballWake** | ACK, reclaim, wake packet, or quiet no-action receipt |
+| answer truth, cited claim, unsupported statement, stale memory in an answer | **AnswerPass** | `answer_receipt_v1` with PASS, WARN, FAIL, BLOCKER, or UNVERIFIED |
+| full product or release quality check | **XPass** | selected XPass receipt rows and aggregate verdict |
+| user journey, task flow, forms, onboarding, recovery | **UXPass** | journey receipt and missing journey evidence |
+| visual layout, typography, mobile fit, screenshots, UI polish, modern component source, shadcn, Radix, React Aria, Base UI, Motion, 21st.dev, Magic UI, Aceternity, Origin UI | **UIPass** | visual evidence receipt, UIPass toolbox scoreboard, missing-gate list, or screenshot blocker |
+| functional test proof, CI, package smoke, regression proof | **TestPass** | test run proof and pass or blocker |
+| exact 1:1 copying | **CopyRoom** first, **FidelityPass** for QC | copy receipt or fidelity blocker |
+| writing quality, clarity, tone, claims in copy | **CopyPass** | copy review receipt |
+| secrets, auth, data boundary, protected surface | **SecurityPass** | security receipt or blocker |
+| legal issue spotting and no-legal-advice boundary | **LegalPass** | scoped legal readiness receipt |
+| compliance or enterprise readiness | **CompliancePass** | readiness receipt, not certification |
+| AI search readiness, public search signals, llms.txt, schema | **SEOPass** and **GEOPass** | search or answer-engine readiness receipt |
+| rough AI output, code smell, maintainability, sloppy claim | **SlopPass** | roughness or maintainability receipt |
+| persistent user facts, standing rules, preferences, project memory | **Memory** | fact, session, identity, search, or invalidation receipt |
+| app connection, credentials, OAuth, API key health | **Passport** and **Connectors** | connection status, missing credential, or safe setup note |
+
+Scoreboard field map for AI seats:
+
+- `current_state_card.zero_touch_scoreboard`: autonomy health and human-touch leaks.
+- `current_state_card.proof_debt_scoreboard`: completed-looking jobs that still need observable proof.
+- `current_state_card.continuous_improvement_scoreboard`: queue, owner, proof, blocker, automation, and naming friction turned into next actions.
+- `current_state_card.continuous_improvement_scoreboard.improvement_packet`: read-only Boardroom ScopePack seed with owned files, proof, risk controls, and create-todo payload.
+- Admin Orchestrator can turn that packet into a Boardroom job only through the explicit create action, which returns a todo receipt.
 
 ## Terms To Use
 
@@ -93,10 +134,11 @@ UnClick
 - Say **worker seats** or **lanes** for ChatGPT, Claude, Codex, and other capacity accounts.
 - Say **trusted ACK** only when it is lane-authored or signed/verified by the current trust spine.
 - Say **observer chatter** for mirrored status text, summaries, or broadcasts that are not lane-authoritative.
-- Say **CopyRoom** for exact 1:1 copy work and **FidelityPass** for the XPass receipt that verifies CopyRoom evidence.
-- Say **CommonSensePass** when checking whether a status claim is actually sensible.
-- Say **CompliancePass**, not EnterprisePass, unless explaining historical aliases.
-- Say **SlopPass**, not QualityPass, unless explaining historical aliases.
+- Say **CopyRoom** for exact 1:1 copying. Do not route exact-copy work to CopyPass. CopyPass reviews writing quality, claims, tone, and clarity. CopyRoom verifies exact reproduction.
+- Say **FidelityPass** when an XPass run needs to QC exact-copy fidelity. FidelityPass must reuse, verify, or wrap CopyRoom receipts. Do not build a second fidelity engine beside CopyRoom.
+- Say **CommonSensePass** when a worker needs to sanity-check a status claim before saying healthy, quiet, PASS, no-work, done, merge-ready, or duplicate-wake.
+- Say **CompliancePass**, not EnterprisePass, for compliance and enterprise-readiness checks.
+- Say **SlopPass**, not QualityPass, for sloppy code, AI-output roughness, and maintainability checks.
 - Treat **QCPass** as process wording for a final XPass/QC receipt, not an official XPass product unless Chris explicitly promotes it.
 
 ## Connector-Level Context Warning
@@ -106,7 +148,7 @@ If a worker only sees tool results, run history, public GitHub search, or a part
 Use this wording:
 
 ```text
-I have connector-level context only. I need to load UnClick memory, the context boot packet, and live GitHub/Fishbowl state before making product or engineering claims.
+I have connector-level context only. I need to load UnClick memory, the context boot packet, and live GitHub/Boardroom state before making product or engineering claims.
 ```
 
 Do not infer the product map from public search results, one failed run, or old memory names.
@@ -123,7 +165,7 @@ Before product claims or routing:
 
 1. Load memory if the tool exists.
 2. Read this file.
-3. Refresh live GitHub and Fishbowl state.
+3. Refresh live GitHub and Boardroom state.
 4. Read `AUTOPILOT.md` for autonomy rules.
 5. Read `FLEET_SYNC.md` for live fleet coordination.
 6. If the requested lane is XPass-specific, read `docs/prd/xpass.md`.
@@ -134,8 +176,8 @@ Before product claims or routing:
 
 - If old docs say "Pass family", treat it as historical wording unless Chris says otherwise.
 - If old docs list Pass products beside Autopilot, prefer the current hierarchy: Autopilot sits higher as the development assembly line.
-- If a parked product name appears in old notes, label it parked unless a live PR, Fishbowl item, or Chris reactivates it.
-- If memory conflicts with live GitHub/Fishbowl state, live state wins for current work.
+- If a parked product name appears in old notes, label it parked unless a live PR, Boardroom item, or Chris reactivates it.
+- If memory conflicts with live GitHub/Boardroom state, live state wins for current work.
 - If connector output conflicts with this packet, this packet wins for product taxonomy.
 
 ## One-Sentence Summary

--- a/docs/uxpass-product-brief.md
+++ b/docs/uxpass-product-brief.md
@@ -8,11 +8,11 @@ A new agent-native usability and journey QC product for UnClick, sister to TestP
 
 ## 1. Executive summary
 
-UXPass is the journey and usability equivalent of TestPass. Where TestPass answers "does this MCP server or API conform to spec," UXPass answers "can a human or AI agent understand the task, move through it, recover from mistakes, and finish with confidence." The product runs a panel of specialised critics in parallel against a live URL, Storybook component, or Figma frame, then synthesises their verdicts into a single 0 to 100 UX Score and a remediation queue that flows into Fishbowl as todos.
+UXPass is the journey and usability equivalent of TestPass. Where TestPass answers "does this MCP server or API conform to spec," UXPass answers "can a human or AI agent understand the task, move through it, recover from mistakes, and finish with confidence." The product runs a panel of specialised critics in parallel against a live URL, Storybook component, or Figma frame, then synthesises their verdicts into a single 0 to 100 UX Score and a remediation queue that flows into Boardroom as todos.
 
 The wedge is unowned. Hotjar and Clarity show frustration after the fact. Lighthouse, axe, and performance tooling answer useful narrow questions. UXPass focuses on the end-to-end human experience: clear goal, clear first step, low friction, useful feedback, safe recovery, and a confident finish. UIPass owns the separate visible interface lane: layout, spacing, typography, responsive fit, state styling, screenshots, and visual polish.
 
-Three architectural commitments make UXPass distinct from the field. First, every UnClick tool gets an internal UXPass pack auto-applied via a bolt-on module, so TestPass, Memory, Fishbowl, Crews, BackstagePass and Signals all run journey QC on themselves continuously. Second, the run loop reuses Crews for the multi-critic deliberation step, avoiding rebuild of multi-agent infrastructure. Third, results route through Signals as severity-tagged events, into Fishbowl as todos, and into BackstagePass for credential storage, all using the existing UnClick fabric.
+Three architectural commitments make UXPass distinct from the field. First, every UnClick tool gets an internal UXPass pack auto-applied via a bolt-on module, so TestPass, Memory, Boardroom, Crews, BackstagePass and Signals all run journey QC on themselves continuously. Second, the run loop reuses Crews for the multi-critic deliberation step, avoiding rebuild of multi-agent infrastructure. Third, results route through Signals as severity-tagged events, into Boardroom as todos, and into BackstagePass for credential storage, all using the existing UnClick fabric.
 
 The build is ten chunks, each one to two days for Bailey or Cowork or Codex Worker 2. Chunks one through six ship a credible MVP (one URL, four hats, one report). Chunks seven through ten add Figma, the creative-edge hats (Agent Readability, Dark Pattern Detector), the marketing site, and the full hat roster.
 
@@ -57,6 +57,20 @@ Lighthouse CI is the orchestrator. **Unlighthouse** (MIT, github.com/harlan-zw/u
 `@storybook/addon-a11y` (MIT) is the canonical pattern reference for the accessibility panel UX: rule overrides, story-scoped config, deep-linking. The Storybook test runner (MIT, v0.24.2 released Nov 2025, ~270 stars) is the universal Jest-plus-Playwright wrapper for non-Vite Storybooks. `chromaui/chromatic-cli` (MIT, v16.3.0 released April 2025) is a high-quality reference for git-aware change detection and JUnit reporting, but tightly coupled to Chromatic SaaS so its value is patterns rather than drop-in reuse.
 
 Note one caveat: `@axe-core/react` does not officially support React 18 or later. Use axe-core directly.
+
+### 2.5.1 UIPass UI toolbox layer
+
+UIPass now has a curated toolbox registry in `packages/uxpass/src/ui-toolbox.ts`. The rule is simple: use proven foundations first, then add tasteful motion or community components only when they pass gates.
+
+The **core default stack** is shadcn/ui for owned React/Tailwind component files, Radix UI Primitives for accessible interaction behavior, React Aria Components or Base UI when complex accessibility and cross-device behavior matter, Floating UI for positioning, Motion for React for purposeful animation, Lucide React for recognizable icons, and the repo's existing styling helpers (`clsx`, `tailwind-merge`, `class-variance-authority`) for variant hygiene.
+
+The **recommended acceleration stack** is 21st.dev Community Components, Magic UI, Aceternity UI, and Origin UI. These are useful because they give AI seats better starting points than inventing a hero, pricing section, nav, footer, or micro-interaction from scratch. They are not free passes. UIPass must record source provenance, license fit, accessibility behavior, local design-system fit, mobile proof, reduced-motion proof, performance budget, brand fit, and screenshot evidence before implementation counts as approved.
+
+The **specialist stack** is cmdk for command palettes, Sonner for toast feedback, Embla for carousels, and Vaul for mobile drawers. These should only be used when the interaction pattern is genuinely needed. Carousels and drawers in particular must prove keyboard, touch, focus, and reachability.
+
+The **advisory stack** includes UI UX Pro Max style intelligence. It can improve taste, references, and critique prompts, but it cannot be treated as a runtime dependency, component source, license proof, or visual evidence.
+
+Continuous improvement is handled by the UIPass toolbox scoreboard: `approved`, `needs_proof`, `blocked`, `unknown_source`, `by_tier`, and `missing_gate_counts`. Repeated missing gates become improvement jobs. For example, if workers repeatedly miss reduced-motion evidence on Aceternity or Magic UI snippets, UIPass should add a fixture or prompt rule rather than relying on Chris to remind the seat.
 
 ### 2.6 Design token layer
 
@@ -197,14 +211,14 @@ Six baseline packs ship with UXPass on day one, one per existing tool. Each pack
 |---|---|---|
 | TestPass | `internal/testpass-admin.yaml` | `/admin/testpass`, pack list, run detail, pack editor |
 | Memory | `internal/memory-admin.yaml` | `/admin/memory`, fact list, identity panel, session search |
-| Fishbowl | `internal/fishbowl-admin.yaml` | `/admin/fishbowl`, todos kanban, ideas, message feed |
+| Boardroom | `internal/fishbowl-admin.yaml` | `/admin/boardroom`, todos kanban, ideas, message feed |
 | Crews | `internal/crews-admin.yaml` | `/admin/crews`, council view, agent roster, run detail |
 | BackstagePass | `internal/backstagepass-admin.yaml` | `/admin/backstagepass`, vault entries, audit log |
 | Signals | `internal/signals-admin.yaml` | `/admin/signals`, route list, severity feed, channel config |
 
 ### 5.3 Result routing
 
-UXPass results route through three existing UnClick layers. Severity-tagged events go to **Signals** (action_needed for any Critical, warning for High, info for Medium, debug for Low). High-severity findings auto-create **Fishbowl todos** through the Fishbowl bolt-on, mirroring TestPass exactly. Credentials for the Figma API, Browserbase keys, and any LLM provider keys live in **BackstagePass** keyed by tenant.
+UXPass results route through three existing UnClick layers. Severity-tagged events go to **Signals** (action_needed for any Critical, warning for High, info for Medium, debug for Low). High-severity findings auto-create **Boardroom todos** through the Boardroom bolt-on, mirroring TestPass exactly. Credentials for the Figma API, Browserbase keys, and any LLM provider keys live in **BackstagePass** keyed by tenant.
 
 ### 5.4 The external surface remains identical in feel to TestPass
 
@@ -226,7 +240,7 @@ Step three: **Parallel hat execution.** Each hat is a single LLM call with a tig
 
 Step four: **Synthesiser.** A single Synthesiser hat reads all hat verdicts and produces the per-item composite and the UX Score. The Synthesiser also resolves overlap: if Accessibility, Visual Designer and Brand Steward all flag the same low-contrast button, the Synthesiser merges them into one finding with three corroborating sources.
 
-Step five: **Routing.** Findings flow into Signals (severity-tagged) and Fishbowl (high-severity creates a todo). The remediation chips are auto-attached to the todo so an agent picking it up has the suggested fix inline.
+Step five: **Routing.** Findings flow into Signals (severity-tagged) and Boardroom (high-severity creates a todo). The remediation chips are auto-attached to the todo so an agent picking it up has the suggested fix inline.
 
 ### 6.2 Reuse Crews where it makes sense
 
@@ -276,7 +290,7 @@ Identical in feel to TestPass. Identical CLI shape. Identical GitHub Action. Ide
 
 ### 7.1 The admin surface
 
-`/admin/uxpass` mirrors `/admin/testpass`: pack list, recent runs, scores over time, top failing items. The pack editor has a YAML preview pane on the right and a form-driven editor on the left, same as TestPass. The run detail page is where UXPass diverges richer: annotated screenshots with bounding boxes on issues, hat-by-hat verdict cards, the Synthesiser composite, the UX Score with a sub-score breakdown, before/after visual diffs (when a previous run exists), and the remediation chip queue with one-click "send to Fishbowl" buttons.
+`/admin/uxpass` mirrors `/admin/testpass`: pack list, recent runs, scores over time, top failing items. The pack editor has a YAML preview pane on the right and a form-driven editor on the left, same as TestPass. The run detail page is where UXPass diverges richer: annotated screenshots with bounding boxes on issues, hat-by-hat verdict cards, the Synthesiser composite, the UX Score with a sub-score breakdown, before/after visual diffs (when a previous run exists), and the remediation chip queue with one-click "send to Boardroom" buttons.
 
 ### 7.2 The pack format
 

--- a/packages/uxpass/package.json
+++ b/packages/uxpass/package.json
@@ -9,7 +9,8 @@
     "./schema": "./dist/schema.js",
     "./types": "./dist/types.js",
     "./visual-audit": "./dist/visual-audit.js",
-    "./design-director": "./dist/design-director.js"
+    "./design-director": "./dist/design-director.js",
+    "./ui-toolbox": "./dist/ui-toolbox.js"
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",

--- a/packages/uxpass/packs/example-marketing-site.yaml
+++ b/packages/uxpass/packs/example-marketing-site.yaml
@@ -23,3 +23,24 @@ budgets:
 remediation:
   high-severity: fishbowl-todos
   all: report-only
+ui_toolbox:
+  sources:
+    - shadcn-ui
+    - radix-ui
+    - react-aria-components
+    - motion
+    - lucide-react
+    - 21st-dev
+    - magic-ui
+    - origin-ui
+  required_gates:
+    - source-provenance
+    - license-ok
+    - a11y-primitive
+    - design-system-fit
+    - mobile-fit
+    - reduced-motion
+    - performance-budget
+    - brand-fit
+    - screenshot-proof
+  scoreboard: true

--- a/packages/uxpass/src/__tests__/schema.test.ts
+++ b/packages/uxpass/src/__tests__/schema.test.ts
@@ -28,6 +28,28 @@ const validPack = {
     "high-severity": "fishbowl-todos",
     all: "report-only",
   },
+  ui_toolbox: {
+    sources: ["shadcn-ui", "radix-ui", "motion", "21st-dev"],
+    required_gates: [
+      "source-provenance",
+      "license-ok",
+      "a11y-primitive",
+      "design-system-fit",
+      "mobile-fit",
+      "reduced-motion",
+      "performance-budget",
+      "brand-fit",
+      "screenshot-proof",
+    ],
+    candidates: [
+      {
+        source_id: "21st-dev",
+        component_name: "Hero CTA",
+        intended_use: "Marketing landing page polish",
+      },
+    ],
+    scoreboard: true,
+  },
 };
 
 describe("UXPassPackSchema", () => {
@@ -117,6 +139,35 @@ describe("UXPassPackSchema", () => {
     const result = UXPassPackSchema.safeParse({
       ...validPack,
       remediation: { "high-severity": "email-bailey" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a UIPass toolbox config with known sources and gates", () => {
+    const result = UXPassPackSchema.safeParse(validPack);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ui_toolbox?.scoreboard).toBe(true);
+      expect(result.data.ui_toolbox?.sources).toContain("21st-dev");
+    }
+  });
+
+  it("rejects an unknown UIPass toolbox source", () => {
+    const result = UXPassPackSchema.safeParse({
+      ...validPack,
+      ui_toolbox: {
+        sources: ["random-gallery-pack"],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown UIPass toolbox gate", () => {
+    const result = UXPassPackSchema.safeParse({
+      ...validPack,
+      ui_toolbox: {
+        required_gates: ["looks-expensive"],
+      },
     });
     expect(result.success).toBe(false);
   });

--- a/packages/uxpass/src/__tests__/ui-toolbox.test.ts
+++ b/packages/uxpass/src/__tests__/ui-toolbox.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  UI_TOOLBOX_GATE_IDS,
+  UI_TOOLBOX_SOURCES,
+  UI_TOOLBOX_SOURCE_IDS,
+  assessUIToolboxCandidate,
+  buildUIToolboxScoreboard,
+  getUIToolboxSource,
+  recommendedUIToolboxSources,
+} from "../ui-toolbox.js";
+
+const completeEvidence = Object.fromEntries(
+  UI_TOOLBOX_GATE_IDS.map((gate) => [gate, true]),
+);
+
+describe("UI_TOOLBOX_SOURCES", () => {
+  it("keeps source ids unique and aligned with the exported id list", () => {
+    const ids = UI_TOOLBOX_SOURCES.map((source) => source.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([...UI_TOOLBOX_SOURCE_IDS]);
+  });
+
+  it("includes the highly recommended UI toolbox sources", () => {
+    expect(getUIToolboxSource("shadcn-ui")?.tier).toBe("core");
+    expect(getUIToolboxSource("radix-ui")?.tier).toBe("core");
+    expect(getUIToolboxSource("react-aria-components")?.tier).toBe("core");
+    expect(getUIToolboxSource("base-ui")?.tier).toBe("core");
+    expect(getUIToolboxSource("motion")?.tier).toBe("core");
+    expect(getUIToolboxSource("21st-dev")?.tier).toBe("recommended");
+    expect(getUIToolboxSource("magic-ui")?.tier).toBe("recommended");
+    expect(getUIToolboxSource("aceternity-ui")?.tier).toBe("recommended");
+    expect(getUIToolboxSource("origin-ui")?.tier).toBe("recommended");
+  });
+
+  it("returns only core and recommended sources for the default shortlist", () => {
+    const tiers = new Set(recommendedUIToolboxSources().map((source) => source.tier));
+    expect([...tiers].sort()).toEqual(["core", "recommended"]);
+    expect(recommendedUIToolboxSources().map((source) => source.id)).toContain("21st-dev");
+  });
+});
+
+describe("assessUIToolboxCandidate", () => {
+  it("approves a core source when all required gates have evidence", () => {
+    const result = assessUIToolboxCandidate({
+      source_id: "motion",
+      component_name: "AnimatedToolbar",
+      evidence: completeEvidence,
+    });
+    expect(result.status).toBe("approved");
+    expect(result.missing_gates).toEqual([]);
+  });
+
+  it("requires provenance, reduced motion, mobile, performance, brand, and screenshot proof for 21st.dev", () => {
+    const result = assessUIToolboxCandidate({
+      source_id: "21st-dev",
+      component_name: "Scroll Morph Hero",
+      evidence: {
+        "source-provenance": "https://21st.dev/r/example/scroll-morph-hero",
+        "license-ok": true,
+      },
+    });
+    expect(result.status).toBe("needs-proof");
+    expect(result.missing_gates).toEqual([
+      "a11y-primitive",
+      "design-system-fit",
+      "mobile-fit",
+      "reduced-motion",
+      "performance-budget",
+      "brand-fit",
+      "screenshot-proof",
+    ]);
+  });
+
+  it("blocks advisory-only sources as component sources", () => {
+    const result = assessUIToolboxCandidate({
+      source_id: "ui-ux-pro-max",
+      intended_use: "Install generated hero component",
+      evidence: completeEvidence,
+    });
+    expect(result.status).toBe("blocked");
+    expect(result.warnings.join(" ")).toMatch(/Advisory source only/);
+  });
+
+  it("fails closed on unknown sources", () => {
+    const result = assessUIToolboxCandidate({ source_id: "random-gallery-pack" });
+    expect(result.status).toBe("unknown-source");
+    expect(result.next_action).toMatch(/Add the source/);
+  });
+});
+
+describe("buildUIToolboxScoreboard", () => {
+  it("summarises approved, blocked, unknown, and needs-proof candidates", () => {
+    const scoreboard = buildUIToolboxScoreboard([
+      { source_id: "shadcn-ui", evidence: completeEvidence },
+      { source_id: "21st-dev", evidence: { "source-provenance": true, "license-ok": true } },
+      { source_id: "ui-ux-pro-max", evidence: completeEvidence },
+      { source_id: "unknown-kit" },
+    ]);
+
+    expect(scoreboard).toMatchObject({
+      total: 4,
+      approved: 1,
+      needs_proof: 1,
+      blocked: 1,
+      unknown_source: 1,
+    });
+    expect(scoreboard.by_tier.core).toBe(1);
+    expect(scoreboard.by_tier.recommended).toBe(1);
+    expect(scoreboard.by_tier.advisory).toBe(1);
+    expect(scoreboard.missing_gate_counts["screenshot-proof"]).toBeGreaterThanOrEqual(1);
+    expect(scoreboard.recommended_next_action).toMatch(/Replace blocked or unknown sources/);
+  });
+});

--- a/packages/uxpass/src/index.ts
+++ b/packages/uxpass/src/index.ts
@@ -6,4 +6,5 @@ export * from "./runner.js";
 export * from "./reporter.js";
 export * from "./visual-audit.js";
 export * from "./design-director.js";
+export * from "./ui-toolbox.js";
 export type * from "./types.js";

--- a/packages/uxpass/src/schema.ts
+++ b/packages/uxpass/src/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { UI_TOOLBOX_GATE_IDS, UI_TOOLBOX_SOURCE_IDS } from "./ui-toolbox.js";
 
 export const SeveritySchema = z.enum(["critical", "high", "medium", "low"]);
 
@@ -32,6 +33,19 @@ export const HAT_IDS = [
 
 export const HatIdSchema = z.string().min(1);
 
+const [FIRST_UI_TOOLBOX_SOURCE_ID, ...REST_UI_TOOLBOX_SOURCE_IDS] = UI_TOOLBOX_SOURCE_IDS;
+const [FIRST_UI_TOOLBOX_GATE_ID, ...REST_UI_TOOLBOX_GATE_IDS] = UI_TOOLBOX_GATE_IDS;
+
+export const UIToolboxSourceIdSchema = z.enum([
+  FIRST_UI_TOOLBOX_SOURCE_ID,
+  ...REST_UI_TOOLBOX_SOURCE_IDS,
+]);
+
+export const UIToolboxGateIdSchema = z.enum([
+  FIRST_UI_TOOLBOX_GATE_ID,
+  ...REST_UI_TOOLBOX_GATE_IDS,
+]);
+
 // Budget assertions follow the TestPass-style operator string ("&gt;= 80",
 // "no critical", "zero", etc.). We keep the values as plain strings here and
 // let the runner parse them at execution time.
@@ -60,6 +74,20 @@ export const RemediationSchema = z
   })
   .catchall(RemediationTargetSchema);
 
+export const UIToolboxCandidateSchema = z.object({
+  source_id: UIToolboxSourceIdSchema,
+  component_name: z.string().min(1).optional(),
+  intended_use: z.string().min(1).optional(),
+  required_gates: z.array(UIToolboxGateIdSchema).optional(),
+});
+
+export const UIToolboxSchema = z.object({
+  sources: z.array(UIToolboxSourceIdSchema).optional(),
+  required_gates: z.array(UIToolboxGateIdSchema).optional(),
+  candidates: z.array(UIToolboxCandidateSchema).optional(),
+  scoreboard: z.boolean().default(true),
+});
+
 export const UXPassPackSchema = z.object({
   name: z.string().min(1, "name is required"),
   url: z.string().url("url must be a valid URL"),
@@ -69,6 +97,7 @@ export const UXPassPackSchema = z.object({
   synthesiser: z.string().min(1, "synthesiser is required"),
   budgets: BudgetsSchema,
   remediation: RemediationSchema,
+  ui_toolbox: UIToolboxSchema.optional(),
   description: z.string().optional(),
   tags: z.array(z.string()).optional(),
 });
@@ -80,3 +109,5 @@ export type Theme = z.infer<typeof ThemeSchema>;
 export type Budgets = z.infer<typeof BudgetsSchema>;
 export type Remediation = z.infer<typeof RemediationSchema>;
 export type RemediationTarget = z.infer<typeof RemediationTargetSchema>;
+export type UIToolboxCandidate = z.infer<typeof UIToolboxCandidateSchema>;
+export type UIToolboxConfig = z.infer<typeof UIToolboxSchema>;

--- a/packages/uxpass/src/ui-toolbox.ts
+++ b/packages/uxpass/src/ui-toolbox.ts
@@ -1,0 +1,484 @@
+export const UI_TOOLBOX_GATE_IDS = [
+  "source-provenance",
+  "license-ok",
+  "a11y-primitive",
+  "design-system-fit",
+  "mobile-fit",
+  "reduced-motion",
+  "performance-budget",
+  "brand-fit",
+  "screenshot-proof",
+] as const;
+
+export type UIToolboxGateId = typeof UI_TOOLBOX_GATE_IDS[number];
+
+export const UI_TOOLBOX_SOURCE_IDS = [
+  "shadcn-ui",
+  "radix-ui",
+  "react-aria-components",
+  "base-ui",
+  "floating-ui",
+  "motion",
+  "framer-motion",
+  "lucide-react",
+  "styling-primitives",
+  "21st-dev",
+  "magic-ui",
+  "aceternity-ui",
+  "origin-ui",
+  "cmdk",
+  "sonner",
+  "embla-carousel",
+  "vaul",
+  "ui-ux-pro-max",
+] as const;
+
+export type UIToolboxSourceId = typeof UI_TOOLBOX_SOURCE_IDS[number];
+export type UIToolboxTier = "core" | "recommended" | "specialist" | "advisory" | "watch";
+export type UIToolboxRisk = "low" | "medium" | "high";
+export type UIToolboxAssessmentStatus = "approved" | "needs-proof" | "blocked" | "unknown-source";
+
+export interface UIToolboxSource {
+  id: UIToolboxSourceId;
+  name: string;
+  tier: UIToolboxTier;
+  risk: UIToolboxRisk;
+  url: string;
+  best_for: string[];
+  install_hint: string;
+  use_when: string;
+  avoid_when: string;
+  required_gates: UIToolboxGateId[];
+  notes: string;
+}
+
+export interface UIToolboxCandidateInput {
+  source_id: string;
+  component_name?: string;
+  intended_use?: string;
+  evidence?: Partial<Record<UIToolboxGateId, boolean | string>>;
+}
+
+export interface UIToolboxAssessment {
+  source_id: string;
+  source_name?: string;
+  status: UIToolboxAssessmentStatus;
+  tier?: UIToolboxTier;
+  risk?: UIToolboxRisk;
+  required_gates: UIToolboxGateId[];
+  missing_gates: UIToolboxGateId[];
+  warnings: string[];
+  next_action: string;
+}
+
+export interface UIToolboxScoreboard {
+  total: number;
+  approved: number;
+  needs_proof: number;
+  blocked: number;
+  unknown_source: number;
+  by_tier: Partial<Record<UIToolboxTier, number>>;
+  missing_gate_counts: Partial<Record<UIToolboxGateId, number>>;
+  recommended_next_action: string;
+}
+
+export const UI_TOOLBOX_GATE_LABELS: Record<UIToolboxGateId, string> = {
+  "source-provenance": "Source, author, install command, and origin URL are recorded.",
+  "license-ok": "License or usage rights are acceptable for the target product.",
+  "a11y-primitive": "Interactive behavior uses an accessibility-tested primitive or equivalent proof.",
+  "design-system-fit": "Styles fit local tokens, spacing, components, and naming conventions.",
+  "mobile-fit": "Mobile viewport proof shows no overlap, clipping, or unusable interaction.",
+  "reduced-motion": "Motion respects prefers-reduced-motion and has a static fallback.",
+  "performance-budget": "Bundle, animation, media, and layout-shift cost are inside budget.",
+  "brand-fit": "The component supports the product tone instead of adding generic visual noise.",
+  "screenshot-proof": "Before/after screenshots or visual run evidence exist for the target surface.",
+};
+
+const FOUNDATION_GATES: UIToolboxGateId[] = [
+  "source-provenance",
+  "license-ok",
+  "a11y-primitive",
+  "design-system-fit",
+  "mobile-fit",
+  "screenshot-proof",
+];
+
+const MOTION_GATES: UIToolboxGateId[] = [
+  "source-provenance",
+  "license-ok",
+  "design-system-fit",
+  "mobile-fit",
+  "reduced-motion",
+  "performance-budget",
+  "brand-fit",
+  "screenshot-proof",
+];
+
+const COMMUNITY_GATES: UIToolboxGateId[] = [
+  "source-provenance",
+  "license-ok",
+  "a11y-primitive",
+  "design-system-fit",
+  "mobile-fit",
+  "reduced-motion",
+  "performance-budget",
+  "brand-fit",
+  "screenshot-proof",
+];
+
+export const UI_TOOLBOX_SOURCES: UIToolboxSource[] = [
+  {
+    id: "shadcn-ui",
+    name: "shadcn/ui",
+    tier: "core",
+    risk: "low",
+    url: "https://ui.shadcn.com/",
+    best_for: ["React", "Tailwind", "owned component code", "registry workflow"],
+    install_hint: "Use the shadcn CLI, then own and adapt the copied component files.",
+    use_when: "A React/Tailwind app needs polished baseline components that stay editable in-repo.",
+    avoid_when: "The app is not React/Tailwind or the team cannot maintain copied component code.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Default styled layer. Pair with Radix, React Aria, or Base UI for complex interaction semantics.",
+  },
+  {
+    id: "radix-ui",
+    name: "Radix UI Primitives",
+    tier: "core",
+    risk: "low",
+    url: "https://www.radix-ui.com/primitives/docs",
+    best_for: ["dialogs", "menus", "popovers", "tabs", "accessible primitives"],
+    install_hint: "Install the specific @radix-ui/react-* primitive or use it through shadcn/ui.",
+    use_when: "A custom control needs focus management, keyboard behavior, and ARIA handled by a proven primitive.",
+    avoid_when: "The native HTML element already solves the interaction cleanly.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Preferred accessibility floor for shadcn-style React apps already using Radix wrappers.",
+  },
+  {
+    id: "react-aria-components",
+    name: "React Aria Components",
+    tier: "core",
+    risk: "low",
+    url: "https://react-spectrum.adobe.com/react-aria/components.html",
+    best_for: ["forms", "pickers", "tables", "internationalization", "advanced accessibility"],
+    install_hint: "Install react-aria-components and style with the local design system.",
+    use_when: "A complex control needs strong accessibility, internationalization, and cross-device behavior.",
+    avoid_when: "A small shadcn/Radix wrapper already fits the existing app with less surface area.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Best heavy-duty accessibility option when components need more than basic primitives.",
+  },
+  {
+    id: "base-ui",
+    name: "Base UI",
+    tier: "core",
+    risk: "low",
+    url: "https://base-ui.com/",
+    best_for: ["unstyled components", "future-proof component libraries", "accessible app primitives"],
+    install_hint: "Install @base-ui-components/react and style with local CSS or Tailwind.",
+    use_when: "A project wants accessible unstyled primitives with direct control over every visual layer.",
+    avoid_when: "The app already standardizes on Radix/shadcn and does not need another primitive layer.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Strong modern primitive candidate from the Base UI, Radix, Floating UI, and MUI design lineage.",
+  },
+  {
+    id: "floating-ui",
+    name: "Floating UI",
+    tier: "specialist",
+    risk: "low",
+    url: "https://floating-ui.com/docs/react",
+    best_for: ["tooltips", "popovers", "dropdown positioning", "collision handling"],
+    install_hint: "Use @floating-ui/react for interactions or @floating-ui/react-dom for positioning only.",
+    use_when: "A floating element must stay anchored and avoid viewport collision across layouts.",
+    avoid_when: "A complete accessible primitive such as Radix, React Aria, or Base UI already handles the whole control.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Positioning engine, not a visual component library. Great underneath custom polished controls.",
+  },
+  {
+    id: "motion",
+    name: "Motion for React",
+    tier: "core",
+    risk: "medium",
+    url: "https://motion.dev/docs/react",
+    best_for: ["micro-interactions", "layout animation", "gesture animation", "motion design"],
+    install_hint: "Install motion and import from motion/react for new React work.",
+    use_when: "Animation improves comprehension, state change, or brand feel.",
+    avoid_when: "The motion is decorative, blocks interaction, causes layout shift, or lacks reduced-motion fallback.",
+    required_gates: MOTION_GATES,
+    notes: "Preferred modern animation package for new work. Motion must be purposeful and prove reduced-motion behavior.",
+  },
+  {
+    id: "framer-motion",
+    name: "Framer Motion",
+    tier: "watch",
+    risk: "medium",
+    url: "https://motion.dev/docs/react-installation",
+    best_for: ["legacy compatibility", "existing codebases", "community snippets"],
+    install_hint: "Prefer motion for new work; keep framer-motion only when the existing app or source component already uses it.",
+    use_when: "A current component depends on framer-motion and migration would be more risk than value.",
+    avoid_when: "Starting a new animation layer from scratch.",
+    required_gates: MOTION_GATES,
+    notes: "Common in older component snippets. Treat as compatibility, not the default recommendation.",
+  },
+  {
+    id: "lucide-react",
+    name: "Lucide React",
+    tier: "core",
+    risk: "low",
+    url: "https://lucide.dev/",
+    best_for: ["icons", "icon buttons", "toolbars", "navigation"],
+    install_hint: "Use lucide-react icons for recognizable actions before inventing custom SVGs.",
+    use_when: "A control needs a standard icon or icon-plus-label pattern.",
+    avoid_when: "The icon meaning would be ambiguous without a label or tooltip.",
+    required_gates: ["source-provenance", "license-ok", "design-system-fit", "mobile-fit", "screenshot-proof"],
+    notes: "Baseline icon source for UIPass. Pair unfamiliar icons with tooltips or visible labels.",
+  },
+  {
+    id: "styling-primitives",
+    name: "clsx, tailwind-merge, class-variance-authority",
+    tier: "core",
+    risk: "low",
+    url: "https://ui.shadcn.com/docs/installation",
+    best_for: ["variants", "class merging", "component styling hygiene"],
+    install_hint: "Use the repo's existing cn helper and variant pattern before adding a new styling abstraction.",
+    use_when: "A component needs variants, sizes, states, or conditional Tailwind classes.",
+    avoid_when: "A one-off style can stay simpler with plain className.",
+    required_gates: ["source-provenance", "license-ok", "design-system-fit", "screenshot-proof"],
+    notes: "Keeps copied components from becoming fragile Tailwind string soup.",
+  },
+  {
+    id: "21st-dev",
+    name: "21st.dev Community Components",
+    tier: "recommended",
+    risk: "medium",
+    url: "https://21st.dev/community/components/s/21st-dev",
+    best_for: ["AI-assisted UI sourcing", "React/Tailwind components", "shadcn registry URLs", "idea mining"],
+    install_hint: "Use npx shadcn@latest add <21st registry URL>, then review and own the copied files.",
+    use_when: "A project needs a faster starting point for a known UI pattern and the source has a clear author and registry URL.",
+    avoid_when: "The component has unclear provenance, heavy visual effects, missing accessibility behavior, or no mobile proof.",
+    required_gates: COMMUNITY_GATES,
+    notes: "Highly useful discovery layer, but community components must pass provenance, accessibility, reduced-motion, mobile, and screenshot proof.",
+  },
+  {
+    id: "magic-ui",
+    name: "Magic UI",
+    tier: "recommended",
+    risk: "medium",
+    url: "https://magicui.design/docs/components",
+    best_for: ["animated accents", "landing-page polish", "micro-effects", "shadcn-adjacent components"],
+    install_hint: "Install only the specific component or copy the source, then adapt tokens and motion.",
+    use_when: "A page needs one tasteful effect that supports the product story.",
+    avoid_when: "Multiple effects would dominate the interface or distract from the task.",
+    required_gates: MOTION_GATES,
+    notes: "Good sparkle when restrained. UIPass should reject effect stacking and motion without fallback.",
+  },
+  {
+    id: "aceternity-ui",
+    name: "Aceternity UI",
+    tier: "recommended",
+    risk: "medium",
+    url: "https://ui.aceternity.com/components",
+    best_for: ["hero sections", "scroll interactions", "animated landing components", "high-impact demos"],
+    install_hint: "Use the shadcn-compatible install command when available; otherwise copy source with attribution notes.",
+    use_when: "A marketing or showcase surface needs a memorable interaction and can afford the QA budget.",
+    avoid_when: "The target is a dense admin/work tool, mobile viewport, or performance-sensitive route.",
+    required_gates: COMMUNITY_GATES,
+    notes: "Strong for wow moments. Strict gate: no giant spacer hacks, no unbounded scroll effects, no missing reduced-motion path.",
+  },
+  {
+    id: "origin-ui",
+    name: "Origin UI",
+    tier: "recommended",
+    risk: "medium",
+    url: "https://originui.com/",
+    best_for: ["application UI", "forms", "tables", "navigation", "copy-paste React/Tailwind patterns"],
+    install_hint: "Copy the smallest useful pattern and map it to existing local components.",
+    use_when: "A practical app control needs a polished variation faster than designing from zero.",
+    avoid_when: "The copied pattern would bypass local design-system components or duplicate primitives.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Useful pattern library for work-focused interfaces when adapted to local components.",
+  },
+  {
+    id: "cmdk",
+    name: "cmdk",
+    tier: "specialist",
+    risk: "low",
+    url: "https://cmdk.paco.me/",
+    best_for: ["command palettes", "searchable action menus"],
+    install_hint: "Use through shadcn command wrappers where the repo already follows that pattern.",
+    use_when: "The user needs fast keyboard-first navigation or command execution.",
+    avoid_when: "A simple search field or menu is enough.",
+    required_gates: FOUNDATION_GATES,
+    notes: "High leverage for power-user admin surfaces when accessibility and keyboard behavior are verified.",
+  },
+  {
+    id: "sonner",
+    name: "Sonner",
+    tier: "specialist",
+    risk: "low",
+    url: "https://sonner.emilkowal.ski/",
+    best_for: ["toast notifications", "receipt feedback", "non-blocking status"],
+    install_hint: "Use through existing shadcn toast/sonner wrappers when present.",
+    use_when: "The user needs lightweight feedback after actions.",
+    avoid_when: "The message is critical enough to require an inline error, modal, or persistent receipt.",
+    required_gates: ["source-provenance", "license-ok", "design-system-fit", "mobile-fit", "screenshot-proof"],
+    notes: "Good for action feedback, not a substitute for receipts or durable status.",
+  },
+  {
+    id: "embla-carousel",
+    name: "Embla Carousel",
+    tier: "specialist",
+    risk: "medium",
+    url: "https://www.embla-carousel.com/",
+    best_for: ["carousels", "sliders", "touch scrolling"],
+    install_hint: "Use only when carousel behavior is genuinely needed and keyboard/touch proof exists.",
+    use_when: "Content benefits from horizontal browsing and all items remain reachable without drag-only interaction.",
+    avoid_when: "A grid, tabs, or simple list would be clearer.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Carousels are often a UX smell. UIPass should force reachability and mobile proof.",
+  },
+  {
+    id: "vaul",
+    name: "Vaul",
+    tier: "specialist",
+    risk: "medium",
+    url: "https://vaul.emilkowal.ski/",
+    best_for: ["mobile drawers", "bottom sheets", "touch-first overlays"],
+    install_hint: "Use when a bottom sheet is the right mobile interaction and desktop has an equivalent.",
+    use_when: "A mobile surface needs a familiar drawer interaction with controlled focus and escape behavior.",
+    avoid_when: "A normal dialog, page, or inline expansion would be simpler.",
+    required_gates: FOUNDATION_GATES,
+    notes: "Mobile-first overlays need extra focus, escape, and viewport testing.",
+  },
+  {
+    id: "ui-ux-pro-max",
+    name: "UI UX Pro Max Skill",
+    tier: "advisory",
+    risk: "medium",
+    url: "https://ui-ux-pro-max-skill.com/docs/faq/",
+    best_for: ["design research", "style search", "AI assistant guidance", "taste calibration"],
+    install_hint: "Use uipro init for assistant-side design intelligence, not as a runtime component dependency.",
+    use_when: "A worker needs design intelligence, style references, or UI critique prompts before building.",
+    avoid_when: "A component source, license proof, runtime dependency, or visual evidence is required.",
+    required_gates: ["source-provenance", "license-ok"],
+    notes: "Advisory only. It can inform UIPass, but it cannot replace screenshots, accessibility proof, or source receipts.",
+  },
+];
+
+const SOURCES_BY_ID = new Map<string, UIToolboxSource>(
+  UI_TOOLBOX_SOURCES.map((source) => [source.id, source]),
+);
+
+function hasGateEvidence(value: boolean | string | undefined): boolean {
+  if (value === true) return true;
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function countByTier(assessments: UIToolboxAssessment[]): Partial<Record<UIToolboxTier, number>> {
+  const out: Partial<Record<UIToolboxTier, number>> = {};
+  for (const assessment of assessments) {
+    if (!assessment.tier) continue;
+    out[assessment.tier] = (out[assessment.tier] ?? 0) + 1;
+  }
+  return out;
+}
+
+function countMissingGates(assessments: UIToolboxAssessment[]): Partial<Record<UIToolboxGateId, number>> {
+  const out: Partial<Record<UIToolboxGateId, number>> = {};
+  for (const assessment of assessments) {
+    for (const gate of assessment.missing_gates) {
+      out[gate] = (out[gate] ?? 0) + 1;
+    }
+  }
+  return out;
+}
+
+export function getUIToolboxSource(sourceId: string): UIToolboxSource | undefined {
+  return SOURCES_BY_ID.get(sourceId);
+}
+
+export function recommendedUIToolboxSources(): UIToolboxSource[] {
+  return UI_TOOLBOX_SOURCES.filter((source) => source.tier === "core" || source.tier === "recommended");
+}
+
+export function assessUIToolboxCandidate(input: UIToolboxCandidateInput): UIToolboxAssessment {
+  const source = getUIToolboxSource(input.source_id);
+  if (!source) {
+    return {
+      source_id: input.source_id,
+      status: "unknown-source",
+      required_gates: ["source-provenance", "license-ok", "screenshot-proof"],
+      missing_gates: ["source-provenance", "license-ok", "screenshot-proof"],
+      warnings: ["Unknown UI toolbox source. Do not use until it has a registry entry and review gates."],
+      next_action: "Add the source to the UIPass toolbox registry or choose a recommended source.",
+    };
+  }
+
+  const missing = source.required_gates.filter((gate) => !hasGateEvidence(input.evidence?.[gate]));
+  const warnings: string[] = [];
+
+  if (source.tier === "advisory") {
+    warnings.push("Advisory source only. It can guide design decisions but cannot be treated as a component source.");
+  }
+  if (source.tier === "watch") {
+    warnings.push("Watch-tier source. Prefer the current core source unless compatibility requires this one.");
+  }
+  if (source.risk !== "low") {
+    warnings.push(`${source.risk} risk source. Keep the copied surface small and require visual proof.`);
+  }
+
+  const blocked = source.tier === "advisory";
+  const status: UIToolboxAssessmentStatus = blocked
+    ? "blocked"
+    : missing.length === 0
+      ? "approved"
+      : "needs-proof";
+
+  return {
+    source_id: source.id,
+    source_name: source.name,
+    status,
+    tier: source.tier,
+    risk: source.risk,
+    required_gates: source.required_gates,
+    missing_gates: missing,
+    warnings,
+    next_action: status === "approved"
+      ? "Use the smallest component slice, adapt it to local patterns, and keep the UIPass proof with the change."
+      : status === "blocked"
+        ? "Use this for research only, then choose a component source from the core or recommended toolbox."
+        : `Collect missing proof: ${missing.map((gate) => UI_TOOLBOX_GATE_LABELS[gate]).join(" ")}`,
+  };
+}
+
+export function buildUIToolboxScoreboard(candidates: UIToolboxCandidateInput[]): UIToolboxScoreboard {
+  const assessments = candidates.map((candidate) => assessUIToolboxCandidate(candidate));
+  const approved = assessments.filter((assessment) => assessment.status === "approved").length;
+  const needsProof = assessments.filter((assessment) => assessment.status === "needs-proof").length;
+  const blocked = assessments.filter((assessment) => assessment.status === "blocked").length;
+  const unknown = assessments.filter((assessment) => assessment.status === "unknown-source").length;
+  const missingGateCounts = countMissingGates(assessments);
+
+  let recommendedNextAction = "Start with shadcn/ui plus Radix, React Aria, Base UI, or Motion when the target needs them.";
+  if (blocked > 0 || unknown > 0) {
+    recommendedNextAction = "Replace blocked or unknown sources before implementation.";
+  } else if (needsProof > 0) {
+    const topMissing = Object.entries(missingGateCounts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([gate]) => gate)[0];
+    recommendedNextAction = topMissing
+      ? `Close the most common missing gate first: ${UI_TOOLBOX_GATE_LABELS[topMissing as UIToolboxGateId]}`
+      : "Collect missing UIPass proof before implementation.";
+  } else if (approved > 0) {
+    recommendedNextAction = "Implementation can proceed with small slices, screenshots, and local design-system adaptation.";
+  }
+
+  return {
+    total: candidates.length,
+    approved,
+    needs_proof: needsProof,
+    blocked,
+    unknown_source: unknown,
+    by_tier: countByTier(assessments),
+    missing_gate_counts: missingGateCounts,
+    recommended_next_action: recommendedNextAction,
+  };
+}

--- a/scripts/UnClick-brainmap.mjs
+++ b/scripts/UnClick-brainmap.mjs
@@ -147,6 +147,7 @@ const STATIC_SYSTEMS = [
   ["Passes and gates", "FidelityPass", "fidelity gate", "Checks exactness and invariant preservation when copying, refactoring, or translating content.", "scripts/fidelitycopy.test.mjs", ""],
   ["Passes and gates", "CommonSensePass", "judgment gate", "Plain-reasoning gate used before healthy, done, merge-ready, or PASS claims.", "api/commonsensepass-bridge.test.ts", ""],
   ["Passes and gates", "WakePass", "wake gate", "Verifies ACKs, stale handoffs, and worker wake requests before motion claims.", "docs/pinballwake-igniteonly-api.md", ""],
+  ["Passes and gates", "UIPass Toolbox", "component source gate", "Curated UI source registry and proof scoreboard for shadcn, Radix, React Aria, Base UI, Floating UI, Motion, 21st.dev, Magic UI, Aceternity, Origin UI, and advisory design intelligence.", "packages/uxpass/src/ui-toolbox.ts", ""],
   ["Wrappers and protocols", "NudgeOnly", "bridge", "Low-risk receipt nudges that never mutate source-of-truth state.", "docs/pinballwake-nudgeonly-api.md", ""],
   ["Wrappers and protocols", "IgniteOnly", "bridge", "Verified worker wake packets only, never build, merge, or completion state.", "docs/pinballwake-igniteonly-api.md", ""],
   ["Wrappers and protocols", "SeatRelay", "claim lifecycle", "Stale release, smart reassignment, and bonded handoff for stuck worker claims.", "docs/UnClick-brainmap.generated.md", ""],
@@ -234,6 +235,9 @@ function meaningForComponent(component, file) {
 }
 
 function displayPageName(component, file) {
+  if (component === "Fishbowl" || path.basename(file, path.extname(file)) === "Fishbowl") {
+    return "Boardroom";
+  }
   const sourceBase = path.basename(file, path.extname(file));
   if (component.endsWith("Page") && (PAGE_MEANINGS[sourceBase] || PUBLIC_PAGE_MEANINGS[sourceBase])) {
     return titleFromName(sourceBase);


### PR DESCRIPTION
## Summary
- add a UIPass UI toolbox registry with curated source tiers, required proof gates, and a scoreboard helper
- wire ui_toolbox into UXPass pack schema, exports, example pack, and tests
- update XPass routing, boot-packet discovery, Boardroom naming, and generated Brainmap so fresh AI seats can find UIPass/toolbox guidance

## Proof
- npm run typecheck --workspace=@unclick/uxpass
- npm run build --workspace=@unclick/uxpass
- npm run test --workspace=@unclick/uxpass
- npm run brainmap:check
- npm run test:brainmap
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new library module, schema validation, and generated docs; no auth or runtime API changes; Brainmap display rename is cosmetic for the same route.
> 
> **Overview**
> Introduces **UIPass** as a first-class product lane: a curated UI source registry (`packages/uxpass/src/ui-toolbox.ts`) with tiered libraries (shadcn, Radix, Motion, 21st.dev, Magic UI, etc.), nine proof gates (provenance, license, a11y, mobile, reduced-motion, screenshots, and more), plus `assessUIToolboxCandidate` and `buildUIToolboxScoreboard` for approve / needs-proof / blocked outcomes.
> 
> **UXPass packs** gain optional `ui_toolbox` in Zod schema, a `./ui-toolbox` package export, example pack YAML, and tests. **Docs and discovery** expand: `docs/prd/xpass.md` and `docs/unclick-context-boot-packet.md` route visual polish to UIPass; the boot packet adds Tool Index, Crews, AnswerPass, a feature-discovery table, and scoreboard field hints. **Naming**: Brainmap and UXPass briefs relabel **Fishbowl → Boardroom** for `/admin/boardroom` (still `Fishbowl.tsx`); generated brainmap inventory updates include the new UIPass Toolbox pass gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07996949648c9ccc335e36ee4fc2e0edd0718f78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->