### PR TITLE
Memory page: change sample name Kate to Jason

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -13170,8 +13170,8 @@
     },
     {
       "source": "src/pages/Memory.tsx",
-      "hash": "147f832aa5b9",
-      "bytes": 19192
+      "hash": "e1c923ee0c61",
+      "bytes": 19193
     },
     {
       "source": "src/pages/NewToAI.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -131,7 +131,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Login.tsx | 86f887990094 | 8440 |
 | src/pages/MemoryConnect.tsx | c760d37398d5 | 18534 |
 | src/pages/MemorySetup.tsx | c46cb67d413e | 19854 |
-| src/pages/Memory.tsx | 147f832aa5b9 | 19192 |
+| src/pages/Memory.tsx | e1c923ee0c61 | 19193 |
 | src/pages/NewToAI.tsx | e2d14ccf9af9 | 13179 |
 | src/pages/Organiser.tsx | a439fcf2092f | 16578 |
 | src/pages/Pricing.tsx | 0830c034b4a3 | 8753 |

--- a/src/pages/Memory.tsx
+++ b/src/pages/Memory.tsx
@@ -52,7 +52,7 @@ const CAPTURE_FEED = [
   {
     time: "2:15 PM",
     tag: "Linked",
-    text: "\"Kate's birthday is 15 July\" to family",
+    text: "\"Jason's birthday is 15 July\" to family",
   },
   {
     time: "2:31 PM",


### PR DESCRIPTION
Changes the sample name in the Memory page capture feed from "Kate" to "Jason" (`"Jason's birthday is 15 July"`). One-line content change. Build clean, brainmap regenerated.

https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeWLRGGXZc2wejFJ2L2RWQ)_