### PR TITLE
feat(admin): rebuild Skills page in the Apps-page layout

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8358,13 +8358,13 @@
     },
     {
       "source": "src/pages/admin/AdminSkills.tsx",
-      "hash": "4b5e69217a39",
-      "bytes": 14848
+      "hash": "a3cf298f1eda",
+      "bytes": 4203
     },
     {
       "source": "src/lib/skillLibrary.ts",
-      "hash": "7d69323f9491",
-      "bytes": 10487
+      "hash": "0ac8025f46f5",
+      "bytes": 12351
     },
     {
       "source": "src/lib/skillLibrarySeeds.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -27,8 +27,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminControlTower.tsx | 2bc870ebf30f | 21782 |
 | src/lib/controltower.ts | c9d18e61e7d8 | 21703 |
 | docs/prd/controltower.md | 83641285316d | 4571 |
-| src/pages/admin/AdminSkills.tsx | 4b5e69217a39 | 14848 |
-| src/lib/skillLibrary.ts | 7d69323f9491 | 10487 |
+| src/pages/admin/AdminSkills.tsx | a3cf298f1eda | 4203 |
+| src/lib/skillLibrary.ts | 0ac8025f46f5 | 12351 |
 | src/lib/skillLibrarySeeds.ts | 51ca658707f8 | 652 |
 | .github/workflows/ci.yml | ab3e717a4ae9 | 1663 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |

--- a/src/components/skills/SkillIcon.tsx
+++ b/src/components/skills/SkillIcon.tsx
@@ -1,0 +1,54 @@
+// Small, consistent skill icon. Same fixed, rounded, category-tinted chip frame
+// as AppIcon so the two libraries feel like one family and the grid never
+// shifts. Skills have no brand domain to fetch a favicon from, so instead of a
+// letter fallback we show a per-category glyph: it carries more meaning at a
+// glance and keeps every row visually anchored.
+
+import {
+  Bug,
+  ClipboardCheck,
+  GitPullRequest,
+  Globe,
+  Brain,
+  Microscope,
+  Network,
+  SearchCheck,
+  ShieldAlert,
+  ShieldCheck,
+  Sparkles,
+  type LucideIcon,
+} from "lucide-react";
+
+const CATEGORY_STYLE: Record<string, { tint: string; Icon: LucideIcon }> = {
+  "agent-orchestration": { tint: "#61C1C4", Icon: Network },
+  "browser-automation": { tint: "#22d3ee", Icon: Globe },
+  "code-review": { tint: "#818cf8", Icon: SearchCheck },
+  "debugging": { tint: "#fbbf24", Icon: Bug },
+  "github-pr": { tint: "#c084fc", Icon: GitPullRequest },
+  "memory-km": { tint: "#a78bfa", Icon: Brain },
+  "research": { tint: "#38bdf8", Icon: Microscope },
+  "safety": { tint: "#34d399", Icon: ShieldCheck },
+  "security": { tint: "#f87171", Icon: ShieldAlert },
+  "testing-qa": { tint: "#4ade80", Icon: ClipboardCheck },
+};
+
+const FALLBACK = { tint: "#9ca3af", Icon: Sparkles };
+
+export function SkillIcon({ category, size = 22 }: { category: string; size?: number }) {
+  const { tint, Icon } = CATEGORY_STYLE[category] ?? FALLBACK;
+  return (
+    <span
+      aria-hidden
+      className="inline-flex shrink-0 items-center justify-center overflow-hidden rounded-md border"
+      style={{
+        width: size,
+        height: size,
+        color: tint,
+        borderColor: `${tint}33`,
+        background: `${tint}1a`,
+      }}
+    >
+      <Icon style={{ width: size * 0.55, height: size * 0.55 }} strokeWidth={2} />
+    </span>
+  );
+}

--- a/src/components/skills/SkillsTable.test.tsx
+++ b/src/components/skills/SkillsTable.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SkillsTable } from "./SkillsTable";
+import { parseSkillMarkdown, type SkillPackage } from "@/lib/skillLibrary";
+
+const RECOMMENDED = parseSkillMarkdown(`---
+name: Coordinator router
+slug: coordinator-router
+version: 1.0.0
+description: Routes a request to the right worker lane.
+category: agent-orchestration
+tags: [routing]
+safety_level: safe
+source_kind: original
+source_license: UnClick original
+reuse: Original UnClick rail.
+unclick_usefulness: 5
+unclick_native: hardwired
+required_worker_roles: [Coordinator]
+required_mcp_tools: []
+required_apps: []
+---
+
+# Coordinator router
+
+Route the work and refuse to mark done without proof.
+`);
+
+const OPTIONAL = parseSkillMarkdown(`---
+name: Deep research analyst
+slug: deep-research-analyst
+version: 1.0.0
+description: Runs a deeper research pass across sources.
+category: research
+tags: [research]
+safety_level: safe
+source_kind: original
+source_license: UnClick original
+reuse: Original UnClick workflow.
+unclick_usefulness: 4
+unclick_native: skill
+required_worker_roles: [Researcher]
+required_mcp_tools: [web.search]
+required_apps: []
+---
+
+# Deep research analyst
+
+Gather primary sources and compare conflicting claims.
+`);
+
+const SKILLS: SkillPackage[] = [RECOMMENDED, OPTIONAL];
+
+function rowOf(name: string): HTMLElement {
+  return screen.getByText(name).closest('[role="button"]') as HTMLElement;
+}
+
+afterEach(cleanup);
+
+describe("SkillsTable", () => {
+  it("groups skills into Recommended and Optional (no hardwired/hybrid jargon)", () => {
+    render(<SkillsTable skills={SKILLS} />);
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+    expect(screen.getByText("Optional")).toBeInTheDocument();
+    expect(screen.getByText("Coordinator router")).toBeInTheDocument();
+    expect(screen.getByText("Deep research analyst")).toBeInTheDocument();
+    // The old mode taxonomy must not leak into the UI.
+    expect(screen.queryByText("Hardwire")).not.toBeInTheDocument();
+    expect(screen.queryByText("Hybrid")).not.toBeInTheDocument();
+  });
+
+  it("searches across names and bodies", () => {
+    render(<SkillsTable skills={SKILLS} />);
+    fireEvent.change(screen.getByLabelText("Search skills"), { target: { value: "conflicting claims" } });
+    expect(screen.getByText("Deep research analyst")).toBeInTheDocument();
+    expect(screen.queryByText("Coordinator router")).not.toBeInTheDocument();
+  });
+
+  it("filters by category chip", () => {
+    render(<SkillsTable skills={SKILLS} />);
+    fireEvent.click(screen.getByRole("button", { name: "Research" }));
+    expect(screen.getByText("Deep research analyst")).toBeInTheDocument();
+    expect(screen.queryByText("Coordinator router")).not.toBeInTheDocument();
+  });
+
+  it("fires per-skill and bulk toggle callbacks (all on by default)", () => {
+    const onToggle = vi.fn();
+    const onToggleAll = vi.fn();
+    render(
+      <SkillsTable
+        skills={SKILLS}
+        enabled={{ "coordinator-router": false }}
+        onToggle={onToggle}
+        onToggleAll={onToggleAll}
+      />,
+    );
+    // Coordinator off in props -> "Turn ... on"; research on -> "Turn ... off".
+    expect(screen.getByLabelText("Turn Coordinator router on")).toBeInTheDocument();
+    expect(screen.getByLabelText("Turn Deep research analyst off")).toBeInTheDocument();
+
+    fireEvent.click(within(rowOf("Coordinator router")).getByRole("checkbox"));
+    expect(onToggle).toHaveBeenCalledWith("coordinator-router", true);
+
+    fireEvent.click(screen.getByRole("button", { name: /turn all off/i }));
+    expect(onToggleAll).toHaveBeenCalledWith(false);
+  });
+
+  it("expands a row to reveal the SKILL.md and copies it", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<SkillsTable skills={SKILLS} />);
+    fireEvent.click(rowOf("Coordinator router"));
+
+    expect(screen.getByText("SKILL.md")).toBeInTheDocument();
+    expect(screen.getByText(/Route the work and refuse to mark done without proof/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("slug: coordinator-router"));
+  });
+
+  it("reveals provenance and hash only behind Show details", () => {
+    render(<SkillsTable skills={SKILLS} />);
+    fireEvent.click(rowOf("Coordinator router"));
+    expect(screen.queryByText("Provenance")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Show skill details"));
+    expect(screen.getByText("Provenance")).toBeInTheDocument();
+    expect(screen.getByText(/^skill-fnv1a-/)).toBeInTheDocument();
+  });
+});

--- a/src/components/skills/SkillsTable.tsx
+++ b/src/components/skills/SkillsTable.tsx
@@ -1,0 +1,395 @@
+// The Skills library table. Same layout language as the Apps table (AppsTable):
+// one compact, full-width, single-line row per skill, instant search + category
+// chips, a per-row enable checkbox, and "turn all on/off". Two differences that
+// fit skills:
+//   - Rows are GROUPED into "Recommended (leave on)" (the native rails UnClick
+//     leans on every session) and "Optional", instead of the old
+//     hardwired/hybrid/skill mode filter.
+//   - Clicking a row expands it to reveal the full SKILL.md text inline (with a
+//     copy button), plus what it needs to run and, behind "Show details", its
+//     provenance. Column widths are fixed so expanding never shifts the layout.
+//
+// Skills are on by default. The checkbox only turns one on/off; everything else
+// in a row is about reading what the skill does before you decide.
+
+import { useMemo, useState } from "react";
+import { ChevronRight, Copy, FileText, Search, SlidersHorizontal, Star } from "lucide-react";
+import {
+  filterSkills,
+  skillCategoryLabel,
+  type SkillPackage,
+  type SkillSafetyLevel,
+} from "@/lib/skillLibrary";
+import { SkillIcon } from "./SkillIcon";
+
+interface SkillsTableProps {
+  skills: SkillPackage[];
+  /** slug -> enabled. A missing slug is treated as enabled (all on by default). */
+  enabled?: Record<string, boolean>;
+  onToggle?: (slug: string, next: boolean) => void;
+  onToggleAll?: (next: boolean) => void;
+  busy?: boolean;
+}
+
+// Safety shows as a quiet pill. "Safe" is the common case, so it reads as muted
+// text with no chrome; anything that needs a second look gets a tinted pill.
+const SAFETY: Record<SkillSafetyLevel, { label: string; tone: string }> = {
+  safe: { label: "Safe", tone: "text-white/30" },
+  cautious: { label: "Caution", tone: "rounded border border-amber-300/25 bg-amber-300/10 px-1.5 py-0.5 text-amber-100" },
+  restricted: { label: "Restricted", tone: "rounded border border-rose-300/25 bg-rose-300/10 px-1.5 py-0.5 text-rose-100" },
+  blocked: { label: "Blocked", tone: "rounded border border-red-400/25 bg-red-400/10 px-1.5 py-0.5 text-red-100" },
+};
+
+// [check] Skill | Category | What it does | Safety | chevron
+const COLS =
+  "grid-cols-[28px_minmax(150px,1.5fr)_minmax(120px,0.9fr)_minmax(0,2.4fr)_84px_28px]";
+
+export function SkillsTable({ skills, enabled, onToggle, onToggleAll, busy }: SkillsTableProps) {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState<string | null>(null);
+  const [showDetails, setShowDetails] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const categories = useMemo(
+    () => [...new Set(skills.map((s) => s.category))].sort(),
+    [skills],
+  );
+
+  const filtered = useMemo(
+    () => filterSkills(skills, query, category ?? "all"),
+    [skills, query, category],
+  );
+
+  const isOn = (slug: string) => (enabled ? enabled[slug] !== false : true);
+  const onCount = filtered.filter((s) => isOn(s.slug)).length;
+
+  const recommended = filtered.filter((s) => s.recommended);
+  const optional = filtered.filter((s) => !s.recommended);
+
+  function toggleExpand(slug: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }
+
+  return (
+    <div>
+      {/* Controls */}
+      <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative w-full sm:max-w-sm">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-white/30" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Search skills"
+            placeholder="Search skills (try 'ci', 'review', 'memory')"
+            className="w-full rounded-lg border border-white/[0.08] bg-white/[0.03] py-2 pl-9 pr-3 text-xs text-white placeholder:text-white/30 focus:border-[#61C1C4]/40 focus:outline-none"
+          />
+        </div>
+        <div className="flex items-center gap-3 text-[11px] text-white/40">
+          <label className="flex cursor-pointer select-none items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={showDetails}
+              onChange={(e) => setShowDetails(e.target.checked)}
+              className="h-3.5 w-3.5 accent-[#61C1C4]"
+              aria-label="Show skill details"
+            />
+            Show details
+          </label>
+          <span>{onCount} of {filtered.length} on</span>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onToggleAll?.(true)}
+            className="rounded-md border border-emerald-300/25 bg-emerald-300/10 px-2.5 py-1 font-semibold text-emerald-100 transition-colors hover:bg-emerald-300/15 disabled:opacity-50"
+          >
+            Turn all on
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onToggleAll?.(false)}
+            className="rounded-md border border-white/10 bg-white/[0.04] px-2.5 py-1 font-semibold text-white/60 transition-colors hover:bg-white/[0.07] disabled:opacity-50"
+          >
+            Turn all off
+          </button>
+        </div>
+      </div>
+
+      {/* Category chips */}
+      <div className="mb-3 flex flex-wrap gap-1.5">
+        <Chip label="All" active={category === null} onClick={() => setCategory(null)} />
+        {categories.map((c) => (
+          <Chip
+            key={c}
+            label={skillCategoryLabel(c)}
+            active={category === c}
+            onClick={() => setCategory(category === c ? null : c)}
+          />
+        ))}
+      </div>
+
+      {/* Header row */}
+      <div className={`grid ${COLS} items-center gap-3 border-b border-white/[0.08] px-3 py-2`}>
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-white/35">On</span>
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-white/35">Skill</span>
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-white/35">Category</span>
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-white/35">What it does</span>
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-white/35">Safety</span>
+        <span aria-hidden />
+      </div>
+
+      <Group
+        title="Recommended"
+        hint="UnClick leans on these every session. Leave them on."
+        Icon={Star}
+        accent="text-[#61C1C4]"
+        skills={recommended}
+        isOn={isOn}
+        expanded={expanded}
+        showDetails={showDetails}
+        busy={busy}
+        onToggle={onToggle}
+        onToggleExpand={toggleExpand}
+      />
+      <Group
+        title="Optional"
+        hint="On by default. Add what you need, turn off the rest."
+        Icon={SlidersHorizontal}
+        accent="text-white/40"
+        skills={optional}
+        isOn={isOn}
+        expanded={expanded}
+        showDetails={showDetails}
+        busy={busy}
+        onToggle={onToggle}
+        onToggleExpand={toggleExpand}
+      />
+
+      {filtered.length === 0 && (
+        <div className="px-3 py-8 text-center text-xs text-white/40">No skills match that search.</div>
+      )}
+    </div>
+  );
+}
+
+function Group({
+  title,
+  hint,
+  Icon,
+  accent,
+  skills,
+  isOn,
+  expanded,
+  showDetails,
+  busy,
+  onToggle,
+  onToggleExpand,
+}: {
+  title: string;
+  hint: string;
+  Icon: typeof Star;
+  accent: string;
+  skills: SkillPackage[];
+  isOn: (slug: string) => boolean;
+  expanded: Set<string>;
+  showDetails: boolean;
+  busy?: boolean;
+  onToggle?: (slug: string, next: boolean) => void;
+  onToggleExpand: (slug: string) => void;
+}) {
+  if (skills.length === 0) return null;
+  const on = skills.filter((s) => isOn(s.slug)).length;
+  return (
+    <section>
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 px-3 pb-1 pt-4">
+        <Icon className={`h-3.5 w-3.5 ${accent}`} />
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-white/55">{title}</span>
+        <span className="text-[10px] tabular-nums text-white/30">{on} of {skills.length} on</span>
+        <span className="text-[11px] text-white/30">· {hint}</span>
+      </div>
+      <div className="divide-y divide-white/[0.04] border-t border-white/[0.04]">
+        {skills.map((skill) => (
+          <SkillRow
+            key={skill.slug}
+            skill={skill}
+            on={isOn(skill.slug)}
+            open={expanded.has(skill.slug)}
+            showDetails={showDetails}
+            busy={busy}
+            onToggle={onToggle}
+            onToggleExpand={onToggleExpand}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SkillRow({
+  skill,
+  on,
+  open,
+  showDetails,
+  busy,
+  onToggle,
+  onToggleExpand,
+}: {
+  skill: SkillPackage;
+  on: boolean;
+  open: boolean;
+  showDetails: boolean;
+  busy?: boolean;
+  onToggle?: (slug: string, next: boolean) => void;
+  onToggleExpand: (slug: string) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const safety = SAFETY[skill.safetyLevel];
+
+  async function copy() {
+    await navigator.clipboard?.writeText(skill.markdown);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <div>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={() => onToggleExpand(skill.slug)}
+        onKeyDown={(e) => {
+          if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget) {
+            e.preventDefault();
+            onToggleExpand(skill.slug);
+          }
+        }}
+        className={`grid ${COLS} cursor-pointer items-center gap-3 px-3 py-1.5 text-xs transition-colors hover:bg-white/[0.02] focus:bg-white/[0.03] focus:outline-none ${on ? "" : "opacity-45"}`}
+      >
+        <input
+          type="checkbox"
+          checked={on}
+          disabled={busy}
+          onClick={(e) => e.stopPropagation()}
+          onChange={(e) => onToggle?.(skill.slug, e.target.checked)}
+          className="h-3.5 w-3.5 accent-[#61C1C4]"
+          aria-label={`Turn ${skill.name} ${on ? "off" : "on"}`}
+        />
+        <span className="flex min-w-0 items-center gap-2">
+          <SkillIcon category={skill.category} />
+          <span className="truncate font-medium text-white">{skill.name}</span>
+        </span>
+        <span className="truncate text-white/45">{skillCategoryLabel(skill.category)}</span>
+        <span className="truncate text-white/50">{skill.description}</span>
+        <span className={`justify-self-start text-[10px] font-medium ${safety.tone}`}>{safety.label}</span>
+        <ChevronRight
+          className={`h-3.5 w-3.5 justify-self-end transition-transform ${open ? "rotate-90 text-[#61C1C4]" : "text-white/30"}`}
+        />
+      </div>
+
+      {/* Inline detail: the SKILL.md text plus what it needs to run. */}
+      {open && (
+        <div className={`grid ${COLS} gap-3 bg-white/[0.015] px-3 pb-3`}>
+          <div style={{ gridColumn: "2 / -1" }} className="min-w-0 space-y-3 pt-1">
+            <NeedsLine skill={skill} />
+
+            <div className="rounded-md border border-white/[0.06] bg-[#0D0D0D]">
+              <div className="flex items-center justify-between border-b border-white/[0.06] px-3 py-2">
+                <span className="flex items-center gap-1.5 text-[11px] font-semibold text-white/70">
+                  <FileText className="h-3.5 w-3.5 text-white/45" />
+                  SKILL.md
+                </span>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void copy();
+                  }}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-[#61C1C4]/35 bg-[#61C1C4]/10 px-2 py-1 text-[11px] font-semibold text-[#9be4e6] transition-colors hover:bg-[#61C1C4]/15"
+                >
+                  <Copy className="h-3 w-3" />
+                  {copied ? "Copied" : "Copy"}
+                </button>
+              </div>
+              <pre className="max-h-96 overflow-auto whitespace-pre-wrap p-3 text-[11px] leading-5 text-white/70">
+                {skill.markdown}
+              </pre>
+            </div>
+
+            {showDetails && <DetailMeta skill={skill} />}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NeedsLine({ skill }: { skill: SkillPackage }) {
+  const parts: Array<{ label: string; value: string }> = [];
+  if (skill.requiredWorkerRoles.length) parts.push({ label: "Workers", value: skill.requiredWorkerRoles.join(", ") });
+  if (skill.requiredMcpTools.length) parts.push({ label: "Tools", value: skill.requiredMcpTools.join(", ") });
+  if (skill.requiredApps.length) parts.push({ label: "Apps", value: skill.requiredApps.join(", ") });
+
+  if (parts.length === 0) {
+    return <p className="text-[11px] text-white/40">Runs with no extra tools or app access.</p>;
+  }
+  return (
+    <p className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-white/50">
+      {parts.map((p) => (
+        <span key={p.label}>
+          <span className="text-white/30">{p.label}:</span> {p.value}
+        </span>
+      ))}
+    </p>
+  );
+}
+
+function DetailMeta({ skill }: { skill: SkillPackage }) {
+  return (
+    <div className="space-y-3">
+      <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+        <Meta label="Provenance">{skill.sourceKind}. {skill.sourceLicense}.</Meta>
+        <Meta label="Reuse">{skill.reuse}</Meta>
+        <Meta label="Setup">{skill.installState}</Meta>
+        <Meta label="Hash"><span className="font-mono">{skill.contentHash}</span></Meta>
+      </dl>
+      {skill.validationIssues.length > 0 && (
+        <ul className="space-y-1 rounded-md border border-amber-300/20 bg-amber-300/[0.06] p-2.5 text-[11px] text-amber-50/80">
+          {skill.validationIssues.map((issue) => (
+            <li key={issue.code}>{issue.message}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Meta({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-[10px] font-semibold uppercase tracking-wide text-white/30">{label}</dt>
+      <dd className="mt-0.5 text-[11px] leading-5 text-white/55">{children}</dd>
+    </div>
+  );
+}
+
+function Chip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+        active
+          ? "border-[#61C1C4]/40 bg-[#61C1C4]/15 text-[#9be4e6]"
+          : "border-white/10 bg-white/[0.03] text-white/45 hover:border-white/20 hover:text-white/65"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/lib/skillLibrary.test.ts
+++ b/src/lib/skillLibrary.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildSkillLibrarySummary,
   filterSkills,
+  isRecommendedMode,
   parseSkillMarkdown,
+  skillCategoryLabel,
   sortSkillsForLibrary,
 } from "./skillLibrary";
 import { STARTER_SKILLS } from "./skillLibrarySeeds";
@@ -80,5 +82,28 @@ Do risky things.
     const sorted = sortSkillsForLibrary(STARTER_SKILLS);
     expect(sorted[0].unclickUsefulness).toBe(5);
     expect(["hardwired", "hybrid"]).toContain(sorted[0].nativeMode);
+  });
+
+  it("derives the recommended (leave-on) group from the native rails", () => {
+    expect(isRecommendedMode("hardwired")).toBe(true);
+    expect(isRecommendedMode("hybrid")).toBe(false);
+    expect(isRecommendedMode("skill")).toBe(false);
+
+    const summary = buildSkillLibrarySummary(STARTER_SKILLS);
+    expect(summary.recommended).toBe(summary.hardwired);
+    expect(summary.recommended + summary.optional).toBe(summary.total);
+
+    const router = STARTER_SKILLS.find((skill) => skill.slug === "coordinator-router");
+    expect(router?.recommended).toBe(true);
+  });
+
+  it("humanises category slugs and filters by category", () => {
+    expect(skillCategoryLabel("agent-orchestration")).toBe("Agent orchestration");
+    expect(skillCategoryLabel("github-pr")).toBe("GitHub PR");
+    expect(skillCategoryLabel("brand-new-area")).toBe("Brand new area");
+
+    const research = filterSkills(STARTER_SKILLS, "", "research");
+    expect(research.length).toBeGreaterThan(0);
+    expect(research.every((skill) => skill.category === "research")).toBe(true);
   });
 });

--- a/src/lib/skillLibrary.ts
+++ b/src/lib/skillLibrary.ts
@@ -25,6 +25,13 @@ export interface SkillPackage {
   reuse: string;
   unclickUsefulness: number;
   nativeMode: SkillNativeMode;
+  /**
+   * Derived "leave this on" flag. These are the native rails UnClick leans on
+   * every session (routing, memory, safety, heartbeat, proof), so the UI groups
+   * them as recommended rather than exposing the raw hardwired/hybrid/skill
+   * taxonomy. Everything else is optional. All skills are on by default.
+   */
+  recommended: boolean;
   requiredWorkerRoles: string[];
   requiredMcpTools: string[];
   requiredApps: string[];
@@ -38,6 +45,10 @@ export interface SkillPackage {
 
 export interface SkillLibrarySummary {
   total: number;
+  /** Native rails the UI surfaces as "recommended, leave on". */
+  recommended: number;
+  /** Everything else: on by default, safe to turn off. */
+  optional: number;
   hardwired: number;
   hybrid: number;
   skillOnly: number;
@@ -74,6 +85,7 @@ export function parseSkillMarkdown(markdown: string): SkillPackage {
     reuse: readRequiredString(frontmatter.reuse, sourceKind === "original" ? "Original UnClick-native skill" : "Rewritten summary"),
     unclickUsefulness: clampNumber(readNumber(frontmatter.unclick_usefulness, 3), 1, 5),
     nativeMode,
+    recommended: isRecommendedMode(nativeMode),
     requiredWorkerRoles: readStringList(frontmatter.required_worker_roles),
     requiredMcpTools: readStringList(frontmatter.required_mcp_tools),
     requiredApps: readStringList(frontmatter.required_apps),
@@ -134,6 +146,8 @@ export function buildSkillLibrarySummary(skills: SkillPackage[]): SkillLibrarySu
   const categories = [...new Set(skills.map((skill) => skill.category))].sort();
   return {
     total: skills.length,
+    recommended: skills.filter((skill) => skill.recommended).length,
+    optional: skills.filter((skill) => !skill.recommended).length,
     hardwired: skills.filter((skill) => skill.nativeMode === "hardwired").length,
     hybrid: skills.filter((skill) => skill.nativeMode === "hybrid").length,
     skillOnly: skills.filter((skill) => skill.nativeMode === "skill").length,
@@ -147,12 +161,10 @@ export function filterSkills(
   skills: SkillPackage[],
   query: string,
   category = "all",
-  nativeMode: SkillNativeMode | "all" = "all",
 ): SkillPackage[] {
   const needle = query.trim().toLowerCase();
   return skills.filter((skill) => {
     if (category !== "all" && skill.category !== category) return false;
-    if (nativeMode !== "all" && skill.nativeMode !== nativeMode) return false;
     if (!needle) return true;
     const haystack = [
       skill.slug,
@@ -166,6 +178,39 @@ export function filterSkills(
     ].join(" ").toLowerCase();
     return haystack.includes(needle);
   });
+}
+
+// The native rails (routing, memory, safety, heartbeat, proof) are the ones we
+// recommend leaving on. We derive this from the underlying native mode so the
+// friendlier two-way grouping stays in sync with the seed metadata, without
+// surfacing the raw hardwired/hybrid/skill jargon in the UI.
+export function isRecommendedMode(mode: SkillNativeMode): boolean {
+  return mode === "hardwired";
+}
+
+// Human-friendly label for a skill category slug (e.g. "agent-orchestration" ->
+// "Agent orchestration", "github-pr" -> "GitHub PR"). Falls back to a tidy
+// title-case of the slug so new categories read well without a code change.
+const SKILL_CATEGORY_LABELS: Record<string, string> = {
+  "agent-orchestration": "Agent orchestration",
+  "browser-automation": "Browser automation",
+  "code-review": "Code review",
+  "debugging": "Debugging",
+  "github-pr": "GitHub PR",
+  "memory-km": "Memory & KM",
+  "research": "Research",
+  "safety": "Safety",
+  "security": "Security",
+  "testing-qa": "Testing & QA",
+};
+
+export function skillCategoryLabel(category: string): string {
+  const known = SKILL_CATEGORY_LABELS[category];
+  if (known) return known;
+  return category
+    .split("-")
+    .map((word, i) => (i === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word))
+    .join(" ");
 }
 
 export function sortSkillsForLibrary(skills: SkillPackage[]): SkillPackage[] {

--- a/src/lib/skillPrefs.test.ts
+++ b/src/lib/skillPrefs.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  SKILL_PREFS_STORAGE_KEY,
+  loadDisabledSkills,
+  saveDisabledSkills,
+} from "./skillPrefs";
+
+describe("skillPrefs", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to nothing disabled (all skills on)", () => {
+    expect(loadDisabledSkills()).toEqual([]);
+  });
+
+  it("round-trips the disabled set and de-duplicates", () => {
+    saveDisabledSkills(["coordinator-router", "deep-research-analyst", "coordinator-router"]);
+    expect(loadDisabledSkills().sort()).toEqual(["coordinator-router", "deep-research-analyst"]);
+  });
+
+  it("ignores corrupt or non-array payloads", () => {
+    window.localStorage.setItem(SKILL_PREFS_STORAGE_KEY, "{ not json");
+    expect(loadDisabledSkills()).toEqual([]);
+
+    window.localStorage.setItem(SKILL_PREFS_STORAGE_KEY, JSON.stringify({ disabled: ["x"] }));
+    expect(loadDisabledSkills()).toEqual([]);
+  });
+
+  it("drops non-string and empty entries", () => {
+    window.localStorage.setItem(SKILL_PREFS_STORAGE_KEY, JSON.stringify(["ok", 1, "", null, "fine"]));
+    expect(loadDisabledSkills().sort()).toEqual(["fine", "ok"]);
+  });
+});

--- a/src/lib/skillPrefs.ts
+++ b/src/lib/skillPrefs.ts
@@ -1,0 +1,73 @@
+// Per-browser on/off state for the Skills library.
+//
+// Apps persist their disabled set server-side (tenant_app_state, enforced by the
+// MCP server). Skills are still a preview library with no runtime enforcement
+// yet, so we keep the user's on/off choices in localStorage instead of inventing
+// a backend contract that does not exist. Same shape as the Apps surface (we
+// only ever store the DISABLED slugs, so any skill we add later is on by
+// default automatically). Mirrors the fishbowl/prefs.ts idiom.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export const SKILL_PREFS_STORAGE_KEY = "unclick.skills.disabled.v1";
+
+export function loadDisabledSkills(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(SKILL_PREFS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return [...new Set(parsed.filter((s): s is string => typeof s === "string" && s.length > 0))];
+  } catch {
+    return [];
+  }
+}
+
+export function saveDisabledSkills(slugs: string[]): void {
+  try {
+    window.localStorage.setItem(SKILL_PREFS_STORAGE_KEY, JSON.stringify([...new Set(slugs)]));
+  } catch {
+    // localStorage may be unavailable (private mode, quota); ignore.
+  }
+}
+
+/**
+ * React hook that loads, exposes, and persists which skills are turned on. All
+ * skills are on by default; only the disabled slugs are stored. Returns an
+ * `enabled` record (slug -> false for off; missing means on) so it drops
+ * straight into SkillsTable, matching the Apps admin contract.
+ */
+export function useSkillEnablement(allSlugs: string[]) {
+  const [disabled, setDisabled] = useState<Set<string>>(() => new Set(loadDisabledSkills()));
+
+  useEffect(() => {
+    saveDisabledSkills([...disabled]);
+  }, [disabled]);
+
+  const enabled = useMemo(() => {
+    const rec: Record<string, boolean> = {};
+    disabled.forEach((slug) => {
+      rec[slug] = false;
+    });
+    return rec;
+  }, [disabled]);
+
+  const toggle = useCallback((slug: string, on: boolean) => {
+    setDisabled((prev) => {
+      const next = new Set(prev);
+      if (on) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback(
+    (on: boolean) => {
+      setDisabled(on ? new Set() : new Set(allSlugs));
+    },
+    [allSlugs],
+  );
+
+  return { enabled, toggle, toggleAll };
+}

--- a/src/pages/admin/AdminSkills.test.tsx
+++ b/src/pages/admin/AdminSkills.test.tsx
@@ -1,43 +1,69 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminSkills from "./AdminSkills";
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminSkills />
+    </MemoryRouter>,
+  );
+}
+
+function rowOf(name: string): HTMLElement {
+  return screen.getByText(name).closest('[role="button"]') as HTMLElement;
+}
+
 describe("AdminSkills", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
   afterEach(() => {
     cleanup();
+    window.localStorage.clear();
     vi.restoreAllMocks();
   });
 
-  it("renders the starter pack with hardwired, hybrid, and optional skill boundaries", () => {
-    render(<AdminSkills />);
-
-    expect(screen.getByRole("heading", { name: "Skills Library" })).toBeInTheDocument();
-    expect(screen.getByText("UnClick-native starter pack")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Coordinator router/i })).toBeInTheDocument();
-    expect(screen.getAllByText("Hardwire").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Hybrid").length).toBeGreaterThan(0);
-    expect(screen.getByText(/Skill text is never a permission grant/i)).toBeInTheDocument();
+  it("renders the Apps-style header, intro, and the recommended grouping", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Skills" })).toBeInTheDocument();
+    expect(screen.getByText(/playbooks your agents can run/i)).toBeInTheDocument();
+    expect(screen.getByText(/never a permission grant/i)).toBeInTheDocument();
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+    expect(screen.getByText("Optional")).toBeInTheDocument();
+    expect(screen.getByText("Coordinator router")).toBeInTheDocument();
   });
 
-  it("filters skills by search text and category", () => {
-    render(<AdminSkills />);
-
-    fireEvent.change(screen.getByLabelText("Search Skills"), { target: { value: "failed ci" } });
-    expect(screen.getByRole("button", { name: /Fix failing CI/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Coordinator router/i })).not.toBeInTheDocument();
-
-    fireEvent.change(screen.getByLabelText("Search Skills"), { target: { value: "" } });
-    fireEvent.change(screen.getByLabelText("Category"), { target: { value: "research" } });
-    expect(screen.getByRole("button", { name: /Research brief generator/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Deep research analyst/i })).toBeInTheDocument();
+  it("expands a skill row to show its SKILL.md text", () => {
+    renderPage();
+    fireEvent.click(rowOf("Coordinator router"));
+    expect(screen.getByText("SKILL.md")).toBeInTheDocument();
+    expect(screen.getByText(/Declare the source of truth before execution/i)).toBeInTheDocument();
   });
 
-  it("copies the selected SKILL.md body", async () => {
+  it("turns a skill off and persists the choice to localStorage", () => {
+    renderPage();
+    // All on by default.
+    const off = screen.getByLabelText("Turn Coordinator router off");
+    fireEvent.click(off);
+    // Now reads as on-able, and the disabled set is saved.
+    expect(screen.getByLabelText("Turn Coordinator router on")).toBeInTheDocument();
+    expect(window.localStorage.getItem("unclick.skills.disabled.v1")).toContain("coordinator-router");
+  });
+
+  it("turns all skills off from the bulk control", () => {
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /turn all off/i }));
+    expect(screen.getByLabelText("Turn Coordinator router on")).toBeInTheDocument();
+  });
+
+  it("copies the selected SKILL.md body", () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
 
-    render(<AdminSkills />);
-
+    renderPage();
+    fireEvent.click(rowOf("Coordinator router"));
     fireEvent.click(screen.getByRole("button", { name: "Copy" }));
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining("slug: coordinator-router"));
   });

--- a/src/pages/admin/AdminSkills.tsx
+++ b/src/pages/admin/AdminSkills.tsx
@@ -1,349 +1,89 @@
-import { useMemo, useState } from "react";
-import {
-  AlertTriangle,
-  CheckCircle2,
-  Copy,
-  FileText,
-  GitBranch,
-  LockKeyhole,
-  Search,
-  ShieldCheck,
-  Sparkles,
-  Wrench,
-} from "lucide-react";
-import {
-  filterSkills,
-  type SkillNativeMode,
-  type SkillPackage,
-  type SkillSafetyLevel,
-} from "@/lib/skillLibrary";
-import { getSkillBySlug, STARTER_SKILL_SUMMARY, STARTER_SKILLS } from "@/lib/skillLibrarySeeds";
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { AppWindow, KeyRound, PenSquare, ShieldCheck, Sparkles } from "lucide-react";
+import { STARTER_SKILLS, STARTER_SKILL_SUMMARY } from "@/lib/skillLibrarySeeds";
+import { useSkillEnablement } from "@/lib/skillPrefs";
+import { SkillsTable } from "@/components/skills/SkillsTable";
 
-const MODE_FILTERS: Array<{ value: SkillNativeMode | "all"; label: string }> = [
-  { value: "all", label: "All" },
-  { value: "hardwired", label: "Hardwired" },
-  { value: "hybrid", label: "Hybrid" },
-  { value: "skill", label: "Skills" },
-];
-
-const DEFAULT_SELECTED_SKILL = getSkillBySlug("coordinator-router") ?? STARTER_SKILLS[0];
-
-const SAFETY_STYLE: Record<SkillSafetyLevel, string> = {
-  safe: "border-emerald-400/20 bg-emerald-400/10 text-emerald-200",
-  cautious: "border-amber-300/20 bg-amber-300/10 text-amber-100",
-  restricted: "border-rose-300/20 bg-rose-300/10 text-rose-100",
-  blocked: "border-red-400/20 bg-red-400/10 text-red-100",
-};
-
-const MODE_STYLE: Record<SkillNativeMode, string> = {
-  hardwired: "border-[#61C1C4]/25 bg-[#61C1C4]/10 text-[#9be4e6]",
-  hybrid: "border-[#E2B93B]/25 bg-[#E2B93B]/10 text-[#f0d577]",
-  skill: "border-fuchsia-300/20 bg-fuchsia-300/10 text-fuchsia-100",
-};
-
-function modeLabel(mode: SkillNativeMode) {
-  if (mode === "hardwired") return "Hardwire";
-  if (mode === "hybrid") return "Hybrid";
-  return "Skill";
-}
-
-function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+function SkillsIntro() {
   return (
-    <div>
-      <dt className="text-[11px] font-semibold uppercase text-white/35">{label}</dt>
-      <dd className="mt-1 text-sm leading-6 text-white/70">{children}</dd>
+    <div className="mb-6 rounded-2xl border border-[#61C1C4]/20 bg-[#61C1C4]/[0.05] p-4">
+      <div className="flex items-start gap-3">
+        <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-[#61C1C4]" />
+        <div>
+          <p className="text-sm font-semibold text-white">Skills are playbooks your agents follow.</p>
+          <p className="mt-1 text-sm leading-6 text-white/55">
+            The recommended ones power UnClick's core behaviour, so leave them on. Everything else is
+            optional. Click any row to read its full SKILL.md, or untick one to stop your agents using
+            it. A skill is never a permission grant: app, browser, and shell access always stay behind
+            your Passport and policy.
+          </p>
+        </div>
+      </div>
     </div>
-  );
-}
-
-function SkillCard({
-  skill,
-  selected,
-  onSelect,
-}: {
-  skill: SkillPackage;
-  selected: boolean;
-  onSelect: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className={`w-full rounded-lg border p-4 text-left transition-colors ${
-        selected
-          ? "border-[#61C1C4]/55 bg-[#61C1C4]/10"
-          : "border-white/[0.07] bg-white/[0.025] hover:border-white/15 hover:bg-white/[0.045]"
-      }`}
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-white">{skill.name}</p>
-          <p className="mt-1 text-xs text-white/45">{skill.category}</p>
-        </div>
-        <span className={`shrink-0 rounded border px-2 py-1 text-[10px] font-semibold ${MODE_STYLE[skill.nativeMode]}`}>
-          {modeLabel(skill.nativeMode)}
-        </span>
-      </div>
-      <p className="mt-3 line-clamp-2 text-xs leading-5 text-white/55">{skill.description}</p>
-      <div className="mt-4 flex flex-wrap gap-2">
-        <span className={`rounded border px-2 py-1 text-[10px] font-medium ${SAFETY_STYLE[skill.safetyLevel]}`}>
-          {skill.safetyLevel}
-        </span>
-        <span className="rounded border border-white/[0.07] bg-white/[0.035] px-2 py-1 text-[10px] font-medium text-white/45">
-          U{skill.unclickUsefulness}
-        </span>
-        <span className="rounded border border-white/[0.07] bg-white/[0.035] px-2 py-1 text-[10px] font-medium text-white/45">
-          {skill.reviewState}
-        </span>
-      </div>
-    </button>
-  );
-}
-
-function SkillDetail({ skill }: { skill: SkillPackage }) {
-  const [copied, setCopied] = useState(false);
-
-  async function copySkill() {
-    await navigator.clipboard?.writeText(skill.markdown);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
-  }
-
-  return (
-    <section className="min-w-0">
-      <div className="rounded-lg border border-white/[0.07] bg-white/[0.025] p-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <div className="flex flex-wrap items-center gap-2">
-              <span className={`rounded border px-2 py-1 text-[10px] font-semibold ${MODE_STYLE[skill.nativeMode]}`}>
-                {modeLabel(skill.nativeMode)}
-              </span>
-              <span className={`rounded border px-2 py-1 text-[10px] font-semibold ${SAFETY_STYLE[skill.safetyLevel]}`}>
-                {skill.safetyLevel}
-              </span>
-              {skill.reviewState === "verified" && (
-                <span className="inline-flex items-center gap-1 rounded border border-emerald-300/20 bg-emerald-300/10 px-2 py-1 text-[10px] font-semibold text-emerald-100">
-                  <CheckCircle2 className="h-3 w-3" />
-                  Verified
-                </span>
-              )}
-            </div>
-            <h1 className="mt-4 text-2xl font-semibold tracking-tight text-white">{skill.name}</h1>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">{skill.description}</p>
-          </div>
-          <button
-            type="button"
-            onClick={copySkill}
-            className="inline-flex items-center justify-center gap-2 rounded-md border border-[#61C1C4]/35 bg-[#61C1C4]/10 px-3 py-2 text-sm font-semibold text-[#9be4e6] transition-colors hover:bg-[#61C1C4]/15"
-          >
-            <Copy className="h-4 w-4" />
-            {copied ? "Copied" : "Copy"}
-          </button>
-        </div>
-
-        <div className="mt-6 grid gap-4 lg:grid-cols-3">
-          <div className="rounded-md border border-white/[0.06] bg-[#0D0D0D] p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-white">
-              <Wrench className="h-4 w-4 text-[#61C1C4]" />
-              Install State
-            </div>
-            <p className="mt-2 text-xs leading-5 text-white/55">{skill.installState}</p>
-          </div>
-          <div className="rounded-md border border-white/[0.06] bg-[#0D0D0D] p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-white">
-              <ShieldCheck className="h-4 w-4 text-emerald-200" />
-              Proof Boundary
-            </div>
-            <p className="mt-2 text-xs leading-5 text-white/55">
-              Skill text is never a permission grant. Apps, browser, shell, and write scopes stay behind UnClick policy.
-            </p>
-          </div>
-          <div className="rounded-md border border-white/[0.06] bg-[#0D0D0D] p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-white">
-              <GitBranch className="h-4 w-4 text-[#E2B93B]" />
-              Provenance
-            </div>
-            <p className="mt-2 text-xs leading-5 text-white/55">
-              {skill.sourceKind}. {skill.sourceLicense}. {skill.reuse}
-            </p>
-          </div>
-        </div>
-
-        <dl className="mt-6 grid gap-5 md:grid-cols-2">
-          <DetailRow label="Worker Roles">
-            {skill.requiredWorkerRoles.length ? skill.requiredWorkerRoles.join(", ") : "None declared"}
-          </DetailRow>
-          <DetailRow label="Tools">
-            {skill.requiredMcpTools.length ? skill.requiredMcpTools.join(", ") : "No direct tools"}
-          </DetailRow>
-          <DetailRow label="Apps">
-            {skill.requiredApps.length ? skill.requiredApps.join(", ") : "No app dependency"}
-          </DetailRow>
-          <DetailRow label="Hash">
-            <span className="font-mono text-xs">{skill.contentHash}</span>
-          </DetailRow>
-        </dl>
-
-        {skill.validationIssues.length > 0 && (
-          <div className="mt-6 rounded-md border border-amber-300/20 bg-amber-300/10 p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-amber-100">
-              <AlertTriangle className="h-4 w-4" />
-              Review Notes
-            </div>
-            <ul className="mt-2 space-y-1 text-xs text-amber-50/75">
-              {skill.validationIssues.map((issue) => (
-                <li key={issue.code}>{issue.message}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
-
-      <div className="mt-5 rounded-lg border border-white/[0.07] bg-[#0D0D0D]">
-        <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-3 text-sm font-semibold text-white">
-          <FileText className="h-4 w-4 text-white/45" />
-          SKILL.md
-        </div>
-        <pre className="max-h-[34rem] overflow-auto p-4 text-xs leading-5 text-white/70">
-          {skill.markdown}
-        </pre>
-      </div>
-    </section>
   );
 }
 
 export default function AdminSkills() {
-  const [query, setQuery] = useState("");
-  const [category, setCategory] = useState("all");
-  const [mode, setMode] = useState<SkillNativeMode | "all">("all");
-  const [selectedSlug, setSelectedSlug] = useState(DEFAULT_SELECTED_SKILL?.slug ?? "");
-
-  const filtered = useMemo(
-    () => filterSkills(STARTER_SKILLS, query, category, mode),
-    [category, mode, query],
-  );
-  const selected = STARTER_SKILLS.find((skill) => skill.slug === selectedSlug) ?? filtered[0] ?? STARTER_SKILLS[0];
+  const allSlugs = useMemo(() => STARTER_SKILLS.map((skill) => skill.slug), []);
+  const { enabled, toggle, toggleAll } = useSkillEnablement(allSlugs);
 
   return (
-    <div className="space-y-6">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <>
+      <div className="mb-6 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#61C1C4]/10">
+          <Sparkles className="h-5 w-5 text-[#61C1C4]" />
+        </div>
         <div>
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#61C1C4]/10">
-              <Sparkles className="h-5 w-5 text-[#61C1C4]" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-semibold tracking-tight text-white">Skills Library</h1>
-              <p className="text-sm text-white/50">UnClick-native starter pack</p>
-            </div>
+          <h1 className="text-2xl font-semibold tracking-tight text-white">Skills</h1>
+          <p className="text-sm text-white/50">
+            {STARTER_SKILL_SUMMARY.total} playbooks your agents can run. All on by default. Turn any off
+            and your agents leave it alone.
+          </p>
+        </div>
+      </div>
+
+      <SkillsIntro />
+
+      <SkillsTable skills={STARTER_SKILLS} enabled={enabled} onToggle={toggle} onToggleAll={toggleAll} />
+
+      {/* Why the Recommended group exists, in plain terms. */}
+      <div className="mt-8 rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-[#E2B93B]" />
+          <div>
+            <p className="text-sm font-semibold text-white">Why some skills are recommended</p>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-white/55">
+              Worker routing, memory distilling, safety gates, heartbeat liveness, and proof rules are
+              recommended on because UnClick relies on them every session. You can still turn them off,
+              but expect your agents to lose those behaviours. The skill file is the inspectable
+              playbook; the authority stays in UnClick's own code and policy.
+            </p>
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
-          <div className="rounded-md border border-white/[0.07] bg-white/[0.025] px-3 py-2">
-            <p className="text-[10px] uppercase text-white/35">Skills</p>
-            <p className="mt-1 text-lg font-semibold text-white">{STARTER_SKILL_SUMMARY.total}</p>
-          </div>
-          <div className="rounded-md border border-[#61C1C4]/20 bg-[#61C1C4]/10 px-3 py-2">
-            <p className="text-[10px] uppercase text-[#9be4e6]/70">Hardwire</p>
-            <p className="mt-1 text-lg font-semibold text-[#9be4e6]">{STARTER_SKILL_SUMMARY.hardwired}</p>
-          </div>
-          <div className="rounded-md border border-[#E2B93B]/20 bg-[#E2B93B]/10 px-3 py-2">
-            <p className="text-[10px] uppercase text-[#f0d577]/70">Hybrid</p>
-            <p className="mt-1 text-lg font-semibold text-[#f0d577]">{STARTER_SKILL_SUMMARY.hybrid}</p>
-          </div>
-          <div className="rounded-md border border-fuchsia-300/20 bg-fuchsia-300/10 px-3 py-2">
-            <p className="text-[10px] uppercase text-fuchsia-100/70">Skill</p>
-            <p className="mt-1 text-lg font-semibold text-fuchsia-100">{STARTER_SKILL_SUMMARY.skillOnly}</p>
-          </div>
-          <div className="rounded-md border border-rose-300/20 bg-rose-300/10 px-3 py-2">
-            <p className="text-[10px] uppercase text-rose-100/70">Guarded</p>
-            <p className="mt-1 text-lg font-semibold text-rose-100">{STARTER_SKILL_SUMMARY.cautiousOrRestricted}</p>
-          </div>
-        </div>
-      </header>
+      </div>
 
-      <section className="grid gap-6 xl:grid-cols-[25rem_minmax(0,1fr)]">
-        <div className="space-y-4">
-          <div className="rounded-lg border border-white/[0.07] bg-white/[0.025] p-4">
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/35" />
-              <input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                aria-label="Search Skills"
-                placeholder="Search skills"
-                className="w-full rounded-md border border-white/[0.08] bg-[#111] px-9 py-2 text-sm text-white outline-none focus:border-[#61C1C4]/50"
-              />
-            </div>
+      {/* Where related surfaces live, mirroring the Apps page footer. */}
+      <div className="mt-6 grid gap-3 sm:grid-cols-3">
+        <FooterLink to="/admin/apps" icon={<AppWindow className="h-4 w-4 text-[#61C1C4]" />} title="Apps" desc="Every action your AI can reach. Turn apps on or off." />
+        <FooterLink to="/admin/keychain" icon={<KeyRound className="h-4 w-4 text-[#E2B93B]" />} title="Passport" desc="Add API keys and logins for apps that need them." />
+        <FooterLink to="/admin/copypass" icon={<PenSquare className="h-4 w-4 text-fuchsia-300" />} title="CopyPass" desc="Quality checks for writing and copy." />
+      </div>
+    </>
+  );
+}
 
-            <div className="mt-4 flex flex-wrap gap-2">
-              {MODE_FILTERS.map((filter) => (
-                <button
-                  key={filter.value}
-                  type="button"
-                  onClick={() => setMode(filter.value)}
-                  className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition-colors ${
-                    mode === filter.value
-                      ? "border-[#61C1C4]/50 bg-[#61C1C4]/10 text-[#9be4e6]"
-                      : "border-white/[0.07] bg-white/[0.025] text-white/50 hover:bg-white/[0.045]"
-                  }`}
-                >
-                  {filter.label}
-                </button>
-              ))}
-            </div>
-
-            <label className="mt-4 block text-xs font-semibold text-white/45" htmlFor="skills-category">
-              Category
-            </label>
-            <select
-              id="skills-category"
-              value={category}
-              onChange={(event) => setCategory(event.target.value)}
-              className="mt-2 w-full rounded-md border border-white/[0.08] bg-[#111] px-3 py-2 text-sm text-white outline-none focus:border-[#61C1C4]/50"
-            >
-              <option value="all">All categories</option>
-              {STARTER_SKILL_SUMMARY.categories.map((item) => (
-                <option key={item} value={item}>{item}</option>
-              ))}
-            </select>
-          </div>
-
-          <div className="space-y-3">
-            {filtered.map((skill) => (
-              <SkillCard
-                key={skill.slug}
-                skill={skill}
-                selected={skill.slug === selected.slug}
-                onSelect={() => setSelectedSlug(skill.slug)}
-              />
-            ))}
-            {filtered.length === 0 && (
-              <div className="rounded-lg border border-white/[0.07] bg-white/[0.025] p-6 text-sm text-white/50">
-                No matching skills.
-              </div>
-            )}
-          </div>
-        </div>
-
-        {selected ? (
-          <SkillDetail skill={selected} />
-        ) : (
-          <div className="rounded-lg border border-white/[0.07] bg-white/[0.025] p-6 text-sm text-white/50">
-            Select a skill.
-          </div>
-        )}
-      </section>
-
-      <section className="rounded-lg border border-white/[0.07] bg-white/[0.025] p-5">
-        <div className="flex items-center gap-2 text-sm font-semibold text-white">
-          <LockKeyhole className="h-4 w-4 text-[#E2B93B]" />
-          Native Boundary
-        </div>
-        <p className="mt-2 max-w-4xl text-sm leading-6 text-white/55">
-          Worker routing, proof rules, heartbeat liveness, safety gates, and memory distillation are marked hardwired when they belong in UnClick itself. The skill file is the inspectable playbook; the authority stays in native code and policy.
-        </p>
-      </section>
-    </div>
+function FooterLink({ to, icon, title, desc }: { to: string; icon: React.ReactNode; title: string; desc: string }) {
+  return (
+    <Link
+      to={to}
+      className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 transition-colors hover:border-white/15 hover:bg-white/[0.04]"
+    >
+      <div className="flex items-center gap-2">
+        {icon}
+        <h3 className="text-sm font-semibold text-white">{title}</h3>
+      </div>
+      <p className="mt-1.5 text-xs leading-5 text-white/45">{desc}</p>
+    </Link>
   );
 }


### PR DESCRIPTION
## What

A UI/UX pass over `/admin/skills`, rebuilt to match the `/admin/apps` layout.

## Why

The Skills page used a two-pane card+detail layout with a jargon-y `hardwired / hybrid / skill` taxonomy. The Apps page's compact, scannable, expandable table is the better pattern, and the mode taxonomy isn't useful to a user deciding what to leave on.

## Changes

- **New `SkillsTable`** mirrors `AppsTable`: compact single-line rows, instant search, category chips, a per-row enable checkbox, "turn all on / off", and click-row-to-expand. Fixed grid columns so expanding never shifts the layout.
- **Dropped the `hardwired/hybrid/skill` taxonomy from the UI.** Skills are **on by default** and grouped into **Recommended (leave on)** (the native rails UnClick leans on every session) and **Optional**. Driven by a new derived `recommended` flag so the seed metadata stays the source of truth.
- **New `SkillIcon`** reuses `AppIcon`'s tinted-chip frame with a per-category glyph (skills have no brand favicon to fetch).
- **Expanding a row reveals the full `SKILL.md` inline** (with copy), what the skill needs to run, and provenance/hash behind a "Show details" toggle.
- **On/off persists per-browser via `localStorage`** (`skillPrefs`). Skills have no runtime-enforcement backend yet (their install state literally says "attach later when runtime policy exists"), so this records a real choice without inventing a server contract. Same all-on-by-default shape as Apps, so swapping to a server-backed store later is a drop-in.
- Friendlier category labels, safety pills, reworded explainers, and footer cross-links to Apps / Passport / CopyPass.

## Tests

- `skillPrefs.test.ts` (persistence + corrupt-payload handling)
- `SkillsTable.test.tsx` (grouping, search, category filter, toggle callbacks, expand→SKILL.md, copy, Show details)
- Rewritten `AdminSkills.test.tsx` (page render, expand, off-toggle persists, bulk off, copy)
- Extra `skillLibrary.test.ts` coverage for the recommended grouping and category labels

All 22 skill tests pass; lint clean; `tsc` clean for the changed files.

https://claude.ai/code/session_01YauQqGdty7R1TwAGDZBvoZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YauQqGdty7R1TwAGDZBvoZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin-only UI and client-side prefs; skill toggles are not enforced at runtime yet, so no auth or policy surface changes.
> 
> **Overview**
> Rebuilds **`/admin/skills`** to follow the same compact, expandable table pattern as Apps, replacing the old two-pane card + detail layout.
> 
> **New `SkillsTable` + `SkillIcon`** provide search, category chips, per-row enable checkboxes, bulk on/off, and row expand for inline **`SKILL.md`** (copy), runtime needs, and optional provenance/hash. The UI drops **hardwired / hybrid / skill** filters in favor of **Recommended** vs **Optional**, driven by a derived **`recommended`** flag on `SkillPackage` (hardwired native mode) plus **`skillCategoryLabel`** and updated **`filterSkills`** (category-only, no native-mode filter).
> 
> **`skillPrefs`** persists disabled skill slugs in **`localStorage`** via **`useSkillEnablement`**, all-on-by-default, mirroring the Apps admin enablement shape without a server API yet. **`AdminSkills`** is slimmed to intro copy, the table, explainers, and footer links to Apps / Passport / CopyPass.
> 
> Tests cover **`skillPrefs`**, **`SkillsTable`**, rewritten **`AdminSkills`**, and extra **`skillLibrary`** cases; brainmap doc hashes updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a12350c9b5ff644e305fd0e805e07acebecf6998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->