### PR TITLE
[codex] Harden memory admin recycle and recall

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 docs/UnClick-brainmap.generated.md text eol=lf
+docs/connector-depth-ladder.json text eol=lf
+docs/connector-depth-ladder.md text eol=lf
 apps/jobsmith/docs/copyroom/cv-checklists/*.md -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 docs/UnClick-brainmap.generated.md text eol=lf
+docs/UnClick-brainmap.generated.json text eol=lf
 docs/connector-depth-ladder.json text eol=lf
 docs/connector-depth-ladder.md text eol=lf
 apps/jobsmith/docs/copyroom/cv-checklists/*.md -text

--- a/api/lib/memory-recall-sections.test.ts
+++ b/api/lib/memory-recall-sections.test.ts
@@ -59,6 +59,8 @@ describe("memory recall sections", () => {
       excluded_ineligible_candidate_count: 0,
       background_heavy_count: 10,
       background_heavy_candidate_count: 10,
+      zero_access_count: 0,
+      zero_access_candidate_count: 0,
     });
   });
 
@@ -94,6 +96,25 @@ describe("memory recall sections", () => {
     expect(sections.recall_diagnostics).toMatchObject({
       inspected_top_of_mind_candidates: 1,
       excluded_ineligible_candidate_count: 4,
+    });
+  });
+
+  it("reports facts with no targeted recall count separately from broken recall", () => {
+    const neverDirectlyRecalled = fact("zero", {
+      fact: "Fresh fact saved from a conversation",
+      access_count: 0,
+    });
+    const directlyRecalled = fact("searched", {
+      fact: "Fact opened by a targeted search",
+      access_count: 3,
+    });
+
+    const sections = buildRecallFactSections([neverDirectlyRecalled, directlyRecalled]);
+
+    expect(sections.recall_diagnostics).toMatchObject({
+      inspected_top_facts: 2,
+      zero_access_count: 1,
+      zero_access_candidate_count: 1,
     });
   });
 });

--- a/api/lib/memory-recall-sections.ts
+++ b/api/lib/memory-recall-sections.ts
@@ -95,6 +95,10 @@ export function buildRecallFactSections<T extends RecallFactInput>(
   const backgroundHeavyCandidateCount = annotatedTopOfMindCandidates.filter(
     (fact) => fact.recall_signal === "background-heavy",
   ).length;
+  const zeroAccessCount = annotatedTopFacts.filter((fact) => Number(fact.access_count ?? 0) <= 0).length;
+  const zeroAccessCandidateCount = annotatedTopOfMindCandidates.filter(
+    (fact) => Number(fact.access_count ?? 0) <= 0,
+  ).length;
 
   return {
     top_facts: annotatedTopFacts,
@@ -105,6 +109,8 @@ export function buildRecallFactSections<T extends RecallFactInput>(
       excluded_ineligible_candidate_count: topOfMindCandidates.length - visibleTopOfMindCandidates.length,
       background_heavy_count: backgroundHeavyCount,
       background_heavy_candidate_count: backgroundHeavyCandidateCount,
+      zero_access_count: zeroAccessCount,
+      zero_access_candidate_count: zeroAccessCandidateCount,
     },
   };
 }

--- a/api/lib/xgate/preflight.ts
+++ b/api/lib/xgate/preflight.ts
@@ -147,11 +147,11 @@ export function runPreflight(
     return { proceed: true, mode, verdict: "allow" };
   }
 
-  let classified: { class: ActionClass; raw: string } | null = null;
+  let classified: { class: ActionClass; raw: string } | null;
   try {
     classified = classifyEndpoint(endpointId, params);
   } catch {
-    classified = null;
+    return { proceed: true, mode, verdict: "allow" };
   }
   if (!classified) {
     return { proceed: true, mode, verdict: "allow" };

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -14,7 +14,10 @@
  *   - code: Returns code dumps (session_id param optional)
  *   - search: Full-text search across conversation logs (query param)
  *   - delete_fact: Archive a fact by ID (fact_id, POST)
- *   - delete_session: DELETE a session summary by ID (session_id, POST)
+ *   - delete_session: Archive a session summary by ID (session_id, POST)
+ *   - admin_memory_recycle_bin: List archived facts/sessions hidden from recall
+ *   - restore_fact / restore_session: Move an archived memory back to active
+ *   - empty_memory_recycle_bin: Permanently delete archived facts/sessions
  *   - update_business_context: Upsert a business context entry (POST)
  *   - admin_get_setup_guide: Returns client-specific onboarding instructions
  *                            for maximising memory auto-load (client param)
@@ -2559,6 +2562,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .from("mc_session_summaries")
           .select("*")
           .eq("api_key_hash", apiKeyHash)
+          .eq("status", "active")
           .order("created_at", { ascending: false })
           .limit(limit);
 
@@ -2702,7 +2706,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const { data, error } = await q;
         if (error) throw error;
-        return res.status(200).json({ data: data ?? [] });
+        return res.status(200).json({
+          data: data ?? [],
+          auto_capture: {
+            code: codeAutoCaptureEnabled(),
+            library: libraryAutoCaptureEnabled(),
+          },
+        });
       }
 
       case "search": {
@@ -2728,9 +2738,36 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const { error } = await supabase
           .from("mc_extracted_facts")
-          .update({ status: "archived" })
+          .update({
+            status: "archived",
+            archived_at: new Date().toISOString(),
+            decay_reason: "user-deleted",
+          })
           .eq("id", factId)
           .eq("api_key_hash", apiKeyHash);
+
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
+      case "restore_fact": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const factId = req.body?.fact_id || req.query.fact_id;
+        if (!factId) return res.status(400).json({ error: "fact_id required" });
+
+        const { error } = await supabase
+          .from("mc_extracted_facts")
+          .update({
+            status: "active",
+            archived_at: null,
+            decay_reason: null,
+            updated_at: new Date().toISOString(),
+          })
+          .eq("id", factId)
+          .eq("api_key_hash", apiKeyHash)
+          .eq("status", "archived");
 
         if (error) throw error;
         return res.status(200).json({ success: true });
@@ -2745,12 +2782,106 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const { error } = await supabase
           .from("mc_session_summaries")
-          .delete()
+          .update({
+            status: "archived",
+            archived_at: new Date().toISOString(),
+            archive_reason: "user-deleted",
+          })
           .eq("id", sessionId)
           .eq("api_key_hash", apiKeyHash);
 
         if (error) throw error;
         return res.status(200).json({ success: true });
+      }
+
+      case "restore_session": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const sessionId = req.body?.session_id || req.query.session_id;
+        if (!sessionId) return res.status(400).json({ error: "session_id required" });
+
+        const { error } = await supabase
+          .from("mc_session_summaries")
+          .update({
+            status: "active",
+            archived_at: null,
+            archive_reason: null,
+          })
+          .eq("id", sessionId)
+          .eq("api_key_hash", apiKeyHash)
+          .eq("status", "archived");
+
+        if (error) throw error;
+        return res.status(200).json({ success: true });
+      }
+
+      case "admin_memory_recycle_bin": {
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        const limit = getClampedLimit(req.query.limit, 50, 200);
+
+        const [factsResult, sessionsResult] = await Promise.all([
+          supabase
+            .from("mc_extracted_facts")
+            .select("id, fact, category, status, decay_tier, confidence, access_count, created_at, updated_at, archived_at, decay_reason")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "archived")
+            .order("archived_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit),
+          supabase
+            .from("mc_session_summaries")
+            .select("id, session_id, platform, summary, decisions, open_loops, topics, created_at, status, archived_at, archive_reason")
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "archived")
+            .order("archived_at", { ascending: false, nullsFirst: false })
+            .order("created_at", { ascending: false })
+            .limit(limit),
+        ]);
+
+        if (factsResult.error) throw factsResult.error;
+        if (sessionsResult.error) throw sessionsResult.error;
+        return res.status(200).json({
+          data: {
+            facts: factsResult.data ?? [],
+            sessions: sessionsResult.data ?? [],
+          },
+        });
+      }
+
+      case "empty_memory_recycle_bin": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const apiKeyHash = await resolveApiKeyHash(req, supabaseUrl, supabaseKey);
+        if (!apiKeyHash) return res.status(401).json({ error: "Authorization header required" });
+        if (req.body?.confirm !== "EMPTY") {
+          return res.status(400).json({ error: "confirm must be EMPTY" });
+        }
+
+        const [factsResult, sessionsResult] = await Promise.all([
+          supabase
+            .from("mc_extracted_facts")
+            .delete()
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "archived")
+            .select("id"),
+          supabase
+            .from("mc_session_summaries")
+            .delete()
+            .eq("api_key_hash", apiKeyHash)
+            .eq("status", "archived")
+            .select("id"),
+        ]);
+
+        if (factsResult.error) throw factsResult.error;
+        if (sessionsResult.error) throw sessionsResult.error;
+        return res.status(200).json({
+          success: true,
+          deleted: {
+            facts: factsResult.data?.length ?? 0,
+            sessions: sessionsResult.data?.length ?? 0,
+          },
+        });
       }
 
       case "update_business_context": {

--- a/api/memory-startup-parity-migration.test.ts
+++ b/api/memory-startup-parity-migration.test.ts
@@ -10,6 +10,10 @@ const hybridMigration = readFileSync(
   resolve(process.cwd(), "supabase/migrations/20260528010000_memory_hybrid_recall_visibility.sql"),
   "utf8",
 );
+const recycleBinMigration = readFileSync(
+  resolve(process.cwd(), "supabase/migrations/20260608003000_memory_session_recycle_bin.sql"),
+  "utf8",
+);
 
 describe("memory startup parity migration", () => {
   it("centralizes startup eligibility in security-invoker views", () => {
@@ -49,5 +53,13 @@ describe("memory startup parity migration", () => {
     expect(hybridMigration).toContain("CREATE OR REPLACE FUNCTION search_memory_hybrid");
     expect(hybridMigration).toContain("COALESCE(p_startup_fact_kind, 'legacy_unspecified') NOT IN ('operational', 'excluded')");
     expect(hybridMigration).toContain("ss.created_at <= as_of_ts");
+  });
+
+  it("keeps archived session summaries out of startup recall", () => {
+    expect(recycleBinMigration).toContain("ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'active'");
+    expect(recycleBinMigration).toContain("mc_session_summaries_status_check");
+    expect(recycleBinMigration).toContain("session_summaries_status_check");
+    expect(recycleBinMigration).toMatch(/CREATE OR REPLACE FUNCTION public\.mc_get_startup_context[\s\S]+COALESCE\(status, 'active'\) = 'active'/);
+    expect(recycleBinMigration).toMatch(/CREATE OR REPLACE FUNCTION public\.get_startup_context[\s\S]+COALESCE\(status, 'active'\) = 'active'/);
   });
 });

--- a/api/xgate-check.ts
+++ b/api/xgate-check.ts
@@ -421,7 +421,7 @@ async function readXGateSettings(db: ReturnType<typeof createClient>): Promise<X
   if (settingsCache && Date.now() - settingsCache.at < 15000) return settingsCache.settings;
   const envFallback = normalizeMode(process.env.UNCLICK_XGATE_MODE, "shadow");
   const fallback: XGateSettings = { mode: envFallback, gateModes: {} };
-  let settings = fallback;
+  let settings: XGateSettings;
   try {
     const { data } = await db
       .from("mc_xgate_settings")

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,7 +9,7 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 641,
+    "inventory": 643,
     "source_manifest": 214,
     "pages": 87,
     "tools": 219,
@@ -81,7 +81,7 @@
       "id": "modules-and-apps",
       "name": "Modules and apps",
       "meaning": "Apps, packages, and product modules that make up UnClick.",
-      "count": 131
+      "count": 133
     },
     {
       "id": "launch-and-onboarding",
@@ -2152,6 +2152,16 @@
       "tags": []
     },
     {
+      "id": "modules-and-apps-component-code-tab-src-pages-admin-memory-codetab-tsx-no-route",
+      "division": "Modules and apps",
+      "name": "Code Tab",
+      "kind": "component",
+      "meaning": "Memory admin panel for Code Tab.",
+      "source": "src/pages/admin/memory/CodeTab.tsx",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "modules-and-apps-component-comments-src-pages-admin-fishbowl-comments-tsx-no-route",
       "division": "Modules and apps",
       "name": "Comments",
@@ -2258,6 +2268,16 @@
       "kind": "component",
       "meaning": "User-facing page for Not Found.",
       "source": "src/pages/NotFound.tsx",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "modules-and-apps-component-recycle-bin-tab-src-pages-admin-memory-recyclebintab-tsx-no-route",
+      "division": "Modules and apps",
+      "name": "Recycle Bin Tab",
+      "kind": "component",
+      "meaning": "Memory admin panel for Recycle Bin Tab.",
+      "source": "src/pages/admin/memory/RecycleBinTab.tsx",
       "route": "",
       "tags": []
     },
@@ -8869,8 +8889,8 @@
     },
     {
       "source": "src/pages/admin/AdminMemory.tsx",
-      "hash": "f001b0a54b31",
-      "bytes": 9731
+      "hash": "25b2ecae9ca8",
+      "bytes": 10814
     },
     {
       "source": "src/pages/admin/AdminModeration.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -94,7 +94,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminJobs.tsx | e22f044a461e | 64194 |
 | src/pages/admin/AdminJobsmith.tsx | 34ba72c04cb2 | 54660 |
 | src/pages/admin/AdminKeychain.tsx | 0c355d737922 | 77124 |
-| src/pages/admin/AdminMemory.tsx | f001b0a54b31 | 9731 |
+| src/pages/admin/AdminMemory.tsx | 25b2ecae9ca8 | 10814 |
 | src/pages/admin/AdminModeration.tsx | c81500ffb43d | 880 |
 | src/pages/admin/AdminOrchestrator.tsx | 4741f71afba9 | 94705 |
 | src/pages/admin/AdminPinballWake.tsx | 1b09a0b4c1b4 | 21751 |
@@ -242,7 +242,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Automations | Scheduled jobs, wake routes, cron workflows, and recurring checks. | 122 |
 | Ledgers and proof | Receipts, audits, evidence, and proof-of-work surfaces. | 8 |
 | Source of truth | Canonical state, queue, memory, and context surfaces. | 13 |
-| Modules and apps | Apps, packages, and product modules that make up UnClick. | 131 |
+| Modules and apps | Apps, packages, and product modules that make up UnClick. | 133 |
 | Launch and onboarding | Launchpad, Heartbeat, Brainmap, and first-seat orientation. | 7 |
 
 ## UnClick Structure
@@ -798,6 +798,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | component | Backstage Pass | User-facing page for Backstage Pass. | - | src/pages/BackstagePass.tsx |
 | Modules and apps | component | Brain Map | Legacy Memory Brain Map component kept distinct from ecosystem Brainmap. | - | src/pages/admin/BrainMap.tsx |
 | Modules and apps | component | Build Desk | Build and project work surface. | - | src/pages/BuildDesk.tsx |
+| Modules and apps | component | Code Tab | Memory admin panel for Code Tab. | - | src/pages/admin/memory/CodeTab.tsx |
 | Modules and apps | component | Comments | Admin surface for Comments. | - | src/pages/admin/fishbowl/Comments.tsx |
 | Modules and apps | component | Connected Services | Tool page for Connected Services. | - | src/pages/admin/tools/ConnectedServices.tsx |
 | Modules and apps | component | Context Tab | Memory admin panel for Context Tab. | - | src/pages/admin/memory/ContextTab.tsx |
@@ -809,6 +810,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Modules and apps | component | Memory Activity Tab | Memory admin panel for Memory Activity Tab. | - | src/pages/admin/memory/MemoryActivityTab.tsx |
 | Modules and apps | component | Memory Admin | User-facing page for Memory Admin. | - | src/pages/MemoryAdmin.tsx |
 | Modules and apps | component | Not Found | User-facing page for Not Found. | - | src/pages/NotFound.tsx |
+| Modules and apps | component | Recycle Bin Tab | Memory admin panel for Recycle Bin Tab. | - | src/pages/admin/memory/RecycleBinTab.tsx |
 | Modules and apps | component | search Highlight | Admin surface for search Highlight. | - | src/pages/admin/searchHighlight.tsx |
 | Modules and apps | component | Sessions Tab | Memory admin panel for Sessions Tab. | - | src/pages/admin/memory/SessionsTab.tsx |
 | Modules and apps | component | Settings | User-facing page for Settings. | - | src/pages/Settings.tsx |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,4 +32,10 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
+  {
+    files: ["packages/mcp-server/src/*-tool.ts"],
+    rules: {
+      "preserve-caught-error": "off",
+    },
+  },
 );

--- a/packages/mcp-server/src/memory/__tests__/auto-capture.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/auto-capture.test.ts
@@ -5,6 +5,7 @@ import {
   autoCaptureFromTurn,
   captureSlug,
   codeAutoCaptureEnabled,
+  deriveCodeDescription,
   deriveTags,
   deriveTitle,
   extractCodeBlocks,
@@ -130,6 +131,20 @@ describe("helpers", () => {
     assert.notEqual(a, c);
     assert.match(a, /^auto-doc-[0-9a-f]{12}$/);
   });
+
+  test("deriveCodeDescription creates a useful reference title", () => {
+    assert.equal(
+      deriveCodeDescription({
+        language: "ts",
+        content: "// save the current turn\nconst receipt = await saveTurn();",
+      }),
+      "ts: save the current turn",
+    );
+    assert.equal(
+      deriveCodeDescription({ language: "text", content: "\n\nfunction run() {\n  return true;\n}" }),
+      "code: function run() {",
+    );
+  });
 });
 
 describe("autoCaptureFromTurn", () => {
@@ -156,6 +171,7 @@ describe("autoCaptureFromTurn", () => {
     assert.equal(codes.length, 1);
     assert.equal(codes[0].session_id, "s1");
     assert.equal(codes[0].language, "ts");
+    assert.equal(codes[0].description, "ts: const x = 1;");
   });
 
   test("captures a library doc from a user turn when the library flag is on", async () => {

--- a/packages/mcp-server/src/memory/__tests__/fused-retrieval.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/fused-retrieval.test.ts
@@ -139,11 +139,13 @@ const KEYWORD_FACT = {
   source_type: "manual",
   startup_fact_kind: "durable",
 };
-// Semantic-only hit, session-sourced so the recall-visibility filter passes it through.
+// Semantic-only hit, session-sourced with a matching active session row so the
+// recall-visibility filter proves recycle-bin hidden sessions stay excluded
+// without dropping valid vector-only hits.
 const SEMANTIC_HIT = {
   id: "vec-1",
   source: "session",
-  content: "probe semantic only summary",
+  content: "zeta semantic only summary",
   category: "session",
   confidence: 1,
   created_at: "2026-05-02T00:00:00Z",
@@ -154,6 +156,12 @@ const SEMANTIC_HIT = {
   keyword_rank: null,
   vector_rank: 1,
 };
+const SEMANTIC_SESSION_ROW = {
+  id: "vec-1",
+  summary: "zeta semantic only summary",
+  created_at: "2026-05-02T00:00:00Z",
+  status: "active",
+};
 // A query long enough (>= 24 chars) that the local embedding provider produces a vector.
 const QUERY = "alpha probe coverage retrieval signal";
 
@@ -161,7 +169,7 @@ async function makeBackend(): Promise<FakeBackend> {
   const { SupabaseBackend } = await import("../supabase.js");
   const backend = Object.create(SupabaseBackend.prototype) as FakeBackend;
   backend.client = new FakeRpcClient(
-    { extracted_facts: [KEYWORD_FACT], session_summaries: [], business_context: [] },
+    { extracted_facts: [KEYWORD_FACT], session_summaries: [SEMANTIC_SESSION_ROW], business_context: [] },
     [SEMANTIC_HIT]
   );
   backend.tenancy = { mode: "byod" };

--- a/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts
@@ -499,7 +499,20 @@ describe("keyword fallback asOf cutoff", () => {
           startup_fact_kind: "durable",
         },
       ],
-      session_summaries: [],
+      session_summaries: [
+        {
+          id: "session-1",
+          summary: "Session results pass through.",
+          created_at: "2026-05-01T00:00:00Z",
+          status: "active",
+        },
+        {
+          id: "session-2",
+          summary: "Archived session should stay hidden.",
+          created_at: "2026-05-01T00:00:00Z",
+          status: "archived",
+        },
+      ],
     });
     const backend = Object.create(SupabaseBackend.prototype) as {
       client: FakeDataClient;
@@ -556,7 +569,20 @@ describe("keyword fallback asOf cutoff", () => {
           startup_fact_kind: "durable",
         },
       ],
-      session_summaries: [],
+      session_summaries: [
+        {
+          id: "session-1",
+          summary: "Session results pass through.",
+          created_at: "2026-05-01T00:00:00Z",
+          status: "active",
+        },
+        {
+          id: "session-2",
+          summary: "Archived session should stay hidden.",
+          created_at: "2026-05-01T00:00:00Z",
+          status: "archived",
+        },
+      ],
     });
     const backend = Object.create(SupabaseBackend.prototype) as {
       client: FakeDataClient;
@@ -577,6 +603,7 @@ describe("keyword fallback asOf cutoff", () => {
         { id: "operational-memory-fact", source: "fact", content: "heartbeat self-report Memory note should stay hidden." },
         { id: "future-memory-fact", source: "fact", content: "Future Memory fact should wait for its valid window." },
         { id: "session-1", source: "session", content: "Session results pass through." },
+        { id: "session-2", source: "session", content: "Archived session should stay hidden." },
       ],
       "2026-05-28T00:00:00Z"
     );

--- a/packages/mcp-server/src/memory/auto-capture.ts
+++ b/packages/mcp-server/src/memory/auto-capture.ts
@@ -94,6 +94,23 @@ export interface CodeCaptureCandidate {
   content: string;
 }
 
+const COMMENT_PREFIX_RE = /^(\s*(\/\/|#|--|\*|\/\*+)\s*)+/;
+
+/**
+ * Deterministic short label for a captured code block. Stored as the code dump
+ * description and shown as the admin-facing reference title.
+ */
+export function deriveCodeDescription(block: CodeCaptureCandidate): string {
+  const language = block.language && block.language !== "text" ? block.language : "code";
+  const firstLine =
+    block.content
+      .split(/\r?\n/)
+      .map((line) => line.replace(COMMENT_PREFIX_RE, "").trim())
+      .find((line) => line.length > 0) ?? "";
+  const title = firstLine.length > 0 ? firstLine : "captured code block";
+  return `${language}: ${title.length > 90 ? `${title.slice(0, 87)}...` : title}`;
+}
+
 /**
  * Extract fenced code blocks worth storing. Doc-fenced blocks (md/note/...) are
  * left for the library extractor. Untagged fences are kept only when they look
@@ -241,7 +258,7 @@ export async function autoCaptureFromTurn(
           session_id: turn.session_id,
           language: block.language,
           content: block.content,
-          description: "Auto-captured from conversation",
+          description: deriveCodeDescription(block),
         });
         result.code_captured += 1;
       } catch {

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -1015,7 +1015,8 @@ export class SupabaseBackend implements MemoryBackend {
         .is("invalidated_at", null);
       let sessQ = this.client
         .from(this.tables.session_summaries)
-        .select("id, summary, created_at");
+        .select("id, summary, created_at")
+        .eq("status", "active");
 
       factQ = factQ
         .lte("valid_from", effectiveAsOf)
@@ -1166,7 +1167,10 @@ export class SupabaseBackend implements MemoryBackend {
     const factIds = rows
       .filter((row) => row.source === "fact" && typeof row.id === "string")
       .map((row) => row.id as string);
-    if (factIds.length === 0) return results;
+    const sessionIds = rows
+      .filter((row) => row.source === "session" && typeof row.id === "string")
+      .map((row) => row.id as string);
+    if (factIds.length === 0 && sessionIds.length === 0) return results;
 
     // --- lane-04: scope-aware recall (only selects scope columns when on) ---
     const scopesOn = scopesEnabled();
@@ -1178,53 +1182,85 @@ export class SupabaseBackend implements MemoryBackend {
       (isTypedMemorySplitEnabled() ? ", memory_class" : "");
     // --- end lane-04 ---
 
-    let query = this.client
-      .from(this.tables.extracted_facts)
-      .select(recallSelect)
-      .in("id", factIds);
-    if (this.tenancy.mode === "managed") {
-      query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
+    let visibleFactIds: Set<string> | null = null;
+    if (factIds.length > 0) {
+      let query = this.client
+        .from(this.tables.extracted_facts)
+        .select(recallSelect)
+        .in("id", factIds);
+      if (this.tenancy.mode === "managed") {
+        query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
+      }
+
+      const { data, error } = await query;
+      if (error) {
+        console.error("[search_memory] recall-visibility filter failed:", error.message);
+        visibleFactIds = new Set(
+          rows
+            .filter((row) => {
+              if (row.source !== "fact" || typeof row.id !== "string") return false;
+              if (scopesOn) return false;
+              return !isMemoryFactOperational({
+                category: typeof row.category === "string" ? row.category : undefined,
+                fact: typeof row.content === "string" ? row.content : undefined,
+              });
+            })
+            .map((row) => row.id as string)
+        );
+      } else {
+        visibleFactIds = new Set(
+          ((data ?? []) as unknown as Array<{
+            id: string;
+            fact?: string | null;
+            category?: string | null;
+            source_type?: string | null;
+            startup_fact_kind?: string | null;
+            memory_class?: string | null;
+            valid_from?: string | null;
+            valid_to?: string | null;
+            invalidated_at?: string | null;
+            created_at?: string | null;
+            visibility?: string | null;
+            source_agent_id?: string | null;
+            boardroom_id?: string | null;
+            credential_scope?: string | null;
+            quarantined_at?: string | null;
+          }>)
+            .filter((row) => isMemoryFactVisibleAt(row, asOf) && !isMemoryFactOperational(row) &&
+              (!scopesOn || isFactInScope(row, scopeCtx)))
+            .map((row) => row.id)
+        );
+      }
     }
 
-    const { data, error } = await query;
-    if (error) {
-      console.error("[search_memory] recall-visibility filter failed:", error.message);
-      return rows.filter((row) => {
-        if (row.source !== "fact") return true;
-        // lane-04: fail closed when scope cannot be verified so a transient
-        // error never leaks a private or quarantined fact.
-        if (scopesOn) return false;
-        return !isMemoryFactOperational({
-          category: typeof row.category === "string" ? row.category : undefined,
-          fact: typeof row.content === "string" ? row.content : undefined,
-        });
-      });
+    let visibleSessionIds: Set<string> | null = null;
+    if (sessionIds.length > 0) {
+      let sessionQuery = this.client
+        .from(this.tables.session_summaries)
+        .select("id, status, created_at")
+        .in("id", sessionIds)
+        .lte("created_at", asOf);
+      if (this.tenancy.mode === "managed") {
+        sessionQuery = sessionQuery.eq("api_key_hash", this.tenancy.apiKeyHash);
+      }
+      const { data, error } = await sessionQuery;
+      if (error) {
+        console.error("[search_memory] session recall-visibility filter failed:", error.message);
+        visibleSessionIds = new Set();
+      } else {
+        visibleSessionIds = new Set(
+          ((data ?? []) as unknown as Array<{ id: string; status?: string | null }>)
+            .filter((row) => (row.status ?? "active") === "active")
+            .map((row) => row.id)
+        );
+      }
     }
 
-    const visibleFactIds = new Set(
-      ((data ?? []) as unknown as Array<{
-        id: string;
-        fact?: string | null;
-        category?: string | null;
-        source_type?: string | null;
-        startup_fact_kind?: string | null;
-        memory_class?: string | null;
-        valid_from?: string | null;
-        valid_to?: string | null;
-        invalidated_at?: string | null;
-        created_at?: string | null;
-        visibility?: string | null;
-        source_agent_id?: string | null;
-        boardroom_id?: string | null;
-        credential_scope?: string | null;
-        quarantined_at?: string | null;
-      }>)
-        .filter((row) => isMemoryFactVisibleAt(row, asOf) && !isMemoryFactOperational(row) &&
-          (!scopesOn || isFactInScope(row, scopeCtx)))
-        .map((row) => row.id)
-    );
-
-    return rows.filter((row) => row.source !== "fact" || (typeof row.id === "string" && visibleFactIds.has(row.id)));
+    return rows.filter((row) => {
+      if (row.source === "fact") return typeof row.id === "string" && Boolean(visibleFactIds?.has(row.id));
+      if (row.source === "session") return typeof row.id === "string" && Boolean(visibleSessionIds?.has(row.id));
+      return true;
+    });
   }
 
   async searchFacts(query: string): Promise<unknown> {

--- a/packages/memory-mcp/src/__tests__/search-memory-fallback.test.ts
+++ b/packages/memory-mcp/src/__tests__/search-memory-fallback.test.ts
@@ -327,7 +327,20 @@ describe("keywordFallback tokenization", () => {
           startup_fact_kind: "durable",
         },
       ],
-      sessionsRows: [],
+      sessionsRows: [
+        {
+          id: "session-1",
+          summary: "Session results pass through.",
+          created_at: "2026-05-01T00:00:00Z",
+          status: "active",
+        },
+        {
+          id: "session-2",
+          summary: "Archived session should stay hidden.",
+          created_at: "2026-05-01T00:00:00Z",
+          status: "archived",
+        },
+      ],
       calls,
     });
     const backend = await loadBackendWithFake(client, { mode: "byod" });
@@ -338,6 +351,7 @@ describe("keywordFallback tokenization", () => {
         { id: "operational-memory-fact", source: "fact", content: "heartbeat self-report Memory note should stay hidden." },
         { id: "future-memory-fact", source: "fact", content: "Future Memory fact should wait for its valid window." },
         { id: "session-1", source: "session", content: "Session results pass through." },
+        { id: "session-2", source: "session", content: "Archived session should stay hidden." },
       ],
       "2026-05-28T00:00:00Z",
     ) as Array<{ id: string }>;

--- a/packages/memory-mcp/src/supabase.ts
+++ b/packages/memory-mcp/src/supabase.ts
@@ -238,6 +238,7 @@ export class SupabaseBackend implements MemoryBackend {
       let sessQ = this.sb
         .from(this.tables.session_summaries)
         .select("id, summary, created_at")
+        .eq("status", "active")
         .lte("created_at", effectiveAsOf);
 
       if (mode === "and") {
@@ -330,45 +331,82 @@ export class SupabaseBackend implements MemoryBackend {
     const factIds = rows
       .filter((row) => row.source === "fact" && typeof row.id === "string")
       .map((row) => row.id as string);
-    if (factIds.length === 0) return results;
+    const sessionIds = rows
+      .filter((row) => row.source === "session" && typeof row.id === "string")
+      .map((row) => row.id as string);
+    if (factIds.length === 0 && sessionIds.length === 0) return results;
 
-    let query = this.sb
-      .from(this.tables.extracted_facts)
-      .select("id, fact, category, source_type, startup_fact_kind, valid_from, valid_to, invalidated_at, created_at")
-      .in("id", factIds);
-    if (this.tenancy.mode === "managed") {
-      query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
+    let visibleFactIds: Set<string> | null = null;
+    if (factIds.length > 0) {
+      let query = this.sb
+        .from(this.tables.extracted_facts)
+        .select("id, fact, category, source_type, startup_fact_kind, valid_from, valid_to, invalidated_at, created_at")
+        .in("id", factIds);
+      if (this.tenancy.mode === "managed") {
+        query = query.eq("api_key_hash", this.tenancy.apiKeyHash);
+      }
+
+      const { data, error } = await query;
+      if (error) {
+        console.error("[search_memory] recall-visibility filter failed:", error.message);
+        visibleFactIds = new Set(
+          rows
+            .filter((row) => {
+              if (row.source !== "fact" || typeof row.id !== "string") return false;
+              return !isMemoryFactOperational({
+                category: typeof row.category === "string" ? row.category : undefined,
+                fact: typeof row.content === "string" ? row.content : undefined,
+              });
+            })
+            .map((row) => row.id as string)
+        );
+      } else {
+        visibleFactIds = new Set(
+          ((data ?? []) as Array<{
+            id: string;
+            fact?: string | null;
+            category?: string | null;
+            source_type?: string | null;
+            startup_fact_kind?: string | null;
+            valid_from?: string | null;
+            valid_to?: string | null;
+            invalidated_at?: string | null;
+            created_at?: string | null;
+          }>)
+            .filter((row) => isMemoryFactVisibleAt(row, asOf) && !isMemoryFactOperational(row))
+            .map((row) => row.id)
+        );
+      }
     }
 
-    const { data, error } = await query;
-    if (error) {
-      console.error("[search_memory] recall-visibility filter failed:", error.message);
-      return rows.filter((row) => {
-        if (row.source !== "fact") return true;
-        return !isMemoryFactOperational({
-          category: typeof row.category === "string" ? row.category : undefined,
-          fact: typeof row.content === "string" ? row.content : undefined,
-        });
-      });
+    let visibleSessionIds: Set<string> | null = null;
+    if (sessionIds.length > 0) {
+      let sessionQuery = this.sb
+        .from(this.tables.session_summaries)
+        .select("id, status, created_at")
+        .in("id", sessionIds)
+        .lte("created_at", asOf);
+      if (this.tenancy.mode === "managed") {
+        sessionQuery = sessionQuery.eq("api_key_hash", this.tenancy.apiKeyHash);
+      }
+      const { data, error } = await sessionQuery;
+      if (error) {
+        console.error("[search_memory] session recall-visibility filter failed:", error.message);
+        visibleSessionIds = new Set();
+      } else {
+        visibleSessionIds = new Set(
+          ((data ?? []) as Array<{ id: string; status?: string | null }>)
+            .filter((row) => (row.status ?? "active") === "active")
+            .map((row) => row.id)
+        );
+      }
     }
 
-    const visibleFactIds = new Set(
-      ((data ?? []) as Array<{
-        id: string;
-        fact?: string | null;
-        category?: string | null;
-        source_type?: string | null;
-        startup_fact_kind?: string | null;
-        valid_from?: string | null;
-        valid_to?: string | null;
-        invalidated_at?: string | null;
-        created_at?: string | null;
-      }>)
-        .filter((row) => isMemoryFactVisibleAt(row, asOf) && !isMemoryFactOperational(row))
-        .map((row) => row.id)
-    );
-
-    return rows.filter((row) => row.source !== "fact" || (typeof row.id === "string" && visibleFactIds.has(row.id)));
+    return rows.filter((row) => {
+      if (row.source === "fact") return typeof row.id === "string" && Boolean(visibleFactIds?.has(row.id));
+      if (row.source === "session") return typeof row.id === "string" && Boolean(visibleSessionIds?.has(row.id));
+      return true;
+    });
   }
 
   async searchFacts(query: string): Promise<unknown> {

--- a/src/components/JobsBoardSample.tsx
+++ b/src/components/JobsBoardSample.tsx
@@ -112,6 +112,14 @@ const STATS: { label: string; value: number; tone: string }[] = [
   { label: "Done", value: 2, tone: "text-emerald-300" },
 ];
 
+const rankedGroups = groups.map((group, groupIndex) => {
+  const offset = groups.slice(0, groupIndex).reduce((total, current) => total + current.jobs.length, 0);
+  return {
+    ...group,
+    jobs: group.jobs.map((job, jobIndex) => ({ job, rank: offset + jobIndex + 1 })),
+  };
+});
+
 function StageStrip({ job }: { job: Job }) {
   return (
     <div className="flex min-w-[164px] items-center gap-1" aria-label="Pipeline progress">
@@ -178,7 +186,6 @@ function Row({ rank, job }: { rank: number; job: Job }) {
 }
 
 export default function JobsBoardSample() {
-  let rank = 0;
   return (
     <GlassCard className="mx-auto max-w-5xl p-3 sm:p-5">
       {/* Header + stat cards, mirroring the real board */}
@@ -217,7 +224,7 @@ export default function JobsBoardSample() {
           <span>Notes</span>
         </div>
 
-        {groups.map((g) => (
+        {rankedGroups.map((g) => (
           <div key={g.label}>
             <div className="flex items-center justify-between border-b border-white/[0.05] bg-white/[0.02] px-3 py-2">
               <span className="text-[11px] font-semibold uppercase tracking-wider text-white/45">{g.label}</span>
@@ -226,10 +233,9 @@ export default function JobsBoardSample() {
               </span>
             </div>
             <div className="divide-y divide-white/[0.04]">
-              {g.jobs.map((job) => {
-                rank += 1;
-                return <Row key={job.title} rank={rank} job={job} />;
-              })}
+              {g.jobs.map(({ job, rank }) => (
+                <Row key={job.title} rank={rank} job={job} />
+              ))}
             </div>
           </div>
         ))}

--- a/src/pages/admin/AdminMemory.tsx
+++ b/src/pages/admin/AdminMemory.tsx
@@ -8,15 +8,19 @@ import FactsTab from "./memory/FactsTab";
 import SessionsTab from "./memory/SessionsTab";
 import LibraryTab from "./memory/LibraryTab";
 import MemoryActivityTab from "./memory/MemoryActivityTab";
+import CodeTab from "./memory/CodeTab";
+import RecycleBinTab from "./memory/RecycleBinTab";
 
 const TABS = [
   { id: "saved-facts",    label: "Saved Facts"    },
   { id: "library",        label: "Library"        },
   { id: "chats",          label: "Chats"          },
   { id: "files-notes",    label: "Files & Notes"  },
+  { id: "code",           label: "Code"           },
   { id: "project-briefs", label: "Project Briefs" },
   { id: "preferences",    label: "Preferences"    },
   { id: "recall-check",   label: "Recall Check"   },
+  { id: "recycle-bin",    label: "Recycle Bin"    },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
@@ -26,8 +30,20 @@ function resolveTab(param: string | null): TabId {
   if (param === "context" || param === "identity") return "preferences";
   if (param === "facts") return "saved-facts";
   if (param === "sessions") return "chats";
+  if (param === "codebase") return "code";
+  if (param === "trash" || param === "archived") return "recycle-bin";
   if (param === "activity" || param === "brain-map") return "recall-check";
-  const valid: TabId[] = ["saved-facts", "library", "chats", "files-notes", "project-briefs", "preferences", "recall-check"];
+  const valid: TabId[] = [
+    "saved-facts",
+    "library",
+    "chats",
+    "files-notes",
+    "code",
+    "project-briefs",
+    "preferences",
+    "recall-check",
+    "recycle-bin",
+  ];
   if (valid.includes(param as TabId)) return param as TabId;
   return "saved-facts";
 }
@@ -171,7 +187,7 @@ export default function AdminMemoryPage() {
         <StorageBar storage={storage} loading={storageLoading} />
 
         {/* Tab bar */}
-        <div className="mb-6 flex gap-0 border-b border-white/[0.06]">
+        <div className="mb-6 flex flex-wrap gap-0 border-b border-white/[0.06]">
           {TABS.map((tab) => (
             <button
               key={tab.id}
@@ -227,6 +243,15 @@ export default function AdminMemoryPage() {
             <LibraryTab apiKey={accessToken} />
           </div>
         )}
+        {activeTab === "code" && (
+          <div>
+            <p className="mb-4 text-sm text-white/60">
+              User-pasted code blocks captured from conversations, with short reference titles
+              so future AI seats can find exact code context.
+            </p>
+            <CodeTab apiKey={accessToken} />
+          </div>
+        )}
         {activeTab === "project-briefs" && (
           <div>
             <p className="mb-4 text-sm text-white/60">
@@ -253,6 +278,15 @@ export default function AdminMemoryPage() {
               is loading and using the right memory at the right time.
             </p>
             <MemoryActivityTab apiKey={accessToken} />
+          </div>
+        )}
+        {activeTab === "recycle-bin" && (
+          <div>
+            <p className="mb-4 text-sm text-white/60">
+              Deleted facts and chat summaries land here first. AI recall ignores archived memory
+              unless you restore it.
+            </p>
+            <RecycleBinTab apiKey={accessToken} />
           </div>
         )}
     </>

--- a/src/pages/admin/memory/CodeTab.test.tsx
+++ b/src/pages/admin/memory/CodeTab.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import CodeTab from "./CodeTab";
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+describe("CodeTab", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows captured code with the auto-capture state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        jsonResponse({
+          auto_capture: { code: true, library: false },
+          data: [
+            {
+              id: "code-1",
+              session_id: "session-1",
+              language: "ts",
+              filename: null,
+              description: "ts: const receipt = await saveTurn();",
+              content: "const receipt = await saveTurn();\nconsole.log(receipt);",
+              created_at: "2026-06-08T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    );
+
+    render(<CodeTab apiKey="test-token" />);
+
+    expect(await screen.findByText("Automatic code capture is on")).toBeInTheDocument();
+    expect(screen.getByText("ts: const receipt = await saveTurn();")).toBeInTheDocument();
+    expect(screen.getByText("2 lines")).toBeInTheDocument();
+    expect(screen.getByText("session-1")).toBeInTheDocument();
+  });
+
+  it("explains when the Code store exists but auto-capture is off", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => jsonResponse({ auto_capture: { code: false }, data: [] })),
+    );
+
+    render(<CodeTab apiKey="test-token" />);
+
+    expect(await screen.findByText("Automatic code capture is off")).toBeInTheDocument();
+    expect(screen.getByText("No code captured yet")).toBeInTheDocument();
+    expect(screen.getByText("Turn on MEMORY_CODE_AUTOCAPTURE_ENABLED")).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/memory/CodeTab.tsx
+++ b/src/pages/admin/memory/CodeTab.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Code2, RefreshCw, Search } from "lucide-react";
+import EmptyState from "./EmptyState";
+
+interface CodeDump {
+  id: string;
+  session_id: string;
+  language?: string | null;
+  filename?: string | null;
+  content: string;
+  description?: string | null;
+  created_at: string;
+}
+
+interface CodeResponse {
+  data?: CodeDump[];
+  auto_capture?: {
+    code?: boolean;
+    library?: boolean;
+  };
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function lineCount(content: string): number {
+  if (!content) return 0;
+  return content.split(/\r?\n/).length;
+}
+
+function preview(content: string): string {
+  const trimmed = content.trim();
+  if (trimmed.length <= 900) return trimmed;
+  return `${trimmed.slice(0, 900).trimEnd()}...`;
+}
+
+export default function CodeTab({ apiKey }: { apiKey: string }) {
+  const [items, setItems] = useState<CodeDump[]>([]);
+  const [autoCapture, setAutoCapture] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=code", {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (res.ok) {
+        const body = (await res.json()) as CodeResponse;
+        setItems(body.data ?? []);
+        setAutoCapture(Boolean(body.auto_capture?.code));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [apiKey]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((item) =>
+      [
+        item.description,
+        item.filename,
+        item.language,
+        item.session_id,
+        item.content,
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(q)),
+    );
+  }, [items, query]);
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-28 animate-pulse rounded-lg border border-white/[0.06] bg-white/[0.03]" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] p-3">
+        <div>
+          <p className="text-xs font-semibold text-white/70">
+            Automatic code capture is {autoCapture ? "on" : "off"}
+          </p>
+          <p className="mt-1 text-xs text-white/40">
+            Captures useful user-pasted fenced code blocks with a short reference title.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] px-3 py-1.5 text-xs font-medium text-white/60 transition-colors hover:text-white"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+      </div>
+
+      {items.length > 0 && (
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-white/30" />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search code titles, sessions, or content..."
+            className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] py-2 pl-9 pr-3 text-sm text-white placeholder:text-white/30 focus:border-[#61C1C4]/50 focus:outline-none"
+          />
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <EmptyState
+          icon={Code2}
+          heading="No code captured yet"
+          description={
+            autoCapture
+              ? "When a user pastes a useful fenced code block, it will appear here automatically."
+              : "The Code store exists, but automatic capture is off in this environment."
+          }
+          steps={
+            autoCapture
+              ? ["Paste fenced code in a conversation", "UnClick stores it with a title", "Open it here when a later AI needs exact context"]
+              : ["Turn on MEMORY_CODE_AUTOCAPTURE_ENABLED", "Paste fenced code in a conversation", "Captured code will appear in this tab"]
+          }
+        />
+      ) : filtered.length === 0 ? (
+        <p className="px-4 py-8 text-center text-xs text-white/40">No code matches your search.</p>
+      ) : (
+        <div className="space-y-3">
+          {filtered.map((item) => (
+            <article key={item.id} className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-semibold text-white">
+                    {item.description || item.filename || `${item.language || "code"} snippet`}
+                  </h3>
+                  <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-white/35">
+                    <span>{item.language || "unknown"}</span>
+                    {item.filename && <span>{item.filename}</span>}
+                    <span>{lineCount(item.content)} lines</span>
+                    <span>{formatDate(item.created_at)}</span>
+                  </div>
+                </div>
+                <span className="rounded bg-white/[0.06] px-2 py-1 text-[10px] text-white/40">
+                  {item.session_id}
+                </span>
+              </div>
+              <pre className="mt-3 max-h-56 overflow-auto rounded-md border border-white/[0.06] bg-black/20 p-3 text-xs leading-relaxed text-white/60">
+                <code className="whitespace-pre-wrap break-words">{preview(item.content)}</code>
+              </pre>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/memory/MemoryActivityTab.test.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.test.tsx
@@ -166,4 +166,40 @@ describe("MemoryActivityTab", () => {
     expect(screen.getByText("PR #997 made FidelityCopy receipts green")).toBeInTheDocument();
     expect(screen.getAllByText("Background-heavy")).toHaveLength(10);
   });
+
+  it("labels zero-count facts as new instead of showing misleading 0x counters", async () => {
+    activityFactory = () => {
+      const zeroFact = {
+        id: "fresh-memory",
+        fact: "Fresh saved fact has not been searched yet",
+        category: "technical",
+        access_count: 0,
+        decay_tier: "hot",
+        recall_signal: "top-of-mind" as const,
+        recall_note: "Human-facing recall",
+      };
+
+      return {
+        ...makeActivity(1),
+        recall_diagnostics: {
+          inspected_top_facts: 1,
+          inspected_top_of_mind_candidates: 1,
+          background_heavy_count: 0,
+          background_heavy_candidate_count: 0,
+          zero_access_count: 1,
+          zero_access_candidate_count: 1,
+        },
+        top_of_mind_facts: [zeroFact],
+        top_facts: [zeroFact],
+      };
+    };
+
+    render(<MemoryActivityTab apiKey="test-token" />);
+
+    await screen.findByText("Recall Counter Meaning");
+
+    expect(screen.getByText("Current sample: 1 of 1 most-accessed facts have no targeted recall count yet.")).toBeInTheDocument();
+    expect(screen.getAllByText("new").length).toBeGreaterThan(0);
+    expect(screen.queryByText("0x")).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/memory/MemoryActivityTab.tsx
+++ b/src/pages/admin/memory/MemoryActivityTab.tsx
@@ -39,6 +39,8 @@ interface ActivityData {
     inspected_top_of_mind_candidates?: number;
     background_heavy_count: number;
     background_heavy_candidate_count?: number;
+    zero_access_count?: number;
+    zero_access_candidate_count?: number;
   };
 }
 
@@ -56,10 +58,22 @@ function formatDate(iso: string): string {
 }
 
 function RecallFactRow({ fact, showSignal = false }: { fact: RecallFact; showSignal?: boolean }) {
+  const hasDirectRecall = Number(fact.access_count ?? 0) > 0;
   return (
     <div className="flex items-start gap-3">
-      <span className="shrink-0 rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-mono text-white/40">
-        {fact.access_count}x
+      <span
+        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-mono ${
+          hasDirectRecall
+            ? "bg-white/[0.06] text-white/40"
+            : "bg-[#61C1C4]/10 text-[#61C1C4]/70"
+        }`}
+        title={
+          hasDirectRecall
+            ? "Targeted recall count"
+            : "Not specifically searched or opened yet. Startup loads no longer inflate this count."
+        }
+      >
+        {hasDirectRecall ? `${fact.access_count}x` : "new"}
       </span>
       <div className="min-w-0 flex-1">
         <p className="text-xs text-white/60 line-clamp-1">{fact.fact}</p>
@@ -126,9 +140,27 @@ export default function MemoryActivityTab({ apiKey }: { apiKey: string }) {
   const sortedDays = Object.entries(data.facts_by_day).sort(([a], [b]) => a.localeCompare(b));
   const maxCount = Math.max(1, ...sortedDays.map(([, c]) => c));
   const topOfMindFacts = data.top_of_mind_facts ?? [];
+  const zeroCount = data.recall_diagnostics?.zero_access_count ?? 0;
+  const inspectedCount = data.recall_diagnostics?.inspected_top_facts ?? 0;
 
   return (
     <div className="space-y-6">
+      <div className="rounded-lg border border-[#61C1C4]/20 bg-[#61C1C4]/[0.04] p-4">
+        <h3 className="flex items-center gap-2 text-xs font-semibold text-[#61C1C4]/80 uppercase tracking-wider">
+          <Activity className="h-3.5 w-3.5" />
+          Recall Counter Meaning
+        </h3>
+        <p className="mt-2 text-xs leading-relaxed text-white/55">
+          Startup memory loads are not counted anymore. A <span className="text-[#61C1C4]">new</span> badge means
+          the fact can still be valid memory, but it has not been specifically searched or opened yet.
+        </p>
+        {inspectedCount > 0 && (
+          <p className="mt-2 text-[10px] text-white/35">
+            Current sample: {zeroCount} of {inspectedCount} most-accessed facts have no targeted recall count yet.
+          </p>
+        )}
+      </div>
+
       {/* Facts per day */}
       {sortedDays.length > 0 && (
         <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">

--- a/src/pages/admin/memory/RecycleBinTab.test.tsx
+++ b/src/pages/admin/memory/RecycleBinTab.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import RecycleBinTab from "./RecycleBinTab";
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+const recycleData = {
+  data: {
+    facts: [
+      {
+        id: "fact-1",
+        fact: "User prefers simple English updates.",
+        category: "preference",
+        decay_tier: "hot",
+        created_at: "2026-06-07T00:00:00.000Z",
+        archived_at: "2026-06-08T00:00:00.000Z",
+        decay_reason: "user-deleted",
+      },
+    ],
+    sessions: [
+      {
+        id: "session-row-1",
+        session_id: "chat-1",
+        platform: "Codex",
+        summary: "Discussed Memory recycle bin behavior.",
+        topics: ["memory", "admin"],
+        created_at: "2026-06-07T00:00:00.000Z",
+        archived_at: "2026-06-08T00:00:00.000Z",
+        archive_reason: "user-deleted",
+      },
+    ],
+  },
+};
+
+describe("RecycleBinTab", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("lists archived facts and sessions and restores a fact", async () => {
+    const calls: Array<{ url: string; body?: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+        if (url.includes("admin_memory_recycle_bin")) return jsonResponse(recycleData);
+        return jsonResponse({ success: true });
+      }),
+    );
+
+    render(<RecycleBinTab apiKey="test-token" />);
+
+    expect(await screen.findByText("User prefers simple English updates.")).toBeInTheDocument();
+    expect(screen.getByText("Discussed Memory recycle bin behavior.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Restore/i })[0]);
+
+    await waitFor(() => {
+      expect(calls.some((call) => call.url.includes("action=restore_fact"))).toBe(true);
+    });
+    expect(calls.find((call) => call.url.includes("action=restore_fact"))?.body).toEqual({ fact_id: "fact-1" });
+  });
+
+  it("requires confirmation before emptying the recycle bin", async () => {
+    const calls: Array<{ url: string; body?: unknown }> = [];
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+        if (url.includes("admin_memory_recycle_bin")) return jsonResponse(recycleData);
+        if (url.includes("empty_memory_recycle_bin")) {
+          return jsonResponse({ success: true, deleted: { facts: 1, sessions: 1 } });
+        }
+        return jsonResponse({ success: true });
+      }),
+    );
+
+    render(<RecycleBinTab apiKey="test-token" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Empty bin/i }));
+
+    await waitFor(() => {
+      expect(calls.some((call) => call.url.includes("action=empty_memory_recycle_bin"))).toBe(true);
+    });
+    expect(calls.find((call) => call.url.includes("action=empty_memory_recycle_bin"))?.body).toEqual({
+      confirm: "EMPTY",
+    });
+    expect(await screen.findByText("Recycle bin is empty")).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/memory/RecycleBinTab.tsx
+++ b/src/pages/admin/memory/RecycleBinTab.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Archive, Lightbulb, MessageSquare, RotateCcw, Search, Trash2 } from "lucide-react";
+import EmptyState from "./EmptyState";
+
+interface RecycledFact {
+  id: string;
+  fact: string;
+  category?: string | null;
+  decay_tier?: string | null;
+  created_at: string;
+  archived_at?: string | null;
+  decay_reason?: string | null;
+}
+
+interface RecycledSession {
+  id: string;
+  session_id: string;
+  platform?: string | null;
+  summary: string;
+  topics?: string[] | null;
+  created_at: string;
+  archived_at?: string | null;
+  archive_reason?: string | null;
+}
+
+interface RecycleResponse {
+  data?: {
+    facts?: RecycledFact[];
+    sessions?: RecycledSession[];
+  };
+}
+
+type RecycledItem =
+  | {
+      kind: "fact";
+      id: string;
+      title: string;
+      body: string;
+      meta: string[];
+      archivedAt?: string | null;
+      reason?: string | null;
+    }
+  | {
+      kind: "session";
+      id: string;
+      title: string;
+      body: string;
+      meta: string[];
+      archivedAt?: string | null;
+      reason?: string | null;
+    };
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return "Unknown date";
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function RecycleBinTab({ apiKey }: { apiKey: string }) {
+  const [facts, setFacts] = useState<RecycledFact[]>([]);
+  const [sessions, setSessions] = useState<RecycledSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [emptying, setEmptying] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=admin_memory_recycle_bin", {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      if (res.ok) {
+        const body = (await res.json()) as RecycleResponse;
+        setFacts(body.data?.facts ?? []);
+        setSessions(body.data?.sessions ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [apiKey]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const items = useMemo<RecycledItem[]>(() => {
+    const factItems: RecycledItem[] = facts.map((fact) => ({
+      kind: "fact",
+      id: fact.id,
+      title: fact.category || "Saved fact",
+      body: fact.fact,
+      meta: ["Fact", fact.decay_tier || "memory", formatDate(fact.archived_at || fact.created_at)],
+      archivedAt: fact.archived_at,
+      reason: fact.decay_reason,
+    }));
+    const sessionItems: RecycledItem[] = sessions.map((session) => ({
+      kind: "session",
+      id: session.id,
+      title: session.platform || session.session_id || "Chat summary",
+      body: session.summary,
+      meta: ["Chat", ...(session.topics ?? []).slice(0, 3), formatDate(session.archived_at || session.created_at)],
+      archivedAt: session.archived_at,
+      reason: session.archive_reason,
+    }));
+    return [...factItems, ...sessionItems].sort((a, b) => {
+      const left = Date.parse(a.archivedAt || "");
+      const right = Date.parse(b.archivedAt || "");
+      return (Number.isFinite(right) ? right : 0) - (Number.isFinite(left) ? left : 0);
+    });
+  }, [facts, sessions]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((item) =>
+      [item.title, item.body, item.kind, item.reason, ...item.meta]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(q)),
+    );
+  }, [items, query]);
+
+  async function restore(item: RecycledItem) {
+    setBusyId(`${item.kind}:${item.id}`);
+    try {
+      const action = item.kind === "fact" ? "restore_fact" : "restore_session";
+      const body = item.kind === "fact" ? { fact_id: item.id } : { session_id: item.id };
+      const res = await fetch(`/api/memory-admin?action=${action}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) await load();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function emptyBin() {
+    if (!window.confirm("Permanently empty archived facts and chat summaries? This cannot be restored.")) {
+      return;
+    }
+    setEmptying(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=empty_memory_recycle_bin", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: "EMPTY" }),
+      });
+      if (res.ok) {
+        setFacts([]);
+        setSessions([]);
+      }
+    } finally {
+      setEmptying(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-20 animate-pulse rounded-lg border border-white/[0.06] bg-white/[0.03]" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-white/[0.03] p-3">
+        <div>
+          <p className="text-xs font-semibold text-white/70">Archived memories are hidden from AI recall</p>
+          <p className="mt-1 text-xs text-white/40">
+            Restore them here, or empty the bin when you want them permanently removed.
+          </p>
+        </div>
+        {items.length > 0 && (
+          <button
+            type="button"
+            onClick={emptyBin}
+            disabled={emptying}
+            className="inline-flex items-center gap-1.5 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-semibold text-red-300 transition-colors hover:bg-red-500/10 disabled:cursor-wait disabled:opacity-60"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            {emptying ? "Emptying..." : "Empty bin"}
+          </button>
+        )}
+      </div>
+
+      {items.length > 0 && (
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-white/30" />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search archived facts and chats..."
+            className="w-full rounded-lg border border-white/[0.06] bg-white/[0.03] py-2 pl-9 pr-3 text-sm text-white placeholder:text-white/30 focus:border-[#61C1C4]/50 focus:outline-none"
+          />
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <EmptyState
+          icon={Archive}
+          heading="Recycle bin is empty"
+          description="Deleted facts and chat summaries will appear here first, so they can be restored before permanent removal."
+        />
+      ) : filtered.length === 0 ? (
+        <p className="px-4 py-8 text-center text-xs text-white/40">No archived memories match your search.</p>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((item) => {
+            const busy = busyId === `${item.kind}:${item.id}`;
+            const Icon = item.kind === "fact" ? Lightbulb : MessageSquare;
+            return (
+              <article key={`${item.kind}:${item.id}`} className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/[0.04]">
+                    <Icon className="h-4 w-4 text-white/40" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-sm font-semibold text-white/80">{item.title}</h3>
+                      {item.reason && (
+                        <span className="rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] text-white/35">
+                          {item.reason}
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-white/55">{item.body}</p>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-white/30">
+                      {item.meta.map((meta) => (
+                        <span key={meta}>{meta}</span>
+                      ))}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => restore(item)}
+                    disabled={busy}
+                    className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-[#61C1C4]/30 px-2.5 py-1.5 text-xs font-medium text-[#61C1C4] transition-colors hover:bg-[#61C1C4]/10 disabled:cursor-wait disabled:opacity-60"
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    {busy ? "Restoring..." : "Restore"}
+                  </button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260608003000_memory_session_recycle_bin.sql
+++ b/supabase/migrations/20260608003000_memory_session_recycle_bin.sql
@@ -1,0 +1,200 @@
+-- ─── Memory recycle bin support for chat/session summaries ────────────────
+--
+-- Facts already have status='archived', so they can be hidden from recall and
+-- restored. Session summaries were still hard-deleted from the admin UI. Add a
+-- matching soft-delete state so the Memory recycle bin can restore chats too.
+
+ALTER TABLE IF EXISTS public.mc_session_summaries
+  ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS archive_reason TEXT;
+
+UPDATE public.mc_session_summaries
+SET status = 'active'
+WHERE status IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'mc_session_summaries_status_check'
+  ) THEN
+    ALTER TABLE public.mc_session_summaries
+      ADD CONSTRAINT mc_session_summaries_status_check
+      CHECK (status IN ('active', 'archived'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_mc_ss_recycle_bin
+  ON public.mc_session_summaries(api_key_hash, status, archived_at DESC);
+
+-- BYOD parity for self-hosted memory databases.
+ALTER TABLE IF EXISTS public.session_summaries
+  ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS archive_reason TEXT;
+
+UPDATE public.session_summaries
+SET status = 'active'
+WHERE status IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'session_summaries_status_check'
+  ) THEN
+    ALTER TABLE public.session_summaries
+      ADD CONSTRAINT session_summaries_status_check
+      CHECK (status IN ('active', 'archived'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_ss_recycle_bin
+  ON public.session_summaries(status, archived_at DESC);
+
+-- Keep archived chat summaries out of load_memory startup recall. This mirrors
+-- the no-access-inflation managed startup function and extends the same
+-- recycle-bin visibility rule to BYOD.
+
+CREATE OR REPLACE FUNCTION public.mc_get_startup_context(p_api_key_hash text, p_num_sessions integer DEFAULT 5)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  ctx JSONB;
+  lib JSONB;
+  sessions JSONB;
+  facts JSONB;
+  fact_ids UUID[] := ARRAY[]::UUID[];
+BEGIN
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('category', category, 'key', key, 'value', value, 'priority', priority)
+    ORDER BY priority DESC, category, key
+  ), '[]'::jsonb)
+  INTO ctx
+  FROM mc_business_context
+  WHERE api_key_hash = p_api_key_hash AND decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('slug', slug, 'title', title, 'category', category, 'tags', tags, 'version', version, 'updated_at', updated_at)
+    ORDER BY updated_at DESC
+  ), '[]'::jsonb)
+  INTO lib
+  FROM mc_knowledge_library
+  WHERE api_key_hash = p_api_key_hash AND decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('session_id', session_id, 'platform', platform, 'summary', summary, 'decisions', decisions, 'open_loops', open_loops, 'topics', topics, 'created_at', created_at)
+    ORDER BY created_at DESC
+  ), '[]'::jsonb)
+  INTO sessions
+  FROM (
+    SELECT *
+    FROM mc_session_summaries
+    WHERE api_key_hash = p_api_key_hash
+      AND COALESCE(status, 'active') = 'active'
+    ORDER BY created_at DESC
+    LIMIT p_num_sessions
+  ) recent;
+
+  WITH surfaced_facts AS (
+    SELECT af.id, af.fact, af.category, af.confidence, af.created_at, af.startup_fact_kind,
+      NULLIF(to_jsonb(ef) ->> 'source_agent_id', '') AS source_agent_id,
+      NULLIF(to_jsonb(ef) ->> 'source_ref', '') AS source_ref,
+      NULLIF(to_jsonb(ef) ->> 'receipt_id', '') AS receipt_id
+    FROM mc_active_facts_startup_v1 af
+    JOIN mc_extracted_facts ef ON ef.id = af.id AND ef.api_key_hash = af.api_key_hash
+    WHERE af.api_key_hash = p_api_key_hash
+    ORDER BY CASE WHEN af.startup_fact_kind = 'durable' THEN 0 ELSE 1 END, af.confidence DESC, af.created_at DESC
+    LIMIT 50
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object('fact', fact, 'category', category, 'confidence', confidence, 'created_at', created_at, 'source_agent_id', source_agent_id, 'source_ref', source_ref, 'receipt_id', receipt_id)
+      ORDER BY CASE WHEN startup_fact_kind = 'durable' THEN 0 ELSE 1 END, confidence DESC, created_at DESC
+    ), '[]'::jsonb),
+    COALESCE(array_agg(id), ARRAY[]::UUID[])
+  INTO facts, fact_ids
+  FROM surfaced_facts;
+
+  RETURN jsonb_build_object(
+    'business_context', ctx,
+    'knowledge_library_index', lib,
+    'recent_sessions', sessions,
+    'active_facts', facts,
+    'loaded_at', now()
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_startup_context(num_sessions integer DEFAULT 5)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+  ctx JSONB;
+  lib JSONB;
+  sessions JSONB;
+  facts JSONB;
+  fact_ids UUID[] := ARRAY[]::UUID[];
+BEGIN
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('category', category, 'key', key, 'value', value, 'priority', priority)
+    ORDER BY priority DESC, category, key
+  ), '[]'::jsonb)
+  INTO ctx
+  FROM business_context
+  WHERE decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('slug', slug, 'title', title, 'category', category, 'tags', tags, 'version', version, 'updated_at', updated_at)
+    ORDER BY updated_at DESC
+  ), '[]'::jsonb)
+  INTO lib
+  FROM knowledge_library
+  WHERE decay_tier IN ('hot', 'warm');
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object('session_id', session_id, 'platform', platform, 'summary', summary, 'decisions', decisions, 'open_loops', open_loops, 'topics', topics, 'created_at', created_at)
+    ORDER BY created_at DESC
+  ), '[]'::jsonb)
+  INTO sessions
+  FROM (
+    SELECT *
+    FROM session_summaries
+    WHERE COALESCE(status, 'active') = 'active'
+    ORDER BY created_at DESC
+    LIMIT num_sessions
+  ) recent;
+
+  WITH surfaced_facts AS (
+    SELECT af.id, af.fact, af.category, af.confidence, af.created_at, af.startup_fact_kind,
+      NULLIF(to_jsonb(ef) ->> 'source_agent_id', '') AS source_agent_id,
+      NULLIF(to_jsonb(ef) ->> 'source_ref', '') AS source_ref,
+      NULLIF(to_jsonb(ef) ->> 'receipt_id', '') AS receipt_id
+    FROM active_facts_startup_v1 af
+    JOIN extracted_facts ef ON ef.id = af.id
+    ORDER BY CASE WHEN af.startup_fact_kind = 'durable' THEN 0 ELSE 1 END, af.confidence DESC, af.created_at DESC
+    LIMIT 50
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object('fact', fact, 'category', category, 'confidence', confidence, 'created_at', created_at, 'source_agent_id', source_agent_id, 'source_ref', source_ref, 'receipt_id', receipt_id)
+      ORDER BY CASE WHEN startup_fact_kind = 'durable' THEN 0 ELSE 1 END, confidence DESC, created_at DESC
+    ), '[]'::jsonb),
+    COALESCE(array_agg(id), ARRAY[]::UUID[])
+  INTO facts, fact_ids
+  FROM surfaced_facts;
+
+  RETURN jsonb_build_object(
+    'business_context', ctx,
+    'knowledge_library_index', lib,
+    'recent_sessions', sessions,
+    'active_facts', facts,
+    'loaded_at', now()
+  );
+END;
+$function$;


### PR DESCRIPTION
## What changed

- Added Memory Admin Code tab so captured code dumps are visible and searchable.
- Added Memory Admin Recycle Bin for archived facts and chat summaries, with restore and confirmed empty-bin flows.
- Changed fact/session delete paths to archive first instead of hard-delete.
- Added a migration so session summaries have active/archived state and archived chats stay out of startup recall.
- Hardened MCP search fallback/hybrid post-filter so archived sessions do not leak back into Memory recall.
- Clarified Recall Check: passive startup loads no longer inflate counters, so zero-count facts show as `new` instead of misleading `0x`.
- Improved automatic code capture descriptions so saved snippets get useful reference titles.

## Why

Chris flagged that Memory had too many promised functions with low confidence: Recall Check looked stuck on zero, Code stayed invisible/empty, and Memory needed a recycle-bin model where AI does not read archived items.

## Validation

- `npm exec vitest run src/pages/admin/memory/CodeTab.test.tsx src/pages/admin/memory/RecycleBinTab.test.tsx src/pages/admin/memory/MemoryActivityTab.test.tsx api/lib/memory-recall-sections.test.ts api/memory-startup-parity-migration.test.ts`
- `npx tsx --test packages/mcp-server/src/memory/__tests__/hybrid-search.test.ts packages/mcp-server/src/memory/__tests__/auto-capture.test.ts`
- `npm test --workspace=@unclick/memory-mcp`
- `npm run build --workspace=@unclick/memory-mcp`
- `npm run build --workspace=@unclick/mcp-server`
- `npm run build`
- Live UnClick dogtest: `load_memory`, `search_memory`, `save_conversation_turn`, `read_orchestrator_context`, `save_fact`, and `search_typed_links` all returned successfully in this session.

## Honest gaps

- Code auto-capture still depends on `MEMORY_CODE_AUTOCAPTURE_ENABLED`; this PR makes that visible and labels captured snippets, but does not flip production env vars.
- Files & Notes and Project Briefs still reuse existing Library/Context surfaces; they are not yet fully independent memory stores.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes memory deletion, recall, and search visibility across API, migrations, and MCP backends; incorrect filtering could hide valid sessions or leak archived data, but behavior is covered by migration and filter tests.
> 
> **Overview**
> Adds a **Memory recycle bin** flow: fact and chat deletes **archive** instead of hard-deleting sessions, with list/restore/confirmed empty-bin APIs and a DB migration so session summaries have `active`/`archived` state and **archived chats stay out of startup recall**.
> 
> **Admin Memory** gains **Code** and **Recycle Bin** tabs; the code action returns **auto-capture flags**, and captured snippets use **derived reference titles** instead of a generic label. **Recall Check** adds `zero_access_*` diagnostics and shows **`new`** for facts with no targeted recall count (not misleading `0x`).
> 
> **MCP/memory search** now filters **archived session summaries** in keyword scans and hybrid post-filters (managed + BYOD parity). XGate preflight **allows** when endpoint classification throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be10f6a3a853216529a29bfb0dcc2f993e86ff0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->