### PR TITLE
feat(admin): AppTesting status table + live tool-test loop

### DIFF
--- a/.claude/commands/app-testing-loop.md
+++ b/.claude/commands/app-testing-loop.md
@@ -1,0 +1,68 @@
+---
+description: Test a batch of UnClick apps by physically calling their MCP tools and record pass/fail/attention into the AppTesting table.
+---
+
+# AppTesting loop
+
+One safe, bounded cycle of live MCP tool testing. Runs the catalog a batch at a
+time and keeps `src/data/app-test-results.json` current so the admin AppTesting
+page (`/admin/app-testing`) shows real green/amber/red status per app.
+
+This is a build loop, but a careful one: it READS tools, it does not send, post,
+pay, or generate.
+
+## Cycle
+
+1. Load `src/data/app-catalog.generated.json` (all apps + their tools) and
+   `src/data/app-test-results.json` (current results).
+2. Pick up to **10** apps to test this cycle, in this priority order:
+   - never-tested apps (no entry), then
+   - stale apps (`testedAt` older than 14 days), then
+   - prior `fail` apps worth a cheap re-check.
+   If every app is tested and fresh, **silent-exit**: change nothing, commit
+   nothing, say nothing.
+3. For each selected app, choose ONE safe representative action:
+   - Prefer read-only verbs: `get` / `list` / `search` / `current` / `info` /
+     `quote` / `lookup` / `status` / `recent` / `top` / `random`.
+   - Use minimal, well-known params (a common id, symbol, city, or query).
+   - Find the action and its params with `unclick_search` / `unclick_tool_info`
+     if the catalog entry is not enough, then call it (direct tool or
+     `unclick_call`).
+4. **Never fire paid or side-effecting actions.** If an app only exposes
+   send / post / create / update / delete / generate / call / upload / pay /
+   charge / react / comment / image / video / speech actions (e.g. Twilio send,
+   SendGrid send, OpenAI image, HeyGen, ElevenLabs, Kling, Runway), do NOT call
+   them. Record `attention` with note `paid or side-effecting only; needs manual test`.
+5. Classify the result:
+   - `pass` - valid structured response with the expected fields.
+   - `attention` - works but blocked on a human step: `not_connected` / missing
+     key / needs login / rate-limited (429) / paid-or-side-effecting-skipped /
+     valid-but-empty.
+   - `fail` - error, timeout, 5xx, malformed, or clearly wrong output.
+6. Update `src/data/app-test-results.json`:
+   - set `results[<slug>]` to `{ status, note, testedAt: <now ISO>, toolsTested: [<tool>] }`.
+   - the `note` is ONE line: what was called and what happened.
+   - bump top-level `updatedAt`.
+   - **Never** write keys, tokens, secrets, or raw credentials into a note. Redact.
+7. Commit the data file to the current branch and push (data-only update, ship
+   without ask). Keep ONE rolling draft PR ("AppTesting results run") updated;
+   do not open a new PR every cycle.
+8. Continuity: `save_conversation_turn` with
+   `session_id='unclick-apptesting-loop'` and a compact line of batch counts
+   (tested N: P pass / A attention / F fail). `save_session` at a natural stop.
+
+## Guardrails
+
+- Read-only by default. No spend, no messages, no posts, no data mutation in the
+  apps under test.
+- Gated surfaces (secrets, auth, billing, migrations) are never touched.
+- One safe step per app; cap the batch at 10 so a cycle stays cheap.
+- If the MCP tool surface itself looks down (many calls failing identically),
+  post ONE `BLOCKER` line and stop instead of churning.
+- Stop the loop once a full pass is complete unless re-testing on a schedule is
+  wanted; stale re-checks keep it useful long-term.
+
+## Suggested cadence
+
+`/loop 30m /app-testing-loop` -> ~10 apps per cycle, a first full pass of the
+catalog in roughly half a day, then quiet except for stale re-checks.

--- a/.claude/commands/app-testing-loop.md
+++ b/.claude/commands/app-testing-loop.md
@@ -42,6 +42,7 @@ pay, or generate.
 6. Update `src/data/app-test-results.json`:
    - set `results[<slug>]` to `{ status, note, testedAt: <now ISO>, toolsTested: [<tool>] }`.
    - the `note` is ONE line: what was called and what happened.
+   - **Preserve** any existing `comment` field (admin notes). Never overwrite or delete it.
    - bump top-level `updatedAt`.
    - **Never** write keys, tokens, secrets, or raw credentials into a note. Redact.
 7. Commit the data file to the current branch and push (data-only update, ship

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8534,8 +8534,8 @@
     },
     {
       "source": "src/pages/admin/AdminAppTesting.tsx",
-      "hash": "8470f67fdb86",
-      "bytes": 10027
+      "hash": "903d395d0c2c",
+      "bytes": 10267
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,9 +9,9 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 624,
-    "source_manifest": 197,
-    "pages": 86,
+    "inventory": 625,
+    "source_manifest": 198,
+    "pages": 87,
     "tools": 219,
     "rooms": 23,
     "workers": 8
@@ -21,7 +21,7 @@
       "id": "admin-surfaces",
       "name": "Admin surfaces",
       "meaning": "Private operator views and internal control panels.",
-      "count": 51
+      "count": 52
     },
     {
       "id": "public-surfaces",
@@ -119,6 +119,16 @@
       "meaning": "Internal analytics view for platform signals and usage.",
       "source": "src/pages/admin/AdminAnalytics.tsx",
       "route": "/admin/analytics",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-app-testing-src-pages-admin-adminapptesting-tsx-admin-app-testing",
+      "division": "Admin surfaces",
+      "name": "Admin App Testing",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin App Testing.",
+      "source": "src/pages/admin/AdminAppTesting.tsx",
+      "route": "/admin/app-testing",
       "tags": []
     },
     {
@@ -6364,6 +6374,12 @@
       "src/pages/admin/AdminAnalytics.tsx"
     ],
     [
+      "/admin/app-testing",
+      "Admin App Testing",
+      "Admin surface for Admin App Testing.",
+      "src/pages/admin/AdminAppTesting.tsx"
+    ],
+    [
       "/admin/apps",
       "Admin Tools",
       "Apps, tools, and connector capability surface.",
@@ -8333,13 +8349,13 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "1957fc5513d9",
-      "bytes": 15323
+      "hash": "029cc9d35a24",
+      "bytes": 15491
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
-      "hash": "f1d9032ae6ed",
-      "bytes": 24781
+      "hash": "a3883c627a08",
+      "bytes": 24869
     },
     {
       "source": "src/pages/admin/AdminControlTower.tsx",
@@ -8515,6 +8531,11 @@
       "source": "src/pages/admin/AdminAnalytics.tsx",
       "hash": "8e3ab82ef00f",
       "bytes": 10336
+    },
+    {
+      "source": "src/pages/admin/AdminAppTesting.tsx",
+      "hash": "8470f67fdb86",
+      "bytes": 10027
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,8 +22,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | de9f41b265f3 | 4881 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | 1957fc5513d9 | 15323 |
-| src/pages/admin/AdminShell.tsx | f1d9032ae6ed | 24781 |
+| src/App.tsx | 029cc9d35a24 | 15491 |
+| src/pages/admin/AdminShell.tsx | a3883c627a08 | 24869 |
 | src/pages/admin/AdminControlTower.tsx | 6ca638bd7002 | 17570 |
 | src/lib/controltower.ts | 4f5aef742c4a | 18625 |
 | docs/prd/controltower.md | db23d54c71d8 | 3830 |
@@ -59,6 +59,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminSeatHeartbeat.tsx | cbafa8394842 | 11617 |
 | src/pages/admin/AdminAgents.tsx | 73353b1405ef | 45563 |
 | src/pages/admin/AdminAnalytics.tsx | 8e3ab82ef00f | 10336 |
+| src/pages/admin/AdminAppTesting.tsx | 8470f67fdb86 | 10027 |
 | src/pages/admin/AdminTools.tsx | 5d2838bcd848 | 6470 |
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 426fed992766 | 22902 |
@@ -215,7 +216,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 
 | Division | Meaning | Items |
 | --- | --- | --- |
-| Admin surfaces | Private operator views and internal control panels. | 51 |
+| Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 35 |
 | Tools | MCP and gateway capabilities available to seats. | 219 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
@@ -264,6 +265,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /admin/agents/heartbeat | Admin Seat Heartbeat | Master heartbeat copy policy for scheduled AI seats. | src/pages/admin/AdminSeatHeartbeat.tsx |
 | /admin/agents | Admin Agents | Admin surface for Admin Agents. | src/pages/admin/AdminAgents.tsx |
 | /admin/analytics | Admin Analytics | Internal analytics view for platform signals and usage. | src/pages/admin/AdminAnalytics.tsx |
+| /admin/app-testing | Admin App Testing | Admin surface for Admin App Testing. | src/pages/admin/AdminAppTesting.tsx |
 | /admin/apps | Admin Tools | Apps, tools, and connector capability surface. | src/pages/admin/AdminTools.tsx |
 | /admin/audit-log | Admin Audit Log | Internal audit trail for sensitive admin actions. | src/pages/admin/AdminAuditLog.tsx |
 | /admin/autopilot/expressbuild | Admin Express Build | Admin surface for Admin Express Build. | src/pages/admin/AdminExpressBuild.tsx |
@@ -577,6 +579,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Admin Activity | Admin surface for Admin Activity. | /admin/activity | src/pages/admin/AdminActivity.tsx |
 | Admin surfaces | admin page | Admin Agents | Admin surface for Admin Agents. | /admin/agents | src/pages/admin/AdminAgents.tsx |
 | Admin surfaces | admin page | Admin Analytics | Internal analytics view for platform signals and usage. | /admin/analytics | src/pages/admin/AdminAnalytics.tsx |
+| Admin surfaces | admin page | Admin App Testing | Admin surface for Admin App Testing. | /admin/app-testing | src/pages/admin/AdminAppTesting.tsx |
 | Admin surfaces | admin page | Admin Audit Log | Internal audit trail for sensitive admin actions. | /admin/audit-log | src/pages/admin/AdminAuditLog.tsx |
 | Admin surfaces | admin page | Admin Autopilot | Admin surface for Admin Ecosystem Pages. | /admin/autopilot | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin Benchmarks | Admin surface for Admin Benchmarks. | /admin/benchmarks | src/pages/admin/AdminBenchmarks.tsx |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -59,7 +59,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminSeatHeartbeat.tsx | cbafa8394842 | 11617 |
 | src/pages/admin/AdminAgents.tsx | 73353b1405ef | 45563 |
 | src/pages/admin/AdminAnalytics.tsx | 8e3ab82ef00f | 10336 |
-| src/pages/admin/AdminAppTesting.tsx | 8470f67fdb86 | 10027 |
+| src/pages/admin/AdminAppTesting.tsx | 903d395d0c2c | 10267 |
 | src/pages/admin/AdminTools.tsx | 5d2838bcd848 | 6470 |
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 426fed992766 | 22902 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import AdminControlTower from "./pages/admin/AdminControlTower.tsx";
 import AdminJobsmith from "./pages/admin/AdminJobsmith.tsx";
 import AdminBenchmarks from "./pages/admin/AdminBenchmarks.tsx";
 import AdminTruthRate from "./pages/admin/AdminTruthRate.tsx";
+import AdminAppTesting from "./pages/admin/AdminAppTesting.tsx";
 import AdminXGate from "./pages/admin/AdminXGate.tsx";
 import AdminExpressBuild from "./pages/admin/AdminExpressBuild.tsx";
 import {
@@ -224,6 +225,7 @@ const App = () => (
             <Route path="brainmap"       element={<RequireAdmin><AdminBrainmap /></RequireAdmin>} />
             <Route path="benchmarks"     element={<RequireAdmin><AdminBenchmarks /></RequireAdmin>} />
             <Route path="truth-rate"     element={<RequireAdmin><AdminTruthRate /></RequireAdmin>} />
+            <Route path="app-testing"    element={<RequireAdmin><AdminAppTesting /></RequireAdmin>} />
             <Route path="xgate"          element={<RequireAdmin><AdminXGate /></RequireAdmin>} />
             <Route path="signals"          element={<SignalsCatalog />} />
             <Route path="signals/settings" element={<SignalsSettings />} />

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -1,0 +1,42 @@
+{
+  "updatedAt": "2026-06-07T02:25:40.911Z",
+  "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app's MCP tools. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested.",
+  "results": {
+    "datetime": {
+      "status": "pass",
+      "note": "datetime_current_time returned ISO + local time for Australia/Sydney.",
+      "testedAt": "2026-06-07T02:25:37.687Z",
+      "toolsTested": ["datetime_current_time"]
+    },
+    "random": {
+      "status": "pass",
+      "note": "random_uuid returned a valid v4 UUID.",
+      "testedAt": "2026-06-07T02:25:37.687Z",
+      "toolsTested": ["random_uuid"]
+    },
+    "calculator": {
+      "status": "pass",
+      "note": "calc_bmi(80kg, 180cm) returned 24.69 (Normal weight) with a healthy range.",
+      "testedAt": "2026-06-07T02:25:37.687Z",
+      "toolsTested": ["calc_bmi"]
+    },
+    "unit-converter": {
+      "status": "pass",
+      "note": "convert_temperature 100C returned 212F plus K and R.",
+      "testedAt": "2026-06-07T02:25:37.687Z",
+      "toolsTested": ["convert_temperature"]
+    },
+    "coingecko": {
+      "status": "pass",
+      "note": "crypto_price(bitcoin, usd) returned a live price with unclick_meta source and next_steps.",
+      "testedAt": "2026-06-07T02:25:40.911Z",
+      "toolsTested": ["crypto_price"]
+    },
+    "alphavantage": {
+      "status": "attention",
+      "note": "stock_quote works but Alpha Vantage is not connected (no API key). Connect via Passport, then re-test.",
+      "testedAt": "2026-06-07T02:25:40.911Z",
+      "toolsTested": ["stock_quote"]
+    }
+  }
+}

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -1,40 +1,46 @@
 {
-  "updatedAt": "2026-06-07T02:25:40.911Z",
-  "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app's MCP tools. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested.",
+  "updatedAt": "2026-06-07T02:52:00.000Z",
+  "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app's MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested.",
   "results": {
     "datetime": {
       "status": "pass",
       "note": "datetime_current_time returned ISO + local time for Australia/Sydney.",
+      "comment": "",
       "testedAt": "2026-06-07T02:25:37.687Z",
       "toolsTested": ["datetime_current_time"]
     },
     "random": {
       "status": "pass",
       "note": "random_uuid returned a valid v4 UUID.",
+      "comment": "",
       "testedAt": "2026-06-07T02:25:37.687Z",
       "toolsTested": ["random_uuid"]
     },
     "calculator": {
       "status": "pass",
       "note": "calc_bmi(80kg, 180cm) returned 24.69 (Normal weight) with a healthy range.",
+      "comment": "",
       "testedAt": "2026-06-07T02:25:37.687Z",
       "toolsTested": ["calc_bmi"]
     },
     "unit-converter": {
       "status": "pass",
       "note": "convert_temperature 100C returned 212F plus K and R.",
+      "comment": "",
       "testedAt": "2026-06-07T02:25:37.687Z",
       "toolsTested": ["convert_temperature"]
     },
     "coingecko": {
       "status": "pass",
       "note": "crypto_price(bitcoin, usd) returned a live price with unclick_meta source and next_steps.",
+      "comment": "Keyless public CoinGecko endpoint; safe default.",
       "testedAt": "2026-06-07T02:25:40.911Z",
       "toolsTested": ["crypto_price"]
     },
     "alphavantage": {
       "status": "attention",
-      "note": "stock_quote works but Alpha Vantage is not connected (no API key). Connect via Passport, then re-test.",
+      "note": "stock_quote works but Alpha Vantage is not connected (no API key).",
+      "comment": "Connect Alpha Vantage in Passport, then re-test to turn this green.",
       "testedAt": "2026-06-07T02:25:40.911Z",
       "toolsTested": ["stock_quote"]
     }

--- a/src/lib/appTestResults.ts
+++ b/src/lib/appTestResults.ts
@@ -13,8 +13,10 @@ export type AppTestStatus = "pass" | "fail" | "attention" | "untested";
 
 export interface AppTestResult {
   status: AppTestStatus;
-  /** One-line human note: what was tested and what happened. */
+  /** One-line auto result from the loop: what was tested and what happened. */
   note?: string;
+  /** Free-text admin comment (behind-the-scenes). Preserved across loop runs. */
+  comment?: string;
   /** ISO timestamp of the last test, or null/undefined if never tested. */
   testedAt?: string | null;
   /** Which tool action(s) were exercised. */

--- a/src/lib/appTestResults.ts
+++ b/src/lib/appTestResults.ts
@@ -1,0 +1,68 @@
+// Typed access to the AppTesting results (src/data/app-test-results.json).
+// The AppTesting loop physically calls a representative action on each app's MCP
+// tools and records the outcome here. The admin AppTesting page joins this with
+// the generated Apps catalog (one row per app) so untested apps still show up.
+//
+// This is intentionally a build-time JSON file (same shape as the generated
+// catalog): no migration, no live writes, fully reversible. The loop commits an
+// updated file; the deploy reflects it. Upgrade to a live store later if needed.
+
+import data from "@/data/app-test-results.json";
+
+export type AppTestStatus = "pass" | "fail" | "attention" | "untested";
+
+export interface AppTestResult {
+  status: AppTestStatus;
+  /** One-line human note: what was tested and what happened. */
+  note?: string;
+  /** ISO timestamp of the last test, or null/undefined if never tested. */
+  testedAt?: string | null;
+  /** Which tool action(s) were exercised. */
+  toolsTested?: string[];
+}
+
+interface ResultsFile {
+  updatedAt: string;
+  note?: string;
+  results: Record<string, AppTestResult>;
+}
+
+const file = data as ResultsFile;
+
+export const APP_TEST_RESULTS: Record<string, AppTestResult> = file.results ?? {};
+export const APP_TEST_UPDATED_AT: string = file.updatedAt ?? "";
+
+/** Result for one app slug. Missing slugs are treated as untested. */
+export function getAppTestResult(slug: string): AppTestResult {
+  return APP_TEST_RESULTS[slug] ?? { status: "untested" };
+}
+
+// Presentation metadata per status. Tones reuse the palette already used by the
+// admin Apps status pills (emerald / red / amber / muted).
+export const APP_TEST_STATUS_META: Record<
+  AppTestStatus,
+  { label: string; tone: string; description: string }
+> = {
+  pass: {
+    label: "Working",
+    tone: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+    description: "Tested and returned a valid response.",
+  },
+  attention: {
+    label: "Needs attention",
+    tone: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+    description: "Works, but needs a manual step: an API key, a login, or a human check.",
+  },
+  fail: {
+    label: "Issue",
+    tone: "border-red-400/30 bg-red-400/10 text-red-200",
+    description: "Errored, timed out, or returned an unusable response.",
+  },
+  untested: {
+    label: "Untested",
+    tone: "border-white/10 bg-white/[0.04] text-white/45",
+    description: "Not checked yet. The loop will get to it.",
+  },
+};
+
+export const APP_TEST_STATUS_ORDER: AppTestStatus[] = ["pass", "attention", "fail", "untested"];

--- a/src/pages/admin/AdminAppTesting.test.tsx
+++ b/src/pages/admin/AdminAppTesting.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import AdminAppTesting from "./AdminAppTesting";
+
+function renderPage() {
+  render(
+    React.createElement(MemoryRouter, null, React.createElement(AdminAppTesting)),
+  );
+}
+
+describe("AdminAppTesting", () => {
+  it("renders the catalog with seeded test statuses", () => {
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: "AppTesting" })).toBeInTheDocument();
+    // Seeded "working" app and the amber "needs attention" app both show up.
+    expect(screen.getByText("CoinGecko")).toBeInTheDocument();
+    expect(screen.getByText("Alpha Vantage")).toBeInTheDocument();
+    // Progress line is present and references the full catalog size.
+    expect(screen.getByText(/of \d+ apps/)).toBeInTheDocument();
+    // Legend explains the amber bucket (the "needs npc"/manual-step case).
+    expect(
+      screen.getByText(/Works, but needs a manual step/i),
+    ).toBeInTheDocument();
+  });
+
+  it("filters the table by search query", () => {
+    renderPage();
+
+    const search = screen.getByPlaceholderText(/search apps/i);
+    fireEvent.change(search, { target: { value: "alpha" } });
+
+    expect(screen.getByText("Alpha Vantage")).toBeInTheDocument();
+    expect(screen.queryByText("CoinGecko")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/AdminAppTesting.test.tsx
+++ b/src/pages/admin/AdminAppTesting.test.tsx
@@ -24,6 +24,11 @@ describe("AdminAppTesting", () => {
     expect(
       screen.getByText(/Works, but needs a manual step/i),
     ).toBeInTheDocument();
+    // Comments column header + a seeded admin comment are rendered.
+    expect(screen.getByText("Comments")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Connect Alpha Vantage in Passport/i),
+    ).toBeInTheDocument();
   });
 
   it("filters the table by search query", () => {

--- a/src/pages/admin/AdminAppTesting.tsx
+++ b/src/pages/admin/AdminAppTesting.tsx
@@ -39,12 +39,12 @@ function StatusBadge({ status }: { status: AppTestStatus }) {
 }
 
 function whenLabel(testedAt?: string | null): string {
-  if (!testedAt) return "—";
+  if (!testedAt) return "-";
   // Date portion of the ISO string; locale-free so it stays stable.
   return testedAt.slice(0, 10);
 }
 
-const COLS = "grid-cols-[132px_minmax(120px,1.3fr)_minmax(90px,0.8fr)_52px_minmax(0,2fr)_92px]";
+const COLS = "grid-cols-[112px_minmax(110px,1fr)_minmax(80px,0.7fr)_46px_minmax(0,1.4fr)_minmax(0,1.4fr)_82px]";
 
 export default function AdminAppTesting() {
   const [status, setStatus] = useState<AppTestStatus | "all">("all");
@@ -102,7 +102,8 @@ export default function AdminAppTesting() {
         <p className="mt-1">
           The AppTesting loop works through the catalog a batch at a time, calls a safe action on each app,
           and records the outcome. Paid or side-effecting actions (send, post, generate) are marked for a
-          manual check rather than fired automatically.
+          manual check rather than fired automatically. The Comments column holds admin notes and is
+          preserved across runs.
         </p>
       </div>
 
@@ -140,13 +141,14 @@ export default function AdminAppTesting() {
 
       {/* Table */}
       <div className="overflow-x-auto rounded-xl border border-white/[0.06] bg-[#111111]">
-        <div className="min-w-[760px]">
+        <div className="min-w-[940px]">
           <div className={`grid ${COLS} items-center gap-3 border-b border-white/[0.08] px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-white/35`}>
             <span>Status</span>
             <span>App</span>
             <span>Category</span>
             <span className="text-right">Actions</span>
-            <span>Last result</span>
+            <span>Result</span>
+            <span>Comments</span>
             <span className="text-right">Tested</span>
           </div>
           <div className="divide-y divide-white/[0.04]">
@@ -158,7 +160,8 @@ export default function AdminAppTesting() {
                 </Link>
                 <span className="truncate text-white/45">{app.category}</span>
                 <span className="text-right tabular-nums text-white/40">{app.toolCount}</span>
-                <span className="truncate text-white/50" title={result.note ?? ""}>{result.note ?? "—"}</span>
+                <span className="truncate text-white/50" title={result.note ?? ""}>{result.note ?? "-"}</span>
+                <span className="truncate text-white/70" title={result.comment ?? ""}>{result.comment ?? "-"}</span>
                 <span className="text-right tabular-nums text-white/35">{whenLabel(result.testedAt)}</span>
               </div>
             ))}

--- a/src/pages/admin/AdminAppTesting.tsx
+++ b/src/pages/admin/AdminAppTesting.tsx
@@ -1,0 +1,227 @@
+// AppTesting - admin-only surface that shows, per app, whether its MCP tools
+// have been physically tested and what happened. Green = working, red = issue,
+// amber = works but needs a manual step (key/login), grey = untested.
+//
+// Data comes from the build-time results file (src/data/app-test-results.json),
+// maintained by the AppTesting loop. This page is read-only: it joins the full
+// Apps catalog with the recorded results so every app has a row, then lets you
+// filter by status and search by name. Admin access is enforced at the route.
+
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { FlaskConical, Check, X, AlertTriangle, Circle, Search, KeyRound } from "lucide-react";
+import { APP_CATALOG, APP_COUNT } from "@/lib/appCatalog";
+import {
+  getAppTestResult,
+  APP_TEST_UPDATED_AT,
+  APP_TEST_STATUS_META,
+  APP_TEST_STATUS_ORDER,
+  type AppTestStatus,
+} from "@/lib/appTestResults";
+
+const YELLOW = "#E2B93B";
+
+function StatusIcon({ status }: { status: AppTestStatus }) {
+  if (status === "pass") return <Check className="h-3.5 w-3.5 text-emerald-300" />;
+  if (status === "fail") return <X className="h-3.5 w-3.5 text-red-400" />;
+  if (status === "attention") return <AlertTriangle className="h-3.5 w-3.5 text-amber-300" />;
+  return <Circle className="h-3.5 w-3.5 text-white/30" />;
+}
+
+function StatusBadge({ status }: { status: AppTestStatus }) {
+  const meta = APP_TEST_STATUS_META[status];
+  return (
+    <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium ${meta.tone}`}>
+      <StatusIcon status={status} />
+      {meta.label}
+    </span>
+  );
+}
+
+function whenLabel(testedAt?: string | null): string {
+  if (!testedAt) return "—";
+  // Date portion of the ISO string; locale-free so it stays stable.
+  return testedAt.slice(0, 10);
+}
+
+const COLS = "grid-cols-[132px_minmax(120px,1.3fr)_minmax(90px,0.8fr)_52px_minmax(0,2fr)_92px]";
+
+export default function AdminAppTesting() {
+  const [status, setStatus] = useState<AppTestStatus | "all">("all");
+  const [query, setQuery] = useState("");
+
+  const rows = useMemo(
+    () => APP_CATALOG.map((app) => ({ app, result: getAppTestResult(app.slug) })),
+    [],
+  );
+
+  const counts = useMemo(() => {
+    const c: Record<AppTestStatus, number> = { pass: 0, attention: 0, fail: 0, untested: 0 };
+    for (const { result } of rows) c[result.status] += 1;
+    return c;
+  }, [rows]);
+
+  const tested = counts.pass + counts.attention + counts.fail;
+  const pctTested = APP_COUNT > 0 ? Math.round((tested / APP_COUNT) * 100) : 0;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return rows.filter(({ app, result }) => {
+      if (status !== "all" && result.status !== status) return false;
+      if (!q) return true;
+      return (
+        app.name.toLowerCase().includes(q) ||
+        app.category.toLowerCase().includes(q) ||
+        app.slug.includes(q)
+      );
+    });
+  }, [rows, status, query]);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <FlaskConical className="h-5 w-5" style={{ color: YELLOW }} />
+            <h1 className="text-2xl font-semibold text-white">AppTesting</h1>
+          </div>
+          <p className="mt-1 text-sm text-[#888]">
+            Live test status of every app's MCP tools. Each result comes from physically calling a
+            representative action, not from a guess.
+          </p>
+        </div>
+        {APP_TEST_UPDATED_AT && (
+          <span className="shrink-0 text-xs text-[#666]">Updated {whenLabel(APP_TEST_UPDATED_AT)}</span>
+        )}
+      </div>
+
+      {/* What you are looking at */}
+      <div className="mb-6 rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 text-xs leading-relaxed text-[#999]">
+        <p className="font-medium text-[#ccc]">How this fills in</p>
+        <p className="mt-1">
+          The AppTesting loop works through the catalog a batch at a time, calls a safe action on each app,
+          and records the outcome. Paid or side-effecting actions (send, post, generate) are marked for a
+          manual check rather than fired automatically.
+        </p>
+      </div>
+
+      {/* Progress + status counts */}
+      <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-5">
+        <div className="rounded-xl border border-white/[0.06] bg-[#111111] p-4">
+          <div className="text-xs uppercase tracking-wider text-[#888]">Tested</div>
+          <div className="mt-2 text-3xl font-semibold text-white">{pctTested}%</div>
+          <div className="mt-1 text-xs text-[#666]">{tested} of {APP_COUNT} apps</div>
+        </div>
+        <CountCard label="Working" value={counts.pass} color="#4ade80" onClick={() => setStatus("pass")} active={status === "pass"} />
+        <CountCard label="Needs attention" value={counts.attention} color="#fbbf24" onClick={() => setStatus("attention")} active={status === "attention"} />
+        <CountCard label="Issue" value={counts.fail} color="#f87171" onClick={() => setStatus("fail")} active={status === "fail"} />
+        <CountCard label="Untested" value={counts.untested} color="#888" onClick={() => setStatus("untested")} active={status === "untested"} />
+      </div>
+
+      {/* Controls */}
+      <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative w-full sm:max-w-sm">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-white/30" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search apps by name or category..."
+            className="w-full rounded-lg border border-white/[0.08] bg-white/[0.03] py-2 pl-9 pr-3 text-xs text-white placeholder:text-white/30 focus:border-[#E2B93B]/40 focus:outline-none"
+          />
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <FilterChip label="All" active={status === "all"} onClick={() => setStatus("all")} />
+          {APP_TEST_STATUS_ORDER.map((s) => (
+            <FilterChip key={s} label={APP_TEST_STATUS_META[s].label} active={status === s} onClick={() => setStatus(s)} />
+          ))}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-white/[0.06] bg-[#111111]">
+        <div className="min-w-[760px]">
+          <div className={`grid ${COLS} items-center gap-3 border-b border-white/[0.08] px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-white/35`}>
+            <span>Status</span>
+            <span>App</span>
+            <span>Category</span>
+            <span className="text-right">Actions</span>
+            <span>Last result</span>
+            <span className="text-right">Tested</span>
+          </div>
+          <div className="divide-y divide-white/[0.04]">
+            {filtered.map(({ app, result }) => (
+              <div key={app.slug} className={`grid ${COLS} items-center gap-3 px-3 py-1.5 text-xs`}>
+                <div><StatusBadge status={result.status} /></div>
+                <Link to={`/apps/${app.slug}`} className="truncate font-medium text-white hover:text-[#9be4e6]">
+                  {app.name}
+                </Link>
+                <span className="truncate text-white/45">{app.category}</span>
+                <span className="text-right tabular-nums text-white/40">{app.toolCount}</span>
+                <span className="truncate text-white/50" title={result.note ?? ""}>{result.note ?? "—"}</span>
+                <span className="text-right tabular-nums text-white/35">{whenLabel(result.testedAt)}</span>
+              </div>
+            ))}
+            {filtered.length === 0 && (
+              <div className="px-3 py-8 text-center text-xs text-white/40">No apps match that filter.</div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="mt-4 grid gap-2 sm:grid-cols-2">
+        {APP_TEST_STATUS_ORDER.map((s) => (
+          <div key={s} className="flex items-start gap-2 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
+            <StatusBadge status={s} />
+            <span className="text-[11px] leading-5 text-white/50">{APP_TEST_STATUS_META[s].description}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Footer: where to fix amber */}
+      <div className="mt-4">
+        <Link
+          to="/admin/keychain"
+          className="inline-flex items-center gap-2 rounded-lg border border-[#E2B93B]/25 bg-[#E2B93B]/[0.06] px-3 py-2 text-xs text-[#E2B93B] transition-colors hover:bg-[#E2B93B]/10"
+        >
+          <KeyRound className="h-4 w-4" />
+          Connect keys in Passport to clear "Needs attention"
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function CountCard({ label, value, color, onClick, active }: {
+  label: string; value: number; color: string; onClick: () => void; active: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-xl border bg-[#111111] p-4 text-left transition-colors ${
+        active ? "border-[#E2B93B]/50" : "border-white/[0.06] hover:border-white/15"
+      }`}
+    >
+      <div className="text-xs uppercase tracking-wider text-[#888]">{label}</div>
+      <div className="mt-2 text-3xl font-semibold" style={{ color }}>{value}</div>
+    </button>
+  );
+}
+
+function FilterChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+        active
+          ? "border-[#E2B93B]/40 bg-[#E2B93B]/15 text-[#E2B93B]"
+          : "border-white/10 bg-white/[0.03] text-white/45 hover:border-white/20 hover:text-white/65"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -301,6 +301,7 @@ const ADMIN_SUBMENU = [
   { path: "/admin/brainmap",      label: "Ecosystem Brainmap",    icon: Sparkles    },
   { path: "/admin/benchmarks",    label: "Benchmarks",            icon: Trophy      },
   { path: "/admin/truth-rate",    label: "Truth Rate",            icon: Gauge       },
+  { path: "/admin/app-testing",   label: "AppTesting",            icon: FlaskConical },
 ] as const;
 
 function AdminSubmenu({ onLinkClick }: { onLinkClick?: () => void }) {


### PR DESCRIPTION
## What

A new admin-only **AppTesting** surface (yellow Admin menu, `/admin/app-testing`) that shows, per app, whether its MCP tools have actually been tested by physically calling them:

- 🟢 **Working** - tested, returned a valid response
- 🟡 **Needs attention** - works but needs a manual step (API key / login / human check)
- 🔴 **Issue** - errored, timed out, or returned an unusable response
- ⚪ **Untested** - not checked yet

Plus a reusable **loop** that works through the catalog (218 apps) a batch at a time, calls a safe read action on each, classifies the outcome, and records it.

## Files

- `src/pages/admin/AdminAppTesting.tsx` - read-only table joining the full Apps catalog with recorded results; progress %, status counts (clickable filters), search, legend, Passport shortcut for clearing amber.
- `src/lib/appTestResults.ts` + `src/data/app-test-results.json` - typed access to a build-time results file (same pattern as the generated catalog: no migration, fully reversible, loop-owned). Seeded with **6 real results** from live calls this session (datetime, random, calculator, unit-converter, coingecko = working; alphavantage = needs key).
- `src/pages/admin/AdminShell.tsx`, `src/App.tsx` - nav entry + admin-guarded route.
- `.claude/commands/app-testing-loop.md` - the loop. Reads tools only; never fires paid or side-effecting actions (send/post/generate are marked for manual check, not called).

## Verification

- New colocated test passes: `npx vitest run src/pages/admin/AdminAppTesting.test.tsx` (2/2).
- `npx vite build` passes (2555 modules, exit 0).
- Pre-existing repo `tsc` errors are unrelated (none in the new files).

## Notes / open question

- Storage is a build-time JSON the loop commits; the page reflects it on deploy. Can upgrade to a live Supabase/KV-backed table later for real-time updates (that path is gated: migration).
- Amber is labelled **"Needs attention"** (key/login/manual step). If "needs npc" meant something more specific, it is a one-constant rename in `appTestResults.ts`.

Tier: ship-without-ask (new admin-only read surface + data file + loop doc). No gated surfaces touched.

https://claude.ai/code/session_01RErHPHobahvM5iGEQhDJYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01RErHPHobahvM5iGEQhDJYe)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only admin page and static results file; no auth, billing, or migration changes; loop doc enforces read-only MCP calls.
> 
> **Overview**
> Adds an **admin-only AppTesting** view at `/admin/app-testing` that joins the full apps catalog with **build-time MCP test results** so every integration shows working / needs attention / issue / untested, with progress %, filters, search, and a Passport link for key-related amber states.
> 
> **Data & UI:** `src/lib/appTestResults.ts` types `src/data/app-test-results.json` (loop-maintained, preserves admin `comment` fields). `AdminAppTesting.tsx` is read-only; routing and yellow-admin nav wire it through `App.tsx` and `AdminShell.tsx`. Initial JSON seeds six live call outcomes.
> 
> **Automation:** `.claude/commands/app-testing-loop.md` defines a bounded batch loop (up to 10 apps/cycle, read-only tools only, no paid/side-effecting calls) that updates the JSON and commits data-only changes. Generated brainmap docs pick up the new admin page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2641eddeca977612649c2875eddde1594f883bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->