### PR TITLE
Add hanger/widow checks to CopyPass and UIPass

### DIFF
--- a/packages/copypass/src/__tests__/copy-library.test.ts
+++ b/packages/copypass/src/__tests__/copy-library.test.ts
@@ -177,4 +177,39 @@ describe("CopyPass copy library", () => {
     expect(checkIds).toContain("risky-guarantee-language");
     expect(checkIds).toContain("ui-honesty-gap");
   });
+
+  it("flags a display heading that risks a one-word hanger, and clears it once bound", () => {
+    const risky: CopyPassCopyBlock[] = [
+      {
+        id: "hero",
+        kind: "hero",
+        text: "Guardrails check every risky action before your AI acts.",
+        public_only: true,
+      },
+    ];
+    expect(detectCopyPassFindings(risky).map((finding) => finding.check_id)).toContain(
+      "display-copy-widow",
+    );
+
+    // A non-breaking space binding the last two words clears the risk.
+    const bound: CopyPassCopyBlock[] = [
+      {
+        id: "hero",
+        kind: "hero",
+        text: "Guardrails check every risky action before your AI\u00A0acts.",
+        public_only: true,
+      },
+    ];
+    expect(detectCopyPassFindings(bound).map((finding) => finding.check_id)).not.toContain(
+      "display-copy-widow",
+    );
+
+    // Short headings are too small to wrap into a hanger.
+    const shortHeading: CopyPassCopyBlock[] = [
+      { id: "hero", kind: "hero", text: "Memory that lasts.", public_only: true },
+    ];
+    expect(detectCopyPassFindings(shortHeading).map((finding) => finding.check_id)).not.toContain(
+      "display-copy-widow",
+    );
+  });
 });

--- a/packages/copypass/src/copy-library.ts
+++ b/packages/copypass/src/copy-library.ts
@@ -119,6 +119,14 @@ export const DEFAULT_COPYPASS_CHECKS: CopyPassCheckDefinition[] = [
     recommended_fix:
       "Qualify the capability, name the proof boundary, or link to the receipt that supports the claim.",
   },
+  {
+    id: "display-copy-widow",
+    label: "Display copy widow risk",
+    goal: "Display headings should not drop one or two short words onto their own line (a hanger).",
+    severity: "low",
+    recommended_fix:
+      "Bind the last two words with a non-breaking space, or apply text-wrap: balance (or pretty), so the heading keeps a tidy last line.",
+  },
 ].map((check) => CopyPassCheckDefinitionSchema.parse(check));
 
 const VALUE_TERMS = [
@@ -546,6 +554,21 @@ export function detectCopyPassFindings(
       );
     }
 
+    if (
+      isActive(activeCheckIds, "display-copy-widow") &&
+      isDisplayBlock(block) &&
+      hasWidowRisk(block.text)
+    ) {
+      findings.push(
+        createFinding(
+          block,
+          requireCheck(checkById, "display-copy-widow"),
+          "Display heading risks a one-word last line",
+          "This heading is long enough to wrap, and its final short word is not bound, so it can drop onto its own line.",
+        ),
+      );
+    }
+
     return findings;
   });
 
@@ -565,6 +588,24 @@ export function normalizeCopy(value: string): string {
 
 function isPrimaryBlock(block: CopyPassCopyBlock): boolean {
   return block.kind === "hero" || block.kind === "headline";
+}
+
+function isDisplayBlock(block: CopyPassCopyBlock): boolean {
+  return block.kind === "hero" || block.kind === "headline";
+}
+
+/**
+ * Heuristic widow ("hanger") risk for display headings, from text alone: long
+ * enough to wrap, ending in a short word, and not already bound with a
+ * non-breaking space. CSS text-wrap: balance also clears the real defect; this
+ * is a low-severity nudge to apply one of those fixes.
+ */
+function hasWidowRisk(value: string): boolean {
+  if (value.includes("\u00A0")) return false; // already bound with a non-breaking space
+  const words = value.replace(/\s+/g, " ").trim().split(" ").filter(Boolean);
+  if (words.length < 6) return false; // short headings rarely wrap into a hanger
+  const lastWord = words[words.length - 1];
+  return lastWord.length <= 5; // a tiny trailing word ("acts.", "that.") is the classic orphan
 }
 
 function isPolicyExampleCatalog(block: CopyPassCopyBlock, normalized: string): boolean {

--- a/packages/copypass/src/schema.ts
+++ b/packages/copypass/src/schema.ts
@@ -23,6 +23,7 @@ export const CopyPassCheckIdSchema = z.enum([
   "ai-slop-language",
   "misleading-urgency",
   "ui-honesty-gap",
+  "display-copy-widow",
 ]);
 
 export const CopyPassBlockKindSchema = z.enum([

--- a/packages/uxpass/src/__tests__/visual-audit.test.ts
+++ b/packages/uxpass/src/__tests__/visual-audit.test.ts
@@ -62,6 +62,51 @@ describe("evaluateVisualAuditSnapshot", () => {
     expect(summary.bySeverity.high).toBe(0);
   });
 
+  it("flags a heading that wraps to a lonely last word (widow)", () => {
+    const summary = evaluateVisualAuditSnapshot({
+      ...cleanSnapshot,
+      elements: [
+        {
+          selector: "h1",
+          tagName: "h1",
+          text: "Guardrails before your AI acts",
+          visible: true,
+          rect: rect(80, 80, 700, 120),
+          clientWidth: 700,
+          clientHeight: 120,
+          fontSize: 48,
+          fontWeight: 800,
+          color: "rgb(255, 255, 255)",
+          backgroundColor: "rgb(6, 32, 44)",
+        },
+      ],
+    });
+    expect(summary.byKind.text_widow).toBe(1);
+    expect(summary.issues[0].remediation).toMatch(/non-breaking space|text-wrap/i);
+  });
+
+  it("does not flag a heading that fits on one line", () => {
+    const summary = evaluateVisualAuditSnapshot({
+      ...cleanSnapshot,
+      elements: [
+        {
+          selector: "h1",
+          tagName: "h1",
+          text: "Guardrails before your AI acts",
+          visible: true,
+          rect: rect(80, 80, 1100, 56),
+          clientWidth: 1100,
+          clientHeight: 56,
+          fontSize: 48,
+          fontWeight: 800,
+          color: "rgb(255, 255, 255)",
+          backgroundColor: "rgb(6, 32, 44)",
+        },
+      ],
+    });
+    expect(summary.byKind.text_widow).toBe(0);
+  });
+
   it("flags clipped text without a full fallback label", () => {
     const summary = evaluateVisualAuditSnapshot({
       ...cleanSnapshot,

--- a/packages/uxpass/src/visual-audit.ts
+++ b/packages/uxpass/src/visual-audit.ts
@@ -16,7 +16,8 @@ export type VisualAuditIssueKind =
   | "generic_ai_surface"
   | "missing_product_mechanics"
   | "unlabelled_action"
-  | "crowded_action_cluster";
+  | "crowded_action_cluster"
+  | "text_widow";
 
 export interface VisualRect {
   x: number;
@@ -105,9 +106,14 @@ const ALL_KINDS: VisualAuditIssueKind[] = [
   "missing_product_mechanics",
   "unlabelled_action",
   "crowded_action_cluster",
+  "text_widow",
 ];
 
 const ALL_SEVERITIES: VisualAuditSeverity[] = ["critical", "high", "medium", "low"];
+
+// A widow ("hanger") leaves one or two short words alone on a heading's last
+// line. Estimated from the rendered rect, font size, and text.
+const WIDOW_CHAR_EM = 0.5;
 
 const MIN_TOUCH_TARGET = 24;
 const TEXT_CLIP_TOLERANCE = 2;
@@ -245,6 +251,55 @@ function isHeadingLike(element: VisualAuditElement): boolean {
   const tag = element.tagName.toLowerCase();
   const role = (element.role ?? "").toLowerCase();
   return /^h[1-6]$/.test(tag) || role === "heading";
+}
+
+function measuredLineCount(element: VisualAuditElement): number {
+  const fontSize = element.fontSize ?? 0;
+  if (fontSize <= 0) return 1;
+  const height = element.clientHeight ?? element.rect.height;
+  return Math.max(1, Math.round(height / (fontSize * 1.2)));
+}
+
+interface WidowEstimate {
+  lines: number;
+  lastLineWords: number;
+  lastLineChars: number;
+  charsPerLine: number;
+}
+
+/**
+ * Greedy-wrap a heading's words into estimated lines using the rendered width
+ * and font size, so we can tell whether the last line is a lonely word or two.
+ */
+function estimateWidow(element: VisualAuditElement): WidowEstimate | null {
+  const fontSize = element.fontSize ?? 0;
+  const width = element.clientWidth ?? element.rect.width;
+  if (fontSize <= 0 || width <= 0) return null;
+  const text = compactText(element.text);
+  const words = text.split(" ").filter(Boolean);
+  if (words.length < 4) return null;
+  const charsPerLine = Math.floor(width / (fontSize * WIDOW_CHAR_EM));
+  if (charsPerLine < 4 || text.length <= charsPerLine) return null;
+
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current.length === 0) current = word;
+    else if (current.length + 1 + word.length <= charsPerLine) current += ` ${word}`;
+    else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current.length > 0) lines.push(current);
+
+  const lastLine = lines[lines.length - 1] ?? "";
+  return {
+    lines: lines.length,
+    lastLineWords: lastLine.split(" ").filter(Boolean).length,
+    lastLineChars: lastLine.length,
+    charsPerLine,
+  };
 }
 
 function visualWeight(element: VisualAuditElement): number {
@@ -511,6 +566,35 @@ export function evaluateVisualAuditSnapshot(snapshot: VisualAuditSnapshot): Visu
           },
           remediation: "Increase foreground contrast or darken/lighten the background token for this state.",
         });
+      }
+
+      const isDisplayText = isHeadingLike(element) || (element.fontSize ?? 0) >= 22;
+      if (isDisplayText && measuredLineCount(element) >= 2) {
+        const widow = estimateWidow(element);
+        if (
+          widow &&
+          widow.lines >= 2 &&
+          widow.lastLineWords <= 2 &&
+          widow.lastLineChars <= Math.floor(widow.charsPerLine * 0.5)
+        ) {
+          pushIssue(issues, {
+            kind: "text_widow",
+            severity: "low",
+            title: "Heading drops a short last line",
+            description: `${describeElement(element)} wraps so the last line holds only ${widow.lastLineWords} short word${widow.lastLineWords === 1 ? "" : "s"}.`,
+            selector: element.selector,
+            elementId: element.id,
+            evidence: {
+              text: text.slice(0, 120),
+              estimated_lines: widow.lines,
+              last_line_words: widow.lastLineWords,
+              last_line_chars: widow.lastLineChars,
+              chars_per_line: widow.charsPerLine,
+              font_size: element.fontSize ?? null,
+            },
+            remediation: "Bind the last two words with a non-breaking space, or apply text-wrap: balance (or pretty), so the heading does not leave one or two words on their own line.",
+          });
+        }
       }
     }
 


### PR DESCRIPTION
Adds a "hanger"/widow check (one or two short words dropped onto a heading's last line) to both quality passes, as requested.

## CopyPass
New **`display-copy-widow`** rule (severity `low`). Flags `hero`/`headline` copy that is long enough to wrap (6+ words) and ends in a tiny word (<= 5 chars, e.g. "acts.", "that."), **unless** the last words are already bound with a non-breaking space. Text-only, so it is kept deliberately precise to avoid nagging normal long headings (verified against the existing "good hero" fixtures).

## UIPass (visual audit)
New **`text_widow`** issue. This is the accurate, render-aware version: it uses the element's rect, font size, and text to greedy-wrap the heading and flag a last line of one or two short words. Only fires on heading-like or large display text that actually wraps to 2+ lines.

Both recommend the same fix: **bind the last two words with a non-breaking space, or apply `text-wrap: balance` (or `pretty`)**.

## Tests
- `copy-library.test.ts`: widow fires on a long heading ending in a short word; clears when bound with ` `; ignores short headings.
- `visual-audit.test.ts`: `text_widow` fires on a heading that wraps to a lonely last word; not on one that fits one line.

CopyPass package 25/25, UXPass package 85/85, MCP wrappers 20/20, root suite 1535/1535. Build clean.

https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint rules and visual heuristics only; no auth, data, or runtime behavior changes beyond new optional findings.
> 
> **Overview**
> Adds **widow/hanger** detection in CopyPass and UXPass so display headings are nudged when a short last line could sit alone.
> 
> **CopyPass** registers a low-severity **`display-copy-widow`** check on `hero`/`headline` blocks: six or more words, final word ≤5 characters, and no non-breaking space already binding the tail. **`hasWidowRisk`** implements the text-only heuristic; the check id is wired through the Zod schema.
> 
> **UXPass** adds **`text_widow`** to the visual audit: for heading-like or large display text that wraps to two+ lines, **`estimateWidow`** greedy-wraps from width and font size and flags when the last line has one or two short words. Remediation matches CopyPass (non-breaking space or `text-wrap: balance` / `pretty`).
> 
> Tests cover CopyPass flag/clear/short-heading cases and UXPass wrap vs single-line headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515ba09bbf220dec07d3bcd2e21d6098672ed962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->