### PR TITLE
feat(memory): embed-backfill cron to restore + maintain semantic recall

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5608,6 +5608,104 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         });
       }
 
+      // ── Embed backfill (cron) ─────────────────────────────────────────
+      // Fills missing OpenAI embeddings so semantic recall stays complete.
+      // Self-heals any gap (e.g. after the embeddings flag was ever toggled
+      // off, which silently left newer facts unembedded). Paid path, so it is
+      // gated by MEMORY_OPENAI_EMBEDDINGS_ENABLED + CRON_SECRET and capped per
+      // run for cost. Skips low-value/operational text and archived rows.
+      case "embed_backfill": {
+        const cronSecret = process.env.CRON_SECRET;
+        if (!cronSecret) {
+          return res.status(503).json({ error: "CRON_SECRET not configured on the server" });
+        }
+        if (bearerFrom(req) !== cronSecret) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const flagRaw = (process.env.MEMORY_OPENAI_EMBEDDINGS_ENABLED ?? "").trim().toLowerCase();
+        if (!(flagRaw === "1" || flagRaw === "true")) {
+          return res.status(200).json({ skipped: "MEMORY_OPENAI_EMBEDDINGS_ENABLED is off" });
+        }
+        const openaiKey = process.env.OPENAI_API_KEY;
+        if (!openaiKey) {
+          return res.status(503).json({ error: "OPENAI_API_KEY not configured" });
+        }
+
+        const EMBED_MODEL = "text-embedding-3-small";
+        const MAX_PER_RUN = 250; // cost + timeout cap per run
+        const OPENAI_BATCH = 100; // inputs per OpenAI call
+
+        const skipEmbed = (text: string): boolean => {
+          const v = (text ?? "").trim();
+          if (v.length < 24) return true;
+          const lower = v.toLowerCase();
+          if (lower.startsWith("heartbeat_last_state:")) return true;
+          if (lower.includes("<heartbeat") || lower.includes("</heartbeat>")) return true;
+          return false;
+        };
+
+        const { data: candidates, error: fetchErr } = await supabase
+          .from("mc_extracted_facts")
+          .select("id, fact")
+          .is("embedding", null)
+          .or("status.is.null,status.eq.active")
+          .not("fact", "ilike", "heartbeat_last_state:%")
+          .order("created_at", { ascending: false })
+          .limit(MAX_PER_RUN * 2);
+        if (fetchErr) throw fetchErr;
+
+        const rows = (candidates ?? [])
+          .filter((r) => typeof r.fact === "string" && !skipEmbed(r.fact))
+          .slice(0, MAX_PER_RUN);
+
+        let embedded = 0;
+        const errors: string[] = [];
+        for (let i = 0; i < rows.length; i += OPENAI_BATCH) {
+          const chunk = rows.slice(i, i + OPENAI_BATCH);
+          try {
+            const resp = await fetch("https://api.openai.com/v1/embeddings", {
+              method: "POST",
+              headers: { Authorization: `Bearer ${openaiKey}`, "Content-Type": "application/json" },
+              body: JSON.stringify({
+                model: EMBED_MODEL,
+                input: chunk.map((r) => String(r.fact).slice(0, 32000)),
+              }),
+            });
+            if (!resp.ok) {
+              errors.push(`openai ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+              break; // stop on provider error (auth/quota); retry next run
+            }
+            const json = (await resp.json()) as { data: Array<{ embedding: number[]; index: number }> };
+            const vectors = json.data.slice().sort((a, b) => a.index - b.index);
+            for (let j = 0; j < chunk.length; j += 1) {
+              const vec = vectors[j]?.embedding;
+              if (!vec) continue;
+              const { error: upErr } = await supabase
+                .from("mc_extracted_facts")
+                .update({
+                  embedding: JSON.stringify(vec),
+                  embedding_model: EMBED_MODEL,
+                  embedding_created_at: new Date().toISOString(),
+                })
+                .eq("id", chunk[j].id);
+              if (upErr) errors.push(`update ${chunk[j].id}: ${upErr.message}`);
+              else embedded += 1;
+            }
+          } catch (err) {
+            errors.push(err instanceof Error ? err.message : String(err));
+            break;
+          }
+        }
+
+        return res.status(200).json({
+          ran_at: new Date().toISOString(),
+          candidates: rows.length,
+          embedded,
+          errors: errors.slice(0, 5),
+        });
+      }
+
       // ── Build Desk admin actions ─────────────────────────────────────
       case "admin_build_tasks": {
         const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);

--- a/vercel.json
+++ b/vercel.json
@@ -50,6 +50,10 @@
       "schedule": "0 4 * * *"
     },
     {
+      "path": "/api/memory-admin?action=embed_backfill",
+      "schedule": "*/30 * * * *"
+    },
+    {
       "path": "/api/signals-dispatch",
       "schedule": "*/1 * * * *"
     },


### PR DESCRIPTION
## Why

Semantic recall (the memory moat) had **regressed**: `MEMORY_OPENAI_EMBEDDINGS_ENABLED` was off, so the search couldn't embed the query → vector search was skipped (`cosine_score = 0` on every result) and every fact created after ~May 10 went unembedded (2,661 null vectors). Re-enabling the flag restores the query side (verified live: searches now return non-zero cosine + `vector_rank`). This PR fixes the **historical gap** and stops it ever silently recurring.

## What

New cron action `embed_backfill` in `api/memory-admin.ts`:
- **Gated** by `CRON_SECRET` (auth) + `MEMORY_OPENAI_EMBEDDINGS_ENABLED` (paid-path opt-in). No-ops if the flag is off.
- Embeds **active, embeddable, currently-null** facts in capped batches: **250/run**, OpenAI batch of 100, `text-embedding-3-small`.
- **Skips** short text (<24 chars), `heartbeat_last_state:` / heartbeat operational text, and archived rows (they correctly don't get vectors).
- **Idempotent** (only `embedding IS NULL` rows); once caught up it returns 0 candidates and does no OpenAI call.
- Scheduled **every 30 min** in `vercel.json`.

## Effect

- Primary tenant has **~401** unembedded active facts → caught up within ~2 runs (~1 hour), then idle.
- Any future flag toggle / new facts self-heal automatically — no more silent regression.
- Cost is negligible (batched embeddings; ~$0.001 for the full catch-up).

## Notes
- The flag re-enable + this cron together are a deliberate opt-in to the paid OpenAI embedding path your free-first guardrail defaults off. Cost is cents/mo.
- Follow-up: `mc_session_summaries` embeddings use the same pattern and can be added next for fully complete semantic recall.

https://claude.ai/code/session_01SsEGUCd36nJmTjB5ukCeAU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsEGUCd36nJmTjB5ukCeAU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paid OpenAI calls and bulk updates to memory facts on a recurring cron; mitigated by secret auth, feature flag, and per-run caps.
> 
> **Overview**
> Adds a **scheduled backfill** so extracted facts missing vectors get embedded again, keeping semantic memory recall from silently degrading when embeddings were off or new rows were never embedded.
> 
> A new **`embed_backfill`** cron action on `/api/memory-admin` runs like other cron jobs: **`CRON_SECRET`** bearer auth, and it **no-ops** unless **`MEMORY_OPENAI_EMBEDDINGS_ENABLED`** and **`OPENAI_API_KEY`** are set. Each run loads up to **250** active `mc_extracted_facts` rows with **`embedding` null**, filters out short text, heartbeat/operational strings, and archived rows, then calls OpenAI **`text-embedding-3-small`** in batches of **100** and writes **`embedding`**, model, and timestamp back to Supabase. Provider or update errors are collected; a failed OpenAI response stops the run for retry on the next schedule.
> 
> **`vercel.json`** schedules this endpoint **every 30 minutes**, alongside existing crons like `nightly_decay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0907656670895e0e968566460fb325410cc74267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->