### PR TITLE
fix(memory-admin): soften channel status auth

### DIFF
--- a/.github/workflows/tier2-rollback.yml
+++ b/.github/workflows/tier2-rollback.yml
@@ -1,0 +1,50 @@
+name: Tier-2 Rollback (manual)
+
+# Manual-only undo path for a safe-tier merge that should not have landed.
+# The script defaults to dry-run, opens a draft revert PR when execute=true,
+# and never rewrites history.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to roll back (the merged PR to revert)"
+        required: true
+        type: string
+      execute:
+        description: "Actually open the revert PR (false = print the plan only)"
+        required: false
+        type: boolean
+        default: false
+      allow_old:
+        description: "Override the 72h freshness guard for an older merge"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rollback:
+    name: One-step rollback of a safe-tier merge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "unclick-tier2-rollback[bot]"
+          git config user.email "tier2-rollback@users.noreply.github.com"
+
+      - name: Plan or execute rollback
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TIER2_ROLLBACK_EXECUTE: ${{ inputs.execute }}
+          TIER2_ROLLBACK_ALLOW_OLD: ${{ inputs.allow_old }}
+        run: node scripts/tier2-rollback.mjs --pr "${{ inputs.pr_number }}"

--- a/api/memory-admin-channel-status-auth.test.ts
+++ b/api/memory-admin-channel-status-auth.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveChannelStatusAuthOutcome } from "./memory-admin";
+
+describe("admin_channel_status auth outcome", () => {
+  it("authorizes a request with a resolved api_key hash", () => {
+    expect(
+      resolveChannelStatusAuthOutcome({ apiKeyHash: "deadbeef", hasValidSession: true }),
+    ).toEqual({ kind: "authorized" });
+  });
+
+  it("authorizes on api_key hash even without a session", () => {
+    expect(
+      resolveChannelStatusAuthOutcome({ apiKeyHash: "deadbeef", hasValidSession: false }),
+    ).toEqual({ kind: "authorized" });
+  });
+
+  it("returns a soft unconfigured state for a signed-in admin with no linked key", () => {
+    expect(
+      resolveChannelStatusAuthOutcome({ apiKeyHash: null, hasValidSession: true }),
+    ).toEqual({ kind: "soft_unconfigured" });
+  });
+
+  it("keeps 401 for a genuinely unauthenticated caller", () => {
+    expect(
+      resolveChannelStatusAuthOutcome({ apiKeyHash: null, hasValidSession: false }),
+    ).toEqual({ kind: "unauthorized" });
+  });
+});

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -1186,6 +1186,20 @@ async function resolveSessionUser(
   }
 }
 
+export type ChannelStatusAuthOutcome =
+  | { kind: "authorized" }
+  | { kind: "soft_unconfigured" }
+  | { kind: "unauthorized" };
+
+export function resolveChannelStatusAuthOutcome(input: {
+  apiKeyHash: string | null;
+  hasValidSession: boolean;
+}): ChannelStatusAuthOutcome {
+  if (input.apiKeyHash) return { kind: "authorized" };
+  if (input.hasValidSession) return { kind: "soft_unconfigured" };
+  return { kind: "unauthorized" };
+}
+
 // ─── AI chat helpers ───────────────────────────────────────────────────────
 
 type ChatProvider = "google" | "openai" | "anthropic";
@@ -6969,7 +6983,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       case "admin_channel_status": {
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
-        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const hasValidSession = apiKeyHash
+          ? true
+          : Boolean(await resolveSessionUser(req, supabaseUrl, supabaseKey));
+        const authOutcome = resolveChannelStatusAuthOutcome({ apiKeyHash, hasValidSession });
+        if (authOutcome.kind === "unauthorized") {
+          return res.status(401).json({ error: "Authorization header required" });
+        }
+        if (authOutcome.kind === "soft_unconfigured") {
+          return res.status(200).json({
+            channel_active: false,
+            configured: false,
+            last_seen: null,
+            client_info: null,
+          });
+        }
+
         const { data, error } = await supabase
           .from("channel_status")
           .select("last_seen, client_info")
@@ -6983,6 +7012,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         return res.status(200).json({
           channel_active: active,
+          configured: true,
           last_seen: lastSeen,
           client_info: data?.client_info ?? null,
         });

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,8 +9,8 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 620,
-    "source_manifest": 192,
+    "inventory": 621,
+    "source_manifest": 193,
     "pages": 84,
     "tools": 219,
     "rooms": 23,
@@ -63,7 +63,7 @@
       "id": "automations",
       "name": "Automations",
       "meaning": "Scheduled jobs, wake routes, cron workflows, and recurring checks.",
-      "count": 121
+      "count": 122
     },
     {
       "id": "ledgers-and-proof",
@@ -1798,6 +1798,16 @@
       "kind": "workflow",
       "meaning": "tier2 auto merge queue check GitHub automation workflow.",
       "source": ".github/workflows/tier2-auto-merge-queue-check.yml",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "automations-workflow-tier2-rollback-yml-github-workflows-tier2-rollback-yml-no-route",
+      "division": "Automations",
+      "name": "tier2 rollback.yml",
+      "kind": "workflow",
+      "meaning": "tier2 rollback GitHub automation workflow.",
+      "source": ".github/workflows/tier2-rollback.yml",
       "route": "",
       "tags": []
     },
@@ -9186,6 +9196,11 @@
       "source": ".github/workflows/tier2-auto-merge-queue-check.yml",
       "hash": "5abfca8c42dc",
       "bytes": 830
+    },
+    {
+      "source": ".github/workflows/tier2-rollback.yml",
+      "hash": "1468c05586fb",
+      "bytes": 1495
     }
   ]
 }

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -205,6 +205,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/testpass-pr-check.yml | bca601f0a1c2 | 20251 |
 | .github/workflows/testpass-scheduled-smoke.yml | 46f9a65b1dbb | 1673 |
 | .github/workflows/tier2-auto-merge-queue-check.yml | 5abfca8c42dc | 830 |
+| .github/workflows/tier2-rollback.yml | 1468c05586fb | 1495 |
 
 ## Division Index
 
@@ -217,7 +218,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
 | Wrappers and protocols | Thin harnesses, bridges, policies, and routing helpers. | 3 |
-| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 121 |
+| Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 122 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 8 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 13 |
 | Modules and apps | Apps, packages, and product modules that make up UnClick. | 116 |
@@ -737,6 +738,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Automations | workflow | testpass pr check.yml | testpass pr check GitHub automation workflow. | - | .github/workflows/testpass-pr-check.yml |
 | Automations | workflow | testpass scheduled smoke.yml | testpass scheduled smoke GitHub automation workflow. | - | .github/workflows/testpass-scheduled-smoke.yml |
 | Automations | workflow | tier2 auto merge queue check.yml | tier2 auto merge queue check GitHub automation workflow. | - | .github/workflows/tier2-auto-merge-queue-check.yml |
+| Automations | workflow | tier2 rollback.yml | tier2 rollback GitHub automation workflow. | - | .github/workflows/tier2-rollback.yml |
 | Launch and onboarding | brainmap source | Un Click brainmap | Un Click brainmap UnClick module. | - | scripts/UnClick-brainmap.mjs |
 | Launch and onboarding | judgement prompt | Crews Council Induction | Launchpad prompt that runs Council Lite on material work and asks for a full Crews Council only when launch, risk, mixed proof, or broad XPass evidence needs judgement. | /admin/pinballwake | scripts/pinballwake-launchpad-room.mjs |
 | Launch and onboarding | map | Ecosystem Brainmap | Generated sitemap and system map that teaches seats what UnClick contains. | /admin/brainmap | src/pages/admin/AdminBrainmap.tsx |


### PR DESCRIPTION
Safe slice salvaged from the old Worker 12 bundle (#1264).\n\nWhat changed:\n- Add a pure auth-outcome helper for admin_channel_status.\n- Return a soft 200 configured:false for a signed-in admin with no linked api_key, avoiding repeated 60s 401 noise.\n- Keep 401 for genuinely unauthenticated callers.\n- Add the missing manual-only Tier-2 rollback workflow.\n- Refresh the generated brainmap.\n\nProof run locally:\n- npx vitest run api/memory-admin-channel-status-auth.test.ts\n- npm run test:tier2-rollback\n- node scripts/UnClick-brainmap.mjs\n\nThe broad #1264 branch remains conflicted and contains already-live overlap, so this PR keeps only the useful narrow slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admin API auth behavior for channel status (session vs API key) and introduces a workflow that can open revert PRs with write permissions when executed.
> 
> **Overview**
> **`admin_channel_status`** no longer treats a signed-in admin without a linked API key as a hard **401**. A pure helper **`resolveChannelStatusAuthOutcome`** drives three outcomes: API key (with or without session) stays authorized; session-only with no key gets **200** with `configured: false` and inactive channel fields; unauthenticated callers still get **401**. Successful key-based responses now include **`configured: true`**. Vitest covers the helper in **`api/memory-admin-channel-status-auth.test.ts`**.
> 
> Adds a **manual** GitHub workflow **`.github/workflows/tier2-rollback.yml`** that runs **`scripts/tier2-rollback.mjs`** (dry-run by default, optional execute to open a draft revert PR, optional override for merges older than 72h). Generated brainmap docs are refreshed to list the new workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19827b5752d755dd6ade22f1e060b44742dcd27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->