### PR TITLE
[codex] Show proof holds separately in jobs dashboard

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8519,8 +8519,8 @@
     },
     {
       "source": "src/pages/admin/AdminJobs.tsx",
-      "hash": "ea5ff201abd2",
-      "bytes": 60846
+      "hash": "43971f309033",
+      "bytes": 61590
     },
     {
       "source": "src/pages/admin/AdminJobsmith.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -71,7 +71,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/crews/CrewsSettings.tsx | 9a2037783312 | 889 |
 | src/pages/admin/crews/CrewsCatalog.tsx | 089b6c00af2e | 5949 |
 | src/pages/admin/AdminDashboard.tsx | 7ee015247aa8 | 5257 |
-| src/pages/admin/AdminJobs.tsx | ea5ff201abd2 | 60846 |
+| src/pages/admin/AdminJobs.tsx | 43971f309033 | 61590 |
 | src/pages/admin/AdminJobsmith.tsx | 34ba72c04cb2 | 54660 |
 | src/pages/admin/AdminKeychain.tsx | 0c355d737922 | 77124 |
 | src/pages/admin/AdminMemory.tsx | f001b0a54b31 | 9731 |

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -170,6 +170,13 @@ describe("AdminJobs", () => {
     expect(screen.getByTitle("UI or browser proof is still missing.")).toBeInTheDocument();
     expect(screen.getByTestId("job-row-title")).not.toHaveClass("line-through");
 
+    const workedCard = screen.getByText("Being worked").closest("div");
+    const proofHoldCard = screen.getByText("Proof holds").closest("div");
+    expect(workedCard).not.toBeNull();
+    expect(proofHoldCard).not.toBeNull();
+    expect(within(workedCard as HTMLElement).getByText("0")).toBeInTheDocument();
+    expect(within(proofHoldCard as HTMLElement).getByText("1")).toBeInTheDocument();
+
     const activeSection = screen.getByRole("button", { name: /Active/i }).closest("section");
     const completedSection = screen.getByRole("button", { name: /Completed/i }).closest("section");
     expect(activeSection).not.toBeNull();

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -68,7 +68,7 @@ type SortDirection = "asc" | "desc";
 type DisplayStatus = JobTodo["status"] | "needs_proof";
 
 const SECTION_LABELS: Record<JobSectionKey, string> = {
-  active: "Active",
+  active: "Active + proof holds",
   next: "Next up",
   inline: "In line",
   done: "Completed",
@@ -1078,12 +1078,14 @@ function JobSection({
 
 function BoardPulse({
   activeCount,
+  proofHoldCount,
   queueCount,
   alertCount,
   queueHydrationBlocked,
   initialLoading,
 }: {
   activeCount: number;
+  proofHoldCount: number;
   queueCount: number;
   alertCount: number;
   queueHydrationBlocked: boolean;
@@ -1141,7 +1143,7 @@ function BoardPulse({
             <p className={`mt-1 max-w-xl text-sm leading-5 ${toneStyles.muted}`}>
               {initialLoading
                 ? "Reading Boardroom before any proof claim."
-                : `${activeCount} active, ${queueCount} waiting, ${alertCount} alert${alertCount === 1 ? "" : "s"}.`}
+                : `${activeCount} being worked, ${queueCount} waiting, ${proofHoldCount} proof hold${proofHoldCount === 1 ? "" : "s"}, ${alertCount} alert${alertCount === 1 ? "" : "s"}.`}
             </p>
           </div>
         </div>
@@ -1312,7 +1314,8 @@ export default function AdminJobs() {
     }),
     [grouped, manualOrder],
   );
-  const activeCount = grouped.active.length;
+  const activeCount = grouped.active.filter((todo) => displayStatusFor(todo) === "in_progress").length;
+  const proofHoldCount = grouped.active.filter((todo) => displayStatusFor(todo) === "needs_proof").length;
   const queueCount = grouped.next.length + grouped.inline.length;
   const queueHydrationBlocked = activeCount === 0 && queueCount > 0;
   const alertCount = filteredTodos.filter(needsAttention).length + (queueHydrationBlocked ? 1 : 0);
@@ -1437,7 +1440,7 @@ export default function AdminJobs() {
             One work list for jobs being worked, open backlog, in-line work, and completed proof.
           </p>
         </div>
-        <div className="grid grid-cols-3 gap-2 text-center sm:min-w-[360px]">
+        <div className="grid grid-cols-2 gap-2 text-center sm:min-w-[480px] sm:grid-cols-4">
           <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2">
             <p className="text-xs text-white/35">Being worked</p>
             <p className="mt-1 flex min-h-7 items-center justify-center text-lg font-semibold text-[#E2B93B]">
@@ -1451,6 +1454,12 @@ export default function AdminJobs() {
             </p>
           </div>
           <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2">
+            <p className="text-xs text-white/35">Proof holds</p>
+            <p className="mt-1 flex min-h-7 items-center justify-center text-lg font-semibold text-red-200">
+              {initialLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : proofHoldCount}
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2">
             <p className="text-xs text-white/35">Alerts</p>
             <p className="mt-1 flex min-h-7 items-center justify-center text-lg font-semibold text-red-200">
               {initialLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : alertCount}
@@ -1461,6 +1470,7 @@ export default function AdminJobs() {
 
       <BoardPulse
         activeCount={activeCount}
+        proofHoldCount={proofHoldCount}
         queueCount={queueCount}
         alertCount={alertCount}
         queueHydrationBlocked={queueHydrationBlocked}


### PR DESCRIPTION
## What changed

- Changed the `/admin/jobs` summary so `Being worked` counts only true `in_progress` jobs.
- Added a separate `Proof holds` summary count for completed-history rows that still resolve to `needs_proof`.
- Renamed the combined active section to `Active + proof holds` so the section count is not mistaken for live work.

## Why

The dashboard was showing a large `Being worked` number because it mixed true active jobs with old completed rows that still need proof. That made it look like jobs were still actively being worked or that safe closures had not moved anything.

This does not mark any job done and does not lower the backlog by hiding records. It only separates the honest buckets.

## Validation

- `npm exec vitest -- run src/pages/admin/AdminJobs.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only counting and labeling on the admin jobs board; no job status or backend behavior changes.
> 
> **Overview**
> The `/admin/jobs` dashboard **splits live work from proof holds** so summary numbers match what operators expect.
> 
> **Being worked** now counts only jobs with display status `in_progress`, not every row in the active group (which still includes `needs_proof` items). A new **Proof holds** header stat and **BoardPulse** line report how many active-section jobs are `needs_proof`. The active list section is labeled **Active + proof holds** so its length is not read as “currently being worked.”
> 
> Tests assert the false-green proof job shows **0** being worked and **1** proof hold. Brainmap generated docs reflect the `AdminJobs.tsx` hash/size update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eebad4912bad805eb357a209d3ad4af8b5bbf76e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->