### PR TITLE
Keep Jobsmith app-only in navigation

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8514,8 +8514,8 @@
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
-      "hash": "a3883c627a08",
-      "bytes": 24869
+      "hash": "ad66a896a463",
+      "bytes": 24739
     },
     {
       "source": "src/pages/admin/AdminControlTower.tsx",
@@ -8774,8 +8774,8 @@
     },
     {
       "source": "src/pages/admin/AdminAppTesting.tsx",
-      "hash": "903d395d0c2c",
-      "bytes": 10267
+      "hash": "fb03a45d06bf",
+      "bytes": 10144
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -23,7 +23,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
 | src/App.tsx | 029cc9d35a24 | 15491 |
-| src/pages/admin/AdminShell.tsx | a3883c627a08 | 24869 |
+| src/pages/admin/AdminShell.tsx | ad66a896a463 | 24739 |
 | src/pages/admin/AdminControlTower.tsx | 2bc870ebf30f | 21782 |
 | src/lib/controltower.ts | c9d18e61e7d8 | 21703 |
 | docs/prd/controltower.md | 83641285316d | 4571 |
@@ -75,7 +75,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminSeatHeartbeat.tsx | cbafa8394842 | 11617 |
 | src/pages/admin/AdminAgents.tsx | 73353b1405ef | 45563 |
 | src/pages/admin/AdminAnalytics.tsx | 8e3ab82ef00f | 10336 |
-| src/pages/admin/AdminAppTesting.tsx | 903d395d0c2c | 10267 |
+| src/pages/admin/AdminAppTesting.tsx | fb03a45d06bf | 10144 |
 | src/pages/admin/AdminTools.tsx | 5d2838bcd848 | 6470 |
 | src/pages/admin/AdminAuditLog.tsx | 028edd82cb11 | 874 |
 | src/pages/admin/AdminExpressBuild.tsx | 426fed992766 | 22902 |

--- a/src/components/apps/AppsTable.test.tsx
+++ b/src/components/apps/AppsTable.test.tsx
@@ -6,6 +6,7 @@ import type { AppEntry } from "@/lib/appCatalog";
 
 const APPS: AppEntry[] = [
   { slug: "github", name: "GitHub", category: "Developer & infra", blurb: "Manage repos.", domain: null, toolCount: 1, tools: [{ name: "github_action", description: "Repos and issues." }], level: 2, hardened: true },
+  { slug: "jobsmith", name: "Jobsmith", category: "Productivity", blurb: "Create source-backed job applications.", domain: null, toolCount: 2, tools: [{ name: "jobsmith_check", description: "Check application quality." }], level: 5, hardened: true },
   { slug: "openmeteo", name: "Open-Meteo", category: "Weather & science", blurb: "Forecasts.", domain: null, toolCount: 3, tools: [{ name: "weather_current", description: "Current weather." }], level: 5, hardened: true },
 ];
 
@@ -29,6 +30,19 @@ describe("AppsTable", () => {
     renderTable(<AppsTable apps={APPS} mode="public" />);
     fireEvent.change(screen.getByPlaceholderText(/search apps/i), { target: { value: "weather" } });
     expect(screen.getByText("Open-Meteo")).toBeInTheDocument();
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+  });
+
+  it("search matches app names with spaces and broken fragments", () => {
+    renderTable(<AppsTable apps={APPS} mode="public" />);
+    const search = screen.getByPlaceholderText(/search apps/i);
+
+    fireEvent.change(search, { target: { value: "job smith" } });
+    expect(screen.getByText("Jobsmith")).toBeInTheDocument();
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "jo smi" } });
+    expect(screen.getByText("Jobsmith")).toBeInTheDocument();
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 

--- a/src/components/apps/appDetailExtras.tsx
+++ b/src/components/apps/appDetailExtras.tsx
@@ -28,12 +28,6 @@ function JobsmithPanel(): ReactNode {
         >
           <ExternalLink className="h-3.5 w-3.5" /> Open JobSmith
         </Link>
-        <Link
-          to="/admin/jobsmith"
-          className="inline-flex items-center gap-1.5 rounded-md border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/60 transition-colors hover:bg-white/[0.07]"
-        >
-          Manage in admin
-        </Link>
       </div>
     </div>
   );

--- a/src/components/apps/useAppFilter.ts
+++ b/src/components/apps/useAppFilter.ts
@@ -1,11 +1,12 @@
 // Shared filtering/sorting smarts for the Apps library, used by BOTH the public
 // app-store page and the admin Apps page so they behave identically. Mirrors the
-// lightweight useMemo + includes() approach used elsewhere (e.g. the Jobsmith
-// page): instant, no extra deps. Search also matches an app's underlying tool
-// names and descriptions, so "weather" finds Open-Meteo even by capability.
+// lightweight useMemo approach used elsewhere (e.g. the Jobsmith page):
+// instant, no extra deps. Search also matches an app's underlying tool names
+// and descriptions, so "weather" finds Open-Meteo even by capability.
 
 import { useMemo, useState } from "react";
 import type { AppEntry } from "@/lib/appCatalog";
+import { appMatchesSearch } from "@/lib/appSearch";
 
 export type AppSortKey = "name" | "category" | "toolCount" | "level";
 export type SortDir = "asc" | "desc";
@@ -17,23 +18,11 @@ export function useAppFilter(apps: AppEntry[]) {
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
     let rows = apps;
 
     if (category) rows = rows.filter((a) => a.category === category);
 
-    if (q) {
-      rows = rows.filter(
-        (a) =>
-          a.name.toLowerCase().includes(q) ||
-          a.blurb.toLowerCase().includes(q) ||
-          a.category.toLowerCase().includes(q) ||
-          a.slug.includes(q) ||
-          a.tools.some(
-            (t) => t.name.includes(q) || t.description.toLowerCase().includes(q),
-          ),
-      );
-    }
+    rows = rows.filter((app) => appMatchesSearch(app, query));
 
     const dir = sortDir === "asc" ? 1 : -1;
     return [...rows].sort((a, b) => {

--- a/src/lib/appSearch.ts
+++ b/src/lib/appSearch.ts
@@ -1,0 +1,40 @@
+import type { AppEntry } from "@/lib/appCatalog";
+
+function normalizeSearchText(value: string): { spaced: string; compact: string } {
+  const spaced = value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+
+  return { spaced, compact: spaced.replace(/\s+/g, "") };
+}
+
+function appSearchText(app: AppEntry): string {
+  return [
+    app.name,
+    app.slug,
+    app.category,
+    app.blurb,
+    app.domain ?? "",
+    ...app.tools.flatMap((tool) => [tool.name, tool.label ?? "", tool.description]),
+  ].join(" ");
+}
+
+export function appMatchesSearch(app: AppEntry, query: string): boolean {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery.spaced) return true;
+
+  const haystack = normalizeSearchText(appSearchText(app));
+  if (
+    haystack.spaced.includes(normalizedQuery.spaced) ||
+    haystack.compact.includes(normalizedQuery.compact)
+  ) {
+    return true;
+  }
+
+  const parts = normalizedQuery.spaced.split(" ").filter(Boolean);
+  return parts.every((part) => haystack.spaced.includes(part) || haystack.compact.includes(part));
+}

--- a/src/pages/AppDetail.test.tsx
+++ b/src/pages/AppDetail.test.tsx
@@ -29,4 +29,10 @@ describe("AppDetail", () => {
     expect(screen.getByRole("heading", { name: /App not found/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Browse all apps/i })).toHaveAttribute("href", "/apps");
   });
+
+  it("keeps JobSmith as an app workspace without an admin-management link", () => {
+    renderAt("/apps/jobsmith");
+    expect(screen.getByRole("link", { name: /Open JobSmith/i })).toHaveAttribute("href", "/jobsmith");
+    expect(screen.queryByRole("link", { name: /Manage in admin/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminAppTesting.test.tsx
+++ b/src/pages/admin/AdminAppTesting.test.tsx
@@ -40,4 +40,17 @@ describe("AdminAppTesting", () => {
     expect(screen.getByText("Alpha Vantage")).toBeInTheDocument();
     expect(screen.queryByText("CoinGecko")).not.toBeInTheDocument();
   });
+
+  it("matches app names with spaces and broken fragments", () => {
+    renderPage();
+
+    const search = screen.getByPlaceholderText(/search apps/i);
+    fireEvent.change(search, { target: { value: "job smith" } });
+    expect(screen.getByRole("link", { name: /jobsmith/i })).toBeInTheDocument();
+    expect(screen.queryByText("CoinGecko")).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "jo smi" } });
+    expect(screen.getByRole("link", { name: /jobsmith/i })).toBeInTheDocument();
+    expect(screen.queryByText("CoinGecko")).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminAppTesting.tsx
+++ b/src/pages/admin/AdminAppTesting.tsx
@@ -18,6 +18,7 @@ import {
   APP_TEST_STATUS_ORDER,
   type AppTestStatus,
 } from "@/lib/appTestResults";
+import { appMatchesSearch } from "@/lib/appSearch";
 
 const YELLOW = "#E2B93B";
 
@@ -65,15 +66,9 @@ export default function AdminAppTesting() {
   const pctTested = APP_COUNT > 0 ? Math.round((tested / APP_COUNT) * 100) : 0;
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
     return rows.filter(({ app, result }) => {
       if (status !== "all" && result.status !== status) return false;
-      if (!q) return true;
-      return (
-        app.name.toLowerCase().includes(q) ||
-        app.category.toLowerCase().includes(q) ||
-        app.slug.includes(q)
-      );
+      return appMatchesSearch(app, query);
     });
   }, [rows, status, query]);
 

--- a/src/pages/admin/AdminShell.test.tsx
+++ b/src/pages/admin/AdminShell.test.tsx
@@ -74,4 +74,16 @@ describe("AdminShell navigation", () => {
     expect(analyticsLinks[0]).toHaveAttribute("href", "/admin/analytics");
     expect(screen.getAllByRole("button", { name: "Admin" }).length).toBeGreaterThan(0);
   });
+
+  it("keeps Jobsmith out of the admin menu", async () => {
+    const { default: AdminShell } = await import("./AdminShell");
+
+    render(
+      <MemoryRouter initialEntries={["/admin/apps"]}>
+        <AdminShell />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: "Jobsmith" })).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -39,7 +39,6 @@ import {
   Sparkles,
   BookOpen,
   FlaskConical,
-  PenSquare,
   ShieldAlert,
   Users as UsersIcon,
   Gauge,
@@ -494,7 +493,6 @@ function SidebarNav({
       <OrchestratorNavItem onClick={onLinkClick} />
       <SurfaceLink path="/admin/apps"     label="Apps"                     icon={AppWindow} onClick={onLinkClick} />
       <SurfaceLink path="/admin/skills"   label="Skills"                   icon={Sparkles} onClick={onLinkClick} />
-      <SurfaceLink path="/admin/jobsmith" label="Jobsmith"                 icon={PenSquare} onClick={onLinkClick} />
       <SurfaceLink path="/admin/keychain" label="Passport"                 icon={KeyRound} onClick={onLinkClick} />
       <SeatsNavItem onClick={onLinkClick} />
       <AutopilotNavGroup onLinkClick={onLinkClick} />


### PR DESCRIPTION
## Summary
- remove Jobsmith from the admin sidebar navigation
- remove the JobSmith app-detail link back into admin management
- add flexible Apps search so spacing and fragments like job smith and jo smi find JobSmith

## Tests
- npm exec vitest -- run src/pages/admin/AdminShell.test.tsx src/components/apps/AppsTable.test.tsx src/pages/admin/AdminAppTesting.test.tsx src/pages/AppDetail.test.tsx
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and client-side search UX only; no auth, billing, or data-path changes.
> 
> **Overview**
> Treats **JobSmith as an app-only workspace** by dropping the admin sidebar entry and the JobSmith app-detail **Manage in admin** link, while keeping **Open JobSmith** on the public app page.
> 
> Introduces shared **`appMatchesSearch`** in `src/lib/appSearch.ts` and wires it into public/admin apps filtering (`useAppFilter`) and **Admin App Testing** search. Queries are normalized (case, accents, punctuation) and match both spaced and compact text plus multi-token fragments (e.g. `job smith`, `jo smi` → Jobsmith).
> 
> Tests cover the nav removal, app-detail links, and the new search behavior on the apps table, app testing page, and related surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd865a14b7845d74cd176b339244ff15d3a6bd62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->