### PR TITLE
Brochure pages for the product nav + re-point header

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8509,8 +8509,8 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "0321c830b3bc",
-      "bytes": 15563
+      "hash": "71a90e55f560",
+      "bytes": 16426
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,7 +22,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | de9f41b265f3 | 4881 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | 0321c830b3bc | 15563 |
+| src/App.tsx | 71a90e55f560 | 16426 |
 | src/pages/admin/AdminShell.tsx | c8bab38bba5e | 24827 |
 | src/pages/admin/AdminControlTower.tsx | 2bc870ebf30f | 21782 |
 | src/lib/controltower.ts | c9d18e61e7d8 | 21703 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import RequireAuth from "./components/RequireAuth.tsx";
 import RequireAdmin from "./components/RequireAdmin.tsx";
 import BetaBanner from "./components/BetaBanner.tsx";
 import { SiteAurora } from "@/components/brand";
+import BrochurePage from "./components/BrochurePage.tsx";
 import AdminShell from "./pages/admin/AdminShell.tsx";
 import AdminDashboard from "./pages/admin/AdminDashboard.tsx";
 import AdminYou from "./pages/admin/AdminYou.tsx";
@@ -156,7 +157,17 @@ const App = () => (
           <Route path="/apps" element={<AppsPage />} />
           <Route path="/apps/:slug" element={<AppDetailPage />} />
           <Route path="/tools" element={<ToolsPage />} />
-          <Route path="/skills" element={<Navigate to="/admin/skills" replace />} />
+          {/* Product brochure pages (public marketing; interactive surfaces live under /admin) */}
+          <Route path="/skills" element={<BrochurePage slug="skills" />} />
+          <Route path="/orchestrator" element={<BrochurePage slug="orchestrator" />} />
+          <Route path="/passport" element={<BrochurePage slug="passport" />} />
+          <Route path="/seats" element={<BrochurePage slug="seats" />} />
+          <Route path="/autopilot" element={<BrochurePage slug="autopilot" />} />
+          <Route path="/xgate" element={<BrochurePage slug="xgate" />} />
+          <Route path="/jobs" element={<BrochurePage slug="jobs" />} />
+          <Route path="/control-tower" element={<BrochurePage slug="control-tower" />} />
+          <Route path="/ledger" element={<BrochurePage slug="ledger" />} />
+          <Route path="/workers" element={<BrochurePage slug="workers" />} />
           <Route path="/jobsmith" element={<JobsmithPage />} />
           <Route path="/memory" element={<MemoryPage />} />
           {/* /memory/admin redirects to the new admin shell */}

--- a/src/components/BrochurePage.tsx
+++ b/src/components/BrochurePage.tsx
@@ -1,0 +1,109 @@
+import { Link } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import FadeIn from "@/components/FadeIn";
+import { Eyebrow, GlassCard, IconChip } from "@/components/brand";
+import { presets } from "@/lib/design-system";
+import { useCanonical } from "@/hooks/use-canonical";
+import { useMetaTags } from "@/hooks/useMetaTags";
+import { BROCHURE, type BrochureSlug } from "@/data/brochure";
+
+/**
+ * Shared layout for the public product "brochure" pages. Visual-first and
+ * low-text by design: eyebrow, gradient headline, one short lede, an
+ * icon-chip feature grid, and a single primary call to action. Renders on the
+ * navy aurora canvas (transparent page shell).
+ */
+const BrochurePage = ({ slug }: { slug: BrochureSlug }) => {
+  const page = BROCHURE[slug];
+
+  useCanonical(page.path);
+  useMetaTags({
+    title: page.meta.title,
+    description: page.meta.description,
+    ogTitle: page.meta.title,
+    ogDescription: page.meta.description,
+    ogUrl: `https://unclick.world${page.path}`,
+  });
+
+  return (
+    <div className={presets.page}>
+      <Navbar />
+      <main>
+        {/* Hero */}
+        <section className="relative px-6 pt-28 pb-16 sm:pt-32">
+          <div className="mx-auto max-w-3xl text-center">
+            <FadeIn>
+              <div className="flex justify-center">
+                <Eyebrow>{page.eyebrow}</Eyebrow>
+              </div>
+            </FadeIn>
+            <FadeIn delay={0.05}>
+              <h1 className="mt-6 text-4xl font-extrabold leading-[1.05] tracking-[-0.025em] text-heading sm:text-5xl md:text-6xl">
+                {page.title}
+              </h1>
+            </FadeIn>
+            <FadeIn delay={0.1}>
+              <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-body">
+                {page.lede}
+              </p>
+            </FadeIn>
+            {(page.primaryCta || page.secondaryCta) && (
+              <FadeIn delay={0.15}>
+                <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+                  {page.primaryCta && (
+                    <a
+                      href={page.primaryCta.href}
+                      className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground shadow-[0_14px_40px_-12px_hsl(182_46%_57%/0.5)] transition-all hover:-translate-y-0.5 hover:shadow-[0_18px_52px_-12px_hsl(182_46%_57%/0.7)]"
+                    >
+                      {page.primaryCta.label}
+                    </a>
+                  )}
+                  {page.secondaryCta && (
+                    <Link
+                      to={page.secondaryCta.href}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-[#86dadd]/20 bg-white/[0.04] px-6 py-3.5 text-sm font-medium text-heading backdrop-blur-sm transition-colors hover:border-primary/40 hover:bg-white/[0.07]"
+                    >
+                      {page.secondaryCta.label}
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  )}
+                </div>
+              </FadeIn>
+            )}
+          </div>
+        </section>
+
+        {/* Feature grid */}
+        <section className="px-6 pb-28">
+          <div className="mx-auto max-w-5xl">
+            {page.featuresTitle && (
+              <FadeIn>
+                <h2 className="mb-10 text-center text-2xl font-bold tracking-tight text-heading sm:text-3xl">
+                  {page.featuresTitle}
+                </h2>
+              </FadeIn>
+            )}
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {page.features.map((f, i) => (
+                <FadeIn key={f.title} delay={0.04 * i}>
+                  <GlassCard className="h-full">
+                    <IconChip>
+                      <f.icon className="h-5 w-5" />
+                    </IconChip>
+                    <h3 className="mt-4 text-base font-semibold text-heading">{f.title}</h3>
+                    <p className="mt-2 text-sm leading-relaxed text-body">{f.desc}</p>
+                  </GlassCard>
+                </FadeIn>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default BrochurePage;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -19,23 +19,26 @@ import { useSession } from "@/lib/auth";
 type NavChild = { label: string; href: string };
 type NavItem = { label: string; href: string; children?: NavChild[] };
 
+// Header is the brochure: every item links to a public marketing page that
+// explains the product. The interactive surfaces live in the signed-in
+// dashboard at /admin/*, reached via "Get started" / "Dashboard".
 const NAV_ITEMS: NavItem[] = [
   { label: "Apps", href: "/apps" },
   { label: "Skills", href: "/skills" },
-  { label: "Orchestrator", href: "/admin/orchestrator" },
-  { label: "Passport", href: "/admin/keychain" },
-  { label: "Seats", href: "/admin/agents" },
+  { label: "Orchestrator", href: "/orchestrator" },
+  { label: "Passport", href: "/passport" },
+  { label: "Seats", href: "/seats" },
   { label: "Memory", href: "/memory" },
   {
     label: "Autopilot",
-    href: "/admin/autopilot",
+    href: "/autopilot",
     children: [
       { label: "XPass", href: "/xpass" },
-      { label: "XGate", href: "/admin/xgate" },
-      { label: "Jobs", href: "/admin/jobs" },
-      { label: "Control Tower", href: "/admin/controltower" },
-      { label: "Ledger", href: "/admin/ledger" },
-      { label: "Workers", href: "/admin/workers" },
+      { label: "XGate", href: "/xgate" },
+      { label: "Jobs", href: "/jobs" },
+      { label: "Control Tower", href: "/control-tower" },
+      { label: "Ledger", href: "/ledger" },
+      { label: "Workers", href: "/workers" },
     ],
   },
   { label: "Docs", href: "/docs" },

--- a/src/data/brochure.tsx
+++ b/src/data/brochure.tsx
@@ -1,0 +1,203 @@
+/**
+ * Brochure content for the product pages linked from the public header.
+ *
+ * These are marketing pages (the "brochure"), shown the same signed in or out.
+ * They explain each product in plain English; the interactive surfaces live in
+ * the signed-in dashboard at /admin/*. Keep copy short and current, lean on
+ * icon-driven visuals, and avoid internal-only names. No em dashes.
+ */
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { GradientText } from "@/components/brand";
+import {
+  Sparkles, Zap, Plug, RefreshCw,
+  BookOpen, Clock, Compass, Link2,
+  KeyRound, Puzzle, ShieldCheck, Lock,
+  Users, HeartPulse, Brain, SlidersHorizontal,
+  Search, Wrench, ClipboardCheck, GitMerge, ShieldHalf, Hand,
+  Terminal, CreditCard, Ban,
+  ListTodo, Bell, ReceiptText,
+  TowerControl, TriangleAlert, Wind,
+  ScrollText, Download,
+  Hammer, FlaskConical, Eye,
+} from "lucide-react";
+
+export type BrochureSlug =
+  | "skills" | "orchestrator" | "passport" | "seats" | "autopilot"
+  | "xgate" | "jobs" | "control-tower" | "ledger" | "workers";
+
+type Cta = { label: string; href: string };
+type Feature = { icon: LucideIcon; title: string; desc: string };
+
+export type BrochureContent = {
+  path: string;
+  eyebrow: string;
+  title: ReactNode;
+  lede: string;
+  primaryCta?: Cta;
+  secondaryCta?: Cta;
+  featuresTitle?: string;
+  features: Feature[];
+  meta: { title: string; description: string };
+};
+
+const GET_STARTED: Cta = { label: "Get started free", href: "/#install" };
+
+export const BROCHURE: Record<BrochureSlug, BrochureContent> = {
+  skills: {
+    path: "/skills",
+    eyebrow: "Skills",
+    title: <>Skills your agent can <GradientText>run</GradientText>.</>,
+    lede: "Ready-made recipes that teach your AI to do real tasks, end to end. Just ask, and it runs the right one.",
+    primaryCta: GET_STARTED,
+    secondaryCta: { label: "Browse apps", href: "/apps" },
+    featuresTitle: "Capability, on tap.",
+    features: [
+      { icon: Sparkles, title: "Curated and trending", desc: "A growing library of the skills people actually use." },
+      { icon: Zap, title: "One-line trigger", desc: "No setup. Ask in plain English and your agent picks the skill." },
+      { icon: Plug, title: "Works everywhere", desc: "Any MCP client: Claude, ChatGPT, Cursor, and more." },
+      { icon: RefreshCw, title: "Kept fresh", desc: "New skills added often, refined from real use." },
+    ],
+    meta: { title: "Skills - UnClick", description: "Ready-made skills that teach your AI to do real tasks. Just ask." },
+  },
+  orchestrator: {
+    path: "/orchestrator",
+    eyebrow: "Orchestrator",
+    title: <>The running <GradientText>story</GradientText> of your work.</>,
+    lede: "Orchestrator keeps the through-line of every job, so you and your agents stay clear on what just happened and what is next.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "Never lose the thread.",
+    features: [
+      { icon: BookOpen, title: "One clear story", desc: "Every job, in plain language, from start to finish." },
+      { icon: Clock, title: "Live timeline", desc: "See what changed, when, and why." },
+      { icon: Compass, title: "Knows the next step", desc: "Points to the next action, not just history." },
+      { icon: Link2, title: "Source-linked", desc: "Every claim traces back to where it came from." },
+    ],
+    meta: { title: "Orchestrator - UnClick", description: "The running story of your work, so your agents always know what is next." },
+  },
+  passport: {
+    path: "/passport",
+    eyebrow: "Passport",
+    title: <>Sign in <GradientText>once</GradientText>. Your AI does the rest.</>,
+    lede: "Passport holds your logins and keys safely, so your agent can use your apps without you pasting credentials every time.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "Access, handled safely.",
+    features: [
+      { icon: KeyRound, title: "OAuth and API keys", desc: "Connect an app once and your agent can use it." },
+      { icon: Puzzle, title: "Browser bridge", desc: "A secure extension signs in where keys are not enough." },
+      { icon: ShieldCheck, title: "You stay in control", desc: "See every connection. Revoke any of them anytime." },
+      { icon: Lock, title: "Encrypted by default", desc: "Credentials are stored safely and kept out of chat." },
+    ],
+    meta: { title: "Passport - UnClick", description: "Sign in once. Passport lets your AI use your apps without sharing credentials in chat." },
+  },
+  seats: {
+    path: "/seats",
+    eyebrow: "Seats",
+    title: <>Give your AI a <GradientText>seat</GradientText> at the table.</>,
+    lede: "Add AI seats that work for you, each with a role, a heartbeat, and shared memory.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "Your AI team.",
+    features: [
+      { icon: Users, title: "Role-based", desc: "Each seat has a clear job, so the right one handles each task." },
+      { icon: HeartPulse, title: "Heartbeat schedule", desc: "Seats wake on a schedule to keep work moving." },
+      { icon: Brain, title: "Shared memory", desc: "Every seat draws on the same memory you own." },
+      { icon: SlidersHorizontal, title: "Your rules", desc: "You set what each seat can and cannot do." },
+    ],
+    meta: { title: "Seats - UnClick", description: "Add AI seats that work for you, each with a role, a heartbeat, and shared memory." },
+  },
+  autopilot: {
+    path: "/autopilot",
+    eyebrow: "Autopilot",
+    title: <>Work that <GradientText>runs itself</GradientText>, with proof.</>,
+    lede: "Autopilot plans, builds, checks, and ships work for you, with visible approvals and a clear stop button at every step.",
+    primaryCta: GET_STARTED,
+    secondaryCta: { label: "See the proof", href: "/xpass" },
+    featuresTitle: "From idea to shipped, on a line you can see.",
+    features: [
+      { icon: Search, title: "Research and plan", desc: "It works out what to do before touching anything." },
+      { icon: Wrench, title: "Build", desc: "Focused changes, one scoped step at a time." },
+      { icon: ClipboardCheck, title: "Check with XPass", desc: "Every result is proven before it moves on." },
+      { icon: GitMerge, title: "Review and ship", desc: "You approve. It merges and publishes." },
+      { icon: ShieldHalf, title: "Guarded by XGate", desc: "Risky actions are stopped before they run." },
+      { icon: Hand, title: "Stop anytime", desc: "One clear stop path. You are always in command." },
+    ],
+    meta: { title: "Autopilot - UnClick", description: "Autopilot plans, builds, checks, and ships work for you, with approvals and proof at every step." },
+  },
+  xgate: {
+    path: "/xgate",
+    eyebrow: "Autopilot - XGate",
+    title: <>Guardrails <GradientText>before</GradientText> your AI acts.</>,
+    lede: "XGate checks every risky action against your rules before it runs, so nothing happens that you would not allow.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "Stop problems before they start.",
+    features: [
+      { icon: Terminal, title: "Command and Git gates", desc: "Stops unsafe commands and risky code changes." },
+      { icon: Lock, title: "Secret and Data gates", desc: "Protects credentials and sensitive data." },
+      { icon: CreditCard, title: "Spend and Ship gates", desc: "No surprise costs or unreviewed releases." },
+      { icon: Ban, title: "Kill switch", desc: "One switch halts everything, instantly." },
+    ],
+    meta: { title: "XGate - UnClick", description: "XGate checks risky AI actions against your rules before they run." },
+  },
+  jobs: {
+    path: "/jobs",
+    eyebrow: "Autopilot - Jobs",
+    title: <>Every task, <GradientText>tracked</GradientText>.</>,
+    lede: "Jobs is the simple queue of what your AI is doing, what is done, and what needs you.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "Always know where things stand.",
+    features: [
+      { icon: ListTodo, title: "Clear status", desc: "See every job at a glance: doing, done, or blocked." },
+      { icon: Compass, title: "Owns the next action", desc: "Each job knows its next step." },
+      { icon: Bell, title: "Needs-you flags", desc: "It tells you when something needs a human." },
+      { icon: ReceiptText, title: "Receipts when done", desc: "Finished work comes with proof." },
+    ],
+    meta: { title: "Jobs - UnClick", description: "The simple queue of what your AI is doing, what is done, and what needs you." },
+  },
+  "control-tower": {
+    path: "/control-tower",
+    eyebrow: "Autopilot - Control Tower",
+    title: <>See everything at a <GradientText>glance</GradientText>.</>,
+    lede: "Control Tower is the live overview of your agents, jobs, and proof, one calm screen instead of ten tabs.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "Calm command and control.",
+    features: [
+      { icon: TowerControl, title: "Live overview", desc: "Agents, jobs, and health in one place." },
+      { icon: Search, title: "Drill into anything", desc: "Jump from the big picture to any detail." },
+      { icon: TriangleAlert, title: "Blockers surfaced", desc: "Problems rise to the top, not the bottom." },
+      { icon: Wind, title: "Calm by default", desc: "Quiet when all is well. Loud only when it matters." },
+    ],
+    meta: { title: "Control Tower - UnClick", description: "The live, calm overview of your agents, jobs, and proof." },
+  },
+  ledger: {
+    path: "/ledger",
+    eyebrow: "Autopilot - Ledger",
+    title: <>A receipt for <GradientText>everything</GradientText>.</>,
+    lede: "The Ledger keeps a receipt for every action, so you can see what happened and why.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "Trust, on the record.",
+    features: [
+      { icon: ReceiptText, title: "Receipts kept", desc: "Every meaningful action leaves a record." },
+      { icon: ScrollText, title: "Full audit trail", desc: "A complete history you can scroll back through." },
+      { icon: ShieldCheck, title: "Signed records", desc: "Records are signed, so you can trust them." },
+      { icon: Download, title: "Export anytime", desc: "Take your records with you whenever you need them." },
+    ],
+    meta: { title: "Ledger - UnClick", description: "A receipt for every action, so you see what happened and why." },
+  },
+  workers: {
+    path: "/workers",
+    eyebrow: "Autopilot - Workers",
+    title: <>A team of <GradientText>specialists</GradientText> for your AI.</>,
+    lede: "Workers are role-based helpers, so the right specialist handles each step of the job.",
+    primaryCta: GET_STARTED,
+    featuresTitle: "The right hat for each job.",
+    features: [
+      { icon: Compass, title: "Coordinator", desc: "Routes work and keeps everything aligned." },
+      { icon: Hammer, title: "Builder", desc: "Makes the focused changes." },
+      { icon: FlaskConical, title: "Tester", desc: "Proves what works and what does not." },
+      { icon: Eye, title: "Reviewer", desc: "Checks quality and catches regressions." },
+      { icon: ShieldHalf, title: "Safety", desc: "Protects secrets and risky actions." },
+      { icon: Sparkles, title: "Improver", desc: "Turns repeat friction into fixes." },
+    ],
+    meta: { title: "Workers - UnClick", description: "Role-based AI workers, so the right specialist handles each step." },
+  },
+};


### PR DESCRIPTION
## What and why

Fixes the header concept: **the header is the brochure** (marketing, same signed in or out); the **interactive product lives in the dashboard** at `/admin/*`. Previously the header pointed at `/admin/*`, so signed-out visitors hit a login wall. Now each header item links to a public page that *explains* the product.

## Changes

- **10 new brochure pages**, all on the navy aurora canvas: Skills, Orchestrator, Passport, Seats, Autopilot, XGate, Jobs, Control Tower, Ledger, Workers.
- **One shared, visual-first layout** (`BrochurePage`) driven by a single data file (`src/data/brochure.tsx`): eyebrow, gradient headline, one short lede, an icon-chip feature grid, and a single CTA. Low-text by design.
- **Header re-pointed**: nav items and the Autopilot dropdown now link to the brochure routes (`/skills`, `/orchestrator`, `/passport`, `/seats`, `/autopilot`, `/xgate`, `/jobs`, `/control-tower`, `/ledger`, `/workers`). `/skills` serves its brochure instead of redirecting to `/admin/skills`. Apps, Memory, Docs, New to AI, XPass already had public pages.
- Copy kept short, current, and plain - no internal-only names, no OS framing.

## Verification

- `npx vite build`: green. `npx vitest run`: 1527 tests pass.
- Brainmap guard: regenerated and clean.
- **CopyPass (brochure copy): pass, 100/100, 0 findings** (softened a few absolutes like "always"/"never" and "Proof the work was done right" to honest, advisory wording to clear the guarantee-language check).

## Next in the loop (not in this PR)

Admin polish (teal scrollbar, collapsible sidebar with toggle icon, swap leftover dark boxes for navy glass, carry the grid background through admin) and a text-trim / more-visuals pass on existing pages.

https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public routing and nav URL changes only; signed-in product surfaces stay under /admin/* with no auth or API changes.
> 
> **Overview**
> Reframes the public header as **marketing brochure** links instead of deep links into `/admin/*`, so signed-out visitors get product explanations instead of auth walls.
> 
> Adds a shared **`BrochurePage`** layout (hero, feature grid, CTAs, SEO hooks) backed by **`src/data/brochure.tsx`** copy for ten products: Skills, Orchestrator, Passport, Seats, Autopilot, XGate, Jobs, Control Tower, Ledger, and Workers. **`App.tsx`** wires public routes like `/skills`, `/orchestrator`, `/passport`, etc.; **`/skills` no longer redirects** to `/admin/skills`. **`Navbar`** Autopilot dropdown and top-level items now point at those public paths. Brainmap metadata is regenerated for the touched files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3daa6e4416856d3e535645a51b65293560bbc9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->