### PR TITLE
fix(boardroom): align job close eligibility with live proof gate

### DIFF
--- a/api/fishbowl-completion-policy.test.ts
+++ b/api/fishbowl-completion-policy.test.ts
@@ -121,6 +121,25 @@ describe("evaluateFishbowlCompletionPolicy", () => {
     expect(result).toMatchObject({ allowed: false, code: "release_or_live_proof_required" });
   });
 
+  it("blocks scheduled wake routes when merge proof lacks live availability proof", () => {
+    const result = evaluateFishbowlCompletionPolicy({
+      todo: {
+        ...baseTodo,
+        title: "Implement Cowork scheduled-task wake route",
+        description: "Dry-run route validates due tasks, but live wake availability is still not proved.",
+      },
+      comments: [
+        {
+          author_agent_id: "reviewer-seat",
+          text: "PASS: PR #1260 merged and CI passed; proof: actions/runs/26270000000.",
+        },
+      ],
+      closerAgentId: "builder-seat",
+    });
+
+    expect(result).toMatchObject({ allowed: false, code: "release_or_live_proof_required" });
+  });
+
   it("allows runtime tool work with registry and discovery proof", () => {
     const result = evaluateFishbowlCompletionPolicy({
       todo: {

--- a/api/fishbowl-job-pipeline.test.ts
+++ b/api/fishbowl-job-pipeline.test.ts
@@ -117,6 +117,60 @@ describe("Fishbowl job pipeline inference", () => {
     });
   });
 
+  it("does not show runtime work as close eligible without release or live availability proof", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "WriterLane #5: heartbeat no-op reason codes",
+          description: "Adds an MCP-server heartbeat policy module. The module must be released or discoverable before close.",
+          status: "in_progress",
+        },
+        [
+          {
+            text:
+              "RELEASE PROOF + close. PR #1258 merged to main as commit e4531bb. File packages/mcp-server/src/heartbeat-noop-reasons.ts confirmed live on origin/main. All required CI green.",
+            created_at: "2026-06-03T12:54:44Z",
+          },
+        ],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      pipeline_evidence: ["build", "ship"],
+      proof_state: "missing",
+      proof_state_reason: "Runtime, package, or tool jobs need release/live availability proof before close.",
+      effective_status: "in_progress",
+      release_blocked: false,
+    });
+  });
+
+  it("keeps shipped runtime work close eligible when live availability proof exists", () => {
+    expect(
+      inferFishbowlJobPipeline(
+        {
+          title: "FidelityCopy: deterministic non-AI copy engine for FidelityPass",
+          description: "Build and expose a live MCP tool.",
+          status: "done",
+        },
+        [
+          {
+            text:
+              "PASS: PR #997 merged, npm view confirms registry latest 0.3.107, and fidelitycopy_copy tool discovery is available.",
+            created_at: "2026-05-22T06:43:59Z",
+          },
+        ],
+      ),
+    ).toMatchObject({
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_source: "receipt: ship",
+      proof_state: "close_eligible",
+      effective_status: "done",
+      release_blocked: false,
+    });
+  });
+
   it("lets newer proof move a reopened job forward again", () => {
     expect(
       inferFishbowlJobPipeline(

--- a/api/lib/fishbowl-completion-policy.ts
+++ b/api/lib/fishbowl-completion-policy.ts
@@ -59,7 +59,7 @@ const noCodeNeededPattern =
   /\b(no[_\s-]?code[_\s-]?needed|no code needed|non-code|no code change|policy only|comment only|routing only|docs only)\b/i;
 
 const runtimeDeliveryTodoPattern =
-  /\b(mcp\s+(?:server|tool)|publish(?:ed|ing)?|registry|npm|release|deploy(?:ed|ment)?|production|live\s+(?:tool|receipt|api|proof)|expos(?:e|ed|ing)|workers?\s+may\s+request|worker(?:s)?\s+tool)\b/i;
+  /\b(mcp[-\s]+(?:server|tool)|publish(?:ed|ing)?|registry|npm|release|deploy(?:ed|ment)?|production|live\s+(?:tool|receipt|api|proof)|expos(?:e|ed|ing)|workers?\s+may\s+request|worker(?:s)?\s+tool|wake\s+route|scheduled[-\s]task\s+wake)\b/i;
 
 const runtimeDeliveryProofPattern =
   /\b(published|npm\s+(?:view|latest|dist-tag)|registry\s+(?:confirms|shows|latest)|deployed|deployment|live\s+on\s+production|production\s+live|vercel\.app|tool(?:s)?\s+(?:discoverable|available|exposed)|(?:mcp|tool)\s+discovery|live\s+(?:receipt|api|tool)|fidelitycopy_(?:copy|verify)|fidelitypass_verify_copy)\b/i;

--- a/api/lib/fishbowl-job-pipeline.ts
+++ b/api/lib/fishbowl-job-pipeline.ts
@@ -62,6 +62,10 @@ const PROOF_PARTIAL_RE = /\b(partial|partial\/blocker|proof ceiling|follow-?up n
 const PROOF_PARKED_RE = /\b(parked|parking|deferred|not next|scopepack needed|missing scopepack)\b/i;
 const PROOF_STALE_RE = /\b(stale|old|outdated)\s+(?:receipt|proof|green chip|claim)|\bfalse[- ]done\b|\bfalse green\b/i;
 const PROOF_WRONG_SCOPE_RE = /\b(wrong scope|scope mismatch|wrong surface|different scope|wrong job|not the requested surface)\b/i;
+const RUNTIME_DELIVERY_TODO_RE =
+  /\b(mcp[-\s]+(?:server|tool)|publish(?:ed|ing)?|registry|npm|release|deploy(?:ed|ment)?|production|live\s+(?:tool|receipt|api|proof)|expos(?:e|ed|ing)|workers?\s+may\s+request|worker(?:s)?\s+tool|wake\s+route|scheduled[-\s]task\s+wake)\b/i;
+const RUNTIME_DELIVERY_PROOF_RE =
+  /\b(published|npm\s+(?:view|latest|dist-tag)|registry\s+(?:confirms|shows|latest)|deployed|deployment|live\s+on\s+production|production\s+live|vercel\.app|tool(?:s)?\s+(?:discoverable|available|exposed)|(?:mcp|tool)\s+discovery|live\s+(?:receipt|api|tool)|fidelitycopy_(?:copy|verify)|fidelitypass_verify_copy)\b/i;
 
 function positiveStageHit(text: string, positive: RegExp, negative?: RegExp): boolean {
   if (!positive.test(text)) return false;
@@ -177,6 +181,10 @@ export function inferFishbowlJobPipeline(
   comments: FishbowlJobPipelineComment[] = [],
 ): FishbowlJobPipelineState {
   const segments = buildSegments(todo, comments);
+  const todoCorpus = [todo.title, todo.description]
+    .filter((value) => typeof value === "string" && value.trim().length > 0)
+    .join("\n")
+    .toLowerCase();
   const latestResetIndex = segments.reduce((latest, segment, index) => {
     return PROOF_RESET_RE.test(segment) || PROOF_MISSING_RE.test(segment) || PROOF_UI_MISSING_RE.test(segment)
       ? index
@@ -273,20 +281,38 @@ export function inferFishbowlJobPipeline(
     source = "receipt: ship";
   }
 
+  const fallbackProofState: Pick<FishbowlJobPipelineState, "proof_state" | "proof_state_reason"> = {
+    proof_state:
+      activeCount >= stageRank.ship && evidence.length > 0 ? "close_eligible" : status === "done" ? "missing" : "live",
+    proof_state_reason:
+      activeCount >= stageRank.ship && evidence.length > 0
+        ? "Ship proof is linked with no newer proof warning."
+        : status === "done"
+          ? "Completed job needs observable proof."
+          : "No newer proof warning is recorded.",
+  };
+
+  const runtimeDeliveryNeedsLiveProof =
+    activeCount >= stageRank.ship &&
+    evidence.length > 0 &&
+    RUNTIME_DELIVERY_TODO_RE.test(todoCorpus) &&
+    !RUNTIME_DELIVERY_PROOF_RE.test(corpus);
+
   return withEffectiveStatus(status, {
     pipeline_stage_count: activeCount,
     pipeline_progress: stageProgress[activeCount] ?? stageProgress[stageRank.brief],
     pipeline_source: source,
     pipeline_evidence: evidence,
-    ...proofStateFromWarning(activeSegments, latestActiveProgressIndex, {
-      proof_state:
-        activeCount >= stageRank.ship && evidence.length > 0 ? "close_eligible" : status === "done" ? "missing" : "live",
-      proof_state_reason:
-        activeCount >= stageRank.ship && evidence.length > 0
-          ? "Ship proof is linked with no newer proof warning."
-          : status === "done"
-            ? "Completed job needs observable proof."
-          : "No newer proof warning is recorded.",
-    }),
+    ...proofStateFromWarning(
+      activeSegments,
+      latestActiveProgressIndex,
+      runtimeDeliveryNeedsLiveProof
+        ? {
+            proof_state: "missing",
+            proof_state_reason:
+              "Runtime, package, or tool jobs need release/live availability proof before close.",
+          }
+        : fallbackProofState,
+    ),
   });
 }


### PR DESCRIPTION
## What changed

- Aligns the Boardroom job-room read badge with the actual close gate.
- Runtime, package, tool, and wake-route jobs with merged/ship proof but no live availability proof now show missing live proof instead of close eligible.
- Keeps jobs close eligible when live availability proof exists, such as registry or tool-discovery proof.
- Expands the close gate to explicitly recognize mcp-server and scheduled wake-route jobs as live-delivery work.

## Why

Some jobs were shown as close eligible, but complete_todo rejected them with release_or_live_proof_required. That made workers think jobs should close while the write gate refused them.

## Local proof

- npm exec vitest -- run api/fishbowl-job-pipeline.test.ts api/fishbowl-completion-policy.test.ts passed, 27 tests.
- npm run test passed, 184 files / 1493 tests plus ESM import guard.
- npm run brainmap:check passed.
- npm run test:brainmap passed, 7 tests.
- git diff --check passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy-only inference changes with matching completion gate and new Vitest coverage; mis-tuned regex could mislabel job proof state but does not affect auth or data writes directly.
> 
> **Overview**
> **Boardroom job pipeline badges** now match the **`complete_todo` close gate**: runtime/package/tool jobs that already show merged/ship progress no longer get **`close_eligible`** unless comments include **release or live availability proof** (registry, deploy, tool discovery, etc.).
> 
> `inferFishbowlJobPipeline` adds the same **runtime-delivery todo/proof regexes** used by `evaluateFishbowlCompletionPolicy`, keyed off todo title/description plus comment corpus. **`proof_state`** becomes **`missing`** with a fixed reason when ship evidence exists but live proof does not; registry/discovery proof still yields **`close_eligible`**.
> 
> The completion-policy **runtime todo pattern** is tightened to **`mcp-server` / `mcp tool` hyphen variants** and explicitly covers **scheduled wake routes**. Tests cover wake-route blocking and the pipeline read vs close mismatch cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66041cab6d6ba4ca6dcceb1e91d8af62e2bb7c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->