### PR TITLE
Jobs board: badges hug content with consistent 3px padding

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -8874,8 +8874,8 @@
     },
     {
       "source": "src/pages/admin/AdminJobs.tsx",
-      "hash": "e22f044a461e",
-      "bytes": 64194
+      "hash": "5417b324cff7",
+      "bytes": 64232
     },
     {
       "source": "src/pages/admin/AdminJobsmith.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -91,7 +91,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/crews/CrewsSettings.tsx | 9a2037783312 | 889 |
 | src/pages/admin/crews/CrewsCatalog.tsx | 089b6c00af2e | 5949 |
 | src/pages/admin/AdminDashboard.tsx | c6c9093d733d | 5303 |
-| src/pages/admin/AdminJobs.tsx | e22f044a461e | 64194 |
+| src/pages/admin/AdminJobs.tsx | 5417b324cff7 | 64232 |
 | src/pages/admin/AdminJobsmith.tsx | 34ba72c04cb2 | 54660 |
 | src/pages/admin/AdminKeychain.tsx | 0c355d737922 | 77124 |
 | src/pages/admin/AdminMemory.tsx | 25b2ecae9ca8 | 10814 |

--- a/src/components/JobsBoardSample.tsx
+++ b/src/components/JobsBoardSample.tsx
@@ -70,7 +70,7 @@ const liveDot: Record<Job["live"], string> = {
 // Grid mirrors the admin row: rank, job, state, priority, worker, live,
 // progress, proof, notes. Switches to a stacked card below lg so nothing squishes.
 const ROW_GRID =
-  "lg:grid lg:grid-cols-[34px_minmax(180px,1.4fr)_88px_64px_minmax(104px,0.5fr)_44px_minmax(176px,0.6fr)_98px_42px] lg:items-center lg:gap-1.5";
+  "lg:grid lg:grid-cols-[34px_minmax(180px,1.4fr)_74px_56px_minmax(118px,0.6fr)_44px_minmax(176px,0.6fr)_98px_42px] lg:items-center lg:gap-1.5";
 
 const groups: { label: string; jobs: Job[] }[] = [
   {
@@ -144,8 +144,10 @@ function StageStrip({ job }: { job: Job }) {
   );
 }
 
+// Hug content with a consistent 3px side padding (left-aligned in its grid cell)
+// instead of stretching to fill the column, so short labels do not look bloated.
 const badge =
-  "inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase";
+  "inline-flex min-w-0 items-center justify-self-start whitespace-nowrap rounded-[4px] border px-[3px] py-px text-[9px] font-semibold uppercase";
 
 function Row({ rank, job }: { rank: number; job: Job }) {
   return (
@@ -172,7 +174,7 @@ function Row({ rank, job }: { rank: number; job: Job }) {
           {job.live}
         </span>
         <StageStrip job={job} />
-        <span className={`inline-flex max-w-[98px] shrink-0 items-center gap-1 whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold ${proofStyle[job.proofTone]}`}>
+        <span className={`inline-flex max-w-[98px] shrink-0 items-center justify-self-start gap-1 whitespace-nowrap rounded-[4px] border px-[3px] py-px text-[9px] font-semibold ${proofStyle[job.proofTone]}`}>
           <GitPullRequest className="h-3 w-3 shrink-0" aria-hidden="true" />
           <span className="min-w-0 truncate">{job.proof}</span>
         </span>

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -157,7 +157,7 @@ const TITLE_MAX_CHARS = 90;
 // columns are wide enough for their real labels, and the Notes column fits the
 // header plus a two-digit count without clipping. Row height is unchanged.
 const JOB_ROW_GRID =
-  "md:grid md:grid-cols-[48px_minmax(260px,1.3fr)_92px_64px_minmax(116px,0.45fr)_44px_minmax(188px,0.5fr)_104px_46px_18px] md:items-center md:gap-1.5";
+  "md:grid md:grid-cols-[48px_minmax(244px,1.2fr)_78px_58px_minmax(132px,0.6fr)_44px_minmax(188px,0.5fr)_104px_46px_18px] md:items-center md:gap-1.5";
 
 interface JobDisplayCopy {
   title: string;
@@ -403,7 +403,7 @@ function SyncSignalPill({ signal }: { signal: JobGithubSyncSignal }) {
       {signal.href && <ExternalLink className="h-2.5 w-2.5 shrink-0 opacity-70" aria-hidden="true" />}
     </>
   );
-  const className = `inline-flex max-w-[104px] shrink-0 items-center gap-1 whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold ${SYNC_SIGNAL_STYLE[signal.tone]}`;
+  const className = `inline-flex max-w-[104px] shrink-0 items-center justify-self-start gap-1 whitespace-nowrap rounded-[4px] border px-[3px] py-px text-[9px] font-semibold ${SYNC_SIGNAL_STYLE[signal.tone]}`;
 
   if (signal.href) {
     return (
@@ -790,12 +790,12 @@ function JobRow({
 
         <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 md:contents">
           <span
-            className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${STATUS_STYLE[displayStatus]}`}
+            className={`inline-flex min-w-0 items-center justify-self-start whitespace-nowrap rounded-[4px] border px-[3px] py-px text-[9px] font-semibold uppercase ${STATUS_STYLE[displayStatus]}`}
           >
             {statusLabel(displayStatus)}
           </span>
           <span
-            className={`inline-flex min-w-0 items-center justify-center whitespace-nowrap rounded-[4px] border px-1 py-px text-[9px] font-semibold uppercase ${PRIORITY_STYLE[todo.priority]}`}
+            className={`inline-flex min-w-0 items-center justify-self-start whitespace-nowrap rounded-[4px] border px-[3px] py-px text-[9px] font-semibold uppercase ${PRIORITY_STYLE[todo.priority]}`}
           >
             {todo.priority}
           </span>


### PR DESCRIPTION
Addresses the feedback that the State/Priority badges had too much, inconsistent padding.

## What was happening
Those chips are grid items, so they default to `justify-self: stretch` and **stretch to fill their fixed column**. Short labels (OPEN, ACTIVE, URGENT, HIGH) ended up centered in a too-wide cell, which read as huge, inconsistent side padding.

## Fix
- Set State, Priority, and Proof chips to `justify-self-start` with a **consistent 3px side padding** so each chip hugs its own text and left-aligns in its cell. Short labels are now compact; all chips share the same padding.
- **Reclaim the freed width**: narrowed the State (92px to 78px) and Priority (64px to 58px) columns and widened Worker (so long worker names truncate less).
- Mirrored the same change in the public brochure sample so it stays a faithful preview.

## Verification
- `/admin/jobs` is auth-gated, so the screenshot proof is the public brochure board (same badge classes + `justify-self-start`): chips now hug their text with consistent padding, left-aligned, columns aligned. **Please eyeball `/admin/jobs` on the preview.**
- Branch was reset onto the latest `main` (includes #1338 and #1339) and the edits re-applied cleanly. `npm run build` clean, brainmap regenerated, `vitest run`: 192 files, 1534 tests pass.

https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout changes on the jobs board UI with no auth, data, or API impact.
> 
> **Overview**
> Fixes **State**, **Priority**, and **Proof** chips on the admin jobs board looking over-padded: grid items no longer stretch to fill their columns—they use **`justify-self-start`** and **3px horizontal padding** (`px-[3px]`) so labels hug the text and align left in the cell.
> 
> **Column widths** are retuned on `/admin/jobs` (narrower State/Priority, wider Worker) so the reclaimed space goes to worker names. The same badge and grid tweaks are applied in **`JobsBoardSample`** so the public preview matches the admin layout. Brainmap docs reflect the `AdminJobs.tsx` hash/size update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ea256385446edc249169d858bfdc6665262337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->