### PR TITLE
fix(docs): align AGENTS.md connector workflow with CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,12 +95,16 @@ Current summary:
 
 Additional memory operations (manage_decay, store_code, log_conversation, supersede_fact, upsert_library_doc, etc.) are callable via `unclick_call` with `endpoint_id: "memory.<op>"`.
 
-## Adding a new tool
+## Adding a new connector (an "App")
 
-1. Create `packages/mcp-server/src/<slug>-tool.ts` with the connector logic
-2. Wire it in `packages/mcp-server/src/tool-wiring.ts` (add name, description, category, and endpoint mapping)
-3. Add a tile in `src/pages/Tools.tsx`
-4. If it should appear in `ListTools`, add it intentionally to the first-party tool surface in `packages/mcp-server/src/server.ts`
+Read `docs/adding-a-connector.md` first for the full playbook.
+
+1. Create `packages/mcp-server/src/<slug>-tool.ts` - the connector file (connectors live here, NOT in `api/`)
+2. Create `packages/mcp-server/src/<slug>-tool.test.ts` - colocated test (required for L2)
+3. Wire it in `packages/mcp-server/src/tool-wiring.ts` (import + `ADDITIONAL_TOOLS` defs + `ADDITIONAL_HANDLERS` dispatch)
+4. Add a `CONNECTOR_SETUP` row in `packages/mcp-server/src/connector-setup.ts`
+5. Add a category bucket in `scripts/generate-app-catalog.mjs`
+6. Regenerate IN ORDER: `generate-tool-index.mjs` -> `connector-depth-ladder.mjs` -> `generate-app-catalog.mjs` -> `UnClick-brainmap.mjs`, then run the `--check` gates. The Apps pages render from the generated catalog (no manual tile edit).
 
 ## Style rules
 


### PR DESCRIPTION
## Summary

- **AGENTS.md** had a stale "Adding a new tool" section that pointed to `api/*-tool.ts` and a manual tile edit in `src/pages/Tools.tsx`
- **CLAUDE.md** (the canonical source) says connectors live in `packages/mcp-server/src/` (NOT in `api/`) and Apps pages render from the generated catalog (no manual tile edit)
- Updated AGENTS.md to match the canonical 6-step connector workflow from CLAUDE.md, including colocated tests, connector-setup.ts, and the regenerate-in-order rule

## Test plan

- [ ] Confirm AGENTS.md connector steps now match CLAUDE.md section "Adding a new connector (an App)"
- [ ] Verify no other doc files reference the old `api/*-tool.ts` pattern for connectors

https://claude.ai/code/session_01Tu1fxAhafB89G3xef7zq2i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tu1fxAhafB89G3xef7zq2i)_