### PR TITLE
[codex] Fix jobs completed total paging

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -10551,23 +10551,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         if (action === "fishbowl_list_todos") {
           const limit = Math.min(Math.max(Number(body.limit ?? 50) || 50, 1), 200);
+          const requestedOffset = Number(body.offset ?? 0);
+          const offset = Number.isFinite(requestedOffset) ? Math.max(Math.floor(requestedOffset), 0) : 0;
           const includeDescription = body.include_description === true || body.full_content === true;
           const includeArchivedDone =
             body.include_archived_done === true ||
             body.include_archived === true ||
             body.show_archived === true;
           const doneArchiveCutoff = new Date(Date.now() - DONE_TODO_ARCHIVE_WINDOW_MS).toISOString();
+          let statusFilter: "open" | "in_progress" | "done" | "dropped" | null = null;
           let q = supabase
             .from("mc_fishbowl_todos")
             .select("*")
             .eq("api_key_hash", apiKeyHash)
             .order("created_at", { ascending: false })
-            .limit(limit);
+            .range(offset, offset + limit - 1);
           if (body.status != null) {
             const s = String(body.status);
             if (!["open", "in_progress", "done", "dropped"].includes(s)) {
               return res.status(400).json({ error: "status filter must be open|in_progress|done|dropped" });
             }
+            statusFilter = s as "open" | "in_progress" | "done" | "dropped";
             q = q.eq("status", s);
           }
           if (body.assigned_to_agent_id != null) {
@@ -10595,6 +10599,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             countTodosByStatus("done"),
             countTodosByStatus("dropped"),
           ]);
+          const matchingTotal =
+            statusFilter === "open" ? openBacklogCount :
+            statusFilter === "in_progress" ? activeCount :
+            statusFilter === "done" ? doneCount :
+            statusFilter === "dropped" ? droppedCount :
+            null;
 
           // Decorate with comment_count and stage evidence for the jobs board.
           const todos = data ?? [];
@@ -10678,6 +10688,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             response_bounds: {
               compact: !includeDescription,
               descriptions_included: includeDescription,
+              offset,
+              limit,
+              requested_status: statusFilter,
+              matching_total: matchingTotal,
+              has_more: matchingTotal == null ? decorated.length === limit : offset + decorated.length < matchingTotal,
               archived_done_hidden: !includeArchivedDone && body.status == null,
               done_archive_cutoff: !includeArchivedDone && body.status == null ? doneArchiveCutoff : null,
               todos_returned: decorated.length,

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8854,8 +8854,8 @@
     },
     {
       "source": "src/pages/admin/AdminJobs.tsx",
-      "hash": "43971f309033",
-      "bytes": 61590
+      "hash": "fb05696540e8",
+      "bytes": 63548
     },
     {
       "source": "src/pages/admin/AdminJobsmith.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -91,7 +91,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/crews/CrewsSettings.tsx | 9a2037783312 | 889 |
 | src/pages/admin/crews/CrewsCatalog.tsx | 089b6c00af2e | 5949 |
 | src/pages/admin/AdminDashboard.tsx | 7ee015247aa8 | 5257 |
-| src/pages/admin/AdminJobs.tsx | 43971f309033 | 61590 |
+| src/pages/admin/AdminJobs.tsx | fb05696540e8 | 63548 |
 | src/pages/admin/AdminJobsmith.tsx | 34ba72c04cb2 | 54660 |
 | src/pages/admin/AdminKeychain.tsx | 0c355d737922 | 77124 |
 | src/pages/admin/AdminMemory.tsx | f001b0a54b31 | 9731 |

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -257,4 +257,71 @@ describe("AdminJobs", () => {
     expect(await screen.findByText("Alpha ready job")).toBeInTheDocument();
     expect(screen.getByText("Jobs are visible, but posting comments is waiting for the admin profile.")).toBeInTheDocument();
   });
+
+  it("shows the true completed total and fetches the next 100 completed jobs", async () => {
+    const makeCompleted = (index: number, effective_status = "done") => ({
+      id: `completed-${index}`,
+      title: index === 1 ? "Completed first job" : index === 101 ? "Completed second page job" : `Completed job ${index}`,
+      description: "Already shipped.",
+      status: "done",
+      effective_status,
+      priority: "normal",
+      created_by_agent_id: "tester",
+      assigned_to_agent_id: "chatgpt-codex-desktop",
+      created_at: `2026-05-${String(Math.max(1, 28 - Math.floor(index / 10))).padStart(2, "0")}T12:00:00.000Z`,
+      completed_at: "2026-05-14T12:30:00.000Z",
+      updated_at: "2026-05-14T12:55:00.000Z",
+      comment_count: 1,
+      pipeline_stage_count: 5,
+      pipeline_progress: 100,
+      pipeline_evidence: ["ship"],
+      proof_state: effective_status === "done" ? "close_eligible" : "missing",
+    });
+    const firstPage = [
+      ...Array.from({ length: 31 }, (_, index) => makeCompleted(index + 1)),
+      ...Array.from({ length: 69 }, (_, index) => makeCompleted(index + 32, "needs_proof")),
+    ];
+    const secondPage = [
+      makeCompleted(101),
+      ...Array.from({ length: 99 }, (_, index) => makeCompleted(index + 102, "needs_proof")),
+    ];
+    const completedOffsets: number[] = [];
+
+    vi.mocked(fetch).mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("fishbowl_admin_claim")) {
+        return Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ error: "claim unavailable" }),
+        } as Response);
+      }
+      if (url.includes("fishbowl_list_todos")) {
+        const request = JSON.parse(String(init?.body ?? "{}")) as { status?: string; offset?: number };
+        if (request.status === "done") {
+          const offset = request.offset ?? 0;
+          completedOffsets.push(offset);
+          return jsonResponse({
+            todos: offset === 0 ? firstPage : secondPage,
+            queue_metrics: { done: 383 },
+            response_bounds: { has_more: true, matching_total: 383 },
+          });
+        }
+        return jsonResponse({ todos: [], queue_metrics: { done: 383 } });
+      }
+      return jsonResponse({});
+    });
+
+    render(React.createElement(AdminJobs));
+
+    expect(await screen.findByText("Completed first job")).toBeInTheDocument();
+    const completedSection = screen.getByRole("button", { name: /^Completed$/i }).closest("section");
+    expect(completedSection).not.toBeNull();
+    expect(within(completedSection as HTMLElement).getByText("31/383")).toBeInTheDocument();
+
+    fireEvent.click(within(completedSection as HTMLElement).getByRole("button", { name: "Show 100 more" }));
+
+    expect(await screen.findByText("Completed second page job")).toBeInTheDocument();
+    expect(within(completedSection as HTMLElement).getByText("32/383")).toBeInTheDocument();
+    expect(completedOffsets).toEqual([0, 100]);
+  });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -62,6 +62,23 @@ interface JobTodo {
   release_block_reason?: string | null;
 }
 
+interface JobQueueMetrics {
+  active: number;
+  open_backlog: number;
+  done: number;
+  dropped: number;
+}
+
+interface JobListResponse {
+  todos?: JobTodo[];
+  queue_metrics?: Partial<JobQueueMetrics>;
+  response_bounds?: {
+    has_more?: boolean;
+    matching_total?: number | null;
+  };
+  error?: string;
+}
+
 type JobSectionKey = "active" | "next" | "inline" | "done";
 type SortKey = "queue" | "title" | "status" | "priority" | "worker" | "live" | "progress" | "notes" | "updated";
 type SortDirection = "asc" | "desc";
@@ -926,8 +943,10 @@ function JobSection({
   onMoveJob,
   sectionExpanded,
   visibleCount,
+  totalCount,
   onToggleSection,
   onShowMore,
+  showMoreLabel,
   hasMoreRemote,
   showMoreLoading,
   loading,
@@ -943,8 +962,10 @@ function JobSection({
   onMoveJob: (sectionKey: JobSectionKey, sourceId: string, targetId: string) => void;
   sectionExpanded?: boolean;
   visibleCount?: number;
+  totalCount?: number;
   onToggleSection?: () => void;
   onShowMore?: () => void;
+  showMoreLabel?: string;
   hasMoreRemote?: boolean;
   showMoreLoading?: boolean;
   loading?: boolean;
@@ -965,6 +986,7 @@ function JobSection({
   );
   const displayCount = Math.min(visibleCount ?? SECTION_PAGE_SIZE, cappedJobs.length);
   const visibleJobs = sortedJobs.slice(0, displayCount);
+  const sectionTotal = Math.max(totalCount ?? cappedJobs.length, cappedJobs.length);
   const canShowMore = displayCount < cappedJobs.length || hasMoreRemote === true;
   const showLoading = loading === true && jobs.length === 0;
   const sectionAccent: Record<JobSectionKey, string> = {
@@ -998,8 +1020,8 @@ function JobSection({
           {showLoading
             ? "Loading"
             : open
-              ? `${visibleJobs.length}/${jobs.length}`
-              : jobs.length}
+              ? `${visibleJobs.length}/${sectionTotal}`
+              : sectionTotal}
         </span>
       </div>
       {!open ? null : showLoading ? (
@@ -1018,7 +1040,7 @@ function JobSection({
               className="mt-3 inline-flex items-center gap-2 text-xs text-[#61C1C4]/80 hover:text-[#61C1C4] disabled:cursor-wait disabled:text-white/30"
             >
               {showMoreLoading && <Loader2 className="h-3 w-3 animate-spin" />}
-              Load more
+              {showMoreLoading ? "Loading more" : showMoreLabel ?? "Load more"}
             </button>
           )}
         </div>
@@ -1066,7 +1088,7 @@ function JobSection({
                 className="inline-flex items-center gap-2 text-xs text-[#61C1C4]/80 hover:text-[#61C1C4] disabled:cursor-wait disabled:text-white/30"
               >
                 {showMoreLoading && <Loader2 className="h-3 w-3 animate-spin" />}
-                Show more
+                {showMoreLoading ? "Loading more" : showMoreLabel ?? "Show more"}
               </button>
             </li>
           )}
@@ -1182,10 +1204,9 @@ export default function AdminJobs() {
   const [completedHistory, setCompletedHistory] = useState<JobTodo[]>([]);
   const [completedHistoryLoaded, setCompletedHistoryLoaded] = useState(false);
   const [completedHistoryLoading, setCompletedHistoryLoading] = useState(false);
+  const [completedHistoryTotal, setCompletedHistoryTotal] = useState<number | null>(null);
   // True once the server has confirmed nothing more sits behind the current
-  // batch (the API maxes out at 200 rows per call). The next iteration of
-  // this UI will add a `before_created_at` cursor for true "till exhausted"
-  // pagination; until then the client tracks "have we fetched the max?".
+  // completed-history batch.
   const [completedHistoryExhausted, setCompletedHistoryExhausted] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
@@ -1255,13 +1276,11 @@ export default function AdminJobs() {
             limit: 200,
           }),
         });
-        const body = (await res.json().catch(() => ({}))) as {
-          todos?: JobTodo[];
-          error?: string;
-        };
+        const body = (await res.json().catch(() => ({}))) as JobListResponse;
         if (!res.ok) throw new Error(body.error ?? "Failed to load jobs");
         if (!cancelled) {
           setTodos((body.todos ?? []).filter((todo) => todo.status !== "dropped"));
+          if (typeof body.queue_metrics?.done === "number") setCompletedHistoryTotal(body.queue_metrics.done);
           setError(null);
         }
       } catch (e) {
@@ -1321,6 +1340,14 @@ export default function AdminJobs() {
   const alertCount = filteredTodos.filter(needsAttention).length + (queueHydrationBlocked ? 1 : 0);
   const initialLoading = !firstLoadDone && loading;
   const visibleJobCount = todos.length + completedHistory.filter((historyJob) => !todos.some((todo) => todo.id === historyJob.id)).length;
+  const completedHistoryHasMore =
+    completedHistoryTotal == null
+      ? !completedHistoryExhausted
+      : completedHistory.length < completedHistoryTotal;
+  const completedSectionTotal =
+    searchQuery.trim().length > 0
+      ? orderedGrouped.done.length
+      : Math.max(orderedGrouped.done.length, completedHistoryTotal ?? orderedGrouped.done.length);
 
   const toggleExpanded = (id: string) => {
     setExpanded((prev) => {
@@ -1370,16 +1397,23 @@ export default function AdminJobs() {
     }));
   };
 
-  // Fetch up to the server's per-call cap (200) of completed jobs in one
-  // shot, sorted newest-first by created_at. The list_todos endpoint does
-  // not yet expose a cursor, so we fetch the whole window once and paginate
-  // the visible count on the client via SectionPreferences. When server
-  // cursor support lands, this becomes a paged loop.
+  useEffect(() => {
+    setCompletedHistory([]);
+    setCompletedHistoryLoaded(false);
+    setCompletedHistoryLoading(false);
+    setCompletedHistoryTotal(null);
+    setCompletedHistoryExhausted(false);
+  }, [jobsReadAgentId]);
+
+  // Completed history is fetched in server-backed pages so the visible
+  // counter can show the real total instead of treating the first slice as
+  // the whole archive.
   const fetchCompletedBatch = useCallback(async () => {
     if (!jobsReadAgentId) return;
     setCompletedHistoryLoading(true);
     try {
-      const requestLimit = 200;
+      const requestLimit = COMPLETED_PAGE_SIZE;
+      const requestOffset = completedHistory.length;
       const res = await fetch("/api/memory-admin?action=fishbowl_list_todos", {
         method: "POST",
         headers: { ...authHeader, "Content-Type": "application/json" },
@@ -1388,16 +1422,28 @@ export default function AdminJobs() {
           include_description: true,
           status: "done",
           limit: requestLimit,
+          offset: requestOffset,
         }),
       });
-      const body = (await res.json().catch(() => ({}))) as {
-        todos?: JobTodo[];
-        error?: string;
-      };
+      const body = (await res.json().catch(() => ({}))) as JobListResponse;
       if (!res.ok) throw new Error(body.error ?? "Failed to load completed jobs");
       const fetched = (body.todos ?? []).filter((todo) => todo.status === "done");
-      setCompletedHistory(fetched);
-      if (fetched.length < requestLimit) setCompletedHistoryExhausted(true);
+      setCompletedHistory((current) => {
+        const byId = new Map(current.map((todo) => [todo.id, todo]));
+        for (const todo of fetched) byId.set(todo.id, todo);
+        return Array.from(byId.values()).sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+      });
+      const totalDone =
+        typeof body.queue_metrics?.done === "number"
+          ? body.queue_metrics.done
+          : typeof body.response_bounds?.matching_total === "number"
+            ? body.response_bounds.matching_total
+            : completedHistoryTotal;
+      if (totalDone != null) setCompletedHistoryTotal(totalDone);
+      const loadedThrough = requestOffset + fetched.length;
+      if (body.response_bounds?.has_more === false || fetched.length < requestLimit || (totalDone != null && loadedThrough >= totalDone)) {
+        setCompletedHistoryExhausted(true);
+      }
       setCompletedHistoryLoaded(true);
       setError(null);
     } catch (e) {
@@ -1405,7 +1451,7 @@ export default function AdminJobs() {
     } finally {
       setCompletedHistoryLoading(false);
     }
-  }, [authHeader, jobsReadAgentId]);
+  }, [authHeader, completedHistory.length, completedHistoryTotal, jobsReadAgentId]);
 
   // Auto-load the first batch as soon as the agent id is known. Replaces the
   // old "Show completed history" first-click gate; users now see the last
@@ -1424,7 +1470,9 @@ export default function AdminJobs() {
       showMore("done");
       return;
     }
-    // Already loaded: reveal the next 100 rows from the local cache.
+    if (sectionPrefs.visible.done >= orderedGrouped.done.length && completedHistoryHasMore) {
+      await fetchCompletedBatch();
+    }
     showMore("done");
   };
 
@@ -1599,9 +1647,11 @@ export default function AdminJobs() {
           onMoveJob={moveJob}
           sectionExpanded={sectionPrefs.expanded.done}
           visibleCount={sectionPrefs.visible.done}
+          totalCount={completedSectionTotal}
           onToggleSection={() => toggleSection("done")}
           onShowMore={loadCompletedHistory}
-          hasMoreRemote={!completedHistoryLoaded && !completedHistoryExhausted}
+          showMoreLabel="Show 100 more"
+          hasMoreRemote={completedHistoryHasMore}
           showMoreLoading={completedHistoryLoading}
           loading={initialLoading}
           searchQuery={searchQuery}


### PR DESCRIPTION
## What changed

- Added `offset` paging support to the Boardroom jobs list endpoint.
- Changed `/admin/jobs` completed history so it keeps the backend `done` total from `queue_metrics.done` instead of treating the loaded slice as the whole count.
- Made the completed section button explicitly load `Show 100 more`.
- Added a regression test for the confusing `31/31` case: 31 clean completed rows visible, 383 total done rows known by the backend, next click requests `offset: 100`.

## Why

The completed section could show `31/31` even though the backend reported hundreds of raw completed jobs. It was counting only the locally loaded/displayed slice. Show more could also hit a false wall because completed history was fetched once instead of paged.

## Validation

- `npm exec vitest -- run src/pages/admin/AdminJobs.test.tsx`
- `npx tsc --noEmit --pretty false`
- `npm run brainmap:check`
- PR checks green: Website, MCP package, TestPass, Vercel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a shared list API contract and admin jobs data-loading behavior; limited to read/list paths with regression tests, not auth or writes.
> 
> **Overview**
> Fixes the admin **Completed** jobs section showing misleading totals (e.g. `31/31`) when hundreds of done jobs exist on the server.
> 
> **API (`fishbowl_list_todos`)** now accepts **`offset`** and pages with Supabase **`.range`** instead of a single **`limit`** slice. Responses include **`response_bounds`**: `offset`, `limit`, `matching_total` (when a status filter is set), and **`has_more`**.
> 
> **`/admin/jobs`** keeps the backend **`queue_metrics.done`** total, loads completed history in **100-row** server pages (merging by id), and drives **Show 100 more** from **`has_more`** / total vs loaded length. Section headers use **`visible/total`** (e.g. `31/383`) via a new **`totalCount`** prop. A regression test covers paging with **`offset: 0`** then **`offset: 100`**.
> 
> Generated brainmap metadata for **`AdminJobs.tsx`** was refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff39bd8af7c0e306e794b191bc2b1ffe5c9f8a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->