### PR TITLE
docs(bookendsbuild): add qc on wake rule

### DIFF
--- a/.claude/agents/heartbeat.md
+++ b/.claude/agents/heartbeat.md
@@ -81,6 +81,26 @@ Capture the build into repo code, a draft PR, or a scoped handoff quickly. Do no
 leave fresh build context for later heartbeat recovery if the active seat can
 safely act now.
 
+This is the FRONT bookend of BookendsBuild (UnClick -> AutoPilot -> BookendsBuild)
+and it is mandatory, not optional. Build-from-the-warm-chat-seat is priority at
+the front of the loop.
+
+## BookendsBuild QC on Wake
+
+This is the BACK bookend of BookendsBuild and it carries equal, hard priority to
+the front-end build capture above. It is mandatory.
+
+On every subscription/chat-seat wake, before idling, run a QC pass over
+everything the free autopilot agents (OpenHands / CodeRoom) shipped or attempted
+since the last subscription wake. Read the diffs, PRs, and proof. If anything is
+wrong, incomplete, or low-quality, the smart subscription seat fixes it
+immediately, re-runs the checks, and repeats until clean.
+
+The smart subscription seat builds at the front and audits at the back; the free
+middle keeps things moving while the operator is away. Do not treat free-agent
+output as done until it has passed this QC pass. The loop only counts as closed
+once this back-end QC has run. See `docs/bookends-build.md`.
+
 ## SeatRelay Priority
 
 Treat SeatRelay as high priority when choosing between safe queue slices because

--- a/docs/bookends-build.md
+++ b/docs/bookends-build.md
@@ -1,0 +1,31 @@
+# BookendsBuild
+
+UnClick -> AutoPilot -> BookendsBuild.
+
+BookendsBuild is the operating pattern where the smart subscription LLM bookends
+a free autonomous build, with QC closing the loop. It is a concept reference,
+not a menu or UI surface.
+
+## The loop
+
+1. Front bookend - DraftRoom / PlanRoom (smart). The subscription seat plans and
+   builds first while the build context is warm. Build-from-chat is priority:
+   never park fresh build context for the free runner to redo later.
+2. Middle - the assembly line, OpenHands / CodeRoom (free). Free models keep
+   things moving unattended: claim, build the small or simple jobs, open the PR,
+   pass the required checks, and merge through the protected rail.
+3. Back bookend - QC (smart). On every subscription-seat wake, run a mandatory
+   QC pass: read everything the free agents shipped or attempted since the last
+   wake, fix what is wrong, and repeat until clean.
+
+## Rules
+
+- Both ends are smart subscription seats. The middle is free autopilot.
+- Front and back carry equal, hard priority. Build-first at the front;
+  QC-and-fix-first at the back.
+- The loop only counts as closed once the back-end QC pass has run over the free
+  middle's output.
+- The free middle keeps momentum while the operator is away; the smart bookends
+  guarantee quality on entry and on exit.
+- This concept is hard-wired across the platform so every seat runs both
+  bookends. It is not optional.


### PR DESCRIPTION
## What changed

- Adds `docs/bookends-build.md` as the canonical BookendsBuild reference.
- Updates `.claude/agents/heartbeat.md` so subscription seats must QC free-agent output on wake before treating the loop as closed.

## Why this is safe

Docs and heartbeat prompt only. No runtime code, auth, billing, secrets, migrations, or production data touched.

## Local proof

- `npm run brainmap:generate`
- `npm run brainmap:check`
- `npm run test:brainmap`
- `git diff --check`

Supersedes stale PR #1043 with the same useful idea on current main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and heartbeat prompt text only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Documents **BookendsBuild** (UnClick → AutoPilot → BookendsBuild) and makes subscription-seat behavior explicit in the heartbeat agent.
> 
> Adds `docs/bookends-build.md` as the canonical loop: smart subscription seats at the **front** (plan/build while context is warm) and **back** (mandatory QC on wake), with free OpenHands/CodeRoom in the middle.
> 
> Updates `.claude/agents/heartbeat.md` to label active chat build capture as the mandatory **front** bookend, and adds **BookendsBuild QC on Wake** as the equally mandatory **back** bookend—on every subscription/chat-seat wake, QC all free-agent output since the last wake, fix issues, re-run checks, and do not treat the loop as closed until that pass completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 117c71bede90a196c0ab0c863ab3f1ad84b7588b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->