### PR TITLE
feat(jobsmith): add submit-ready proof summary

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8699,8 +8699,8 @@
     },
     {
       "source": "src/pages/Jobsmith.tsx",
-      "hash": "08e9c9874c22",
-      "bytes": 61541
+      "hash": "da0fc0d07f50",
+      "bytes": 62558
     },
     {
       "source": "src/pages/Login.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -107,7 +107,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/DogfoodReport.tsx | 4103b5e68d6c | 16693 |
 | src/pages/FAQPage.tsx | 507e1ed5789c | 712 |
 | src/pages/InstallRecover.tsx | 56c822e69817 | 6971 |
-| src/pages/Jobsmith.tsx | 08e9c9874c22 | 61541 |
+| src/pages/Jobsmith.tsx | da0fc0d07f50 | 62558 |
 | src/pages/Login.tsx | 86f887990094 | 8440 |
 | src/pages/MemoryConnect.tsx | c760d37398d5 | 18534 |
 | src/pages/MemorySetup.tsx | c46cb67d413e | 19854 |

--- a/src/pages/Jobsmith.test.tsx
+++ b/src/pages/Jobsmith.test.tsx
@@ -91,6 +91,11 @@ describe("JobsmithPage", () => {
     expect(managedRunReport).toHaveTextContent("No run proof attached yet.");
     expect(managedRunReport).toHaveTextContent("Decision cards");
     expect(managedRunReport).toHaveTextContent("Not submit-ready");
+    const proofSummary = within(managedRunReport).getByTestId("jobsmith-final-report-proof-summary");
+    expect(proofSummary).toHaveTextContent("Submit-ready status: not ready");
+    expect(proofSummary).toHaveTextContent("Rules passed:");
+    expect(proofSummary).toHaveTextContent("Artifacts: 0/3 ready");
+    expect(proofSummary).toHaveTextContent("Proof receipts: 0");
     expect(screen.queryByText(/ApplyPass/i)).not.toBeInTheDocument();
   });
 
@@ -150,6 +155,11 @@ describe("JobsmithPage", () => {
     const managedRunReport = screen.getByRole("region", { name: "Jobsmith managed run report" });
     expect(managedRunReport).toHaveTextContent("Browser-local cover letter draft: Ready");
     expect(managedRunReport).toHaveTextContent("Managed run report UI");
+    const proofSummary = within(managedRunReport).getByTestId("jobsmith-final-report-proof-summary");
+    expect(proofSummary).toHaveTextContent("Submit-ready status: not ready");
+    expect(proofSummary).toHaveTextContent(/Decision cards: \d+ resolved/);
+    expect(proofSummary).toHaveTextContent("Artifacts: 1/3 ready");
+    expect(proofSummary).toHaveTextContent("Proof receipts: 2");
   });
 
   it("logs an application and persists it across a remount", async () => {

--- a/src/pages/Jobsmith.tsx
+++ b/src/pages/Jobsmith.tsx
@@ -412,6 +412,16 @@ function ManagedRunReport({
   );
   const visibleBlockers = report.blockers.slice(0, 4);
   const visibleFindings = report.deterministicFindings.slice(0, 3);
+  const finalReportLines = [
+    `Submit-ready status: ${report.submitReady ? "ready" : "not ready"}`,
+    `Rules passed: ${report.rulesPassed}`,
+    `Blockers: ${report.blockers.length}`,
+    `Deterministic findings: ${report.deterministicFindings.length}`,
+    `Review-needed rules: ${report.reviewNeededCount}`,
+    `Decision cards: ${decisionSummary.resolved} resolved, ${decisionSummary.unresolved} unresolved`,
+    `Artifacts: ${report.artifacts.filter((artifact) => artifact.ready).length}/${report.artifacts.length} ready`,
+    `Proof receipts: ${report.proof.length}`,
+  ];
 
   return (
     <section
@@ -481,6 +491,16 @@ function ManagedRunReport({
             <div>
               <dt className="font-semibold text-white/45">Next safe action</dt>
               <dd className="mt-1 text-white/70">{report.nextSafeAction}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-white/45">Submit-ready proof summary</dt>
+              <dd className="mt-1 space-y-1 text-white/70" data-testid="jobsmith-final-report-proof-summary">
+                {finalReportLines.map((line) => (
+                  <span key={line} className="block">
+                    {line}
+                  </span>
+                ))}
+              </dd>
             </div>
             <div>
               <dt className="font-semibold text-white/45">Artifacts</dt>


### PR DESCRIPTION
## Summary
- Adds a compact submit-ready proof summary inside the existing JobSmith managed run report.
- Shows rules passed, blocker count, deterministic findings, review-needed rules, decision-card state, artifact readiness, and proof receipt count in one visible block.
- Keeps the app browser-local and does not add any submission path.

## Why this is safe
- This ports the useful 26-line feature from stale #958 onto current main.
- No API, auth, billing, deploy, or external submission behavior changes.
- The old #958 branch is conflicting, so this fresh slice avoids stale branch history.

## Verification
- `npx vitest run src/pages/Jobsmith.test.tsx` - pass, 5 tests.
- `npm run build` - pass.
- `npm run brainmap:check` - pass.
- `npm run test:brainmap` - pass, 7 tests.
- `git diff --check` - pass.

Supersedes #958 if the hosted checks pass and this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display of existing report fields in the browser-local Jobsmith page; no API, auth, or submission behavior changes.
> 
> **Overview**
> Adds a **Submit-ready proof summary** block to the Jobsmith managed run report’s **Final report** section, rendering a compact checklist from existing `ManagedApplicationRunReport` data (submit-ready flag, rules passed, blockers, findings, review-needed count, decision-card resolution, artifact readiness, proof receipt count).
> 
> Tests now assert the new `jobsmith-final-report-proof-summary` test id for empty and post-draft states; brainmap metadata reflects the `Jobsmith.tsx` size/hash update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a94bd16c0834825763e2884a106811e1848f1bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->