### PR TITLE
feat: batch 52-57 local connectors (525 apps, 1447 tools)

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 931,
+    "inventory": 941,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 506,
+    "tools": 516,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 506
+      "count": 516
     },
     {
       "id": "rooms",
@@ -4402,6 +4402,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-areacalc-packages-mcp-server-src-areacalc-tool-ts-no-route",
+      "division": "Tools",
+      "name": "areacalc",
+      "kind": "MCP tool",
+      "meaning": "areacalc MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/areacalc-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-artic-packages-mcp-server-src-artic-tool-ts-no-route",
       "division": "Tools",
       "name": "artic",
@@ -5048,6 +5058,16 @@
       "kind": "MCP tool",
       "meaning": "commonsensepass MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/commonsensepass-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-complexnum-packages-mcp-server-src-complexnum-tool-ts-no-route",
+      "division": "Tools",
+      "name": "complexnum",
+      "kind": "MCP tool",
+      "meaning": "complexnum MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/complexnum-tool.ts",
       "route": "",
       "tags": []
     },
@@ -6632,6 +6652,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-logbase-packages-mcp-server-src-logbase-tool-ts-no-route",
+      "division": "Tools",
+      "name": "logbase",
+      "kind": "MCP tool",
+      "meaning": "logbase MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/logbase-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-lorem-packages-mcp-server-src-lorem-tool-ts-no-route",
       "division": "Tools",
       "name": "lorem",
@@ -6838,6 +6868,16 @@
       "kind": "MCP tool",
       "meaning": "mhwdb MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/mhwdb-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-midpoint-packages-mcp-server-src-midpoint-tool-ts-no-route",
+      "division": "Tools",
+      "name": "midpoint",
+      "kind": "MCP tool",
+      "meaning": "midpoint MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/midpoint-tool.ts",
       "route": "",
       "tags": []
     },
@@ -7062,6 +7102,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-normaldistr-packages-mcp-server-src-normaldistr-tool-ts-no-route",
+      "division": "Tools",
+      "name": "normaldistr",
+      "kind": "MCP tool",
+      "meaning": "normaldistr MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/normaldistr-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-notion-packages-mcp-server-src-notion-tool-ts-no-route",
       "division": "Tools",
       "name": "notion",
@@ -7078,6 +7128,16 @@
       "kind": "MCP tool",
       "meaning": "npm registry MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/npm-registry-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-nthroot-packages-mcp-server-src-nthroot-tool-ts-no-route",
+      "division": "Tools",
+      "name": "nthroot",
+      "kind": "MCP tool",
+      "meaning": "nthroot MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/nthroot-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8262,6 +8322,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-slopeintercept-packages-mcp-server-src-slopeintercept-tool-ts-no-route",
+      "division": "Tools",
+      "name": "slopeintercept",
+      "kind": "MCP tool",
+      "meaning": "slopeintercept MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/slopeintercept-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-sloppass-packages-mcp-server-src-sloppass-tool-ts-no-route",
       "division": "Tools",
       "name": "sloppass",
@@ -8388,6 +8458,16 @@
       "kind": "MCP tool",
       "meaning": "stackexchange MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/stackexchange-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-standardform-packages-mcp-server-src-standardform-tool-ts-no-route",
+      "division": "Tools",
+      "name": "standardform",
+      "kind": "MCP tool",
+      "meaning": "standardform MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/standardform-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8722,6 +8802,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-trianglesolve-packages-mcp-server-src-trianglesolve-tool-ts-no-route",
+      "division": "Tools",
+      "name": "trianglesolve",
+      "kind": "MCP tool",
+      "meaning": "trianglesolve MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/trianglesolve-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-trivia-packages-mcp-server-src-trivia-tool-ts-no-route",
       "division": "Tools",
       "name": "trivia",
@@ -9008,6 +9098,16 @@
       "kind": "MCP tool",
       "meaning": "virustotal MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/virustotal-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-wavelength-packages-mcp-server-src-wavelength-tool-ts-no-route",
+      "division": "Tools",
+      "name": "wavelength",
+      "kind": "MCP tool",
+      "meaning": "wavelength MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/wavelength-tool.ts",
       "route": "",
       "tags": []
     },
@@ -10106,6 +10206,11 @@
       "packages/mcp-server/src/archiveorg-tool.ts"
     ],
     [
+      "areacalc",
+      "areacalc MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/areacalc-tool.ts"
+    ],
+    [
       "artic",
       "artic MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/artic-tool.ts"
@@ -10429,6 +10534,11 @@
       "commonsensepass",
       "commonsensepass MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/commonsensepass-tool.ts"
+    ],
+    [
+      "complexnum",
+      "complexnum MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/complexnum-tool.ts"
     ],
     [
       "compliancepass",
@@ -11221,6 +11331,11 @@
       "packages/mcp-server/src/linear-tool.ts"
     ],
     [
+      "logbase",
+      "logbase MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/logbase-tool.ts"
+    ],
+    [
       "lorem",
       "lorem MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/lorem-tool.ts"
@@ -11324,6 +11439,11 @@
       "mhwdb",
       "mhwdb MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/mhwdb-tool.ts"
+    ],
+    [
+      "midpoint",
+      "midpoint MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/midpoint-tool.ts"
     ],
     [
       "miro",
@@ -11436,6 +11556,11 @@
       "packages/mcp-server/src/nominatim-tool.ts"
     ],
     [
+      "normaldistr",
+      "normaldistr MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/normaldistr-tool.ts"
+    ],
+    [
       "notion",
       "notion MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/notion-tool.ts"
@@ -11444,6 +11569,11 @@
       "npm registry",
       "npm registry MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/npm-registry-tool.ts"
+    ],
+    [
+      "nthroot",
+      "nthroot MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/nthroot-tool.ts"
     ],
     [
       "NudgeOnly",
@@ -12036,6 +12166,11 @@
       "packages/mcp-server/src/sleeper-tool.ts"
     ],
     [
+      "slopeintercept",
+      "slopeintercept MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/slopeintercept-tool.ts"
+    ],
+    [
       "sloppass",
       "sloppass MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/sloppass-tool.ts"
@@ -12099,6 +12234,11 @@
       "stackexchange",
       "stackexchange MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/stackexchange-tool.ts"
+    ],
+    [
+      "standardform",
+      "standardform MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/standardform-tool.ts"
     ],
     [
       "stapi",
@@ -12266,6 +12406,11 @@
       "packages/mcp-server/src/trello-tool.ts"
     ],
     [
+      "trianglesolve",
+      "trianglesolve MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/trianglesolve-tool.ts"
+    ],
+    [
       "trivia",
       "trivia MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/trivia-tool.ts"
@@ -12409,6 +12554,11 @@
       "virustotal",
       "virustotal MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/virustotal-tool.ts"
+    ],
+    [
+      "wavelength",
+      "wavelength MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/wavelength-tool.ts"
     ],
     [
       "wayback",
@@ -13684,6 +13834,11 @@
       "bytes": 4106
     },
     {
+      "source": "packages/mcp-server/src/areacalc-tool.ts",
+      "hash": "550eb5992182",
+      "bytes": 3924
+    },
+    {
       "source": "packages/mcp-server/src/artic-tool.ts",
       "hash": "6e076252fe5d",
       "bytes": 2428
@@ -13777,11 +13932,6 @@
       "source": "packages/mcp-server/src/bitbucket-tool.ts",
       "hash": "a6a405951262",
       "bytes": 4388
-    },
-    {
-      "source": "packages/mcp-server/src/bitwise-tool.ts",
-      "hash": "5b0b0365aefe",
-      "bytes": 2091
     },
     {
       "source": ".github/workflows/apply-migrations.yml",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 921,
+    "inventory": 931,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 496,
+    "tools": 506,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 496
+      "count": 506
     },
     {
       "id": "rooms",
@@ -4342,6 +4342,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-angleconv-packages-mcp-server-src-angleconv-tool-ts-no-route",
+      "division": "Tools",
+      "name": "angleconv",
+      "kind": "MCP tool",
+      "meaning": "angleconv MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/angleconv-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-animechan-packages-mcp-server-src-animechan-tool-ts-no-route",
       "division": "Tools",
       "name": "animechan",
@@ -4558,6 +4568,16 @@
       "kind": "MCP tool",
       "meaning": "binaryconv MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/binaryconv-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-binomprob-packages-mcp-server-src-binomprob-tool-ts-no-route",
+      "division": "Tools",
+      "name": "binomprob",
+      "kind": "MCP tool",
+      "meaning": "binomprob MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/binomprob-tool.ts",
       "route": "",
       "tags": []
     },
@@ -6272,6 +6292,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-interpolate-packages-mcp-server-src-interpolate-tool-ts-no-route",
+      "division": "Tools",
+      "name": "interpolate",
+      "kind": "MCP tool",
+      "meaning": "interpolate MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/interpolate-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-ipaddrinfo-packages-mcp-server-src-ipaddrinfo-tool-ts-no-route",
       "division": "Tools",
       "name": "ipaddrinfo",
@@ -6838,6 +6868,16 @@
       "kind": "MCP tool",
       "meaning": "mixpanel MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/mixpanel-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-modpow-packages-mcp-server-src-modpow-tool-ts-no-route",
+      "division": "Tools",
+      "name": "modpow",
+      "kind": "MCP tool",
+      "meaning": "modpow MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/modpow-tool.ts",
       "route": "",
       "tags": []
     },
@@ -7562,6 +7602,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-polygon-packages-mcp-server-src-polygon-tool-ts-no-route",
+      "division": "Tools",
+      "name": "polygon",
+      "kind": "MCP tool",
+      "meaning": "polygon MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/polygon-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-postcodes-packages-mcp-server-src-postcodes-tool-ts-no-route",
       "division": "Tools",
       "name": "postcodes",
@@ -7608,6 +7658,16 @@
       "kind": "MCP tool",
       "meaning": "primecheck MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/primecheck-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-primefactor-packages-mcp-server-src-primefactor-tool-ts-no-route",
+      "division": "Tools",
+      "name": "primefactor",
+      "kind": "MCP tool",
+      "meaning": "primefactor MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/primefactor-tool.ts",
       "route": "",
       "tags": []
     },
@@ -7712,6 +7772,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-quadratic-packages-mcp-server-src-quadratic-tool-ts-no-route",
+      "division": "Tools",
+      "name": "quadratic",
+      "kind": "MCP tool",
+      "meaning": "quadratic MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/quadratic-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-quickbooks-packages-mcp-server-src-quickbooks-tool-ts-no-route",
       "division": "Tools",
       "name": "quickbooks",
@@ -7798,6 +7868,16 @@
       "kind": "MCP tool",
       "meaning": "randomuser MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/randomuser-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-ratiosimplify-packages-mcp-server-src-ratiosimplify-tool-ts-no-route",
+      "division": "Tools",
+      "name": "ratiosimplify",
+      "kind": "MCP tool",
+      "meaning": "ratiosimplify MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/ratiosimplify-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8148,6 +8228,16 @@
       "kind": "MCP tool",
       "meaning": "shortcut MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/shortcut-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-sigmoid-packages-mcp-server-src-sigmoid-tool-ts-no-route",
+      "division": "Tools",
+      "name": "sigmoid",
+      "kind": "MCP tool",
+      "meaning": "sigmoid MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/sigmoid-tool.ts",
       "route": "",
       "tags": []
     },
@@ -9162,6 +9252,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-zscore-packages-mcp-server-src-zscore-tool-ts-no-route",
+      "division": "Tools",
+      "name": "zscore",
+      "kind": "MCP tool",
+      "meaning": "zscore MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/zscore-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "workers-and-seats-seat-claude-reviewer-seat-docs-fleet-worker-roles-md-no-route",
       "division": "Workers and seats",
       "name": "Claude Reviewer Seat",
@@ -9976,6 +10076,11 @@
       "packages/mcp-server/src/amiibo-tool.ts"
     ],
     [
+      "angleconv",
+      "angleconv MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/angleconv-tool.ts"
+    ],
+    [
       "animechan",
       "animechan MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/animechan-tool.ts"
@@ -10084,6 +10189,11 @@
       "binaryconv",
       "binaryconv MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/binaryconv-tool.ts"
+    ],
+    [
+      "binomprob",
+      "binomprob MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/binomprob-tool.ts"
     ],
     [
       "bitbucket",
@@ -10941,6 +11051,11 @@
       "packages/mcp-server/src/intercom-tool.ts"
     ],
     [
+      "interpolate",
+      "interpolate MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/interpolate-tool.ts"
+    ],
+    [
       "ipaddrinfo",
       "ipaddrinfo MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/ipaddrinfo-tool.ts"
@@ -11224,6 +11339,11 @@
       "mixpanel",
       "mixpanel MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/mixpanel-tool.ts"
+    ],
+    [
+      "modpow",
+      "modpow MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/modpow-tool.ts"
     ],
     [
       "monday",
@@ -11586,6 +11706,11 @@
       "packages/mcp-server/src/pokemontcg-tool.ts"
     ],
     [
+      "polygon",
+      "polygon MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/polygon-tool.ts"
+    ],
+    [
       "postcodes",
       "postcodes MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/postcodes-tool.ts"
@@ -11609,6 +11734,11 @@
       "primecheck",
       "primecheck MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/primecheck-tool.ts"
+    ],
+    [
+      "primefactor",
+      "primefactor MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/primefactor-tool.ts"
     ],
     [
       "proportion",
@@ -11661,6 +11791,11 @@
       "packages/mcp-server/src/qrserver-tool.ts"
     ],
     [
+      "quadratic",
+      "quadratic MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/quadratic-tool.ts"
+    ],
+    [
       "quickbooks",
       "quickbooks MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/quickbooks-tool.ts"
@@ -11704,6 +11839,11 @@
       "randomuser",
       "randomuser MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/randomuser-tool.ts"
+    ],
+    [
+      "ratiosimplify",
+      "ratiosimplify MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/ratiosimplify-tool.ts"
     ],
     [
       "rawg",
@@ -11879,6 +12019,11 @@
       "shortcut",
       "shortcut MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/shortcut-tool.ts"
+    ],
+    [
+      "sigmoid",
+      "sigmoid MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/sigmoid-tool.ts"
     ],
     [
       "slack",
@@ -12384,6 +12529,11 @@
       "zippopotamus",
       "zippopotamus MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/zippopotamus-tool.ts"
+    ],
+    [
+      "zscore",
+      "zscore MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/zscore-tool.ts"
     ]
   ],
   "roomRows": [
@@ -13504,6 +13654,11 @@
       "bytes": 2101
     },
     {
+      "source": "packages/mcp-server/src/angleconv-tool.ts",
+      "hash": "6e8ddaf9344f",
+      "bytes": 1663
+    },
+    {
       "source": "packages/mcp-server/src/animechan-tool.ts",
       "hash": "f77b9af84d81",
       "bytes": 1735
@@ -13614,6 +13769,11 @@
       "bytes": 1337
     },
     {
+      "source": "packages/mcp-server/src/binomprob-tool.ts",
+      "hash": "08174a2866e7",
+      "bytes": 1770
+    },
+    {
       "source": "packages/mcp-server/src/bitbucket-tool.ts",
       "hash": "a6a405951262",
       "bytes": 4388
@@ -13622,16 +13782,6 @@
       "source": "packages/mcp-server/src/bitwise-tool.ts",
       "hash": "5b0b0365aefe",
       "bytes": 2091
-    },
-    {
-      "source": "packages/mcp-server/src/bluesky-tool.ts",
-      "hash": "9c63ad10f656",
-      "bytes": 16256
-    },
-    {
-      "source": "packages/mcp-server/src/bored-tool.ts",
-      "hash": "076a2a94303b",
-      "bytes": 3043
     },
     {
       "source": ".github/workflows/apply-migrations.yml",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 941,
+    "inventory": 951,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 516,
+    "tools": 526,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 516
+      "count": 526
     },
     {
       "id": "rooms",
@@ -5212,6 +5212,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-crossproduct-packages-mcp-server-src-crossproduct-tool-ts-no-route",
+      "division": "Tools",
+      "name": "crossproduct",
+      "kind": "MCP tool",
+      "meaning": "crossproduct MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/crossproduct-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-crossref-packages-mcp-server-src-crossref-tool-ts-no-route",
       "division": "Tools",
       "name": "crossref",
@@ -5502,6 +5512,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-dotproduct-packages-mcp-server-src-dotproduct-tool-ts-no-route",
+      "division": "Tools",
+      "name": "dotproduct",
+      "kind": "MCP tool",
+      "meaning": "dotproduct MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/dotproduct-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-dropbox-packages-mcp-server-src-dropbox-tool-ts-no-route",
       "division": "Tools",
       "name": "dropbox",
@@ -5698,6 +5718,16 @@
       "kind": "MCP tool",
       "meaning": "excuser MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/excuser-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-expgrowth-packages-mcp-server-src-expgrowth-tool-ts-no-route",
+      "division": "Tools",
+      "name": "expgrowth",
+      "kind": "MCP tool",
+      "meaning": "expgrowth MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/expgrowth-tool.ts",
       "route": "",
       "tags": []
     },
@@ -5972,6 +6002,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-geomseries-packages-mcp-server-src-geomseries-tool-ts-no-route",
+      "division": "Tools",
+      "name": "geomseries",
+      "kind": "MCP tool",
+      "meaning": "geomseries MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/geomseries-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-geopass-packages-mcp-server-src-geopass-tool-ts-no-route",
       "division": "Tools",
       "name": "geopass",
@@ -6098,6 +6138,16 @@
       "kind": "MCP tool",
       "meaning": "hamming MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/hamming-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-harmonicseries-packages-mcp-server-src-harmonicseries-tool-ts-no-route",
+      "division": "Tools",
+      "name": "harmonicseries",
+      "kind": "MCP tool",
+      "meaning": "harmonicseries MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/harmonicseries-tool.ts",
       "route": "",
       "tags": []
     },
@@ -7522,6 +7572,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-piapprox-packages-mcp-server-src-piapprox-tool-ts-no-route",
+      "division": "Tools",
+      "name": "piapprox",
+      "kind": "MCP tool",
+      "meaning": "piapprox MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/piapprox-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-picsum-packages-mcp-server-src-picsum-tool-ts-no-route",
       "division": "Tools",
       "name": "picsum",
@@ -7638,6 +7698,16 @@
       "kind": "MCP tool",
       "meaning": "poetrydb MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/poetrydb-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-poisson-packages-mcp-server-src-poisson-tool-ts-no-route",
+      "division": "Tools",
+      "name": "poisson",
+      "kind": "MCP tool",
+      "meaning": "poisson MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/poisson-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8592,6 +8662,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-taylor-packages-mcp-server-src-taylor-tool-ts-no-route",
+      "division": "Tools",
+      "name": "taylor",
+      "kind": "MCP tool",
+      "meaning": "taylor MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/taylor-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-telegram-packages-mcp-server-src-telegram-tool-ts-no-route",
       "division": "Tools",
       "name": "telegram",
@@ -9052,6 +9132,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-variancecalc-packages-mcp-server-src-variancecalc-tool-ts-no-route",
+      "division": "Tools",
+      "name": "variancecalc",
+      "kind": "MCP tool",
+      "meaning": "variancecalc MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/variancecalc-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-vatcomply-packages-mcp-server-src-vatcomply-tool-ts-no-route",
       "division": "Tools",
       "name": "vatcomply",
@@ -9128,6 +9218,16 @@
       "kind": "MCP tool",
       "meaning": "webflow MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/webflow-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-weightedmean-packages-mcp-server-src-weightedmean-tool-ts-no-route",
+      "division": "Tools",
+      "name": "weightedmean",
+      "kind": "MCP tool",
+      "meaning": "weightedmean MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/weightedmean-tool.ts",
       "route": "",
       "tags": []
     },
@@ -10611,6 +10711,11 @@
       "packages/mcp-server/src/crontab-tool.ts"
     ],
     [
+      "crossproduct",
+      "crossproduct MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/crossproduct-tool.ts"
+    ],
+    [
       "crossref",
       "crossref MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/crossref-tool.ts"
@@ -10756,6 +10861,11 @@
       "packages/mcp-server/src/domainsdb-tool.ts"
     ],
     [
+      "dotproduct",
+      "dotproduct MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/dotproduct-tool.ts"
+    ],
+    [
       "dropbox",
       "dropbox MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/dropbox-tool.ts"
@@ -10854,6 +10964,11 @@
       "excuser",
       "excuser MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/excuser-tool.ts"
+    ],
+    [
+      "expgrowth",
+      "expgrowth MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/expgrowth-tool.ts"
     ],
     [
       "fakerapi",
@@ -10991,6 +11106,11 @@
       "packages/mcp-server/src/geojs-tool.ts"
     ],
     [
+      "geomseries",
+      "geomseries MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/geomseries-tool.ts"
+    ],
+    [
       "geopass",
       "geopass MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/geopass-tool.ts"
@@ -11054,6 +11174,11 @@
       "hamming",
       "hamming MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/hamming-tool.ts"
+    ],
+    [
+      "harmonicseries",
+      "harmonicseries MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/harmonicseries-tool.ts"
     ],
     [
       "harrypotter",
@@ -11766,6 +11891,11 @@
       "packages/mcp-server/src/phonetic-tool.ts"
     ],
     [
+      "piapprox",
+      "piapprox MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/piapprox-tool.ts"
+    ],
+    [
       "picsum",
       "picsum MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/picsum-tool.ts"
@@ -11824,6 +11954,11 @@
       "poetrydb",
       "poetrydb MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/poetrydb-tool.ts"
+    ],
+    [
+      "poisson",
+      "poisson MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/poisson-tool.ts"
     ],
     [
       "pokeapi",
@@ -12301,6 +12436,11 @@
       "packages/mcp-server/src/tarot-tool.ts"
     ],
     [
+      "taylor",
+      "taylor MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/taylor-tool.ts"
+    ],
+    [
       "telegram",
       "telegram MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/telegram-tool.ts"
@@ -12531,6 +12671,11 @@
       "packages/mcp-server/src/uxpass-tool.ts"
     ],
     [
+      "variancecalc",
+      "variancecalc MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/variancecalc-tool.ts"
+    ],
+    [
       "vatcomply",
       "vatcomply MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/vatcomply-tool.ts"
@@ -12569,6 +12714,11 @@
       "webflow",
       "webflow MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/webflow-tool.ts"
+    ],
+    [
+      "weightedmean",
+      "weightedmean MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/weightedmean-tool.ts"
     ],
     [
       "wger",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -189,6 +189,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/aoe2-tool.ts | 13377d4c8ad0 | 3685 |
 | packages/mcp-server/src/apifootball-tool.ts | ff6ec8c8d646 | 3682 |
 | packages/mcp-server/src/archiveorg-tool.ts | 31481deccc20 | 4106 |
+| packages/mcp-server/src/areacalc-tool.ts | 550eb5992182 | 3924 |
 | packages/mcp-server/src/artic-tool.ts | 6e076252fe5d | 2428 |
 | packages/mcp-server/src/arxiv-tool.ts | 251cb296ee4f | 2365 |
 | packages/mcp-server/src/asana-tool.ts | 2519967f5105 | 9808 |
@@ -208,7 +209,6 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/binaryconv-tool.ts | b09d86831da2 | 1337 |
 | packages/mcp-server/src/binomprob-tool.ts | 08174a2866e7 | 1770 |
 | packages/mcp-server/src/bitbucket-tool.ts | a6a405951262 | 4388 |
-| packages/mcp-server/src/bitwise-tool.ts | 5b0b0365aefe | 2091 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
 | .github/workflows/autonomous-runner.yml | 942080b620ac | 15338 |
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 506 |
+| Tools | MCP and gateway capabilities available to seats. | 516 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -390,6 +390,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | aoe2 | aoe2 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/aoe2-tool.ts |
 | apifootball | apifootball MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/apifootball-tool.ts |
 | archiveorg | archiveorg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/archiveorg-tool.ts |
+| areacalc | areacalc MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/areacalc-tool.ts |
 | artic | artic MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/artic-tool.ts |
 | arxiv | arxiv MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/arxiv-tool.ts |
 | asana | asana MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/asana-tool.ts |
@@ -455,6 +456,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | colr | colr MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/colr-tool.ts |
 | combination | combination MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/combination-tool.ts |
 | commonsensepass | commonsensepass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/commonsensepass-tool.ts |
+| complexnum | complexnum MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/complexnum-tool.ts |
 | compliancepass | compliancepass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/compliancepass-tool.ts |
 | confluence | confluence MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/confluence-tool.ts |
 | contentful | contentful MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/contentful-tool.ts |
@@ -613,6 +615,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | lichess | lichess MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lichess-tool.ts |
 | line | line MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/line-tool.ts |
 | linear | linear MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/linear-tool.ts |
+| logbase | logbase MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/logbase-tool.ts |
 | lorem | lorem MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lorem-tool.ts |
 | lorem2 | lorem2 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lorem2-tool.ts |
 | loremname | loremname MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/loremname-tool.ts |
@@ -634,6 +637,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | metaphone | metaphone MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/metaphone-tool.ts |
 | metmuseum | metmuseum MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/metmuseum-tool.ts |
 | mhwdb | mhwdb MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mhwdb-tool.ts |
+| midpoint | midpoint MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/midpoint-tool.ts |
 | miro | miro MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/miro-tool.ts |
 | mistral | mistral MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mistral-tool.ts |
 | mixpanel | mixpanel MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mixpanel-tool.ts |
@@ -656,8 +660,10 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | nhtsa | nhtsa MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/nhtsa-tool.ts |
 | nobelprize | nobelprize MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/nobelprize-tool.ts |
 | nominatim | nominatim MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/nominatim-tool.ts |
+| normaldistr | normaldistr MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/normaldistr-tool.ts |
 | notion | notion MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/notion-tool.ts |
 | npm registry | npm registry MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/npm-registry-tool.ts |
+| nthroot | nthroot MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/nthroot-tool.ts |
 | NudgeOnly | NudgeOnly low-token receipt bridge and advisory classifier. | packages/mcp-server/src/nudgeonly-tool.ts |
 | numbers | numbers MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/numbers-tool.ts |
 | nvd | nvd MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/nvd-tool.ts |
@@ -776,6 +782,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | sigmoid | sigmoid MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sigmoid-tool.ts |
 | slack | slack MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/slack-tool.ts |
 | sleeper | sleeper MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sleeper-tool.ts |
+| slopeintercept | slopeintercept MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/slopeintercept-tool.ts |
 | sloppass | sloppass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sloppass-tool.ts |
 | slug | slug MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/slug-tool.ts |
 | solarsystem | solarsystem MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/solarsystem-tool.ts |
@@ -789,6 +796,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | square | square MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/square-tool.ts |
 | stability | stability MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/stability-tool.ts |
 | stackexchange | stackexchange MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/stackexchange-tool.ts |
+| standardform | standardform MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/standardform-tool.ts |
 | stapi | stapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/stapi-tool.ts |
 | statistics | statistics MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/statistics-tool.ts |
 | steam | steam MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/steam-tool.ts |
@@ -822,6 +830,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | tokencount | tokencount MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tokencount-tool.ts |
 | tomorrowio | tomorrowio MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tomorrowio-tool.ts |
 | trello | trello MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/trello-tool.ts |
+| trianglesolve | trianglesolve MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/trianglesolve-tool.ts |
 | trivia | trivia MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/trivia-tool.ts |
 | trove | trove MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/trove-tool.ts |
 | turso | turso MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/turso-tool.ts |
@@ -851,6 +860,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | vercel | vercel MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/vercel-tool.ts |
 | vigenere | vigenere MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/vigenere-tool.ts |
 | virustotal | virustotal MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/virustotal-tool.ts |
+| wavelength | wavelength MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wavelength-tool.ts |
 | wayback | wayback MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wayback-tool.ts |
 | webflow | webflow MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/webflow-tool.ts |
 | wger | wger MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wger-tool.ts |
@@ -1312,6 +1322,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | aoe2 | aoe2 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/aoe2-tool.ts |
 | Tools | MCP tool | apifootball | apifootball MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/apifootball-tool.ts |
 | Tools | MCP tool | archiveorg | archiveorg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/archiveorg-tool.ts |
+| Tools | MCP tool | areacalc | areacalc MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/areacalc-tool.ts |
 | Tools | MCP tool | artic | artic MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/artic-tool.ts |
 | Tools | MCP tool | arxiv | arxiv MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/arxiv-tool.ts |
 | Tools | MCP tool | asana | asana MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/asana-tool.ts |
@@ -1377,6 +1388,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | colr | colr MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/colr-tool.ts |
 | Tools | MCP tool | combination | combination MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/combination-tool.ts |
 | Tools | MCP tool | commonsensepass | commonsensepass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/commonsensepass-tool.ts |
+| Tools | MCP tool | complexnum | complexnum MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/complexnum-tool.ts |
 | Tools | MCP tool | compliancepass | compliancepass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/compliancepass-tool.ts |
 | Tools | MCP tool | confluence | confluence MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/confluence-tool.ts |
 | Tools | MCP tool | contentful | contentful MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/contentful-tool.ts |
@@ -1535,6 +1547,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | lichess | lichess MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lichess-tool.ts |
 | Tools | MCP tool | line | line MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/line-tool.ts |
 | Tools | MCP tool | linear | linear MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/linear-tool.ts |
+| Tools | MCP tool | logbase | logbase MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/logbase-tool.ts |
 | Tools | MCP tool | lorem | lorem MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lorem-tool.ts |
 | Tools | MCP tool | lorem2 | lorem2 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lorem2-tool.ts |
 | Tools | MCP tool | loremname | loremname MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/loremname-tool.ts |
@@ -1556,6 +1569,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | metaphone | metaphone MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/metaphone-tool.ts |
 | Tools | MCP tool | metmuseum | metmuseum MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/metmuseum-tool.ts |
 | Tools | MCP tool | mhwdb | mhwdb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mhwdb-tool.ts |
+| Tools | MCP tool | midpoint | midpoint MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/midpoint-tool.ts |
 | Tools | MCP tool | miro | miro MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/miro-tool.ts |
 | Tools | MCP tool | mistral | mistral MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mistral-tool.ts |
 | Tools | MCP tool | mixpanel | mixpanel MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mixpanel-tool.ts |
@@ -1578,8 +1592,10 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | nhtsa | nhtsa MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nhtsa-tool.ts |
 | Tools | MCP tool | nobelprize | nobelprize MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nobelprize-tool.ts |
 | Tools | MCP tool | nominatim | nominatim MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nominatim-tool.ts |
+| Tools | MCP tool | normaldistr | normaldistr MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/normaldistr-tool.ts |
 | Tools | MCP tool | notion | notion MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/notion-tool.ts |
 | Tools | MCP tool | npm registry | npm registry MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/npm-registry-tool.ts |
+| Tools | MCP tool | nthroot | nthroot MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nthroot-tool.ts |
 | Tools | MCP tool | NudgeOnly | NudgeOnly low-token receipt bridge and advisory classifier. | - | packages/mcp-server/src/nudgeonly-tool.ts |
 | Tools | MCP tool | numbers | numbers MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/numbers-tool.ts |
 | Tools | MCP tool | nvd | nvd MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nvd-tool.ts |
@@ -1698,6 +1714,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | sigmoid | sigmoid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sigmoid-tool.ts |
 | Tools | MCP tool | slack | slack MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/slack-tool.ts |
 | Tools | MCP tool | sleeper | sleeper MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sleeper-tool.ts |
+| Tools | MCP tool | slopeintercept | slopeintercept MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/slopeintercept-tool.ts |
 | Tools | MCP tool | sloppass | sloppass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sloppass-tool.ts |
 | Tools | MCP tool | slug | slug MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/slug-tool.ts |
 | Tools | MCP tool | solarsystem | solarsystem MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/solarsystem-tool.ts |
@@ -1711,6 +1728,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | square | square MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/square-tool.ts |
 | Tools | MCP tool | stability | stability MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/stability-tool.ts |
 | Tools | MCP tool | stackexchange | stackexchange MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/stackexchange-tool.ts |
+| Tools | MCP tool | standardform | standardform MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/standardform-tool.ts |
 | Tools | MCP tool | stapi | stapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/stapi-tool.ts |
 | Tools | MCP tool | statistics | statistics MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/statistics-tool.ts |
 | Tools | MCP tool | steam | steam MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/steam-tool.ts |
@@ -1744,6 +1762,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | tokencount | tokencount MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tokencount-tool.ts |
 | Tools | MCP tool | tomorrowio | tomorrowio MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tomorrowio-tool.ts |
 | Tools | MCP tool | trello | trello MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trello-tool.ts |
+| Tools | MCP tool | trianglesolve | trianglesolve MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trianglesolve-tool.ts |
 | Tools | MCP tool | trivia | trivia MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trivia-tool.ts |
 | Tools | MCP tool | trove | trove MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trove-tool.ts |
 | Tools | MCP tool | turso | turso MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/turso-tool.ts |
@@ -1773,6 +1792,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | vercel | vercel MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/vercel-tool.ts |
 | Tools | MCP tool | vigenere | vigenere MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/vigenere-tool.ts |
 | Tools | MCP tool | virustotal | virustotal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/virustotal-tool.ts |
+| Tools | MCP tool | wavelength | wavelength MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wavelength-tool.ts |
 | Tools | MCP tool | wayback | wayback MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wayback-tool.ts |
 | Tools | MCP tool | webflow | webflow MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/webflow-tool.ts |
 | Tools | MCP tool | wger | wger MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wger-tool.ts |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -183,6 +183,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/amazon-tool.ts | faeea675e2f5 | 15899 |
 | packages/mcp-server/src/amber-tool.ts | 635b10e30a39 | 7078 |
 | packages/mcp-server/src/amiibo-tool.ts | 81076c40936a | 2101 |
+| packages/mcp-server/src/angleconv-tool.ts | 6e8ddaf9344f | 1663 |
 | packages/mcp-server/src/animechan-tool.ts | f77b9af84d81 | 1735 |
 | packages/mcp-server/src/anthropic-tool.ts | 72906c764b43 | 9657 |
 | packages/mcp-server/src/aoe2-tool.ts | 13377d4c8ad0 | 3685 |
@@ -205,10 +206,9 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/bible-tool.ts | 94f62f2fa1c1 | 2338 |
 | packages/mcp-server/src/bibleverse-tool.ts | c5c118d0eb27 | 1698 |
 | packages/mcp-server/src/binaryconv-tool.ts | b09d86831da2 | 1337 |
+| packages/mcp-server/src/binomprob-tool.ts | 08174a2866e7 | 1770 |
 | packages/mcp-server/src/bitbucket-tool.ts | a6a405951262 | 4388 |
 | packages/mcp-server/src/bitwise-tool.ts | 5b0b0365aefe | 2091 |
-| packages/mcp-server/src/bluesky-tool.ts | 9c63ad10f656 | 16256 |
-| packages/mcp-server/src/bored-tool.ts | 076a2a94303b | 3043 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
 | .github/workflows/autonomous-runner.yml | 942080b620ac | 15338 |
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 496 |
+| Tools | MCP and gateway capabilities available to seats. | 506 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -384,6 +384,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | amazon | amazon MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/amazon-tool.ts |
 | amber | amber MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/amber-tool.ts |
 | amiibo | amiibo MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/amiibo-tool.ts |
+| angleconv | angleconv MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/angleconv-tool.ts |
 | animechan | animechan MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/animechan-tool.ts |
 | anthropic | anthropic MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/anthropic-tool.ts |
 | aoe2 | aoe2 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/aoe2-tool.ts |
@@ -406,6 +407,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | bible | bible MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bible-tool.ts |
 | bibleverse | bibleverse MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bibleverse-tool.ts |
 | binaryconv | binaryconv MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/binaryconv-tool.ts |
+| binomprob | binomprob MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/binomprob-tool.ts |
 | bitbucket | bitbucket MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bitbucket-tool.ts |
 | bitwise | bitwise MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bitwise-tool.ts |
 | bluesky | bluesky MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bluesky-tool.ts |
@@ -577,6 +579,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | imgflip | imgflip MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/imgflip-tool.ts |
 | instapaper | instapaper MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/instapaper-tool.ts |
 | intercom | intercom MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/intercom-tool.ts |
+| interpolate | interpolate MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/interpolate-tool.ts |
 | ipaddrinfo | ipaddrinfo MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ipaddrinfo-tool.ts |
 | ipapi | ipapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ipapi-tool.ts |
 | ipaustralia | ipaustralia MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ipaustralia-tool.ts |
@@ -634,6 +637,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | miro | miro MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/miro-tool.ts |
 | mistral | mistral MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mistral-tool.ts |
 | mixpanel | mixpanel MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mixpanel-tool.ts |
+| modpow | modpow MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/modpow-tool.ts |
 | monday | monday MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/monday-tool.ts |
 | monica | monica MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/monica-tool.ts |
 | morse | morse MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/morse-tool.ts |
@@ -706,11 +710,13 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | poetrydb | poetrydb MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/poetrydb-tool.ts |
 | pokeapi | pokeapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pokeapi-tool.ts |
 | pokemontcg | pokemontcg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pokemontcg-tool.ts |
+| polygon | polygon MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/polygon-tool.ts |
 | postcodes | postcodes MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/postcodes-tool.ts |
 | posthog | posthog MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/posthog-tool.ts |
 | postman | postman MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/postman-tool.ts |
 | postmark | postmark MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/postmark-tool.ts |
 | primecheck | primecheck MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/primecheck-tool.ts |
+| primefactor | primefactor MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/primefactor-tool.ts |
 | proportion | proportion MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/proportion-tool.ts |
 | ptv | ptv MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ptv-tool.ts |
 | pubchem | pubchem MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pubchem-tool.ts |
@@ -721,6 +727,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | pypi | pypi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pypi-tool.ts |
 | qc | qc MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/qc-tool.ts |
 | qrserver | qrserver MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/qrserver-tool.ts |
+| quadratic | quadratic MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/quadratic-tool.ts |
 | quickbooks | quickbooks MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/quickbooks-tool.ts |
 | quotable | quotable MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/quotable-tool.ts |
 | radiobrowser | radiobrowser MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/radiobrowser-tool.ts |
@@ -730,6 +737,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | randomduck | randomduck MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/randomduck-tool.ts |
 | randomfox | randomfox MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/randomfox-tool.ts |
 | randomuser | randomuser MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/randomuser-tool.ts |
+| ratiosimplify | ratiosimplify MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ratiosimplify-tool.ts |
 | rawg | rawg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rawg-tool.ts |
 | rdap | rdap MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rdap-tool.ts |
 | readability | readability MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/readability-tool.ts |
@@ -765,6 +773,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | shodan | shodan MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/shodan-tool.ts |
 | shopify | shopify MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/shopify-tool.ts |
 | shortcut | shortcut MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/shortcut-tool.ts |
+| sigmoid | sigmoid MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sigmoid-tool.ts |
 | slack | slack MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/slack-tool.ts |
 | sleeper | sleeper MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sleeper-tool.ts |
 | sloppass | sloppass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/sloppass-tool.ts |
@@ -866,6 +875,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | zendesk | zendesk MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/zendesk-tool.ts |
 | zenquotes | zenquotes MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/zenquotes-tool.ts |
 | zippopotamus | zippopotamus MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/zippopotamus-tool.ts |
+| zscore | zscore MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/zscore-tool.ts |
 
 ## Tool and Worker Tree
 
@@ -1296,6 +1306,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | amazon | amazon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/amazon-tool.ts |
 | Tools | MCP tool | amber | amber MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/amber-tool.ts |
 | Tools | MCP tool | amiibo | amiibo MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/amiibo-tool.ts |
+| Tools | MCP tool | angleconv | angleconv MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/angleconv-tool.ts |
 | Tools | MCP tool | animechan | animechan MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/animechan-tool.ts |
 | Tools | MCP tool | anthropic | anthropic MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/anthropic-tool.ts |
 | Tools | MCP tool | aoe2 | aoe2 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/aoe2-tool.ts |
@@ -1318,6 +1329,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | bible | bible MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bible-tool.ts |
 | Tools | MCP tool | bibleverse | bibleverse MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bibleverse-tool.ts |
 | Tools | MCP tool | binaryconv | binaryconv MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/binaryconv-tool.ts |
+| Tools | MCP tool | binomprob | binomprob MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/binomprob-tool.ts |
 | Tools | MCP tool | bitbucket | bitbucket MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bitbucket-tool.ts |
 | Tools | MCP tool | bitwise | bitwise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bitwise-tool.ts |
 | Tools | MCP tool | bluesky | bluesky MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bluesky-tool.ts |
@@ -1489,6 +1501,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | imgflip | imgflip MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/imgflip-tool.ts |
 | Tools | MCP tool | instapaper | instapaper MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/instapaper-tool.ts |
 | Tools | MCP tool | intercom | intercom MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/intercom-tool.ts |
+| Tools | MCP tool | interpolate | interpolate MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/interpolate-tool.ts |
 | Tools | MCP tool | ipaddrinfo | ipaddrinfo MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ipaddrinfo-tool.ts |
 | Tools | MCP tool | ipapi | ipapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ipapi-tool.ts |
 | Tools | MCP tool | ipaustralia | ipaustralia MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ipaustralia-tool.ts |
@@ -1546,6 +1559,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | miro | miro MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/miro-tool.ts |
 | Tools | MCP tool | mistral | mistral MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mistral-tool.ts |
 | Tools | MCP tool | mixpanel | mixpanel MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mixpanel-tool.ts |
+| Tools | MCP tool | modpow | modpow MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/modpow-tool.ts |
 | Tools | MCP tool | monday | monday MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/monday-tool.ts |
 | Tools | MCP tool | monica | monica MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/monica-tool.ts |
 | Tools | MCP tool | morse | morse MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/morse-tool.ts |
@@ -1618,11 +1632,13 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | poetrydb | poetrydb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/poetrydb-tool.ts |
 | Tools | MCP tool | pokeapi | pokeapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pokeapi-tool.ts |
 | Tools | MCP tool | pokemontcg | pokemontcg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pokemontcg-tool.ts |
+| Tools | MCP tool | polygon | polygon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/polygon-tool.ts |
 | Tools | MCP tool | postcodes | postcodes MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/postcodes-tool.ts |
 | Tools | MCP tool | posthog | posthog MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/posthog-tool.ts |
 | Tools | MCP tool | postman | postman MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/postman-tool.ts |
 | Tools | MCP tool | postmark | postmark MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/postmark-tool.ts |
 | Tools | MCP tool | primecheck | primecheck MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/primecheck-tool.ts |
+| Tools | MCP tool | primefactor | primefactor MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/primefactor-tool.ts |
 | Tools | MCP tool | proportion | proportion MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/proportion-tool.ts |
 | Tools | MCP tool | ptv | ptv MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ptv-tool.ts |
 | Tools | MCP tool | pubchem | pubchem MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pubchem-tool.ts |
@@ -1633,6 +1649,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | pypi | pypi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pypi-tool.ts |
 | Tools | MCP tool | qc | qc MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/qc-tool.ts |
 | Tools | MCP tool | qrserver | qrserver MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/qrserver-tool.ts |
+| Tools | MCP tool | quadratic | quadratic MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/quadratic-tool.ts |
 | Tools | MCP tool | quickbooks | quickbooks MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/quickbooks-tool.ts |
 | Tools | MCP tool | quotable | quotable MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/quotable-tool.ts |
 | Tools | MCP tool | radiobrowser | radiobrowser MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/radiobrowser-tool.ts |
@@ -1642,6 +1659,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | randomduck | randomduck MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/randomduck-tool.ts |
 | Tools | MCP tool | randomfox | randomfox MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/randomfox-tool.ts |
 | Tools | MCP tool | randomuser | randomuser MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/randomuser-tool.ts |
+| Tools | MCP tool | ratiosimplify | ratiosimplify MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ratiosimplify-tool.ts |
 | Tools | MCP tool | rawg | rawg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rawg-tool.ts |
 | Tools | MCP tool | rdap | rdap MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rdap-tool.ts |
 | Tools | MCP tool | readability | readability MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/readability-tool.ts |
@@ -1677,6 +1695,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | shodan | shodan MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shodan-tool.ts |
 | Tools | MCP tool | shopify | shopify MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shopify-tool.ts |
 | Tools | MCP tool | shortcut | shortcut MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/shortcut-tool.ts |
+| Tools | MCP tool | sigmoid | sigmoid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sigmoid-tool.ts |
 | Tools | MCP tool | slack | slack MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/slack-tool.ts |
 | Tools | MCP tool | sleeper | sleeper MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sleeper-tool.ts |
 | Tools | MCP tool | sloppass | sloppass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/sloppass-tool.ts |
@@ -1778,6 +1797,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | zendesk | zendesk MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/zendesk-tool.ts |
 | Tools | MCP tool | zenquotes | zenquotes MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/zenquotes-tool.ts |
 | Tools | MCP tool | zippopotamus | zippopotamus MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/zippopotamus-tool.ts |
+| Tools | MCP tool | zscore | zscore MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/zscore-tool.ts |
 | Workers and seats | seat | Claude Reviewer Seat | External reviewer lane used for independent checks and proof review. | - | docs/fleet-worker-roles.md |
 | Workers and seats | seat | Codex Builder Seat | Codex lane used for scoped implementation, routing, and proof updates. | - | docs/fleet-worker-roles.md |
 | Workers and seats | seat | Cursor Builder Seat | External builder lane used for scoped code work and PRs. | - | docs/fleet-worker-roles.md |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 516 |
+| Tools | MCP and gateway capabilities available to seats. | 526 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -471,6 +471,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | crc32 | crc32 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/crc32-tool.ts |
 | crews | crews MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/crews-tool.ts |
 | crontab | crontab MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/crontab-tool.ts |
+| crossproduct | crossproduct MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/crossproduct-tool.ts |
 | crossref | crossref MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/crossref-tool.ts |
 | csuite | csuite MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/csuite-tool.ts |
 | csvparse | csvparse MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/csvparse-tool.ts |
@@ -500,6 +501,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | dohdns | dohdns MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dohdns-tool.ts |
 | domain | domain MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/domain-tool.ts |
 | domainsdb | domainsdb MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/domainsdb-tool.ts |
+| dotproduct | dotproduct MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dotproduct-tool.ts |
 | dropbox | dropbox MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dropbox-tool.ts |
 | dummyimage | dummyimage MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dummyimage-tool.ts |
 | dummyjson | dummyjson MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dummyjson-tool.ts |
@@ -520,6 +522,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | exchangerate2 | exchangerate2 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/exchangerate2-tool.ts |
 | exchangerate3 | exchangerate3 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/exchangerate3-tool.ts |
 | excuser | excuser MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/excuser-tool.ts |
+| expgrowth | expgrowth MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/expgrowth-tool.ts |
 | fakerapi | fakerapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fakerapi-tool.ts |
 | fakestoreapi | fakestoreapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fakestoreapi-tool.ts |
 | feedly | feedly MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/feedly-tool.ts |
@@ -547,6 +550,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | genderize | genderize MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/genderize-tool.ts |
 | genius | genius MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/genius-tool.ts |
 | geojs | geojs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/geojs-tool.ts |
+| geomseries | geomseries MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/geomseries-tool.ts |
 | geopass | geopass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/geopass-tool.ts |
 | ghibli | ghibli MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ghibli-tool.ts |
 | ghost | ghost MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ghost-tool.ts |
@@ -560,6 +564,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | gutendex | gutendex MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/gutendex-tool.ts |
 | hackernews | hackernews MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/hackernews-tool.ts |
 | hamming | hamming MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/hamming-tool.ts |
+| harmonicseries | harmonicseries MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/harmonicseries-tool.ts |
 | harrypotter | harrypotter MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/harrypotter-tool.ts |
 | hashgen | hashgen MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/hashgen-tool.ts |
 | haveibeenpwned | haveibeenpwned MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/haveibeenpwned-tool.ts |
@@ -702,6 +707,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | permutation | permutation MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/permutation-tool.ts |
 | perplexity | perplexity MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/perplexity-tool.ts |
 | phonetic | phonetic MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/phonetic-tool.ts |
+| piapprox | piapprox MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/piapprox-tool.ts |
 | picsum | picsum MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/picsum-tool.ts |
 | piglatin | piglatin MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/piglatin-tool.ts |
 | pika | pika MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pika-tool.ts |
@@ -714,6 +720,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | plaid | plaid MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/plaid-tool.ts |
 | podcastindex | podcastindex MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/podcastindex-tool.ts |
 | poetrydb | poetrydb MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/poetrydb-tool.ts |
+| poisson | poisson MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/poisson-tool.ts |
 | pokeapi | pokeapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pokeapi-tool.ts |
 | pokemontcg | pokemontcg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/pokemontcg-tool.ts |
 | polygon | polygon MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/polygon-tool.ts |
@@ -809,6 +816,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | tab | tab MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tab-tool.ts |
 | tacofancy | tacofancy MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tacofancy-tool.ts |
 | tarot | tarot MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tarot-tool.ts |
+| taylor | taylor MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/taylor-tool.ts |
 | telegram | telegram MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/telegram-tool.ts |
 | tempconvert | tempconvert MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tempconvert-tool.ts |
 | testpass | TestPass proof and test orchestration capability. | packages/mcp-server/src/testpass-tool.ts |
@@ -855,6 +863,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | usgs | usgs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/usgs-tool.ts |
 | uuidgen | uuidgen MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/uuidgen-tool.ts |
 | uxpass | UXPass experience verification capability. | packages/mcp-server/src/uxpass-tool.ts |
+| variancecalc | variancecalc MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/variancecalc-tool.ts |
 | vatcomply | vatcomply MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/vatcomply-tool.ts |
 | vault | vault MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/vault-tool.ts |
 | vercel | vercel MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/vercel-tool.ts |
@@ -863,6 +872,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | wavelength | wavelength MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wavelength-tool.ts |
 | wayback | wayback MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wayback-tool.ts |
 | webflow | webflow MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/webflow-tool.ts |
+| weightedmean | weightedmean MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/weightedmean-tool.ts |
 | wger | wger MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wger-tool.ts |
 | whatsapp | whatsapp MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/whatsapp-tool.ts |
 | wheretheiss | wheretheiss MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/wheretheiss-tool.ts |
@@ -1403,6 +1413,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | crc32 | crc32 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/crc32-tool.ts |
 | Tools | MCP tool | crews | crews MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/crews-tool.ts |
 | Tools | MCP tool | crontab | crontab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/crontab-tool.ts |
+| Tools | MCP tool | crossproduct | crossproduct MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/crossproduct-tool.ts |
 | Tools | MCP tool | crossref | crossref MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/crossref-tool.ts |
 | Tools | MCP tool | csuite | csuite MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/csuite-tool.ts |
 | Tools | MCP tool | csvparse | csvparse MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/csvparse-tool.ts |
@@ -1432,6 +1443,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | dohdns | dohdns MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dohdns-tool.ts |
 | Tools | MCP tool | domain | domain MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/domain-tool.ts |
 | Tools | MCP tool | domainsdb | domainsdb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/domainsdb-tool.ts |
+| Tools | MCP tool | dotproduct | dotproduct MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dotproduct-tool.ts |
 | Tools | MCP tool | dropbox | dropbox MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dropbox-tool.ts |
 | Tools | MCP tool | dummyimage | dummyimage MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dummyimage-tool.ts |
 | Tools | MCP tool | dummyjson | dummyjson MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dummyjson-tool.ts |
@@ -1452,6 +1464,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | exchangerate2 | exchangerate2 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/exchangerate2-tool.ts |
 | Tools | MCP tool | exchangerate3 | exchangerate3 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/exchangerate3-tool.ts |
 | Tools | MCP tool | excuser | excuser MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/excuser-tool.ts |
+| Tools | MCP tool | expgrowth | expgrowth MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/expgrowth-tool.ts |
 | Tools | MCP tool | fakerapi | fakerapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fakerapi-tool.ts |
 | Tools | MCP tool | fakestoreapi | fakestoreapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fakestoreapi-tool.ts |
 | Tools | MCP tool | feedly | feedly MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/feedly-tool.ts |
@@ -1479,6 +1492,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | genderize | genderize MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/genderize-tool.ts |
 | Tools | MCP tool | genius | genius MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/genius-tool.ts |
 | Tools | MCP tool | geojs | geojs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/geojs-tool.ts |
+| Tools | MCP tool | geomseries | geomseries MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/geomseries-tool.ts |
 | Tools | MCP tool | geopass | geopass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/geopass-tool.ts |
 | Tools | MCP tool | ghibli | ghibli MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ghibli-tool.ts |
 | Tools | MCP tool | ghost | ghost MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ghost-tool.ts |
@@ -1492,6 +1506,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | gutendex | gutendex MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/gutendex-tool.ts |
 | Tools | MCP tool | hackernews | hackernews MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/hackernews-tool.ts |
 | Tools | MCP tool | hamming | hamming MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/hamming-tool.ts |
+| Tools | MCP tool | harmonicseries | harmonicseries MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/harmonicseries-tool.ts |
 | Tools | MCP tool | harrypotter | harrypotter MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/harrypotter-tool.ts |
 | Tools | MCP tool | hashgen | hashgen MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/hashgen-tool.ts |
 | Tools | MCP tool | haveibeenpwned | haveibeenpwned MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/haveibeenpwned-tool.ts |
@@ -1634,6 +1649,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | permutation | permutation MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/permutation-tool.ts |
 | Tools | MCP tool | perplexity | perplexity MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/perplexity-tool.ts |
 | Tools | MCP tool | phonetic | phonetic MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/phonetic-tool.ts |
+| Tools | MCP tool | piapprox | piapprox MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/piapprox-tool.ts |
 | Tools | MCP tool | picsum | picsum MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/picsum-tool.ts |
 | Tools | MCP tool | piglatin | piglatin MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/piglatin-tool.ts |
 | Tools | MCP tool | pika | pika MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pika-tool.ts |
@@ -1646,6 +1662,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | plaid | plaid MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/plaid-tool.ts |
 | Tools | MCP tool | podcastindex | podcastindex MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/podcastindex-tool.ts |
 | Tools | MCP tool | poetrydb | poetrydb MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/poetrydb-tool.ts |
+| Tools | MCP tool | poisson | poisson MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/poisson-tool.ts |
 | Tools | MCP tool | pokeapi | pokeapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pokeapi-tool.ts |
 | Tools | MCP tool | pokemontcg | pokemontcg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/pokemontcg-tool.ts |
 | Tools | MCP tool | polygon | polygon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/polygon-tool.ts |
@@ -1741,6 +1758,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | tab | tab MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tab-tool.ts |
 | Tools | MCP tool | tacofancy | tacofancy MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tacofancy-tool.ts |
 | Tools | MCP tool | tarot | tarot MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tarot-tool.ts |
+| Tools | MCP tool | taylor | taylor MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/taylor-tool.ts |
 | Tools | MCP tool | telegram | telegram MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/telegram-tool.ts |
 | Tools | MCP tool | tempconvert | tempconvert MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tempconvert-tool.ts |
 | Tools | MCP tool | testpass | TestPass proof and test orchestration capability. | - | packages/mcp-server/src/testpass-tool.ts |
@@ -1787,6 +1805,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | usgs | usgs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/usgs-tool.ts |
 | Tools | MCP tool | uuidgen | uuidgen MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/uuidgen-tool.ts |
 | Tools | MCP tool | uxpass | UXPass experience verification capability. | - | packages/mcp-server/src/uxpass-tool.ts |
+| Tools | MCP tool | variancecalc | variancecalc MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/variancecalc-tool.ts |
 | Tools | MCP tool | vatcomply | vatcomply MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/vatcomply-tool.ts |
 | Tools | MCP tool | vault | vault MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/vault-tool.ts |
 | Tools | MCP tool | vercel | vercel MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/vercel-tool.ts |
@@ -1795,6 +1814,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | wavelength | wavelength MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wavelength-tool.ts |
 | Tools | MCP tool | wayback | wayback MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wayback-tool.ts |
 | Tools | MCP tool | webflow | webflow MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/webflow-tool.ts |
+| Tools | MCP tool | weightedmean | weightedmean MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/weightedmean-tool.ts |
 | Tools | MCP tool | wger | wger MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wger-tool.ts |
 | Tools | MCP tool | whatsapp | whatsapp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/whatsapp-tool.ts |
 | Tools | MCP tool | wheretheiss | wheretheiss MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/wheretheiss-tool.ts |

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -380,6 +380,26 @@
     }
   },
   {
+    "connector": "areacalc",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "artic",
     "level": 5,
     "levelName": "Agentic",
@@ -1541,6 +1561,26 @@
   },
   {
     "connector": "combination",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "complexnum",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,
@@ -4320,6 +4360,26 @@
     }
   },
   {
+    "connector": "logbase",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "lorem",
     "level": 5,
     "levelName": "Agentic",
@@ -4712,6 +4772,26 @@
       "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 1,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "midpoint",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
       "proactive": false,
@@ -5140,6 +5220,26 @@
     }
   },
   {
+    "connector": "normaldistr",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "npm-registry",
     "level": 5,
     "levelName": "Agentic",
@@ -5152,6 +5252,26 @@
       "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 1,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "nthroot",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
       "proactive": false,
@@ -7120,6 +7240,26 @@
     }
   },
   {
+    "connector": "slopeintercept",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "slug",
     "level": 5,
     "levelName": "Agentic",
@@ -7308,6 +7448,26 @@
     "capReason": null,
     "signals": {
       "hasTimeout": true,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "standardform",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
       "handles429": false,
       "hasRetry": false,
       "readsErrorBody": false,
@@ -7880,6 +8040,26 @@
     }
   },
   {
+    "connector": "trianglesolve",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "trivia",
     "level": 5,
     "levelName": "Agentic",
@@ -8390,6 +8570,26 @@
       "hasTimeout": true,
       "handles429": true,
       "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "wavelength",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -260,6 +260,26 @@
     }
   },
   {
+    "connector": "angleconv",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "animechan",
     "level": 5,
     "levelName": "Agentic",
@@ -681,6 +701,26 @@
   },
   {
     "connector": "binaryconv",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "binomprob",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,
@@ -3680,6 +3720,26 @@
     }
   },
   {
+    "connector": "interpolate",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "ipaddrinfo",
     "level": 5,
     "levelName": "Agentic",
@@ -4710,6 +4770,26 @@
       "hasTimeout": true,
       "handles429": true,
       "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "modpow",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,
@@ -6040,6 +6120,26 @@
     }
   },
   {
+    "connector": "polygon",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "postcodes",
     "level": 5,
     "levelName": "Agentic",
@@ -6081,6 +6181,26 @@
   },
   {
     "connector": "primecheck",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "primefactor",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,
@@ -6240,6 +6360,26 @@
     }
   },
   {
+    "connector": "quadratic",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "quotable",
     "level": 5,
     "levelName": "Agentic",
@@ -6352,6 +6492,26 @@
       "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 1,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "ratiosimplify",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
       "proactive": false,
@@ -6911,6 +7071,26 @@
       "handles429": true,
       "hasRetry": true,
       "readsErrorBody": true,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "sigmoid",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
@@ -8610,6 +8790,26 @@
       "hasTimeout": true,
       "handles429": true,
       "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "zscore",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -1820,6 +1820,26 @@
     }
   },
   {
+    "connector": "crossproduct",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "crossref",
     "level": 5,
     "levelName": "Agentic",
@@ -2340,6 +2360,26 @@
     }
   },
   {
+    "connector": "dotproduct",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "dropbox",
     "level": 5,
     "levelName": "Agentic",
@@ -2712,6 +2752,26 @@
       "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 1,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "expgrowth",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
       "proactive": false,
@@ -3200,6 +3260,26 @@
     }
   },
   {
+    "connector": "geomseries",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "ghibli",
     "level": 5,
     "levelName": "Agentic",
@@ -3381,6 +3461,26 @@
   },
   {
     "connector": "hamming",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "harmonicseries",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,
@@ -5960,6 +6060,26 @@
     }
   },
   {
+    "connector": "piapprox",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "picsum",
     "level": 5,
     "levelName": "Agentic",
@@ -6192,6 +6312,26 @@
       "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 1,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "poisson",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
       "proactive": false,
@@ -7700,6 +7840,26 @@
     }
   },
   {
+    "connector": "taylor",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "tempconvert",
     "level": 5,
     "levelName": "Agentic",
@@ -8500,6 +8660,26 @@
     }
   },
   {
+    "connector": "variancecalc",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "vatcomply",
     "level": 5,
     "levelName": "Agentic",
@@ -8634,6 +8814,26 @@
       "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": true,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "weightedmean",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
       "proactive": false,
       "agentic": true,
       "sourceStamped": true

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (480 external connectors)
+## Distribution (490 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 441 | 92% |
+| L5 | Agentic | 451 | 92% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
-| L2 | Reliable | 36 | 8% |
+| L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 480 (50%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 490 (49%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 441 of 444 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 451 of 454 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -46,6 +46,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `amiibo` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `angleconv` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `animechan` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `areacalc` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `artic` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `arxiv` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `aspectratio` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -80,6 +81,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `colornames` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `colr` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `combination` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `complexnum` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `cosinesim` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `countdowncalc` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `countryflag` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -155,6 +157,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `languagetool` (L5 Agentic): not-hardened, 2x-bare-error, no-memory
 - `levenshtein` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `libretranslate` (L5 Agentic): not-hardened, no-rate-limit, no-memory
+- `logbase` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `lorem2` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `loremname` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `lotr` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -169,6 +172,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `memegen` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `metaphone` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mhwdb` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `midpoint` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `modpow` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `morse` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mtg` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -181,7 +185,9 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `nhtsa` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `nobelprize` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `nominatim` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `normaldistr` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `npm-registry` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `nthroot` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `oeis` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `officialjoke` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `open-elevation` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -239,12 +245,14 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `setops` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `shibe` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `sigmoid` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `slopeintercept` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `slug` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `solarsystem` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `sortlines` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `soundex` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `spacex` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `stackexchange` (L5 Agentic): not-hardened, no-rate-limit, no-memory
+- `standardform` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `stapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `statistics` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `stringcase` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -257,6 +265,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `timeapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `timezone` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `tokencount` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `trianglesolve` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `tvmaze` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `ukpolice` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `unitpressure` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -268,6 +277,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `uuidgen` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `vatcomply` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `vigenere` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `wavelength` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `wayback` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `wger` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `wheretheiss` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -300,6 +310,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `aoe2` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `apifootball` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `archiveorg` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `areacalc` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `artic` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `arxiv` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `asana` | Yes | - | - | Yes | Yes | no-memory |
@@ -359,6 +370,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `colornames` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `colr` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `combination` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `complexnum` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `confluence` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `contentful` | Yes | Yes | - | Yes | Yes |  |
 | L5 Agentic | `convertkit` | Yes | - | - | Yes | Yes | no-memory |
@@ -497,6 +509,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `levenshtein` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `libretranslate` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `lichess` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `logbase` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `lorem` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `lorem2` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `loremname` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -517,6 +530,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `metaphone` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `metmuseum` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mhwdb` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `midpoint` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `miro` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mistral` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mixpanel` | Yes | - | - | Yes | Yes | no-memory |
@@ -538,7 +552,9 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `nhtsa` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `nobelprize` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `nominatim` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `normaldistr` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `npm-registry` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `nthroot` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `nvd` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `oeis` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `officialjoke` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -637,6 +653,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `shortcut` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `sigmoid` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `sleeper` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `slopeintercept` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `slug` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `solarsystem` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `sortlines` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -647,6 +664,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `spotify` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `stability` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `stackexchange` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
+| L5 Agentic | `standardform` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `stapi` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `statistics` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `steam` | Yes | - | - | Yes | Yes | no-memory |
@@ -675,6 +693,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `toilets` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `tokencount` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `tomorrowio` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `trianglesolve` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `trivia` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `trove` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `turso` | Yes | Yes | - | Yes | Yes |  |
@@ -701,6 +720,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `vercel` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `vigenere` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `virustotal` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `wavelength` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `wayback` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `webflow` | Yes | Yes | - | Yes | Yes |  |
 | L5 Agentic | `wger` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (470 external connectors)
+## Distribution (480 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 431 | 92% |
+| L5 | Agentic | 441 | 92% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 8% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 470 (51%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 480 (50%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 431 of 434 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 441 of 444 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -44,6 +44,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `acnhapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `acronymgen` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `amiibo` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `angleconv` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `animechan` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `artic` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `arxiv` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -56,6 +57,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `bgpview` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `bibleverse` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `binaryconv` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `binomprob` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `bitwise` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `braille` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `breakingbad` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -137,6 +139,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `iban` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `iceandfire` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `imgflip` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `interpolate` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `ipaddrinfo` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `ipinfo` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `ipvalidate` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -166,6 +169,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `memegen` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `metaphone` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mhwdb` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `modpow` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `morse` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mtg` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `multiavatar` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -206,17 +210,21 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `placekitten` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `poetrydb` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `pokemontcg` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `polygon` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `postcodes` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `primecheck` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `primefactor` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `proportion` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `pubchem` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `publicapis` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `punkapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `pypi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `qrserver` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `quadratic` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `railfence` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `randomduck` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `randomuser` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `ratiosimplify` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `rdap` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `readability` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `regexr` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -230,6 +238,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `semver` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `setops` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `shibe` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `sigmoid` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `slug` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `solarsystem` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `sortlines` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -266,6 +275,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `wordcount` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `wordfreq` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `worldbank` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `zscore` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 
 ## Per-connector, highest rung first
 
@@ -284,6 +294,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `amazon` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `amber` | Yes | Yes | - | Yes | Yes |  |
 | L5 Agentic | `amiibo` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `angleconv` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `animechan` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `anthropic` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `aoe2` | Yes | - | - | Yes | Yes | no-memory |
@@ -306,6 +317,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `bible` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `bibleverse` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `binaryconv` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `binomprob` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bitbucket` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `bitwise` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bored` | Yes | - | - | Yes | Yes | no-memory |
@@ -455,6 +467,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `igdb` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `imgflip` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `intercom` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `interpolate` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `ipaddrinfo` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `ipapi` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `ipaustralia` | Yes | - | - | Yes | Yes | no-memory |
@@ -507,6 +520,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `miro` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mistral` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mixpanel` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `modpow` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `monday` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `morse` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `mtg` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -573,9 +587,11 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `poetrydb` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `pokeapi` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `pokemontcg` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `polygon` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `postcodes` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `posthog` | Yes | Yes | - | Yes | Yes |  |
 | L5 Agentic | `primecheck` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `primefactor` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `proportion` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `ptv` | Yes | Yes | Yes | Yes | Yes |  |
 | L5 Agentic | `pubchem` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -583,12 +599,14 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `punkapi` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `pypi` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `qrserver` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `quadratic` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `quotable` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `radiobrowser` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `railfence` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `randomduck` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `randomfox` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `randomuser` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `ratiosimplify` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `rawg` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `rdap` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `readability` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -617,6 +635,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `shibe` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `shodan` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `shortcut` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `sigmoid` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `sleeper` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `slug` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `solarsystem` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -702,6 +721,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `zendesk` | Yes | - | Yes | Yes | Yes | no-memory |
 | L5 Agentic | `zenquotes` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `zippopotamus` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `zscore` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L2 Reliable | `airtable` | Yes | - | - | - | - | L2 by design (action-multiplexer) |
 | L2 Reliable | `bluesky` | Yes | - | - | - | - | L2 by design (action-multiplexer) |
 | L2 Reliable | `clickup` | Yes | - | - | - | - | L2 by design (action-multiplexer) |

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (490 external connectors)
+## Distribution (500 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 451 | 92% |
+| L5 | Agentic | 461 | 92% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 490 (49%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 500 (48%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 451 of 454 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 461 of 464 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -89,6 +89,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `crates` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `crc32` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `crontab` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `crossproduct` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `crossref` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `csvparse` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `cvecircl` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -103,6 +104,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `dogfacts` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `dohdns` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `domainsdb` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `dotproduct` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `dummyimage` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `dummyjson` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `emojihub` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -112,6 +114,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `europeana` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `exchangerate3` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `excuser` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `expgrowth` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `fakerapi` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `fakestoreapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `fibonacci` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -129,9 +132,11 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `gcdlcm` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `genderize` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `geojs` (L5 Agentic): not-hardened, no-rate-limit, no-memory
+- `geomseries` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `ghibli` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `gutendex` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `hamming` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `harmonicseries` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `harrypotter` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `hashgen` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `histogram` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -210,11 +215,13 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `percentage` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `permutation` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `phonetic` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `piapprox` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `piglatin` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `placebear` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `placehold` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `placekitten` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `poetrydb` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `poisson` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `pokemontcg` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `polygon` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `postcodes` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -257,6 +264,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `statistics` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `stringcase` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `tacofancy` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `taylor` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `tempconvert` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `textstats` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `textwrap` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -275,10 +283,12 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `urlencode` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `urlhaus` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `uuidgen` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `variancecalc` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `vatcomply` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `vigenere` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `wavelength` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `wayback` (L5 Agentic): not-hardened, no-rate-limit, no-memory
+- `weightedmean` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `wger` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `wheretheiss` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `wikidata` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -382,6 +392,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `crates` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `crc32` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `crontab` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `crossproduct` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `crossref` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `csvparse` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `cvecircl` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -408,6 +419,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `dohdns` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `domain` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `domainsdb` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `dotproduct` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `dropbox` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `dummyimage` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `dummyjson` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -427,6 +439,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `exchangerate2` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `exchangerate3` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `excuser` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `expgrowth` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `fakerapi` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `fakestoreapi` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `fibonacci` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -451,6 +464,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `genderize` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `genius` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `geojs` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
+| L5 Agentic | `geomseries` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `ghibli` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `ghost` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `giphy` | Yes | - | - | Yes | Yes | no-memory |
@@ -461,6 +475,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `gutendex` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `hackernews` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `hamming` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `harmonicseries` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `harrypotter` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `hashgen` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `haveibeenpwned` | Yes | - | - | Yes | Yes | no-memory |
@@ -589,6 +604,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `percentage` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `permutation` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `phonetic` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `piapprox` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `picsum` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `piglatin` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `pika` | Yes | - | - | Yes | Yes | no-memory |
@@ -601,6 +617,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `plaid` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `podcastindex` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `poetrydb` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `poisson` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `pokeapi` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `pokemontcg` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `polygon` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -676,6 +693,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `tab` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `tacofancy` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `tarot` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `taylor` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `tempconvert` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `textstats` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `textwrap` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -716,6 +734,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `uselessfacts` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `usgs` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `uuidgen` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `variancecalc` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `vatcomply` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `vercel` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `vigenere` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -723,6 +742,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `wavelength` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `wayback` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `webflow` | Yes | Yes | - | Yes | Yes |  |
+| L5 Agentic | `weightedmean` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `wger` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `wheretheiss` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `wikidata` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -240,6 +240,16 @@
     ]
   },
   {
+    "app": "angleconv",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "angle_convert",
+        "description": "Convert angles between degrees, radians, gradians, and turns. Includes trig values."
+      }
+    ]
+  },
+  {
     "app": "animechan",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -604,6 +614,16 @@
       {
         "name": "number_base_convert",
         "description": "Convert numbers between binary, octal, decimal, hex, and any base 2-36."
+      }
+    ]
+  },
+  {
+    "app": "binomprob",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "binomial_probability",
+        "description": "Calculate binomial distribution probability P(X=k) and cumulative probabilities for n trials with probability p."
       }
     ]
   },
@@ -3516,6 +3536,16 @@
     ]
   },
   {
+    "app": "interpolate",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "interpolate_calc",
+        "description": "Linear interpolation (or extrapolation) between two points. Returns the y value for a given x."
+      }
+    ]
+  },
+  {
     "app": "ipaddrinfo",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4438,6 +4468,16 @@
       {
         "name": "mixpanel_export_data",
         "description": "Export raw Mixpanel event data for a date range."
+      }
+    ]
+  },
+  {
+    "app": "modpow",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "modular_arithmetic",
+        "description": "Modular arithmetic operations: modpow (a^b mod m), modinverse (a^-1 mod m), or mod (a mod m)."
       }
     ]
   },
@@ -5638,6 +5678,16 @@
     ]
   },
   {
+    "app": "polygon",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "polygon_calculate",
+        "description": "Calculate properties of a regular polygon: area, perimeter, angles, apothem, circumradius, diagonals."
+      }
+    ]
+  },
+  {
     "app": "postcodes",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -5720,6 +5770,16 @@
       {
         "name": "prime_check",
         "description": "Check if a number is prime, get its factorization, and find adjacent primes."
+      }
+    ]
+  },
+  {
+    "app": "primefactor",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "prime_factor",
+        "description": "Find the prime factorization of an integer."
       }
     ]
   },
@@ -5896,6 +5956,16 @@
     ]
   },
   {
+    "app": "quadratic",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "quadratic_solve",
+        "description": "Solve a quadratic equation ax^2 + bx + c = 0. Returns roots, discriminant, and vertex."
+      }
+    ]
+  },
+  {
     "app": "quickbooks",
     "category": "AI",
     "tools": [
@@ -6062,6 +6132,16 @@
       {
         "name": "random_user",
         "description": "Generate random user profiles with names, emails, addresses, and photos."
+      }
+    ]
+  },
+  {
+    "app": "ratiosimplify",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "ratio_simplify",
+        "description": "Simplify a ratio a:b to its lowest terms. Returns decimal and percentage forms."
       }
     ]
   },
@@ -6744,6 +6824,16 @@
       {
         "name": "shortcut_list_epics",
         "description": "List Shortcut epics."
+      }
+    ]
+  },
+  {
+    "app": "sigmoid",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "sigmoid_calculate",
+        "description": "Compute activation functions (sigmoid, tanh, relu, leaky_relu, elu, swish) and their derivatives."
       }
     ]
   },
@@ -8634,6 +8724,16 @@
       {
         "name": "zip_by_city",
         "description": "Look up zip/postal codes for a city and state."
+      }
+    ]
+  },
+  {
+    "app": "zscore",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "zscore_calculate",
+        "description": "Calculate z-score, cumulative probability, and percentile for a value given mean and standard deviation."
       }
     ]
   }

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -340,6 +340,16 @@
     ]
   },
   {
+    "app": "areacalc",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "area_calculate",
+        "description": "Calculate area (and perimeter where possible) of common shapes: circle, rectangle, triangle, trapezoid, ellipse, parallelogram, sector."
+      }
+    ]
+  },
+  {
     "app": "artic",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -1410,6 +1420,16 @@
       {
         "name": "commonsensepass_rules",
         "description": "Return the worker-readable CommonSensePass rules, verdict vocabulary, and fixture ids. Set include_fixtures=true for full example packets."
+      }
+    ]
+  },
+  {
+    "app": "complexnum",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "complex_calc",
+        "description": "Complex number arithmetic: add, subtract, multiply, divide, magnitude, conjugate, or polar conversion."
       }
     ]
   },
@@ -4108,6 +4128,16 @@
     ]
   },
   {
+    "app": "logbase",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "log_base",
+        "description": "Compute logarithm with any base. Also returns ln, log10, and log2."
+      }
+    ]
+  },
+  {
     "app": "lorem",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4406,6 +4436,16 @@
       {
         "name": "mhw_weapons",
         "description": "Browse Monster Hunter World weapons by type."
+      }
+    ]
+  },
+  {
+    "app": "midpoint",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "midpoint_calc",
+        "description": "Calculate the midpoint, distance, slope, and angle between two 2D points."
       }
     ]
   },
@@ -4774,6 +4814,16 @@
     ]
   },
   {
+    "app": "normaldistr",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "normal_distribution",
+        "description": "Calculate normal (Gaussian) distribution PDF, CDF, and percentile for a given value."
+      }
+    ]
+  },
+  {
     "app": "notion",
     "category": "Productivity",
     "tools": [
@@ -4794,6 +4844,16 @@
       {
         "name": "npm_get_package",
         "description": "Get metadata for an npm package (latest version)."
+      }
+    ]
+  },
+  {
+    "app": "nthroot",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "nth_root",
+        "description": "Calculate the nth root of a number. Default is square root (n=2)."
       }
     ]
   },
@@ -6878,6 +6938,16 @@
     ]
   },
   {
+    "app": "slopeintercept",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "slope_intercept",
+        "description": "Find the line equation (slope-intercept and standard form) from two points."
+      }
+    ]
+  },
+  {
     "app": "sloppass",
     "category": "SlopPass (AI-code quality and slop-signal QC)",
     "tools": [
@@ -7092,6 +7162,16 @@
       {
         "name": "stackexchange_question",
         "description": "Get a Stack Exchange question by ID."
+      }
+    ]
+  },
+  {
+    "app": "standardform",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "standard_form",
+        "description": "Convert a number to scientific and engineering notation."
       }
     ]
   },
@@ -7730,6 +7810,16 @@
     ]
   },
   {
+    "app": "trianglesolve",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "triangle_solve",
+        "description": "Solve a triangle given three side lengths. Returns angles, area, perimeter, inradius, circumradius, and type."
+      }
+    ]
+  },
+  {
     "app": "trivia",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -8288,6 +8378,16 @@
       {
         "name": "virustotal_scan_domain",
         "description": "Get a VirusTotal report for a domain."
+      }
+    ]
+  },
+  {
+    "app": "wavelength",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "wavelength_convert",
+        "description": "Convert between wavelength and frequency. Returns energy and EM spectrum band."
       }
     ]
   },

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1642,6 +1642,16 @@
     ]
   },
   {
+    "app": "crossproduct",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "cross_product",
+        "description": "Compute the cross product of two 3D vectors. Returns magnitude and parallelism check."
+      }
+    ]
+  },
+  {
     "app": "crossref",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -2168,6 +2178,16 @@
     ]
   },
   {
+    "app": "dotproduct",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "dot_product",
+        "description": "Compute the dot product of two vectors. Returns magnitude, angle, and orthogonality check."
+      }
+    ]
+  },
+  {
     "app": "dropbox",
     "category": "Marketing / Communication / Data",
     "tools": [
@@ -2528,6 +2548,16 @@
       {
         "name": "excuser_random",
         "description": "Get a random excuse, optionally by category."
+      }
+    ]
+  },
+  {
+    "app": "expgrowth",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "exponential_growth",
+        "description": "Model exponential growth or decay: final = initial * e^(rate*time). Includes doubling time or half-life."
       }
     ]
   },
@@ -2990,6 +3020,16 @@
     ]
   },
   {
+    "app": "geomseries",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "geometric_series",
+        "description": "Calculate finite and infinite sums of a geometric series: a, ar, ar^2, ..."
+      }
+    ]
+  },
+  {
     "app": "geopass",
     "category": "GEOPass (AI answer-engine readiness QC, sister to SEOPass)",
     "tools": [
@@ -3204,6 +3244,16 @@
       {
         "name": "hamming_distance",
         "description": "Calculate Hamming distance between two equal-length strings."
+      }
+    ]
+  },
+  {
+    "app": "harmonicseries",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "harmonic_series",
+        "description": "Calculate partial sum of the harmonic series H(n) = 1 + 1/2 + 1/3 + ... + 1/n."
       }
     ]
   },
@@ -5466,6 +5516,16 @@
     ]
   },
   {
+    "app": "piapprox",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "pi_approx",
+        "description": "Approximate pi using Leibniz, Nilakantha, and Wallis formulas. Compare convergence rates."
+      }
+    ]
+  },
+  {
     "app": "picsum",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -5694,6 +5754,16 @@
       {
         "name": "poetry_random",
         "description": "Get a random poem from PoetryDB."
+      }
+    ]
+  },
+  {
+    "app": "poisson",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "poisson_probability",
+        "description": "Calculate Poisson distribution PMF and CDF for k events with rate lambda."
       }
     ]
   },
@@ -7408,6 +7478,16 @@
     ]
   },
   {
+    "app": "taylor",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "taylor_expand",
+        "description": "Taylor series approximation for exp, sin, cos, ln(1+x), and atan(x)."
+      }
+    ]
+  },
+  {
     "app": "telegram",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -8288,6 +8368,16 @@
     ]
   },
   {
+    "app": "variancecalc",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "variance_calc",
+        "description": "Calculate population/sample variance, standard deviation, median, range, and coefficient of variation."
+      }
+    ]
+  },
+  {
     "app": "vatcomply",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -8420,6 +8510,16 @@
       {
         "name": "webflow_list_items",
         "description": "List items in a Webflow CMS collection."
+      }
+    ]
+  },
+  {
+    "app": "weightedmean",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "weighted_mean",
+        "description": "Compute weighted, arithmetic, geometric, and harmonic means of a set of values."
       }
     ]
   },

--- a/packages/mcp-server/src/angleconv-tool.test.ts
+++ b/packages/mcp-server/src/angleconv-tool.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { angleConvert } from "./angleconv-tool.js";
+
+describe("angleConvert", () => {
+  it("converts 180 degrees to radians", async () => {
+    const r = await angleConvert({ value: 180, from: "degrees" }) as any;
+    expect(r.radians).toBeCloseTo(Math.PI, 6);
+    expect(r.gradians).toBe(200);
+    expect(r.turns).toBe(0.5);
+  });
+
+  it("converts pi radians to degrees", async () => {
+    const r = await angleConvert({ value: Math.PI, from: "radians" }) as any;
+    expect(r.degrees).toBeCloseTo(180, 5);
+  });
+
+  it("converts 1 turn to degrees", async () => {
+    const r = await angleConvert({ value: 1, from: "turns" }) as any;
+    expect(r.degrees).toBeCloseTo(360, 5);
+  });
+
+  it("returns error for invalid unit", async () => {
+    const r = await angleConvert({ value: 90, from: "foo" }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/angleconv-tool.ts
+++ b/packages/mcp-server/src/angleconv-tool.ts
@@ -1,0 +1,43 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function angleConvert(args: Record<string, unknown>) {
+  const value = typeof args.value === "number" ? args.value : NaN;
+  const from = typeof args.from === "string" ? args.from.toLowerCase() : "";
+  if (isNaN(value)) return { error: "value is required (number)" };
+
+  const validUnits = ["degrees", "radians", "gradians", "turns"];
+  if (!validUnits.includes(from)) return { error: `from is required (one of: ${validUnits.join(", ")})` };
+
+  let radians: number;
+  switch (from) {
+    case "degrees": radians = value * Math.PI / 180; break;
+    case "radians": radians = value; break;
+    case "gradians": radians = value * Math.PI / 200; break;
+    case "turns": radians = value * 2 * Math.PI; break;
+    default: radians = 0;
+  }
+
+  const degrees = radians * 180 / Math.PI;
+  const gradians = radians * 200 / Math.PI;
+  const turns = radians / (2 * Math.PI);
+
+  const normalized = ((degrees % 360) + 360) % 360;
+  const sin = Math.sin(radians);
+  const cos = Math.cos(radians);
+  const tan = Math.abs(cos) < 1e-15 ? "undefined" : +(sin / cos).toFixed(8);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use normalized_degrees for compass bearings", "Trig values included for convenience"],
+  };
+  return stampMeta({
+    input: { value, from },
+    degrees: +degrees.toFixed(8),
+    radians: +radians.toFixed(8),
+    gradians: +gradians.toFixed(8),
+    turns: +turns.toFixed(8),
+    normalized_degrees: +normalized.toFixed(8),
+    trig: { sin: +sin.toFixed(8), cos: +cos.toFixed(8), tan },
+  }, meta);
+}

--- a/packages/mcp-server/src/areacalc-tool.test.ts
+++ b/packages/mcp-server/src/areacalc-tool.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { areaCalculate } from "./areacalc-tool.js";
+
+describe("areaCalculate", () => {
+  it("computes circle area", async () => {
+    const r = await areaCalculate({ shape: "circle", radius: 5 }) as any;
+    expect(r.area).toBeCloseTo(78.5398, 3);
+    expect(r.perimeter).toBeCloseTo(31.4159, 3);
+  });
+
+  it("computes rectangle area", async () => {
+    const r = await areaCalculate({ shape: "rectangle", width: 4, height: 6 }) as any;
+    expect(r.area).toBe(24);
+    expect(r.perimeter).toBe(20);
+  });
+
+  it("computes triangle area", async () => {
+    const r = await areaCalculate({ shape: "triangle", base: 10, height: 5 }) as any;
+    expect(r.area).toBe(25);
+  });
+
+  it("returns error for invalid shape", async () => {
+    const r = await areaCalculate({ shape: "hexagon" }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/areacalc-tool.ts
+++ b/packages/mcp-server/src/areacalc-tool.ts
@@ -1,0 +1,88 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function areaCalculate(args: Record<string, unknown>) {
+  const shape = typeof args.shape === "string" ? args.shape.toLowerCase() : "";
+  const validShapes = ["circle", "rectangle", "triangle", "trapezoid", "ellipse", "parallelogram", "sector"];
+  if (!validShapes.includes(shape)) return { error: `shape is required (one of: ${validShapes.join(", ")})` };
+
+  let area: number;
+  let perimeter: number;
+  let params: Record<string, number> = {};
+
+  switch (shape) {
+    case "circle": {
+      const r = typeof args.radius === "number" ? args.radius : NaN;
+      if (isNaN(r) || r <= 0) return { error: "radius is required (positive number)" };
+      area = Math.PI * r * r;
+      perimeter = 2 * Math.PI * r;
+      params = { radius: r };
+      break;
+    }
+    case "rectangle": {
+      const w = typeof args.width === "number" ? args.width : NaN;
+      const h = typeof args.height === "number" ? args.height : NaN;
+      if (isNaN(w) || isNaN(h) || w <= 0 || h <= 0) return { error: "width and height are required (positive numbers)" };
+      area = w * h;
+      perimeter = 2 * (w + h);
+      params = { width: w, height: h };
+      break;
+    }
+    case "triangle": {
+      const b = typeof args.base === "number" ? args.base : NaN;
+      const h = typeof args.height === "number" ? args.height : NaN;
+      if (isNaN(b) || isNaN(h) || b <= 0 || h <= 0) return { error: "base and height are required (positive numbers)" };
+      area = 0.5 * b * h;
+      perimeter = NaN;
+      params = { base: b, height: h };
+      break;
+    }
+    case "trapezoid": {
+      const a = typeof args.base1 === "number" ? args.base1 : NaN;
+      const b = typeof args.base2 === "number" ? args.base2 : NaN;
+      const h = typeof args.height === "number" ? args.height : NaN;
+      if (isNaN(a) || isNaN(b) || isNaN(h) || a <= 0 || b <= 0 || h <= 0) return { error: "base1, base2, and height are required (positive numbers)" };
+      area = 0.5 * (a + b) * h;
+      perimeter = NaN;
+      params = { base1: a, base2: b, height: h };
+      break;
+    }
+    case "ellipse": {
+      const a = typeof args.semi_major === "number" ? args.semi_major : NaN;
+      const b = typeof args.semi_minor === "number" ? args.semi_minor : NaN;
+      if (isNaN(a) || isNaN(b) || a <= 0 || b <= 0) return { error: "semi_major and semi_minor are required (positive numbers)" };
+      area = Math.PI * a * b;
+      perimeter = Math.PI * (3 * (a + b) - Math.sqrt((3 * a + b) * (a + 3 * b)));
+      params = { semi_major: a, semi_minor: b };
+      break;
+    }
+    case "parallelogram": {
+      const b = typeof args.base === "number" ? args.base : NaN;
+      const h = typeof args.height === "number" ? args.height : NaN;
+      if (isNaN(b) || isNaN(h) || b <= 0 || h <= 0) return { error: "base and height are required (positive numbers)" };
+      area = b * h;
+      perimeter = NaN;
+      params = { base: b, height: h };
+      break;
+    }
+    case "sector": {
+      const r = typeof args.radius === "number" ? args.radius : NaN;
+      const angle = typeof args.angle_degrees === "number" ? args.angle_degrees : NaN;
+      if (isNaN(r) || isNaN(angle) || r <= 0 || angle <= 0 || angle > 360) return { error: "radius and angle_degrees (0-360) are required" };
+      const rad = angle * Math.PI / 180;
+      area = 0.5 * r * r * rad;
+      perimeter = 2 * r + r * rad;
+      params = { radius: r, angle_degrees: angle };
+      break;
+    }
+    default: area = 0; perimeter = 0;
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Perimeter may not be available for all shapes without full side lengths"],
+  };
+  const result: Record<string, unknown> = { shape, ...params, area: +area.toFixed(8) };
+  if (!isNaN(perimeter)) result.perimeter = +perimeter.toFixed(8);
+  return stampMeta(result, meta);
+}

--- a/packages/mcp-server/src/binomprob-tool.test.ts
+++ b/packages/mcp-server/src/binomprob-tool.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { binomialProbability } from "./binomprob-tool.js";
+
+describe("binomialProbability", () => {
+  it("computes coin flip probability", async () => {
+    const r = await binomialProbability({ n: 10, k: 5, p: 0.5 }) as any;
+    expect(r.pmf_exact).toBeCloseTo(0.24609375, 6);
+    expect(r.mean).toBe(5);
+  });
+
+  it("computes edge case k=0", async () => {
+    const r = await binomialProbability({ n: 5, k: 0, p: 0.3 }) as any;
+    expect(r.pmf_exact).toBeCloseTo(0.16807, 4);
+    expect(r.cdf_at_most_k).toBeCloseTo(0.16807, 4);
+  });
+
+  it("returns error for invalid p", async () => {
+    const r = await binomialProbability({ n: 10, k: 5, p: 1.5 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+
+  it("returns error for k > n", async () => {
+    const r = await binomialProbability({ n: 5, k: 10, p: 0.5 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/binomprob-tool.ts
+++ b/packages/mcp-server/src/binomprob-tool.ts
@@ -1,0 +1,52 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+function lnFactorial(n: number): number {
+  let s = 0;
+  for (let i = 2; i <= n; i++) s += Math.log(i);
+  return s;
+}
+
+function binomPmf(k: number, n: number, p: number): number {
+  const lnCoeff = lnFactorial(n) - lnFactorial(k) - lnFactorial(n - k);
+  return Math.exp(lnCoeff + k * Math.log(p) + (n - k) * Math.log(1 - p));
+}
+
+export async function binomialProbability(args: Record<string, unknown>) {
+  const n = typeof args.n === "number" ? Math.floor(args.n) : NaN;
+  const k = typeof args.k === "number" ? Math.floor(args.k) : NaN;
+  const p = typeof args.p === "number" ? args.p : NaN;
+  if (isNaN(n) || n < 0 || n > 1000) return { error: "n is required (integer 0-1000)" };
+  if (isNaN(k) || k < 0 || k > n) return { error: "k is required (integer 0 to n)" };
+  if (isNaN(p) || p < 0 || p > 1) return { error: "p is required (number 0 to 1)" };
+
+  const pmf = binomPmf(k, n, p);
+
+  let cdfLe = 0;
+  for (let i = 0; i <= k; i++) cdfLe += binomPmf(i, n, p);
+  const cdfLt = cdfLe - pmf;
+  const cdfGe = 1 - cdfLt;
+  const cdfGt = 1 - cdfLe;
+
+  const mean = n * p;
+  const variance = n * p * (1 - p);
+  const stddev = Math.sqrt(variance);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["P(X=k) is the exact probability", "P(X<=k) is cumulative for at-most-k successes"],
+  };
+  return stampMeta({
+    n,
+    k,
+    p,
+    pmf_exact: +pmf.toFixed(10),
+    cdf_at_most_k: +cdfLe.toFixed(10),
+    cdf_less_than_k: +cdfLt.toFixed(10),
+    cdf_at_least_k: +cdfGe.toFixed(10),
+    cdf_more_than_k: +cdfGt.toFixed(10),
+    mean: +mean.toFixed(6),
+    variance: +variance.toFixed(6),
+    stddev: +stddev.toFixed(6),
+  }, meta);
+}

--- a/packages/mcp-server/src/complexnum-tool.test.ts
+++ b/packages/mcp-server/src/complexnum-tool.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { complexCalc } from "./complexnum-tool.js";
+
+describe("complexCalc", () => {
+  it("adds two complex numbers", async () => {
+    const r = await complexCalc({ operation: "add", real1: 1, imag1: 2, real2: 3, imag2: 4 }) as any;
+    expect(r.real).toBe(4);
+    expect(r.imag).toBe(6);
+  });
+
+  it("multiplies two complex numbers", async () => {
+    const r = await complexCalc({ operation: "multiply", real1: 1, imag1: 2, real2: 3, imag2: 4 }) as any;
+    expect(r.real).toBe(-5);
+    expect(r.imag).toBe(10);
+  });
+
+  it("computes magnitude", async () => {
+    const r = await complexCalc({ operation: "magnitude", real1: 3, imag1: 4 }) as any;
+    expect(r.magnitude).toBe(5);
+  });
+
+  it("converts to polar", async () => {
+    const r = await complexCalc({ operation: "polar", real1: 1, imag1: 0 }) as any;
+    expect(r.magnitude).toBe(1);
+    expect(r.angle_degrees).toBe(0);
+  });
+
+  it("returns error for missing operand2 on binary op", async () => {
+    const r = await complexCalc({ operation: "add", real1: 1, imag1: 2 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/complexnum-tool.ts
+++ b/packages/mcp-server/src/complexnum-tool.ts
@@ -1,0 +1,59 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function complexCalc(args: Record<string, unknown>) {
+  const op = typeof args.operation === "string" ? args.operation.toLowerCase() : "";
+  const validOps = ["add", "subtract", "multiply", "divide", "magnitude", "conjugate", "polar"];
+  if (!validOps.includes(op)) return { error: `operation is required (one of: ${validOps.join(", ")})` };
+
+  const r1 = typeof args.real1 === "number" ? args.real1 : NaN;
+  const i1 = typeof args.imag1 === "number" ? args.imag1 : NaN;
+  if (isNaN(r1) || isNaN(i1)) return { error: "real1 and imag1 are required" };
+
+  const format = (r: number, i: number) => {
+    const rs = r.toFixed(6);
+    const is = Math.abs(i).toFixed(6);
+    if (i >= 0) return `${rs} + ${is}i`;
+    return `${rs} - ${is}i`;
+  };
+
+  if (op === "magnitude") {
+    const mag = Math.sqrt(r1 * r1 + i1 * i1);
+    const meta: ConnectorMeta = { source: "local-computation", fetched_at: new Date().toISOString(), next_steps: ["Magnitude is the distance from origin in the complex plane"] };
+    return stampMeta({ input: format(r1, i1), magnitude: +mag.toFixed(8) }, meta);
+  }
+  if (op === "conjugate") {
+    const meta: ConnectorMeta = { source: "local-computation", fetched_at: new Date().toISOString(), next_steps: ["Conjugate flips the sign of the imaginary part"] };
+    return stampMeta({ input: format(r1, i1), conjugate: format(r1, -i1), real: +r1.toFixed(6), imag: +(-i1).toFixed(6) }, meta);
+  }
+  if (op === "polar") {
+    const mag = Math.sqrt(r1 * r1 + i1 * i1);
+    const angle = Math.atan2(i1, r1);
+    const meta: ConnectorMeta = { source: "local-computation", fetched_at: new Date().toISOString(), next_steps: ["Polar form: r * e^(i*theta)"] };
+    return stampMeta({ input: format(r1, i1), magnitude: +mag.toFixed(8), angle_radians: +angle.toFixed(8), angle_degrees: +(angle * 180 / Math.PI).toFixed(6) }, meta);
+  }
+
+  const r2 = typeof args.real2 === "number" ? args.real2 : NaN;
+  const i2 = typeof args.imag2 === "number" ? args.imag2 : NaN;
+  if (isNaN(r2) || isNaN(i2)) return { error: "real2 and imag2 are required for binary operations" };
+
+  let rr: number, ri: number;
+  switch (op) {
+    case "add": rr = r1 + r2; ri = i1 + i2; break;
+    case "subtract": rr = r1 - r2; ri = i1 - i2; break;
+    case "multiply": rr = r1 * r2 - i1 * i2; ri = r1 * i2 + i1 * r2; break;
+    case "divide": {
+      const denom = r2 * r2 + i2 * i2;
+      if (denom === 0) return { error: "Division by zero" };
+      rr = (r1 * r2 + i1 * i2) / denom;
+      ri = (i1 * r2 - r1 * i2) / denom;
+      break;
+    }
+    default: rr = 0; ri = 0;
+  }
+
+  const meta: ConnectorMeta = { source: "local-computation", fetched_at: new Date().toISOString(), next_steps: ["Use polar form for powers and roots of complex numbers"] };
+  return stampMeta({
+    operand1: format(r1, i1), operand2: format(r2, i2), operation: op,
+    result: format(rr, ri), real: +rr.toFixed(6), imag: +ri.toFixed(6),
+  }, meta);
+}

--- a/packages/mcp-server/src/crossproduct-tool.test.ts
+++ b/packages/mcp-server/src/crossproduct-tool.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { crossProduct } from "./crossproduct-tool.js";
+
+describe("crossProduct", () => {
+  it("computes i x j = k", async () => {
+    const r = await crossProduct({ a: [1, 0, 0], b: [0, 1, 0] }) as any;
+    expect(r.cross_product).toEqual([0, 0, 1]);
+  });
+  it("detects parallel vectors", async () => {
+    const r = await crossProduct({ a: [2, 4, 6], b: [1, 2, 3] }) as any;
+    expect(r.are_parallel).toBe(true);
+  });
+  it("returns error for non-3D", async () => {
+    const r = await crossProduct({ a: [1, 2], b: [3, 4] }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/crossproduct-tool.ts
+++ b/packages/mcp-server/src/crossproduct-tool.ts
@@ -1,0 +1,26 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function crossProduct(args: Record<string, unknown>) {
+  const a = Array.isArray(args.a) ? args.a.filter((v) => typeof v === "number") as number[] : [];
+  const b = Array.isArray(args.b) ? args.b.filter((v) => typeof v === "number") as number[] : [];
+  if (a.length !== 3 || b.length !== 3) return { error: "a and b must each be 3-element arrays (3D vectors)" };
+
+  const result = [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+  const magnitude = Math.sqrt(result[0] ** 2 + result[1] ** 2 + result[2] ** 2);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Cross product magnitude = area of parallelogram", "Result is perpendicular to both input vectors"],
+  };
+  return stampMeta({
+    a, b,
+    cross_product: result.map((v) => +v.toFixed(8)),
+    magnitude: +magnitude.toFixed(8),
+    are_parallel: magnitude < 1e-10,
+  }, meta);
+}

--- a/packages/mcp-server/src/dotproduct-tool.test.ts
+++ b/packages/mcp-server/src/dotproduct-tool.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { dotProduct } from "./dotproduct-tool.js";
+
+describe("dotProduct", () => {
+  it("computes dot product", async () => {
+    const r = await dotProduct({ a: [1, 2, 3], b: [4, 5, 6] }) as any;
+    expect(r.dot_product).toBe(32);
+  });
+  it("detects orthogonal vectors", async () => {
+    const r = await dotProduct({ a: [1, 0], b: [0, 1] }) as any;
+    expect(r.are_orthogonal).toBe(true);
+    expect(r.angle_degrees).toBeCloseTo(90, 4);
+  });
+  it("returns error for length mismatch", async () => {
+    const r = await dotProduct({ a: [1, 2], b: [3] }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/dotproduct-tool.ts
+++ b/packages/mcp-server/src/dotproduct-tool.ts
@@ -1,0 +1,30 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function dotProduct(args: Record<string, unknown>) {
+  const a = Array.isArray(args.a) ? args.a.filter((v) => typeof v === "number") as number[] : [];
+  const b = Array.isArray(args.b) ? args.b.filter((v) => typeof v === "number") as number[] : [];
+  if (a.length === 0 || b.length === 0) return { error: "a and b are required (arrays of numbers)" };
+  if (a.length !== b.length) return { error: "a and b must have the same length" };
+
+  const dot = a.reduce((sum, ai, i) => sum + ai * b[i], 0);
+  const magA = Math.sqrt(a.reduce((s, v) => s + v * v, 0));
+  const magB = Math.sqrt(b.reduce((s, v) => s + v * v, 0));
+  const cosAngle = magA > 0 && magB > 0 ? dot / (magA * magB) : 0;
+  const angleDeg = Math.acos(Math.max(-1, Math.min(1, cosAngle))) * 180 / Math.PI;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Dot product = 0 means orthogonal vectors", "cos(angle) = dot / (|a| * |b|)"],
+  };
+  return stampMeta({
+    a, b,
+    dot_product: +dot.toFixed(8),
+    magnitude_a: +magA.toFixed(8),
+    magnitude_b: +magB.toFixed(8),
+    cos_angle: +cosAngle.toFixed(8),
+    angle_degrees: +angleDeg.toFixed(6),
+    are_orthogonal: Math.abs(dot) < 1e-10,
+    dimensions: a.length,
+  }, meta);
+}

--- a/packages/mcp-server/src/expgrowth-tool.test.ts
+++ b/packages/mcp-server/src/expgrowth-tool.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { exponentialGrowth } from "./expgrowth-tool.js";
+
+describe("exponentialGrowth", () => {
+  it("computes growth", async () => {
+    const r = await exponentialGrowth({ initial: 100, rate: 0.1, time: 10 }) as any;
+    expect(r.final).toBeCloseTo(271.8281828, 3);
+    expect(r.is_growth).toBe(true);
+    expect(r.doubling_time).toBeCloseTo(6.93147, 3);
+  });
+  it("computes decay", async () => {
+    const r = await exponentialGrowth({ initial: 100, rate: -0.1, time: 10 }) as any;
+    expect(r.is_growth).toBe(false);
+    expect(r.half_life).toBeCloseTo(6.93147, 3);
+  });
+  it("returns error for missing args", async () => {
+    const r = await exponentialGrowth({}) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/expgrowth-tool.ts
+++ b/packages/mcp-server/src/expgrowth-tool.ts
@@ -1,0 +1,27 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function exponentialGrowth(args: Record<string, unknown>) {
+  const initial = typeof args.initial === "number" ? args.initial : NaN;
+  const rate = typeof args.rate === "number" ? args.rate : NaN;
+  const time = typeof args.time === "number" ? args.time : NaN;
+  if (isNaN(initial) || isNaN(rate) || isNaN(time)) return { error: "initial, rate, and time are required (numbers)" };
+
+  const final = initial * Math.exp(rate * time);
+  const doublingTime = rate > 0 ? Math.log(2) / rate : rate < 0 ? NaN : Infinity;
+  const halfLife = rate < 0 ? Math.log(2) / Math.abs(rate) : rate > 0 ? NaN : Infinity;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Positive rate = growth; negative rate = decay", "Doubling time = ln(2) / rate"],
+  };
+  const result: Record<string, unknown> = {
+    initial, rate, time,
+    final: +final.toFixed(8),
+    growth_factor: +Math.exp(rate * time).toFixed(8),
+    is_growth: rate > 0,
+  };
+  if (!isNaN(doublingTime) && isFinite(doublingTime)) result.doubling_time = +doublingTime.toFixed(8);
+  if (!isNaN(halfLife) && isFinite(halfLife)) result.half_life = +halfLife.toFixed(8);
+  return stampMeta(result, meta);
+}

--- a/packages/mcp-server/src/geomseries-tool.test.ts
+++ b/packages/mcp-server/src/geomseries-tool.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { geometricSeries } from "./geomseries-tool.js";
+
+describe("geometricSeries", () => {
+  it("computes finite sum", async () => {
+    const r = await geometricSeries({ a: 1, r: 2, n: 5 }) as any;
+    expect(r.finite_sum).toBe(31);
+    expect(r.nth_term).toBe(16);
+  });
+  it("computes convergent infinite sum", async () => {
+    const r = await geometricSeries({ a: 1, r: 0.5, n: 10 }) as any;
+    expect(r.converges).toBe(true);
+    expect(r.infinite_sum).toBeCloseTo(2, 4);
+  });
+  it("returns error for invalid n", async () => {
+    const r = await geometricSeries({ a: 1, r: 2, n: 0 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/geomseries-tool.ts
+++ b/packages/mcp-server/src/geomseries-tool.ts
@@ -1,0 +1,34 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function geometricSeries(args: Record<string, unknown>) {
+  const a = typeof args.a === "number" ? args.a : NaN;
+  const r = typeof args.r === "number" ? args.r : NaN;
+  const n = typeof args.n === "number" ? Math.floor(args.n) : NaN;
+  if (isNaN(a) || isNaN(r)) return { error: "a (first term) and r (common ratio) are required" };
+  if (isNaN(n) || n < 1 || n > 1000) return { error: "n (number of terms) is required (1-1000)" };
+
+  const finiteSum = r === 1 ? a * n : a * (1 - Math.pow(r, n)) / (1 - r);
+  const nthTerm = a * Math.pow(r, n - 1);
+  const hasInfiniteSum = Math.abs(r) < 1;
+  const infiniteSum = hasInfiniteSum ? a / (1 - r) : NaN;
+
+  const terms: number[] = [];
+  for (let i = 0; i < Math.min(n, 10); i++) {
+    terms.push(+(a * Math.pow(r, i)).toFixed(8));
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Infinite sum converges only when |r| < 1", "Each term = previous term * r"],
+  };
+  const result: Record<string, unknown> = {
+    first_term: a, common_ratio: r, num_terms: n,
+    nth_term: +nthTerm.toFixed(8),
+    finite_sum: +finiteSum.toFixed(8),
+    first_terms: terms,
+    converges: hasInfiniteSum,
+  };
+  if (hasInfiniteSum) result.infinite_sum = +infiniteSum.toFixed(8);
+  return stampMeta(result, meta);
+}

--- a/packages/mcp-server/src/harmonicseries-tool.test.ts
+++ b/packages/mcp-server/src/harmonicseries-tool.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { harmonicSeries } from "./harmonicseries-tool.js";
+
+describe("harmonicSeries", () => {
+  it("computes H(4)", async () => {
+    const r = await harmonicSeries({ n: 4 }) as any;
+    expect(r.harmonic_sum).toBeCloseTo(2.08333, 4);
+  });
+  it("computes H(1)", async () => {
+    const r = await harmonicSeries({ n: 1 }) as any;
+    expect(r.harmonic_sum).toBe(1);
+  });
+  it("returns error for n=0", async () => {
+    const r = await harmonicSeries({ n: 0 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/harmonicseries-tool.ts
+++ b/packages/mcp-server/src/harmonicseries-tool.ts
@@ -1,0 +1,29 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function harmonicSeries(args: Record<string, unknown>) {
+  const n = typeof args.n === "number" ? Math.floor(args.n) : NaN;
+  if (isNaN(n) || n < 1 || n > 100000) return { error: "n is required (integer 1-100000)" };
+
+  let sum = 0;
+  for (let i = 1; i <= n; i++) sum += 1 / i;
+
+  let alternatingSum = 0;
+  for (let i = 1; i <= n; i++) alternatingSum += (i % 2 === 1 ? 1 : -1) / i;
+
+  const eulerMascheroni = 0.5772156649015329;
+  const approx = Math.log(n) + eulerMascheroni;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Harmonic series diverges (grows without bound)", "H(n) is approximately ln(n) + gamma"],
+  };
+  return stampMeta({
+    n,
+    harmonic_sum: +sum.toFixed(10),
+    alternating_sum: +alternatingSum.toFixed(10),
+    ln_approximation: +approx.toFixed(10),
+    error_from_approx: +Math.abs(sum - approx).toFixed(10),
+    ln_2_limit: +Math.LN2.toFixed(10),
+  }, meta);
+}

--- a/packages/mcp-server/src/interpolate-tool.test.ts
+++ b/packages/mcp-server/src/interpolate-tool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { interpolateCalc } from "./interpolate-tool.js";
+
+describe("interpolateCalc", () => {
+  it("interpolates midpoint", async () => {
+    const r = await interpolateCalc({ x1: 0, y1: 0, x2: 10, y2: 20, x: 5 }) as any;
+    expect(r.result_y).toBe(10);
+    expect(r.t).toBe(0.5);
+    expect(r.is_extrapolation).toBe(false);
+  });
+
+  it("detects extrapolation", async () => {
+    const r = await interpolateCalc({ x1: 0, y1: 0, x2: 10, y2: 20, x: 15 }) as any;
+    expect(r.result_y).toBe(30);
+    expect(r.is_extrapolation).toBe(true);
+  });
+
+  it("returns error for same x values", async () => {
+    const r = await interpolateCalc({ x1: 5, y1: 0, x2: 5, y2: 10, x: 5 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/interpolate-tool.ts
+++ b/packages/mcp-server/src/interpolate-tool.ts
@@ -1,0 +1,35 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function interpolateCalc(args: Record<string, unknown>) {
+  const x1 = typeof args.x1 === "number" ? args.x1 : NaN;
+  const y1 = typeof args.y1 === "number" ? args.y1 : NaN;
+  const x2 = typeof args.x2 === "number" ? args.x2 : NaN;
+  const y2 = typeof args.y2 === "number" ? args.y2 : NaN;
+  const x = typeof args.x === "number" ? args.x : NaN;
+  if (isNaN(x1) || isNaN(y1) || isNaN(x2) || isNaN(y2) || isNaN(x)) {
+    return { error: "x1, y1, x2, y2, and x are required (numbers)" };
+  }
+  if (x1 === x2) return { error: "x1 and x2 must be different" };
+
+  const t = (x - x1) / (x2 - x1);
+  const y = y1 + t * (y2 - y1);
+  const slope = (y2 - y1) / (x2 - x1);
+  const intercept = y1 - slope * x1;
+  const isExtrapolation = t < 0 || t > 1;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["t between 0 and 1 means interpolation; outside means extrapolation", "Use slope and intercept for the full line equation"],
+  };
+  return stampMeta({
+    point1: { x: x1, y: y1 },
+    point2: { x: x2, y: y2 },
+    query_x: x,
+    result_y: +y.toFixed(8),
+    t: +t.toFixed(8),
+    is_extrapolation: isExtrapolation,
+    line: { slope: +slope.toFixed(8), intercept: +intercept.toFixed(8) },
+    equation: `y = ${slope.toFixed(4)}x + ${intercept.toFixed(4)}`,
+  }, meta);
+}

--- a/packages/mcp-server/src/logbase-tool.test.ts
+++ b/packages/mcp-server/src/logbase-tool.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { logBase } from "./logbase-tool.js";
+
+describe("logBase", () => {
+  it("computes log base 10 of 1000", async () => {
+    const r = await logBase({ value: 1000, base: 10 }) as any;
+    expect(r.result).toBeCloseTo(3, 8);
+    expect(r.is_integer_result).toBe(true);
+  });
+
+  it("computes log base 2 of 8", async () => {
+    const r = await logBase({ value: 8, base: 2 }) as any;
+    expect(r.result).toBeCloseTo(3, 8);
+  });
+
+  it("defaults to base 10", async () => {
+    const r = await logBase({ value: 100 }) as any;
+    expect(r.result).toBeCloseTo(2, 8);
+  });
+
+  it("returns error for negative value", async () => {
+    const r = await logBase({ value: -5 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/logbase-tool.ts
+++ b/packages/mcp-server/src/logbase-tool.ts
@@ -1,0 +1,28 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function logBase(args: Record<string, unknown>) {
+  const value = typeof args.value === "number" ? args.value : NaN;
+  const base = typeof args.base === "number" ? args.base : 10;
+  if (isNaN(value) || value <= 0) return { error: "value is required (positive number)" };
+  if (base <= 0 || base === 1) return { error: "base must be positive and not equal to 1" };
+
+  const result = Math.log(value) / Math.log(base);
+  const ln = Math.log(value);
+  const log10 = Math.log10(value);
+  const log2 = Math.log2(value);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["log_b(x) = ln(x) / ln(b)", "Common bases: 2 (binary), e (natural), 10 (common)"],
+  };
+  return stampMeta({
+    value,
+    base,
+    result: +result.toFixed(10),
+    ln: +ln.toFixed(10),
+    log10: +log10.toFixed(10),
+    log2: +log2.toFixed(10),
+    is_integer_result: Math.abs(result - Math.round(result)) < 1e-10,
+  }, meta);
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -254,6 +254,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "angleconv",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "angle_convert",
+        "description": "Convert angles between degrees, radians, gradians, and turns. Includes trig values."
+      }
+    ]
+  },
+  {
     "app": "animechan",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -618,6 +628,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "number_base_convert",
         "description": "Convert numbers between binary, octal, decimal, hex, and any base 2-36."
+      }
+    ]
+  },
+  {
+    "app": "binomprob",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "binomial_probability",
+        "description": "Calculate binomial distribution probability P(X=k) and cumulative probabilities for n trials with probability p."
       }
     ]
   },
@@ -3530,6 +3550,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "interpolate",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "interpolate_calc",
+        "description": "Linear interpolation (or extrapolation) between two points. Returns the y value for a given x."
+      }
+    ]
+  },
+  {
     "app": "ipaddrinfo",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4452,6 +4482,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "mixpanel_export_data",
         "description": "Export raw Mixpanel event data for a date range."
+      }
+    ]
+  },
+  {
+    "app": "modpow",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "modular_arithmetic",
+        "description": "Modular arithmetic operations: modpow (a^b mod m), modinverse (a^-1 mod m), or mod (a mod m)."
       }
     ]
   },
@@ -5652,6 +5692,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "polygon",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "polygon_calculate",
+        "description": "Calculate properties of a regular polygon: area, perimeter, angles, apothem, circumradius, diagonals."
+      }
+    ]
+  },
+  {
     "app": "postcodes",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -5734,6 +5784,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "prime_check",
         "description": "Check if a number is prime, get its factorization, and find adjacent primes."
+      }
+    ]
+  },
+  {
+    "app": "primefactor",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "prime_factor",
+        "description": "Find the prime factorization of an integer."
       }
     ]
   },
@@ -5910,6 +5970,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "quadratic",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "quadratic_solve",
+        "description": "Solve a quadratic equation ax^2 + bx + c = 0. Returns roots, discriminant, and vertex."
+      }
+    ]
+  },
+  {
     "app": "quickbooks",
     "category": "AI",
     "tools": [
@@ -6076,6 +6146,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "random_user",
         "description": "Generate random user profiles with names, emails, addresses, and photos."
+      }
+    ]
+  },
+  {
+    "app": "ratiosimplify",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "ratio_simplify",
+        "description": "Simplify a ratio a:b to its lowest terms. Returns decimal and percentage forms."
       }
     ]
   },
@@ -6758,6 +6838,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "shortcut_list_epics",
         "description": "List Shortcut epics."
+      }
+    ]
+  },
+  {
+    "app": "sigmoid",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "sigmoid_calculate",
+        "description": "Compute activation functions (sigmoid, tanh, relu, leaky_relu, elu, swish) and their derivatives."
       }
     ]
   },
@@ -8648,6 +8738,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "zip_by_city",
         "description": "Look up zip/postal codes for a city and state."
+      }
+    ]
+  },
+  {
+    "app": "zscore",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "zscore_calculate",
+        "description": "Calculate z-score, cumulative probability, and percentile for a value given mean and standard deviation."
       }
     ]
   }

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -354,6 +354,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "areacalc",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "area_calculate",
+        "description": "Calculate area (and perimeter where possible) of common shapes: circle, rectangle, triangle, trapezoid, ellipse, parallelogram, sector."
+      }
+    ]
+  },
+  {
     "app": "artic",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -1424,6 +1434,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "commonsensepass_rules",
         "description": "Return the worker-readable CommonSensePass rules, verdict vocabulary, and fixture ids. Set include_fixtures=true for full example packets."
+      }
+    ]
+  },
+  {
+    "app": "complexnum",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "complex_calc",
+        "description": "Complex number arithmetic: add, subtract, multiply, divide, magnitude, conjugate, or polar conversion."
       }
     ]
   },
@@ -4122,6 +4142,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "logbase",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "log_base",
+        "description": "Compute logarithm with any base. Also returns ln, log10, and log2."
+      }
+    ]
+  },
+  {
     "app": "lorem",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4420,6 +4450,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "mhw_weapons",
         "description": "Browse Monster Hunter World weapons by type."
+      }
+    ]
+  },
+  {
+    "app": "midpoint",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "midpoint_calc",
+        "description": "Calculate the midpoint, distance, slope, and angle between two 2D points."
       }
     ]
   },
@@ -4788,6 +4828,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "normaldistr",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "normal_distribution",
+        "description": "Calculate normal (Gaussian) distribution PDF, CDF, and percentile for a given value."
+      }
+    ]
+  },
+  {
     "app": "notion",
     "category": "Productivity",
     "tools": [
@@ -4808,6 +4858,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "npm_get_package",
         "description": "Get metadata for an npm package (latest version)."
+      }
+    ]
+  },
+  {
+    "app": "nthroot",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "nth_root",
+        "description": "Calculate the nth root of a number. Default is square root (n=2)."
       }
     ]
   },
@@ -6892,6 +6952,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "slopeintercept",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "slope_intercept",
+        "description": "Find the line equation (slope-intercept and standard form) from two points."
+      }
+    ]
+  },
+  {
     "app": "sloppass",
     "category": "SlopPass (AI-code quality and slop-signal QC)",
     "tools": [
@@ -7106,6 +7176,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "stackexchange_question",
         "description": "Get a Stack Exchange question by ID."
+      }
+    ]
+  },
+  {
+    "app": "standardform",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "standard_form",
+        "description": "Convert a number to scientific and engineering notation."
       }
     ]
   },
@@ -7744,6 +7824,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "trianglesolve",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "triangle_solve",
+        "description": "Solve a triangle given three side lengths. Returns angles, area, perimeter, inradius, circumradius, and type."
+      }
+    ]
+  },
+  {
     "app": "trivia",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -8302,6 +8392,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "virustotal_scan_domain",
         "description": "Get a VirusTotal report for a domain."
+      }
+    ]
+  },
+  {
+    "app": "wavelength",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "wavelength_convert",
+        "description": "Convert between wavelength and frequency. Returns energy and EM spectrum band."
       }
     ]
   },

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1656,6 +1656,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "crossproduct",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "cross_product",
+        "description": "Compute the cross product of two 3D vectors. Returns magnitude and parallelism check."
+      }
+    ]
+  },
+  {
     "app": "crossref",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -2182,6 +2192,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "dotproduct",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "dot_product",
+        "description": "Compute the dot product of two vectors. Returns magnitude, angle, and orthogonality check."
+      }
+    ]
+  },
+  {
     "app": "dropbox",
     "category": "Marketing / Communication / Data",
     "tools": [
@@ -2542,6 +2562,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "excuser_random",
         "description": "Get a random excuse, optionally by category."
+      }
+    ]
+  },
+  {
+    "app": "expgrowth",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "exponential_growth",
+        "description": "Model exponential growth or decay: final = initial * e^(rate*time). Includes doubling time or half-life."
       }
     ]
   },
@@ -3004,6 +3034,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "geomseries",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "geometric_series",
+        "description": "Calculate finite and infinite sums of a geometric series: a, ar, ar^2, ..."
+      }
+    ]
+  },
+  {
     "app": "geopass",
     "category": "GEOPass (AI answer-engine readiness QC, sister to SEOPass)",
     "tools": [
@@ -3218,6 +3258,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "hamming_distance",
         "description": "Calculate Hamming distance between two equal-length strings."
+      }
+    ]
+  },
+  {
+    "app": "harmonicseries",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "harmonic_series",
+        "description": "Calculate partial sum of the harmonic series H(n) = 1 + 1/2 + 1/3 + ... + 1/n."
       }
     ]
   },
@@ -5480,6 +5530,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "piapprox",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "pi_approx",
+        "description": "Approximate pi using Leibniz, Nilakantha, and Wallis formulas. Compare convergence rates."
+      }
+    ]
+  },
+  {
     "app": "picsum",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -5708,6 +5768,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "poetry_random",
         "description": "Get a random poem from PoetryDB."
+      }
+    ]
+  },
+  {
+    "app": "poisson",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "poisson_probability",
+        "description": "Calculate Poisson distribution PMF and CDF for k events with rate lambda."
       }
     ]
   },
@@ -7422,6 +7492,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "taylor",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "taylor_expand",
+        "description": "Taylor series approximation for exp, sin, cos, ln(1+x), and atan(x)."
+      }
+    ]
+  },
+  {
     "app": "telegram",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -8302,6 +8382,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "variancecalc",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "variance_calc",
+        "description": "Calculate population/sample variance, standard deviation, median, range, and coefficient of variation."
+      }
+    ]
+  },
+  {
     "app": "vatcomply",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -8434,6 +8524,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "webflow_list_items",
         "description": "List items in a Webflow CMS collection."
+      }
+    ]
+  },
+  {
+    "app": "weightedmean",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "weighted_mean",
+        "description": "Compute weighted, arithmetic, geometric, and harmonic means of a set of values."
       }
     ]
   },

--- a/packages/mcp-server/src/midpoint-tool.test.ts
+++ b/packages/mcp-server/src/midpoint-tool.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { midpointCalc } from "./midpoint-tool.js";
+
+describe("midpointCalc", () => {
+  it("finds midpoint of (0,0) and (10,10)", async () => {
+    const r = await midpointCalc({ x1: 0, y1: 0, x2: 10, y2: 10 }) as any;
+    expect(r.midpoint.x).toBe(5);
+    expect(r.midpoint.y).toBe(5);
+    expect(r.distance).toBeCloseTo(14.14213562, 4);
+  });
+
+  it("computes slope", async () => {
+    const r = await midpointCalc({ x1: 0, y1: 0, x2: 4, y2: 2 }) as any;
+    expect(r.slope).toBe(0.5);
+  });
+
+  it("returns error for missing coords", async () => {
+    const r = await midpointCalc({ x1: 0 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/midpoint-tool.ts
+++ b/packages/mcp-server/src/midpoint-tool.ts
@@ -1,0 +1,33 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function midpointCalc(args: Record<string, unknown>) {
+  const x1 = typeof args.x1 === "number" ? args.x1 : NaN;
+  const y1 = typeof args.y1 === "number" ? args.y1 : NaN;
+  const x2 = typeof args.x2 === "number" ? args.x2 : NaN;
+  const y2 = typeof args.y2 === "number" ? args.y2 : NaN;
+  if (isNaN(x1) || isNaN(y1) || isNaN(x2) || isNaN(y2)) {
+    return { error: "x1, y1, x2, and y2 are required (numbers)" };
+  }
+
+  const mx = (x1 + x2) / 2;
+  const my = (y1 + y2) / 2;
+  const distance = Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const slope = dx === 0 ? "undefined" : +(dy / dx).toFixed(8);
+  const angle = Math.atan2(dy, dx) * 180 / Math.PI;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Midpoint divides the segment in ratio 1:1", "Distance uses the Euclidean formula"],
+  };
+  return stampMeta({
+    point1: { x: x1, y: y1 },
+    point2: { x: x2, y: y2 },
+    midpoint: { x: +mx.toFixed(8), y: +my.toFixed(8) },
+    distance: +distance.toFixed(8),
+    slope,
+    angle_degrees: +angle.toFixed(6),
+  }, meta);
+}

--- a/packages/mcp-server/src/modpow-tool.test.ts
+++ b/packages/mcp-server/src/modpow-tool.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { modularArithmetic } from "./modpow-tool.js";
+
+describe("modularArithmetic", () => {
+  it("computes modular exponentiation", async () => {
+    const r = await modularArithmetic({ operation: "modpow", a: 2, b: 10, m: 1000 }) as any;
+    expect(r.result_numeric).toBe("24");
+  });
+
+  it("computes modular inverse", async () => {
+    const r = await modularArithmetic({ operation: "modinverse", a: 3, m: 7 }) as any;
+    expect(r.result_numeric).toBe("5");
+  });
+
+  it("computes simple mod", async () => {
+    const r = await modularArithmetic({ operation: "mod", a: -7, m: 3 }) as any;
+    expect(r.result_numeric).toBe("2");
+  });
+
+  it("returns error for no inverse", async () => {
+    const r = await modularArithmetic({ operation: "modinverse", a: 4, m: 8 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/modpow-tool.ts
+++ b/packages/mcp-server/src/modpow-tool.ts
@@ -1,0 +1,71 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+function bigModPow(base: bigint, exp: bigint, mod: bigint): bigint {
+  let result = 1n;
+  base = base % mod;
+  while (exp > 0n) {
+    if (exp % 2n === 1n) result = (result * base) % mod;
+    exp = exp / 2n;
+    base = (base * base) % mod;
+  }
+  return result;
+}
+
+function bigModInverse(a: bigint, m: bigint): bigint | null {
+  let [old_r, r] = [a % m, m];
+  let [old_s, s] = [1n, 0n];
+  while (r !== 0n) {
+    const q = old_r / r;
+    [old_r, r] = [r, old_r - q * r];
+    [old_s, s] = [s, old_s - q * s];
+  }
+  if (old_r !== 1n) return null;
+  return ((old_s % m) + m) % m;
+}
+
+export async function modularArithmetic(args: Record<string, unknown>) {
+  const op = typeof args.operation === "string" ? args.operation.toLowerCase() : "";
+  const validOps = ["modpow", "modinverse", "mod"];
+  if (!validOps.includes(op)) return { error: `operation is required (one of: ${validOps.join(", ")})` };
+
+  const a = typeof args.a === "number" ? BigInt(Math.floor(args.a)) : null;
+  const b = typeof args.b === "number" ? BigInt(Math.floor(args.b)) : null;
+  const m = typeof args.m === "number" ? BigInt(Math.floor(args.m)) : null;
+  if (a === null || m === null || m <= 0n) return { error: "a and m are required (m must be positive)" };
+
+  let result: string;
+  let details: Record<string, unknown>;
+
+  switch (op) {
+    case "modpow": {
+      if (b === null || b < 0n) return { error: "b (exponent) is required and must be non-negative" };
+      const r = bigModPow(a, b, m);
+      result = r.toString();
+      details = { operation: "modpow", expression: `${a}^${b} mod ${m}`, result: r.toString() };
+      break;
+    }
+    case "modinverse": {
+      const inv = bigModInverse(a, m);
+      if (inv === null) return { error: `No modular inverse exists for ${a} mod ${m}` };
+      result = inv.toString();
+      details = { operation: "modinverse", expression: `${a}^(-1) mod ${m}`, result: inv.toString() };
+      break;
+    }
+    case "mod": {
+      const r = ((a % m) + m) % m;
+      result = r.toString();
+      details = { operation: "mod", expression: `${a} mod ${m}`, result: r.toString() };
+      break;
+    }
+    default:
+      result = "0";
+      details = {};
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["modpow is used in RSA and Diffie-Hellman", "modinverse exists only when gcd(a, m) = 1"],
+  };
+  return stampMeta({ ...details, result_numeric: result }, meta);
+}

--- a/packages/mcp-server/src/normaldistr-tool.test.ts
+++ b/packages/mcp-server/src/normaldistr-tool.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { normalDistribution } from "./normaldistr-tool.js";
+
+describe("normalDistribution", () => {
+  it("computes standard normal at 0", async () => {
+    const r = await normalDistribution({ x: 0 }) as any;
+    expect(r.cdf).toBeCloseTo(0.5, 4);
+    expect(r.pdf).toBeCloseTo(0.3989, 3);
+  });
+
+  it("computes custom mean/stddev", async () => {
+    const r = await normalDistribution({ x: 100, mean: 100, stddev: 15 }) as any;
+    expect(r.percentile).toBeCloseTo(50, 0);
+  });
+
+  it("returns error for missing x", async () => {
+    const r = await normalDistribution({}) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/normaldistr-tool.ts
+++ b/packages/mcp-server/src/normaldistr-tool.ts
@@ -1,0 +1,40 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+function normalPdf(x: number, mean: number, stddev: number): number {
+  const z = (x - mean) / stddev;
+  return Math.exp(-0.5 * z * z) / (stddev * Math.sqrt(2 * Math.PI));
+}
+
+function normalCdf(x: number, mean: number, stddev: number): number {
+  const z = (x - mean) / stddev;
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989422804014327;
+  const p = d * Math.exp(-z * z / 2) * (t * (0.319381530 + t * (-0.356563782 + t * (1.781477937 + t * (-1.821255978 + t * 1.330274429)))));
+  return z > 0 ? 1 - p : p;
+}
+
+export async function normalDistribution(args: Record<string, unknown>) {
+  const x = typeof args.x === "number" ? args.x : NaN;
+  const mean = typeof args.mean === "number" ? args.mean : 0;
+  const stddev = typeof args.stddev === "number" ? args.stddev : 1;
+  if (isNaN(x)) return { error: "x is required (number)" };
+  if (stddev <= 0) return { error: "stddev must be positive" };
+
+  const pdf = normalPdf(x, mean, stddev);
+  const cdf = normalCdf(x, mean, stddev);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["CDF gives P(X <= x)", "For P(a < X < b), compute CDF(b) - CDF(a)"],
+  };
+  return stampMeta({
+    x,
+    mean,
+    stddev,
+    pdf: +pdf.toFixed(10),
+    cdf: +cdf.toFixed(10),
+    survival: +(1 - cdf).toFixed(10),
+    percentile: +(cdf * 100).toFixed(4),
+  }, meta);
+}

--- a/packages/mcp-server/src/nthroot-tool.test.ts
+++ b/packages/mcp-server/src/nthroot-tool.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { nthRoot } from "./nthroot-tool.js";
+
+describe("nthRoot", () => {
+  it("computes square root", async () => {
+    const r = await nthRoot({ value: 16, n: 2 }) as any;
+    expect(r.result).toBeCloseTo(4, 8);
+    expect(r.is_integer_result).toBe(true);
+  });
+
+  it("computes cube root of negative", async () => {
+    const r = await nthRoot({ value: -27, n: 3 }) as any;
+    expect(r.result).toBeCloseTo(-3, 8);
+  });
+
+  it("returns error for even root of negative", async () => {
+    const r = await nthRoot({ value: -4, n: 2 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+
+  it("defaults to square root", async () => {
+    const r = await nthRoot({ value: 25 }) as any;
+    expect(r.result).toBeCloseTo(5, 8);
+  });
+});

--- a/packages/mcp-server/src/nthroot-tool.ts
+++ b/packages/mcp-server/src/nthroot-tool.ts
@@ -1,0 +1,33 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function nthRoot(args: Record<string, unknown>) {
+  const value = typeof args.value === "number" ? args.value : NaN;
+  const n = typeof args.n === "number" ? args.n : 2;
+  if (isNaN(value)) return { error: "value is required (number)" };
+  if (n === 0) return { error: "n must not be zero" };
+  if (value < 0 && n % 2 === 0) return { error: "Even roots of negative numbers are not real" };
+
+  let result: number;
+  if (value < 0) {
+    result = -Math.pow(-value, 1 / n);
+  } else {
+    result = Math.pow(value, 1 / n);
+  }
+
+  const inverse = Math.pow(result, n);
+  const isExact = Math.abs(inverse - value) < 1e-8;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["nth root is the same as raising to the power 1/n", "Square root (n=2) and cube root (n=3) are the most common"],
+  };
+  return stampMeta({
+    value,
+    n,
+    result: +result.toFixed(10),
+    verification: +inverse.toFixed(10),
+    is_exact: isExact,
+    is_integer_result: Math.abs(result - Math.round(result)) < 1e-10,
+  }, meta);
+}

--- a/packages/mcp-server/src/piapprox-tool.test.ts
+++ b/packages/mcp-server/src/piapprox-tool.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { piApprox } from "./piapprox-tool.js";
+
+describe("piApprox", () => {
+  it("approximates pi with default terms", async () => {
+    const r = await piApprox({}) as any;
+    expect(r.leibniz).toBeCloseTo(Math.PI, 2);
+    expect(r.nilakantha).toBeCloseTo(Math.PI, 4);
+  });
+  it("returns actual pi", async () => {
+    const r = await piApprox({ terms: 100 }) as any;
+    expect(r.actual_pi).toBeCloseTo(Math.PI, 10);
+  });
+});

--- a/packages/mcp-server/src/piapprox-tool.ts
+++ b/packages/mcp-server/src/piapprox-tool.ts
@@ -1,0 +1,42 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function piApprox(args: Record<string, unknown>) {
+  const terms = typeof args.terms === "number" ? Math.floor(args.terms) : 1000;
+  if (terms < 1 || terms > 1000000) return { error: "terms must be between 1 and 1,000,000" };
+
+  let leibniz = 0;
+  for (let i = 0; i < terms; i++) {
+    leibniz += (i % 2 === 0 ? 1 : -1) / (2 * i + 1);
+  }
+  leibniz *= 4;
+
+  let nilakantha = 3;
+  for (let i = 1; i < terms; i++) {
+    const d = 2 * i;
+    nilakantha += (i % 2 === 1 ? 1 : -1) * 4 / (d * (d + 1) * (d + 2));
+  }
+
+  let wallis = 1;
+  for (let i = 1; i <= terms; i++) {
+    wallis *= (4 * i * i) / (4 * i * i - 1);
+  }
+  wallis *= 2;
+
+  const actual = Math.PI;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Nilakantha converges faster than Leibniz", "More terms = better approximation"],
+  };
+  return stampMeta({
+    terms,
+    leibniz: +leibniz.toFixed(12),
+    nilakantha: +nilakantha.toFixed(12),
+    wallis: +wallis.toFixed(12),
+    actual_pi: +actual.toFixed(12),
+    leibniz_error: +Math.abs(leibniz - actual).toExponential(6),
+    nilakantha_error: +Math.abs(nilakantha - actual).toExponential(6),
+    wallis_error: +Math.abs(wallis - actual).toExponential(6),
+  }, meta);
+}

--- a/packages/mcp-server/src/poisson-tool.test.ts
+++ b/packages/mcp-server/src/poisson-tool.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { poissonProbability } from "./poisson-tool.js";
+
+describe("poissonProbability", () => {
+  it("computes P(X=3) for lambda=2", async () => {
+    const r = await poissonProbability({ k: 3, lambda: 2 }) as any;
+    expect(r.pmf).toBeCloseTo(0.18045, 4);
+    expect(r.mean).toBe(2);
+  });
+  it("computes P(X=0)", async () => {
+    const r = await poissonProbability({ k: 0, lambda: 1 }) as any;
+    expect(r.pmf).toBeCloseTo(0.36788, 4);
+  });
+  it("returns error for negative lambda", async () => {
+    const r = await poissonProbability({ k: 1, lambda: -1 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/poisson-tool.ts
+++ b/packages/mcp-server/src/poisson-tool.ts
@@ -1,0 +1,38 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+function lnFactorial(n: number): number {
+  let s = 0;
+  for (let i = 2; i <= n; i++) s += Math.log(i);
+  return s;
+}
+
+export async function poissonProbability(args: Record<string, unknown>) {
+  const k = typeof args.k === "number" ? Math.floor(args.k) : NaN;
+  const lambda = typeof args.lambda === "number" ? args.lambda : NaN;
+  if (isNaN(k) || k < 0) return { error: "k is required (non-negative integer)" };
+  if (isNaN(lambda) || lambda <= 0) return { error: "lambda is required (positive number)" };
+  if (k > 170) return { error: "k must be <= 170" };
+
+  const pmf = Math.exp(k * Math.log(lambda) - lambda - lnFactorial(k));
+
+  let cdfLe = 0;
+  for (let i = 0; i <= k; i++) {
+    cdfLe += Math.exp(i * Math.log(lambda) - lambda - lnFactorial(i));
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Lambda is both the mean and variance", "Useful for modeling rare events over a fixed interval"],
+  };
+  return stampMeta({
+    k,
+    lambda,
+    pmf: +pmf.toFixed(10),
+    cdf_at_most_k: +cdfLe.toFixed(10),
+    cdf_more_than_k: +(1 - cdfLe).toFixed(10),
+    mean: lambda,
+    variance: lambda,
+    stddev: +Math.sqrt(lambda).toFixed(6),
+  }, meta);
+}

--- a/packages/mcp-server/src/polygon-tool.test.ts
+++ b/packages/mcp-server/src/polygon-tool.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { polygonCalculate } from "./polygon-tool.js";
+
+describe("polygonCalculate", () => {
+  it("calculates a square", async () => {
+    const r = await polygonCalculate({ sides: 4, side_length: 10 }) as any;
+    expect(r.perimeter).toBe(40);
+    expect(r.area).toBeCloseTo(100, 4);
+    expect(r.interior_angle).toBe(90);
+    expect(r.diagonals).toBe(2);
+  });
+
+  it("calculates a hexagon", async () => {
+    const r = await polygonCalculate({ sides: 6, side_length: 1 }) as any;
+    expect(r.interior_angle).toBe(120);
+    expect(r.diagonals).toBe(9);
+    expect(r.area).toBeCloseTo(2.598076, 4);
+  });
+
+  it("returns error for fewer than 3 sides", async () => {
+    const r = await polygonCalculate({ sides: 2, side_length: 5 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/polygon-tool.ts
+++ b/packages/mcp-server/src/polygon-tool.ts
@@ -1,0 +1,35 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function polygonCalculate(args: Record<string, unknown>) {
+  const sides = typeof args.sides === "number" ? Math.floor(args.sides) : NaN;
+  const length = typeof args.side_length === "number" ? args.side_length : NaN;
+  if (isNaN(sides) || sides < 3) return { error: "sides is required (integer >= 3)" };
+  if (isNaN(length) || length <= 0) return { error: "side_length is required (positive number)" };
+
+  const interiorAngle = (sides - 2) * 180 / sides;
+  const exteriorAngle = 360 / sides;
+  const perimeter = sides * length;
+  const apothem = length / (2 * Math.tan(Math.PI / sides));
+  const area = (perimeter * apothem) / 2;
+  const circumradius = length / (2 * Math.sin(Math.PI / sides));
+  const sumInteriorAngles = (sides - 2) * 180;
+  const diagonals = sides * (sides - 3) / 2;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Apothem = distance from center to midpoint of a side", "Circumradius = distance from center to a vertex"],
+  };
+  return stampMeta({
+    sides,
+    side_length: length,
+    perimeter: +perimeter.toFixed(6),
+    area: +area.toFixed(6),
+    interior_angle: +interiorAngle.toFixed(6),
+    exterior_angle: +exteriorAngle.toFixed(6),
+    sum_interior_angles: sumInteriorAngles,
+    apothem: +apothem.toFixed(6),
+    circumradius: +circumradius.toFixed(6),
+    diagonals,
+  }, meta);
+}

--- a/packages/mcp-server/src/primefactor-tool.test.ts
+++ b/packages/mcp-server/src/primefactor-tool.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { primeFactor } from "./primefactor-tool.js";
+
+describe("primeFactor", () => {
+  it("factors a composite number", async () => {
+    const r = await primeFactor({ n: 60 }) as any;
+    expect(r.factors).toEqual([2, 2, 3, 5]);
+    expect(r.is_prime).toBe(false);
+    expect(r.expression).toBe("2^2 x 3 x 5");
+  });
+
+  it("identifies a prime", async () => {
+    const r = await primeFactor({ n: 17 }) as any;
+    expect(r.factors).toEqual([17]);
+    expect(r.is_prime).toBe(true);
+  });
+
+  it("factors a power of 2", async () => {
+    const r = await primeFactor({ n: 64 }) as any;
+    expect(r.factors).toEqual([2, 2, 2, 2, 2, 2]);
+    expect(r.unique_primes).toEqual([2]);
+  });
+
+  it("returns error for n < 2", async () => {
+    const r = await primeFactor({ n: 1 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/primefactor-tool.ts
+++ b/packages/mcp-server/src/primefactor-tool.ts
@@ -1,0 +1,40 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function primeFactor(args: Record<string, unknown>) {
+  const n = typeof args.n === "number" ? Math.floor(args.n) : NaN;
+  if (isNaN(n) || n < 2) return { error: "n is required (integer >= 2)" };
+  if (n > 1e12) return { error: "n must be <= 1,000,000,000,000" };
+
+  const factors: number[] = [];
+  let remaining = n;
+
+  for (let d = 2; d * d <= remaining; d++) {
+    while (remaining % d === 0) {
+      factors.push(d);
+      remaining /= d;
+    }
+  }
+  if (remaining > 1) factors.push(remaining);
+
+  const unique = [...new Set(factors)];
+  const grouped: Record<number, number> = {};
+  for (const f of factors) {
+    grouped[f] = (grouped[f] || 0) + 1;
+  }
+
+  const expression = unique.map((p) => grouped[p] > 1 ? `${p}^${grouped[p]}` : `${p}`).join(" x ");
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use factors to find GCD/LCM with other numbers", "A single-factor result means the number is prime"],
+  };
+  return stampMeta({
+    n,
+    factors,
+    unique_primes: unique,
+    exponents: grouped,
+    expression,
+    is_prime: factors.length === 1,
+  }, meta);
+}

--- a/packages/mcp-server/src/quadratic-tool.test.ts
+++ b/packages/mcp-server/src/quadratic-tool.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { quadraticSolve } from "./quadratic-tool.js";
+
+describe("quadraticSolve", () => {
+  it("finds two real roots", async () => {
+    const r = await quadraticSolve({ a: 1, b: -3, c: 2 }) as any;
+    expect(r.roots.type).toBe("two_real");
+    expect(r.roots.x1).toBe(2);
+    expect(r.roots.x2).toBe(1);
+  });
+
+  it("finds one repeated root", async () => {
+    const r = await quadraticSolve({ a: 1, b: -2, c: 1 }) as any;
+    expect(r.roots.type).toBe("one_repeated");
+    expect(r.roots.x1).toBe(1);
+  });
+
+  it("finds complex roots", async () => {
+    const r = await quadraticSolve({ a: 1, b: 0, c: 1 }) as any;
+    expect(r.roots.type).toBe("two_complex");
+    expect(r.roots.x1).toContain("i");
+  });
+
+  it("returns error when a is zero", async () => {
+    const r = await quadraticSolve({ a: 0, b: 1, c: 1 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+
+  it("returns error for missing args", async () => {
+    const r = await quadraticSolve({}) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/quadratic-tool.ts
+++ b/packages/mcp-server/src/quadratic-tool.ts
@@ -1,0 +1,40 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function quadraticSolve(args: Record<string, unknown>) {
+  const a = typeof args.a === "number" ? args.a : NaN;
+  const b = typeof args.b === "number" ? args.b : NaN;
+  const c = typeof args.c === "number" ? args.c : NaN;
+  if (isNaN(a) || isNaN(b) || isNaN(c)) return { error: "a, b, and c are required (numbers)" };
+  if (a === 0) return { error: "a must not be zero (not a quadratic equation)" };
+
+  const discriminant = b * b - 4 * a * c;
+  let roots: { x1: string | number; x2: string | number; type: string };
+
+  if (discriminant > 0) {
+    const x1 = (-b + Math.sqrt(discriminant)) / (2 * a);
+    const x2 = (-b - Math.sqrt(discriminant)) / (2 * a);
+    roots = { x1: +x1.toFixed(8), x2: +x2.toFixed(8), type: "two_real" };
+  } else if (discriminant === 0) {
+    const x1 = -b / (2 * a);
+    roots = { x1: +x1.toFixed(8), x2: +x1.toFixed(8), type: "one_repeated" };
+  } else {
+    const realPart = (-b / (2 * a)).toFixed(8);
+    const imagPart = (Math.sqrt(-discriminant) / (2 * a)).toFixed(8);
+    roots = { x1: `${realPart} + ${imagPart}i`, x2: `${realPart} - ${imagPart}i`, type: "two_complex" };
+  }
+
+  const vertex_x = -b / (2 * a);
+  const vertex_y = a * vertex_x * vertex_x + b * vertex_x + c;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Discriminant > 0 means two real roots", "Vertex form: a(x - h)^2 + k"],
+  };
+  return stampMeta({
+    equation: `${a}x^2 + ${b}x + ${c} = 0`,
+    discriminant: +discriminant.toFixed(8),
+    roots,
+    vertex: { x: +vertex_x.toFixed(8), y: +vertex_y.toFixed(8) },
+  }, meta);
+}

--- a/packages/mcp-server/src/ratiosimplify-tool.test.ts
+++ b/packages/mcp-server/src/ratiosimplify-tool.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { ratioSimplify } from "./ratiosimplify-tool.js";
+
+describe("ratioSimplify", () => {
+  it("simplifies 4:8 to 1:2", async () => {
+    const r = await ratioSimplify({ a: 4, b: 8 }) as any;
+    expect(r.simplified.a).toBe(1);
+    expect(r.simplified.b).toBe(2);
+  });
+
+  it("simplifies 15:25 to 3:5", async () => {
+    const r = await ratioSimplify({ a: 15, b: 25 }) as any;
+    expect(r.simplified.ratio).toBe("3:5");
+  });
+
+  it("returns error for zero denominator", async () => {
+    const r = await ratioSimplify({ a: 5, b: 0 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/ratiosimplify-tool.ts
+++ b/packages/mcp-server/src/ratiosimplify-tool.ts
@@ -1,0 +1,42 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+function gcd(a: number, b: number): number {
+  a = Math.abs(a);
+  b = Math.abs(b);
+  while (b) { [a, b] = [b, a % b]; }
+  return a;
+}
+
+export async function ratioSimplify(args: Record<string, unknown>) {
+  const a = typeof args.a === "number" ? args.a : NaN;
+  const b = typeof args.b === "number" ? args.b : NaN;
+  if (isNaN(a) || isNaN(b)) return { error: "a and b are required (numbers)" };
+  if (b === 0) return { error: "b must not be zero" };
+
+  const scale = 1e8;
+  const intA = Math.round(a * scale);
+  const intB = Math.round(b * scale);
+  const g = gcd(Math.abs(intA), Math.abs(intB));
+  const simpA = intA / g;
+  const simpB = intB / g;
+
+  const sign = simpB < 0 ? -1 : 1;
+  const finalA = simpA * sign;
+  const finalB = simpB * sign;
+
+  const decimal = a / b;
+  const percentage = (a / b) * 100;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Simplified ratio can be used as a fraction", "Decimal and percentage forms included"],
+  };
+  return stampMeta({
+    original: { a, b, ratio: `${a}:${b}` },
+    simplified: { a: finalA, b: finalB, ratio: `${finalA}:${finalB}` },
+    decimal: +decimal.toFixed(8),
+    percentage: +percentage.toFixed(4),
+    gcd_factor: g / scale,
+  }, meta);
+}

--- a/packages/mcp-server/src/sigmoid-tool.test.ts
+++ b/packages/mcp-server/src/sigmoid-tool.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { sigmoidCalculate } from "./sigmoid-tool.js";
+
+describe("sigmoidCalculate", () => {
+  it("computes sigmoid at 0", async () => {
+    const r = await sigmoidCalculate({ x: 0, function: "sigmoid" }) as any;
+    expect(r.result).toBe(0.5);
+  });
+
+  it("computes relu for negative", async () => {
+    const r = await sigmoidCalculate({ x: -5, function: "relu" }) as any;
+    expect(r.result).toBe(0);
+    expect(r.derivative).toBe(0);
+  });
+
+  it("computes tanh", async () => {
+    const r = await sigmoidCalculate({ x: 0, function: "tanh" }) as any;
+    expect(r.result).toBe(0);
+    expect(r.derivative).toBe(1);
+  });
+
+  it("defaults to sigmoid", async () => {
+    const r = await sigmoidCalculate({ x: 0 }) as any;
+    expect(r.function).toBe("sigmoid");
+    expect(r.result).toBe(0.5);
+  });
+
+  it("returns error for invalid function", async () => {
+    const r = await sigmoidCalculate({ x: 0, function: "nope" }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/sigmoid-tool.ts
+++ b/packages/mcp-server/src/sigmoid-tool.ts
@@ -1,0 +1,64 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function sigmoidCalculate(args: Record<string, unknown>) {
+  const x = typeof args.x === "number" ? args.x : NaN;
+  const fn = typeof args.function === "string" ? args.function.toLowerCase() : "sigmoid";
+  if (isNaN(x)) return { error: "x is required (number)" };
+
+  const validFns = ["sigmoid", "tanh", "relu", "leaky_relu", "elu", "swish"];
+  if (!validFns.includes(fn)) return { error: `function must be one of: ${validFns.join(", ")}` };
+
+  let result: number;
+  let derivative: number;
+
+  switch (fn) {
+    case "sigmoid": {
+      result = 1 / (1 + Math.exp(-x));
+      derivative = result * (1 - result);
+      break;
+    }
+    case "tanh": {
+      result = Math.tanh(x);
+      derivative = 1 - result * result;
+      break;
+    }
+    case "relu": {
+      result = Math.max(0, x);
+      derivative = x > 0 ? 1 : 0;
+      break;
+    }
+    case "leaky_relu": {
+      const alpha = 0.01;
+      result = x > 0 ? x : alpha * x;
+      derivative = x > 0 ? 1 : alpha;
+      break;
+    }
+    case "elu": {
+      const a = 1;
+      result = x > 0 ? x : a * (Math.exp(x) - 1);
+      derivative = x > 0 ? 1 : result + a;
+      break;
+    }
+    case "swish": {
+      const sig = 1 / (1 + Math.exp(-x));
+      result = x * sig;
+      derivative = sig + x * sig * (1 - sig);
+      break;
+    }
+    default:
+      result = 0;
+      derivative = 0;
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Sigmoid/tanh output is bounded; relu is unbounded above 0", "Derivative is useful for backpropagation"],
+  };
+  return stampMeta({
+    function: fn,
+    x,
+    result: +result.toFixed(8),
+    derivative: +derivative.toFixed(8),
+  }, meta);
+}

--- a/packages/mcp-server/src/slopeintercept-tool.test.ts
+++ b/packages/mcp-server/src/slopeintercept-tool.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { slopeIntercept } from "./slopeintercept-tool.js";
+
+describe("slopeIntercept", () => {
+  it("finds line through (0,0) and (1,1)", async () => {
+    const r = await slopeIntercept({ x1: 0, y1: 0, x2: 1, y2: 1 }) as any;
+    expect(r.slope).toBe(1);
+    expect(r.y_intercept).toBe(0);
+  });
+
+  it("handles vertical line", async () => {
+    const r = await slopeIntercept({ x1: 5, y1: 0, x2: 5, y2: 10 }) as any;
+    expect(r.is_vertical).toBe(true);
+  });
+
+  it("returns error for identical points", async () => {
+    const r = await slopeIntercept({ x1: 3, y1: 3, x2: 3, y2: 3 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/slopeintercept-tool.ts
+++ b/packages/mcp-server/src/slopeintercept-tool.ts
@@ -1,0 +1,40 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function slopeIntercept(args: Record<string, unknown>) {
+  const x1 = typeof args.x1 === "number" ? args.x1 : NaN;
+  const y1 = typeof args.y1 === "number" ? args.y1 : NaN;
+  const x2 = typeof args.x2 === "number" ? args.x2 : NaN;
+  const y2 = typeof args.y2 === "number" ? args.y2 : NaN;
+  if (isNaN(x1) || isNaN(y1) || isNaN(x2) || isNaN(y2)) {
+    return { error: "x1, y1, x2, and y2 are required (numbers)" };
+  }
+  if (x1 === x2 && y1 === y2) return { error: "Points must be distinct" };
+
+  const isVertical = x1 === x2;
+  if (isVertical) {
+    const meta: ConnectorMeta = { source: "local-computation", fetched_at: new Date().toISOString(), next_steps: ["Vertical lines have undefined slope"] };
+    return stampMeta({ point1: { x: x1, y: y1 }, point2: { x: x2, y: y2 }, is_vertical: true, equation: `x = ${x1}` }, meta);
+  }
+
+  const slope = (y2 - y1) / (x2 - x1);
+  const intercept = y1 - slope * x1;
+  const A = y2 - y1;
+  const B = x1 - x2;
+  const C = A * x1 + B * y1;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["y = mx + b is slope-intercept form", "Ax + By = C is standard form"],
+  };
+  return stampMeta({
+    point1: { x: x1, y: y1 },
+    point2: { x: x2, y: y2 },
+    is_vertical: false,
+    slope: +slope.toFixed(8),
+    y_intercept: +intercept.toFixed(8),
+    x_intercept: slope !== 0 ? +(-intercept / slope).toFixed(8) : "none",
+    slope_intercept: `y = ${slope.toFixed(4)}x + ${intercept.toFixed(4)}`,
+    standard_form: { A: +A.toFixed(6), B: +B.toFixed(6), C: +C.toFixed(6) },
+  }, meta);
+}

--- a/packages/mcp-server/src/standardform-tool.test.ts
+++ b/packages/mcp-server/src/standardform-tool.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { standardForm } from "./standardform-tool.js";
+
+describe("standardForm", () => {
+  it("converts large number", async () => {
+    const r = await standardForm({ value: 12345 }) as any;
+    expect(r.mantissa).toBeCloseTo(1.2345, 4);
+    expect(r.exponent).toBe(4);
+  });
+
+  it("converts small number", async () => {
+    const r = await standardForm({ value: 0.0042 }) as any;
+    expect(r.mantissa).toBeCloseTo(4.2, 1);
+    expect(r.exponent).toBe(-3);
+  });
+
+  it("handles zero", async () => {
+    const r = await standardForm({ value: 0 }) as any;
+    expect(r.mantissa).toBe(0);
+    expect(r.exponent).toBe(0);
+  });
+
+  it("returns error for non-number", async () => {
+    const r = await standardForm({}) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/standardform-tool.ts
+++ b/packages/mcp-server/src/standardform-tool.ts
@@ -1,0 +1,40 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function standardForm(args: Record<string, unknown>) {
+  const value = typeof args.value === "number" ? args.value : typeof args.value === "string" ? parseFloat(args.value as string) : NaN;
+  if (isNaN(value)) return { error: "value is required (number or numeric string)" };
+
+  const isNeg = value < 0;
+  const absVal = Math.abs(value);
+
+  let mantissa: number;
+  let exponent: number;
+  if (absVal === 0) {
+    mantissa = 0;
+    exponent = 0;
+  } else {
+    exponent = Math.floor(Math.log10(absVal));
+    mantissa = absVal / Math.pow(10, exponent);
+  }
+
+  if (isNeg) mantissa = -mantissa;
+
+  const scientific = `${mantissa.toFixed(6)}e${exponent >= 0 ? "+" : ""}${exponent}`;
+  const engineering_exp = exponent >= 0 ? exponent - (exponent % 3) : exponent - ((exponent % 3 + 3) % 3);
+  const engineering_mantissa = value / Math.pow(10, engineering_exp);
+  const engineering = `${engineering_mantissa.toFixed(6)}e${engineering_exp >= 0 ? "+" : ""}${engineering_exp}`;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Scientific notation: coefficient between 1 and 10", "Engineering notation: exponent is a multiple of 3"],
+  };
+  return stampMeta({
+    value,
+    mantissa: +mantissa.toFixed(6),
+    exponent,
+    scientific,
+    engineering,
+    digits: absVal === 0 ? 1 : Math.floor(Math.log10(absVal)) + 1,
+  }, meta);
+}

--- a/packages/mcp-server/src/taylor-tool.test.ts
+++ b/packages/mcp-server/src/taylor-tool.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { taylorExpand } from "./taylor-tool.js";
+
+describe("taylorExpand", () => {
+  it("approximates e^1", async () => {
+    const r = await taylorExpand({ function: "exp", x: 1, terms: 15 }) as any;
+    expect(r.approximation).toBeCloseTo(Math.E, 8);
+  });
+  it("approximates sin(0)", async () => {
+    const r = await taylorExpand({ function: "sin", x: 0, terms: 5 }) as any;
+    expect(r.approximation).toBe(0);
+  });
+  it("returns error for invalid function", async () => {
+    const r = await taylorExpand({ function: "sqrt", x: 1 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/taylor-tool.ts
+++ b/packages/mcp-server/src/taylor-tool.ts
@@ -1,0 +1,83 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function taylorExpand(args: Record<string, unknown>) {
+  const fn = typeof args.function === "string" ? args.function.toLowerCase() : "";
+  const x = typeof args.x === "number" ? args.x : NaN;
+  const terms = typeof args.terms === "number" ? Math.floor(args.terms) : 10;
+  if (isNaN(x)) return { error: "x is required (number)" };
+
+  const validFns = ["exp", "sin", "cos", "ln1p", "atan"];
+  if (!validFns.includes(fn)) return { error: `function is required (one of: ${validFns.join(", ")})` };
+  if (terms < 1 || terms > 50) return { error: "terms must be between 1 and 50" };
+
+  let approx = 0;
+  let factorial = 1;
+  const coefficients: number[] = [];
+
+  switch (fn) {
+    case "exp":
+      for (let n = 0; n < terms; n++) {
+        if (n > 0) factorial *= n;
+        const term = Math.pow(x, n) / factorial;
+        coefficients.push(+term.toFixed(12));
+        approx += term;
+      }
+      break;
+    case "sin":
+      for (let n = 0; n < terms; n++) {
+        const k = 2 * n + 1;
+        factorial = 1;
+        for (let i = 2; i <= k; i++) factorial *= i;
+        const term = (n % 2 === 0 ? 1 : -1) * Math.pow(x, k) / factorial;
+        coefficients.push(+term.toFixed(12));
+        approx += term;
+      }
+      break;
+    case "cos":
+      for (let n = 0; n < terms; n++) {
+        const k = 2 * n;
+        factorial = 1;
+        for (let i = 2; i <= k; i++) factorial *= i;
+        const term = (n % 2 === 0 ? 1 : -1) * Math.pow(x, k) / factorial;
+        coefficients.push(+term.toFixed(12));
+        approx += term;
+      }
+      break;
+    case "ln1p":
+      if (x <= -1 || x > 1) return { error: "For ln(1+x), x must be in (-1, 1]" };
+      for (let n = 1; n <= terms; n++) {
+        const term = (n % 2 === 1 ? 1 : -1) * Math.pow(x, n) / n;
+        coefficients.push(+term.toFixed(12));
+        approx += term;
+      }
+      break;
+    case "atan":
+      if (Math.abs(x) > 1) return { error: "For atan(x), |x| must be <= 1" };
+      for (let n = 0; n < terms; n++) {
+        const k = 2 * n + 1;
+        const term = (n % 2 === 0 ? 1 : -1) * Math.pow(x, k) / k;
+        coefficients.push(+term.toFixed(12));
+        approx += term;
+      }
+      break;
+  }
+
+  const exactMap: Record<string, (v: number) => number> = {
+    exp: Math.exp, sin: Math.sin, cos: Math.cos,
+    ln1p: Math.log1p, atan: Math.atan,
+  };
+  const exact = exactMap[fn](x);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["More terms = better approximation near center", "Convergence radius varies by function"],
+  };
+  return stampMeta({
+    function: fn, x, terms,
+    approximation: +approx.toFixed(12),
+    exact: +exact.toFixed(12),
+    error: +Math.abs(approx - exact).toExponential(6),
+    first_terms: coefficients.slice(0, 8),
+  }, meta);
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -670,6 +670,16 @@ import { interpolateCalc } from "./interpolate-tool.js";
 import { modularArithmetic } from "./modpow-tool.js";
 import { ratioSimplify } from "./ratiosimplify-tool.js";
 import { binomialProbability } from "./binomprob-tool.js";
+import { normalDistribution } from "./normaldistr-tool.js";
+import { triangleSolve } from "./trianglesolve-tool.js";
+import { standardForm } from "./standardform-tool.js";
+import { complexCalc } from "./complexnum-tool.js";
+import { wavelengthConvert } from "./wavelength-tool.js";
+import { midpointCalc } from "./midpoint-tool.js";
+import { slopeIntercept } from "./slopeintercept-tool.js";
+import { logBase } from "./logbase-tool.js";
+import { nthRoot } from "./nthroot-tool.js";
+import { areaCalculate } from "./areacalc-tool.js";
 
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
@@ -10205,6 +10215,142 @@ export const ADDITIONAL_TOOLS = [
         k: { type: "number" as const, description: "Number of successes (0 to n)." },
         p: { type: "number" as const, description: "Probability of success per trial (0 to 1)." },
       }, required: ["n", "k", "p"],
+    },
+  },
+
+  // ── normaldistr-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "normal_distribution",
+    description: "Calculate normal (Gaussian) distribution PDF, CDF, and percentile for a given value.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        x: { type: "number" as const, description: "The value to evaluate." },
+        mean: { type: "number" as const, description: "Distribution mean (default 0)." },
+        stddev: { type: "number" as const, description: "Standard deviation (default 1, must be positive)." },
+      }, required: ["x"],
+    },
+  },
+
+  // ── trianglesolve-tool.ts ─────────────────────────────────────────────────────
+  {
+    name: "triangle_solve",
+    description: "Solve a triangle given three side lengths. Returns angles, area, perimeter, inradius, circumradius, and type.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        a: { type: "number" as const, description: "Side a length." },
+        b: { type: "number" as const, description: "Side b length." },
+        c: { type: "number" as const, description: "Side c length." },
+      }, required: ["a", "b", "c"],
+    },
+  },
+
+  // ── standardform-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "standard_form",
+    description: "Convert a number to scientific and engineering notation.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        value: { type: "number" as const, description: "Number to convert." },
+      }, required: ["value"],
+    },
+  },
+
+  // ── complexnum-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "complex_calc",
+    description: "Complex number arithmetic: add, subtract, multiply, divide, magnitude, conjugate, or polar conversion.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        operation: { type: "string" as const, description: "Operation: add, subtract, multiply, divide, magnitude, conjugate, or polar." },
+        real1: { type: "number" as const, description: "Real part of first complex number." },
+        imag1: { type: "number" as const, description: "Imaginary part of first complex number." },
+        real2: { type: "number" as const, description: "Real part of second complex number (for binary ops)." },
+        imag2: { type: "number" as const, description: "Imaginary part of second complex number (for binary ops)." },
+      }, required: ["operation", "real1", "imag1"],
+    },
+  },
+
+  // ── wavelength-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "wavelength_convert",
+    description: "Convert between wavelength and frequency. Returns energy and EM spectrum band.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        wavelength_m: { type: "number" as const, description: "Wavelength in meters." },
+        frequency_hz: { type: "number" as const, description: "Frequency in hertz." },
+      },
+    },
+  },
+
+  // ── midpoint-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "midpoint_calc",
+    description: "Calculate the midpoint, distance, slope, and angle between two 2D points.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        x1: { type: "number" as const, description: "X of first point." },
+        y1: { type: "number" as const, description: "Y of first point." },
+        x2: { type: "number" as const, description: "X of second point." },
+        y2: { type: "number" as const, description: "Y of second point." },
+      }, required: ["x1", "y1", "x2", "y2"],
+    },
+  },
+
+  // ── slopeintercept-tool.ts ────────────────────────────────────────────────────
+  {
+    name: "slope_intercept",
+    description: "Find the line equation (slope-intercept and standard form) from two points.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        x1: { type: "number" as const, description: "X of first point." },
+        y1: { type: "number" as const, description: "Y of first point." },
+        x2: { type: "number" as const, description: "X of second point." },
+        y2: { type: "number" as const, description: "Y of second point." },
+      }, required: ["x1", "y1", "x2", "y2"],
+    },
+  },
+
+  // ── logbase-tool.ts ───────────────────────────────────────────────────────────
+  {
+    name: "log_base",
+    description: "Compute logarithm with any base. Also returns ln, log10, and log2.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        value: { type: "number" as const, description: "Positive number to compute log of." },
+        base: { type: "number" as const, description: "Logarithm base (default 10, must be positive and not 1)." },
+      }, required: ["value"],
+    },
+  },
+
+  // ── nthroot-tool.ts ───────────────────────────────────────────────────────────
+  {
+    name: "nth_root",
+    description: "Calculate the nth root of a number. Default is square root (n=2).",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        value: { type: "number" as const, description: "Number to find root of." },
+        n: { type: "number" as const, description: "Root degree (default 2 for square root)." },
+      }, required: ["value"],
+    },
+  },
+
+  // ── areacalc-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "area_calculate",
+    description: "Calculate area (and perimeter where possible) of common shapes: circle, rectangle, triangle, trapezoid, ellipse, parallelogram, sector.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        shape: { type: "string" as const, description: "Shape: circle, rectangle, triangle, trapezoid, ellipse, parallelogram, or sector." },
+        radius: { type: "number" as const, description: "Radius (circle, sector)." },
+        width: { type: "number" as const, description: "Width (rectangle)." },
+        height: { type: "number" as const, description: "Height (rectangle, triangle, trapezoid, parallelogram)." },
+        base: { type: "number" as const, description: "Base (triangle, parallelogram)." },
+        base1: { type: "number" as const, description: "First base (trapezoid)." },
+        base2: { type: "number" as const, description: "Second base (trapezoid)." },
+        semi_major: { type: "number" as const, description: "Semi-major axis (ellipse)." },
+        semi_minor: { type: "number" as const, description: "Semi-minor axis (ellipse)." },
+        angle_degrees: { type: "number" as const, description: "Angle in degrees (sector)." },
+      }, required: ["shape"],
     },
   },
 
@@ -21855,6 +22001,36 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
 
   // binomprob-tool.ts
   binomial_probability:      (args) => binomialProbability(args),
+
+  // normaldistr-tool.ts
+  normal_distribution:       (args) => normalDistribution(args),
+
+  // trianglesolve-tool.ts
+  triangle_solve:            (args) => triangleSolve(args),
+
+  // standardform-tool.ts
+  standard_form:             (args) => standardForm(args),
+
+  // complexnum-tool.ts
+  complex_calc:              (args) => complexCalc(args),
+
+  // wavelength-tool.ts
+  wavelength_convert:        (args) => wavelengthConvert(args),
+
+  // midpoint-tool.ts
+  midpoint_calc:             (args) => midpointCalc(args),
+
+  // slopeintercept-tool.ts
+  slope_intercept:           (args) => slopeIntercept(args),
+
+  // logbase-tool.ts
+  log_base:                  (args) => logBase(args),
+
+  // nthroot-tool.ts
+  nth_root:                  (args) => nthRoot(args),
+
+  // areacalc-tool.ts
+  area_calculate:            (args) => areaCalculate(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -660,6 +660,16 @@ import { gcdCalculate } from "./gcd-tool.js";
 import { permutationCalc } from "./permutation-tool.js";
 import { combinationCalc } from "./combination-tool.js";
 import { proportionSolve } from "./proportion-tool.js";
+import { quadraticSolve } from "./quadratic-tool.js";
+import { primeFactor } from "./primefactor-tool.js";
+import { zscoreCalculate } from "./zscore-tool.js";
+import { angleConvert } from "./angleconv-tool.js";
+import { polygonCalculate } from "./polygon-tool.js";
+import { sigmoidCalculate } from "./sigmoid-tool.js";
+import { interpolateCalc } from "./interpolate-tool.js";
+import { modularArithmetic } from "./modpow-tool.js";
+import { ratioSimplify } from "./ratiosimplify-tool.js";
+import { binomialProbability } from "./binomprob-tool.js";
 
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
@@ -10068,6 +10078,133 @@ export const ADDITIONAL_TOOLS = [
         c: { type: "number" as const, description: "Value c." },
         d: { type: "number" as const, description: "Value d." },
       },
+    },
+  },
+
+  // ── quadratic-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "quadratic_solve",
+    description: "Solve a quadratic equation ax^2 + bx + c = 0. Returns roots, discriminant, and vertex.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        a: { type: "number" as const, description: "Coefficient a (must not be 0)." },
+        b: { type: "number" as const, description: "Coefficient b." },
+        c: { type: "number" as const, description: "Coefficient c." },
+      }, required: ["a", "b", "c"],
+    },
+  },
+
+  // ── primefactor-tool.ts ───────────────────────────────────────────────────────
+  {
+    name: "prime_factor",
+    description: "Find the prime factorization of an integer.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        n: { type: "number" as const, description: "Integer to factorize (>= 2, max 1 trillion)." },
+      }, required: ["n"],
+    },
+  },
+
+  // ── zscore-tool.ts ────────────────────────────────────────────────────────────
+  {
+    name: "zscore_calculate",
+    description: "Calculate z-score, cumulative probability, and percentile for a value given mean and standard deviation.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        value: { type: "number" as const, description: "The observed value." },
+        mean: { type: "number" as const, description: "Population mean." },
+        stddev: { type: "number" as const, description: "Population standard deviation (positive)." },
+      }, required: ["value", "mean", "stddev"],
+    },
+  },
+
+  // ── angleconv-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "angle_convert",
+    description: "Convert angles between degrees, radians, gradians, and turns. Includes trig values.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        value: { type: "number" as const, description: "Angle value to convert." },
+        from: { type: "string" as const, description: "Unit of input: degrees, radians, gradians, or turns." },
+      }, required: ["value", "from"],
+    },
+  },
+
+  // ── polygon-tool.ts ───────────────────────────────────────────────────────────
+  {
+    name: "polygon_calculate",
+    description: "Calculate properties of a regular polygon: area, perimeter, angles, apothem, circumradius, diagonals.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        sides: { type: "number" as const, description: "Number of sides (>= 3)." },
+        side_length: { type: "number" as const, description: "Length of each side." },
+      }, required: ["sides", "side_length"],
+    },
+  },
+
+  // ── sigmoid-tool.ts ───────────────────────────────────────────────────────────
+  {
+    name: "sigmoid_calculate",
+    description: "Compute activation functions (sigmoid, tanh, relu, leaky_relu, elu, swish) and their derivatives.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        x: { type: "number" as const, description: "Input value." },
+        function: { type: "string" as const, description: "Activation function: sigmoid, tanh, relu, leaky_relu, elu, or swish. Default: sigmoid." },
+      }, required: ["x"],
+    },
+  },
+
+  // ── interpolate-tool.ts ───────────────────────────────────────────────────────
+  {
+    name: "interpolate_calc",
+    description: "Linear interpolation (or extrapolation) between two points. Returns the y value for a given x.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        x1: { type: "number" as const, description: "X coordinate of first point." },
+        y1: { type: "number" as const, description: "Y coordinate of first point." },
+        x2: { type: "number" as const, description: "X coordinate of second point." },
+        y2: { type: "number" as const, description: "Y coordinate of second point." },
+        x: { type: "number" as const, description: "X value to interpolate at." },
+      }, required: ["x1", "y1", "x2", "y2", "x"],
+    },
+  },
+
+  // ── modpow-tool.ts ────────────────────────────────────────────────────────────
+  {
+    name: "modular_arithmetic",
+    description: "Modular arithmetic operations: modpow (a^b mod m), modinverse (a^-1 mod m), or mod (a mod m).",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        operation: { type: "string" as const, description: "Operation: modpow, modinverse, or mod." },
+        a: { type: "number" as const, description: "Base value." },
+        b: { type: "number" as const, description: "Exponent (required for modpow)." },
+        m: { type: "number" as const, description: "Modulus (positive integer)." },
+      }, required: ["operation", "a", "m"],
+    },
+  },
+
+  // ── ratiosimplify-tool.ts ─────────────────────────────────────────────────────
+  {
+    name: "ratio_simplify",
+    description: "Simplify a ratio a:b to its lowest terms. Returns decimal and percentage forms.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        a: { type: "number" as const, description: "First value." },
+        b: { type: "number" as const, description: "Second value (non-zero)." },
+      }, required: ["a", "b"],
+    },
+  },
+
+  // ── binomprob-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "binomial_probability",
+    description: "Calculate binomial distribution probability P(X=k) and cumulative probabilities for n trials with probability p.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        n: { type: "number" as const, description: "Number of trials (0-1000)." },
+        k: { type: "number" as const, description: "Number of successes (0 to n)." },
+        p: { type: "number" as const, description: "Probability of success per trial (0 to 1)." },
+      }, required: ["n", "k", "p"],
     },
   },
 
@@ -21688,6 +21825,36 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
 
   // proportion-tool.ts
   proportion_solve:          (args) => proportionSolve(args),
+
+  // quadratic-tool.ts
+  quadratic_solve:           (args) => quadraticSolve(args),
+
+  // primefactor-tool.ts
+  prime_factor:              (args) => primeFactor(args),
+
+  // zscore-tool.ts
+  zscore_calculate:          (args) => zscoreCalculate(args),
+
+  // angleconv-tool.ts
+  angle_convert:             (args) => angleConvert(args),
+
+  // polygon-tool.ts
+  polygon_calculate:         (args) => polygonCalculate(args),
+
+  // sigmoid-tool.ts
+  sigmoid_calculate:         (args) => sigmoidCalculate(args),
+
+  // interpolate-tool.ts
+  interpolate_calc:          (args) => interpolateCalc(args),
+
+  // modpow-tool.ts
+  modular_arithmetic:        (args) => modularArithmetic(args),
+
+  // ratiosimplify-tool.ts
+  ratio_simplify:            (args) => ratioSimplify(args),
+
+  // binomprob-tool.ts
+  binomial_probability:      (args) => binomialProbability(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -680,6 +680,16 @@ import { slopeIntercept } from "./slopeintercept-tool.js";
 import { logBase } from "./logbase-tool.js";
 import { nthRoot } from "./nthroot-tool.js";
 import { areaCalculate } from "./areacalc-tool.js";
+import { dotProduct } from "./dotproduct-tool.js";
+import { crossProduct } from "./crossproduct-tool.js";
+import { weightedMean } from "./weightedmean-tool.js";
+import { varianceCalc } from "./variancecalc-tool.js";
+import { poissonProbability } from "./poisson-tool.js";
+import { exponentialGrowth } from "./expgrowth-tool.js";
+import { geometricSeries } from "./geomseries-tool.js";
+import { harmonicSeries } from "./harmonicseries-tool.js";
+import { piApprox } from "./piapprox-tool.js";
+import { taylorExpand } from "./taylor-tool.js";
 
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
@@ -10351,6 +10361,126 @@ export const ADDITIONAL_TOOLS = [
         semi_minor: { type: "number" as const, description: "Semi-minor axis (ellipse)." },
         angle_degrees: { type: "number" as const, description: "Angle in degrees (sector)." },
       }, required: ["shape"],
+    },
+  },
+
+  // ── dotproduct-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "dot_product",
+    description: "Compute the dot product of two vectors. Returns magnitude, angle, and orthogonality check.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        a: { type: "array" as const, items: { type: "number" as const }, description: "First vector." },
+        b: { type: "array" as const, items: { type: "number" as const }, description: "Second vector (same length)." },
+      }, required: ["a", "b"],
+    },
+  },
+
+  // ── crossproduct-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "cross_product",
+    description: "Compute the cross product of two 3D vectors. Returns magnitude and parallelism check.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        a: { type: "array" as const, items: { type: "number" as const }, description: "First 3D vector [x,y,z]." },
+        b: { type: "array" as const, items: { type: "number" as const }, description: "Second 3D vector [x,y,z]." },
+      }, required: ["a", "b"],
+    },
+  },
+
+  // ── weightedmean-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "weighted_mean",
+    description: "Compute weighted, arithmetic, geometric, and harmonic means of a set of values.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        values: { type: "array" as const, items: { type: "number" as const }, description: "Array of numeric values." },
+        weights: { type: "array" as const, items: { type: "number" as const }, description: "Optional weights (same length as values)." },
+      }, required: ["values"],
+    },
+  },
+
+  // ── variancecalc-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "variance_calc",
+    description: "Calculate population/sample variance, standard deviation, median, range, and coefficient of variation.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        values: { type: "array" as const, items: { type: "number" as const }, description: "Array of numeric values (at least 2)." },
+      }, required: ["values"],
+    },
+  },
+
+  // ── poisson-tool.ts ───────────────────────────────────────────────────────────
+  {
+    name: "poisson_probability",
+    description: "Calculate Poisson distribution PMF and CDF for k events with rate lambda.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        k: { type: "number" as const, description: "Number of events (non-negative integer)." },
+        lambda: { type: "number" as const, description: "Expected rate (positive)." },
+      }, required: ["k", "lambda"],
+    },
+  },
+
+  // ── expgrowth-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "exponential_growth",
+    description: "Model exponential growth or decay: final = initial * e^(rate*time). Includes doubling time or half-life.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        initial: { type: "number" as const, description: "Initial value." },
+        rate: { type: "number" as const, description: "Growth rate (positive=growth, negative=decay)." },
+        time: { type: "number" as const, description: "Time elapsed." },
+      }, required: ["initial", "rate", "time"],
+    },
+  },
+
+  // ── geomseries-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "geometric_series",
+    description: "Calculate finite and infinite sums of a geometric series: a, ar, ar^2, ...",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        a: { type: "number" as const, description: "First term." },
+        r: { type: "number" as const, description: "Common ratio." },
+        n: { type: "number" as const, description: "Number of terms (1-1000)." },
+      }, required: ["a", "r", "n"],
+    },
+  },
+
+  // ── harmonicseries-tool.ts ────────────────────────────────────────────────────
+  {
+    name: "harmonic_series",
+    description: "Calculate partial sum of the harmonic series H(n) = 1 + 1/2 + 1/3 + ... + 1/n.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        n: { type: "number" as const, description: "Number of terms (1-100000)." },
+      }, required: ["n"],
+    },
+  },
+
+  // ── piapprox-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "pi_approx",
+    description: "Approximate pi using Leibniz, Nilakantha, and Wallis formulas. Compare convergence rates.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        terms: { type: "number" as const, description: "Number of terms (default 1000, max 1000000)." },
+      },
+    },
+  },
+
+  // ── taylor-tool.ts ────────────────────────────────────────────────────────────
+  {
+    name: "taylor_expand",
+    description: "Taylor series approximation for exp, sin, cos, ln(1+x), and atan(x).",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        function: { type: "string" as const, description: "Function: exp, sin, cos, ln1p, or atan." },
+        x: { type: "number" as const, description: "Point to evaluate at." },
+        terms: { type: "number" as const, description: "Number of terms (default 10, max 50)." },
+      }, required: ["function", "x"],
     },
   },
 
@@ -22031,6 +22161,36 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
 
   // areacalc-tool.ts
   area_calculate:            (args) => areaCalculate(args),
+
+  // dotproduct-tool.ts
+  dot_product:               (args) => dotProduct(args),
+
+  // crossproduct-tool.ts
+  cross_product:             (args) => crossProduct(args),
+
+  // weightedmean-tool.ts
+  weighted_mean:             (args) => weightedMean(args),
+
+  // variancecalc-tool.ts
+  variance_calc:             (args) => varianceCalc(args),
+
+  // poisson-tool.ts
+  poisson_probability:       (args) => poissonProbability(args),
+
+  // expgrowth-tool.ts
+  exponential_growth:        (args) => exponentialGrowth(args),
+
+  // geomseries-tool.ts
+  geometric_series:          (args) => geometricSeries(args),
+
+  // harmonicseries-tool.ts
+  harmonic_series:           (args) => harmonicSeries(args),
+
+  // piapprox-tool.ts
+  pi_approx:                 (args) => piApprox(args),
+
+  // taylor-tool.ts
+  taylor_expand:             (args) => taylorExpand(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/packages/mcp-server/src/trianglesolve-tool.test.ts
+++ b/packages/mcp-server/src/trianglesolve-tool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { triangleSolve } from "./trianglesolve-tool.js";
+
+describe("triangleSolve", () => {
+  it("solves a 3-4-5 right triangle", async () => {
+    const r = await triangleSolve({ a: 3, b: 4, c: 5 }) as any;
+    expect(r.type).toBe("right");
+    expect(r.area).toBeCloseTo(6, 4);
+    expect(r.perimeter).toBe(12);
+  });
+
+  it("identifies equilateral triangle", async () => {
+    const r = await triangleSolve({ a: 5, b: 5, c: 5 }) as any;
+    expect(r.side_type).toBe("equilateral");
+    expect(r.angles.A).toBeCloseTo(60, 3);
+  });
+
+  it("returns error for invalid triangle", async () => {
+    const r = await triangleSolve({ a: 1, b: 2, c: 10 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/trianglesolve-tool.ts
+++ b/packages/mcp-server/src/trianglesolve-tool.ts
@@ -1,0 +1,51 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function triangleSolve(args: Record<string, unknown>) {
+  const a = typeof args.a === "number" ? args.a : undefined;
+  const b = typeof args.b === "number" ? args.b : undefined;
+  const c = typeof args.c === "number" ? args.c : undefined;
+
+  if (a === undefined || b === undefined || c === undefined) {
+    return { error: "a, b, and c (three side lengths) are required" };
+  }
+  if (a <= 0 || b <= 0 || c <= 0) return { error: "All sides must be positive" };
+  if (a + b <= c || a + c <= b || b + c <= a) return { error: "Invalid triangle: sides do not satisfy triangle inequality" };
+
+  const cosA = (b * b + c * c - a * a) / (2 * b * c);
+  const cosB = (a * a + c * c - b * b) / (2 * a * c);
+  const cosC = (a * a + b * b - c * c) / (2 * a * b);
+  const A = Math.acos(cosA) * 180 / Math.PI;
+  const B = Math.acos(cosB) * 180 / Math.PI;
+  const C = 180 - A - B;
+
+  const s = (a + b + c) / 2;
+  const area = Math.sqrt(s * (s - a) * (s - b) * (s - c));
+  const perimeter = a + b + c;
+  const inradius = area / s;
+  const circumradius = (a * b * c) / (4 * area);
+
+  let type: string;
+  if (Math.abs(A - 90) < 0.0001 || Math.abs(B - 90) < 0.0001 || Math.abs(C - 90) < 0.0001) type = "right";
+  else if (A > 90 || B > 90 || C > 90) type = "obtuse";
+  else type = "acute";
+
+  const sides = [a, b, c].sort();
+  const sideType = sides[0] === sides[2] ? "equilateral" : sides[0] === sides[1] || sides[1] === sides[2] ? "isosceles" : "scalene";
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Area uses Heron's formula", "Angles computed via law of cosines"],
+  };
+  return stampMeta({
+    sides: { a, b, c },
+    angles: { A: +A.toFixed(6), B: +B.toFixed(6), C: +C.toFixed(6) },
+    area: +area.toFixed(6),
+    perimeter: +perimeter.toFixed(6),
+    semi_perimeter: +s.toFixed(6),
+    inradius: +inradius.toFixed(6),
+    circumradius: +circumradius.toFixed(6),
+    type,
+    side_type: sideType,
+  }, meta);
+}

--- a/packages/mcp-server/src/variancecalc-tool.test.ts
+++ b/packages/mcp-server/src/variancecalc-tool.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { varianceCalc } from "./variancecalc-tool.js";
+
+describe("varianceCalc", () => {
+  it("computes variance and stddev", async () => {
+    const r = await varianceCalc({ values: [2, 4, 4, 4, 5, 5, 7, 9] }) as any;
+    expect(r.mean).toBe(5);
+    expect(r.population_variance).toBe(4);
+    expect(r.population_stddev).toBe(2);
+  });
+  it("computes median", async () => {
+    const r = await varianceCalc({ values: [1, 3, 5] }) as any;
+    expect(r.median).toBe(3);
+  });
+  it("returns error for fewer than 2 values", async () => {
+    const r = await varianceCalc({ values: [5] }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/variancecalc-tool.ts
+++ b/packages/mcp-server/src/variancecalc-tool.ts
@@ -1,0 +1,35 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function varianceCalc(args: Record<string, unknown>) {
+  const values = Array.isArray(args.values) ? args.values.filter((v) => typeof v === "number") as number[] : [];
+  if (values.length < 2) return { error: "values is required (array with at least 2 numbers)" };
+
+  const n = values.length;
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  const popVariance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / n;
+  const sampleVariance = values.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1);
+  const popStddev = Math.sqrt(popVariance);
+  const sampleStddev = Math.sqrt(sampleVariance);
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const median = n % 2 === 0 ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2 : sorted[Math.floor(n / 2)];
+  const range = sorted[n - 1] - sorted[0];
+  const cv = mean !== 0 ? (sampleStddev / Math.abs(mean)) * 100 : NaN;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use sample variance (n-1) for estimating from a sample", "CV (coefficient of variation) is useful for comparing spread across datasets"],
+  };
+  return stampMeta({
+    count: n,
+    mean: +mean.toFixed(8),
+    median: +median.toFixed(8),
+    range: +range.toFixed(8),
+    population_variance: +popVariance.toFixed(8),
+    sample_variance: +sampleVariance.toFixed(8),
+    population_stddev: +popStddev.toFixed(8),
+    sample_stddev: +sampleStddev.toFixed(8),
+    coefficient_of_variation: isNaN(cv) ? "N/A" : +cv.toFixed(4),
+  }, meta);
+}

--- a/packages/mcp-server/src/wavelength-tool.test.ts
+++ b/packages/mcp-server/src/wavelength-tool.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { wavelengthConvert } from "./wavelength-tool.js";
+
+describe("wavelengthConvert", () => {
+  it("converts visible light wavelength", async () => {
+    const r = await wavelengthConvert({ wavelength_m: 5.5e-7 }) as any;
+    expect(r.wavelength_nm).toBeCloseTo(550, 0);
+    expect(r.spectrum_band).toBe("visible light");
+  });
+
+  it("converts from frequency", async () => {
+    const r = await wavelengthConvert({ frequency_hz: 1e9 }) as any;
+    expect(r.spectrum_band).toBe("microwave");
+  });
+
+  it("returns error for missing input", async () => {
+    const r = await wavelengthConvert({}) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/wavelength-tool.ts
+++ b/packages/mcp-server/src/wavelength-tool.ts
@@ -1,0 +1,55 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+const SPEED_OF_LIGHT = 299792458;
+
+const SPECTRUM: { name: string; min: number; max: number }[] = [
+  { name: "gamma ray", min: 0, max: 1e-11 },
+  { name: "x-ray", min: 1e-11, max: 1e-8 },
+  { name: "ultraviolet", min: 1e-8, max: 3.8e-7 },
+  { name: "visible light", min: 3.8e-7, max: 7.5e-7 },
+  { name: "infrared", min: 7.5e-7, max: 1e-3 },
+  { name: "microwave", min: 1e-3, max: 1 },
+  { name: "radio wave", min: 1, max: Infinity },
+];
+
+export async function wavelengthConvert(args: Record<string, unknown>) {
+  const wavelength_m = typeof args.wavelength_m === "number" ? args.wavelength_m : undefined;
+  const frequency_hz = typeof args.frequency_hz === "number" ? args.frequency_hz : undefined;
+
+  if (wavelength_m === undefined && frequency_hz === undefined) {
+    return { error: "Provide either wavelength_m (meters) or frequency_hz (hertz)" };
+  }
+
+  let wl: number;
+  let freq: number;
+  if (wavelength_m !== undefined) {
+    if (wavelength_m <= 0) return { error: "wavelength_m must be positive" };
+    wl = wavelength_m;
+    freq = SPEED_OF_LIGHT / wl;
+  } else {
+    if (frequency_hz! <= 0) return { error: "frequency_hz must be positive" };
+    freq = frequency_hz!;
+    wl = SPEED_OF_LIGHT / freq;
+  }
+
+  const h = 6.62607015e-34;
+  const energy_j = h * freq;
+  const energy_ev = energy_j / 1.602176634e-19;
+
+  const band = SPECTRUM.find((s) => wl >= s.min && wl < s.max);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["E = hf (photon energy)", "c = wavelength * frequency"],
+  };
+  return stampMeta({
+    wavelength_m: +wl.toExponential(6),
+    wavelength_nm: +(wl * 1e9).toFixed(4),
+    frequency_hz: +freq.toExponential(6),
+    frequency_thz: +(freq / 1e12).toFixed(6),
+    energy_joules: +energy_j.toExponential(6),
+    energy_ev: +energy_ev.toExponential(6),
+    spectrum_band: band ? band.name : "unknown",
+  }, meta);
+}

--- a/packages/mcp-server/src/weightedmean-tool.test.ts
+++ b/packages/mcp-server/src/weightedmean-tool.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { weightedMean } from "./weightedmean-tool.js";
+
+describe("weightedMean", () => {
+  it("computes weighted mean", async () => {
+    const r = await weightedMean({ values: [80, 90], weights: [1, 3] }) as any;
+    expect(r.weighted_mean).toBe(87.5);
+  });
+  it("falls back to arithmetic mean without weights", async () => {
+    const r = await weightedMean({ values: [10, 20, 30] }) as any;
+    expect(r.arithmetic_mean).toBe(20);
+    expect(r.weighted_mean).toBe(20);
+  });
+  it("returns error for empty values", async () => {
+    const r = await weightedMean({ values: [] }) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/weightedmean-tool.ts
+++ b/packages/mcp-server/src/weightedmean-tool.ts
@@ -1,0 +1,38 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function weightedMean(args: Record<string, unknown>) {
+  const values = Array.isArray(args.values) ? args.values.filter((v) => typeof v === "number") as number[] : [];
+  const weights = Array.isArray(args.weights) ? args.weights.filter((v) => typeof v === "number") as number[] : [];
+  if (values.length === 0) return { error: "values is required (array of numbers)" };
+
+  if (weights.length > 0 && weights.length !== values.length) {
+    return { error: "weights must have the same length as values" };
+  }
+
+  const w = weights.length > 0 ? weights : values.map(() => 1);
+  const totalWeight = w.reduce((a, b) => a + b, 0);
+  if (totalWeight === 0) return { error: "Total weight must not be zero" };
+
+  const wMean = values.reduce((s, v, i) => s + v * w[i], 0) / totalWeight;
+  const arithmeticMean = values.reduce((a, b) => a + b, 0) / values.length;
+
+  const positiveValues = values.filter((v) => v > 0);
+  const geometricMean = positiveValues.length === values.length
+    ? Math.exp(values.reduce((s, v) => s + Math.log(v), 0) / values.length) : NaN;
+  const harmonicMean = values.every((v) => v !== 0)
+    ? values.length / values.reduce((s, v) => s + 1 / v, 0) : NaN;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Weighted mean accounts for varying importance", "Geometric mean suits growth rates; harmonic mean suits rates/ratios"],
+  };
+  return stampMeta({
+    count: values.length,
+    weighted_mean: +wMean.toFixed(8),
+    arithmetic_mean: +arithmeticMean.toFixed(8),
+    geometric_mean: isNaN(geometricMean) ? "N/A (requires all positive)" : +geometricMean.toFixed(8),
+    harmonic_mean: isNaN(harmonicMean) ? "N/A (requires all non-zero)" : +harmonicMean.toFixed(8),
+    total_weight: +totalWeight.toFixed(8),
+  }, meta);
+}

--- a/packages/mcp-server/src/zscore-tool.test.ts
+++ b/packages/mcp-server/src/zscore-tool.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { zscoreCalculate } from "./zscore-tool.js";
+
+describe("zscoreCalculate", () => {
+  it("calculates z-score for a value at the mean", async () => {
+    const r = await zscoreCalculate({ value: 100, mean: 100, stddev: 15 }) as any;
+    expect(r.z_score).toBe(0);
+    expect(r.percentile).toBeCloseTo(50, 0);
+  });
+
+  it("calculates z-score above the mean", async () => {
+    const r = await zscoreCalculate({ value: 130, mean: 100, stddev: 15 }) as any;
+    expect(r.z_score).toBe(2);
+    expect(r.is_significant_95).toBe(true);
+  });
+
+  it("returns error for zero stddev", async () => {
+    const r = await zscoreCalculate({ value: 5, mean: 5, stddev: 0 }) as any;
+    expect(r.error).toBeTruthy();
+  });
+
+  it("returns error for missing args", async () => {
+    const r = await zscoreCalculate({}) as any;
+    expect(r.error).toBeTruthy();
+  });
+});

--- a/packages/mcp-server/src/zscore-tool.ts
+++ b/packages/mcp-server/src/zscore-tool.ts
@@ -1,0 +1,34 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function zscoreCalculate(args: Record<string, unknown>) {
+  const value = typeof args.value === "number" ? args.value : NaN;
+  const mean = typeof args.mean === "number" ? args.mean : NaN;
+  const stddev = typeof args.stddev === "number" ? args.stddev : NaN;
+  if (isNaN(value) || isNaN(mean) || isNaN(stddev)) return { error: "value, mean, and stddev are required (numbers)" };
+  if (stddev <= 0) return { error: "stddev must be positive" };
+
+  const z = (value - mean) / stddev;
+
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989422804014327;
+  const p = d * Math.exp(-z * z / 2) * (t * (0.319381530 + t * (-0.356563782 + t * (1.781477937 + t * (-1.821255978 + t * 1.330274429)))));
+  const cumulative = z > 0 ? 1 - p : p;
+
+  const percentile = +(cumulative * 100).toFixed(4);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["|z| > 1.96 is significant at 95%", "|z| > 2.576 is significant at 99%"],
+  };
+  return stampMeta({
+    value,
+    mean,
+    stddev,
+    z_score: +z.toFixed(6),
+    cumulative_probability: +cumulative.toFixed(6),
+    percentile,
+    is_significant_95: Math.abs(z) > 1.96,
+    is_significant_99: Math.abs(z) > 2.576,
+  }, meta);
+}

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -180,6 +180,11 @@ const NAME_OF = {
   polygon: "Polygon Calculator", sigmoid: "Activation Functions",
   interpolate: "Interpolation", modpow: "Modular Arithmetic",
   ratiosimplify: "Ratio Simplifier", binomprob: "Binomial Probability",
+  normaldistr: "Normal Distribution", trianglesolve: "Triangle Solver",
+  standardform: "Scientific Notation", complexnum: "Complex Numbers",
+  wavelength: "Wavelength Converter", midpoint: "Midpoint & Distance",
+  slopeintercept: "Line Equation", logbase: "Logarithm Calculator",
+  nthroot: "Nth Root", areacalc: "Area Calculator",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -532,6 +537,16 @@ const BLURB_OF = {
   modpow: "Modular exponentiation, modular inverse, and modular reduction.",
   ratiosimplify: "Simplify ratios to lowest terms with decimal and percentage forms.",
   binomprob: "Binomial distribution probability, cumulative probabilities, mean, and variance.",
+  normaldistr: "Normal (Gaussian) distribution PDF, CDF, survival, and percentile.",
+  trianglesolve: "Solve triangles from three side lengths: angles, area, inradius, circumradius.",
+  standardform: "Convert numbers to scientific and engineering notation.",
+  complexnum: "Complex number arithmetic: add, subtract, multiply, divide, polar form.",
+  wavelength: "Convert between wavelength and frequency with energy and EM spectrum band.",
+  midpoint: "Midpoint, Euclidean distance, slope, and angle between two 2D points.",
+  slopeintercept: "Line equation from two points in slope-intercept and standard form.",
+  logbase: "Logarithm with any base, plus natural log, log10, and log2.",
+  nthroot: "Nth root of a number with verification and integer detection.",
+  areacalc: "Area and perimeter of circles, rectangles, triangles, trapezoids, ellipses, and more.",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -697,6 +712,8 @@ const DOMAIN_OF = {
   baseconvert: "local", gcd: "local", permutation: "local", combination: "local", proportion: "local",
   quadratic: "local", primefactor: "local", zscore: "local", angleconv: "local", polygon: "local",
   sigmoid: "local", interpolate: "local", modpow: "local", ratiosimplify: "local", binomprob: "local",
+  normaldistr: "local", trianglesolve: "local", standardform: "local", complexnum: "local", wavelength: "local",
+  midpoint: "local", slopeintercept: "local", logbase: "local", nthroot: "local", areacalc: "local",
 };
 
 function titleCase(slug) {

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -185,6 +185,11 @@ const NAME_OF = {
   wavelength: "Wavelength Converter", midpoint: "Midpoint & Distance",
   slopeintercept: "Line Equation", logbase: "Logarithm Calculator",
   nthroot: "Nth Root", areacalc: "Area Calculator",
+  dotproduct: "Dot Product", crossproduct: "Cross Product",
+  weightedmean: "Weighted Mean", variancecalc: "Variance Calculator",
+  poisson: "Poisson Distribution", expgrowth: "Exponential Growth",
+  geomseries: "Geometric Series", harmonicseries: "Harmonic Series",
+  piapprox: "Pi Approximation", taylor: "Taylor Series",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -547,6 +552,16 @@ const BLURB_OF = {
   logbase: "Logarithm with any base, plus natural log, log10, and log2.",
   nthroot: "Nth root of a number with verification and integer detection.",
   areacalc: "Area and perimeter of circles, rectangles, triangles, trapezoids, ellipses, and more.",
+  dotproduct: "Dot product of two vectors with angle and orthogonality detection.",
+  crossproduct: "Cross product of two 3D vectors with magnitude and parallelism check.",
+  weightedmean: "Weighted, arithmetic, geometric, and harmonic means of a value set.",
+  variancecalc: "Population/sample variance, standard deviation, median, range, and CV.",
+  poisson: "Poisson distribution PMF and CDF for modeling rare events.",
+  expgrowth: "Exponential growth and decay with doubling time and half-life.",
+  geomseries: "Finite and infinite sums of geometric series.",
+  harmonicseries: "Partial sums of the harmonic series with ln approximation.",
+  piapprox: "Approximate pi using Leibniz, Nilakantha, and Wallis formulas.",
+  taylor: "Taylor series approximation for exp, sin, cos, ln(1+x), and atan.",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -714,6 +729,8 @@ const DOMAIN_OF = {
   sigmoid: "local", interpolate: "local", modpow: "local", ratiosimplify: "local", binomprob: "local",
   normaldistr: "local", trianglesolve: "local", standardform: "local", complexnum: "local", wavelength: "local",
   midpoint: "local", slopeintercept: "local", logbase: "local", nthroot: "local", areacalc: "local",
+  dotproduct: "local", crossproduct: "local", weightedmean: "local", variancecalc: "local", poisson: "local",
+  expgrowth: "local", geomseries: "local", harmonicseries: "local", piapprox: "local", taylor: "local",
 };
 
 function titleCase(slug) {

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -175,6 +175,11 @@ const NAME_OF = {
   baseconvert: "Base Converter", gcd: "GCD/LCM Calculator",
   permutation: "Permutations", combination: "Combinations",
   proportion: "Proportion Solver",
+  quadratic: "Quadratic Solver", primefactor: "Prime Factorization",
+  zscore: "Z-Score Calculator", angleconv: "Angle Converter",
+  polygon: "Polygon Calculator", sigmoid: "Activation Functions",
+  interpolate: "Interpolation", modpow: "Modular Arithmetic",
+  ratiosimplify: "Ratio Simplifier", binomprob: "Binomial Probability",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -517,6 +522,16 @@ const BLURB_OF = {
   permutation: "Calculate permutations P(n,r) for ordered arrangements.",
   combination: "Calculate combinations C(n,r) for unordered selections.",
   proportion: "Solve a proportion a/b = c/d given any three of the four values.",
+  quadratic: "Solve quadratic equations with real or complex roots, discriminant, and vertex.",
+  primefactor: "Find the prime factorization of any integer up to one trillion.",
+  zscore: "Calculate z-scores, cumulative probabilities, and percentiles.",
+  angleconv: "Convert between degrees, radians, gradians, and turns with trig values.",
+  polygon: "Calculate area, perimeter, angles, apothem, and circumradius of regular polygons.",
+  sigmoid: "Compute activation functions (sigmoid, tanh, relu, etc.) and their derivatives.",
+  interpolate: "Linear interpolation and extrapolation between two points.",
+  modpow: "Modular exponentiation, modular inverse, and modular reduction.",
+  ratiosimplify: "Simplify ratios to lowest terms with decimal and percentage forms.",
+  binomprob: "Binomial distribution probability, cumulative probabilities, mean, and variance.",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -680,6 +695,8 @@ const DOMAIN_OF = {
   setops: "local",
   collatz: "local", pascaltri: "local", histogram: "local", regression: "local",
   baseconvert: "local", gcd: "local", permutation: "local", combination: "local", proportion: "local",
+  quadratic: "local", primefactor: "local", zscore: "local", angleconv: "local", polygon: "local",
+  sigmoid: "local", interpolate: "local", modpow: "local", ratiosimplify: "local", binomprob: "local",
 };
 
 function titleCase(slug) {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 505,
-  "toolCount": 1427,
+  "appCount": 515,
+  "toolCount": 1437,
   "categories": [
     "AI",
     "Books",
@@ -428,6 +428,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "areacalc",
+      "name": "Area Calculator",
+      "category": "Utilities",
+      "blurb": "Area and perimeter of circles, rectangles, triangles, trapezoids, ellipses, and more.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "area_calculate",
+          "description": "Calculate area (and perimeter where possible) of common shapes: circle, rectangle, triangle, trapezoid, ellipse, parallelogram, sector."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "artic",
@@ -1807,6 +1823,22 @@
         }
       ],
       "level": null,
+      "hardened": false
+    },
+    {
+      "slug": "complexnum",
+      "name": "Complex Numbers",
+      "category": "Utilities",
+      "blurb": "Complex number arithmetic: add, subtract, multiply, divide, polar form.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "complex_calc",
+          "description": "Complex number arithmetic: add, subtract, multiply, divide, magnitude, conjugate, or polar conversion."
+        }
+      ],
+      "level": 5,
       "hardened": false
     },
     {
@@ -5318,6 +5350,22 @@
       "hardened": true
     },
     {
+      "slug": "slopeintercept",
+      "name": "Line Equation",
+      "category": "Utilities",
+      "blurb": "Line equation from two points in slope-intercept and standard form.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "slope_intercept",
+          "description": "Find the line equation (slope-intercept and standard form) from two points."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "sortlines",
       "name": "Line Sorter",
       "category": "Utilities",
@@ -5360,6 +5408,22 @@
         {
           "name": "regression_fit",
           "description": "Fit a linear regression (y = mx + b) to x/y data points, returns slope, intercept, R-squared."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "logbase",
+      "name": "Logarithm Calculator",
+      "category": "Utilities",
+      "blurb": "Logarithm with any base, plus natural log, log10, and log2.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "log_base",
+          "description": "Compute logarithm with any base. Also returns ln, log10, and log2."
         }
       ],
       "level": 5,
@@ -5788,6 +5852,22 @@
         {
           "name": "metaphone_encode",
           "description": "Encode words using the Metaphone phonetic algorithm, optionally comparing two words."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "midpoint",
+      "name": "Midpoint & Distance",
+      "category": "Utilities",
+      "blurb": "Midpoint, Euclidean distance, slope, and angle between two 2D points.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "midpoint_calc",
+          "description": "Calculate the midpoint, distance, slope, and angle between two 2D points."
         }
       ],
       "level": 5,
@@ -6310,6 +6390,22 @@
       "hardened": false
     },
     {
+      "slug": "normaldistr",
+      "name": "Normal Distribution",
+      "category": "Utilities",
+      "blurb": "Normal (Gaussian) distribution PDF, CDF, survival, and percentile.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "normal_distribution",
+          "description": "Calculate normal (Gaussian) distribution PDF, CDF, and percentile for a given value."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "notion",
       "name": "Notion",
       "category": "Productivity",
@@ -6340,6 +6436,22 @@
         {
           "name": "npm_get_package",
           "description": "Get metadata for an npm package (latest version)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "nthroot",
+      "name": "Nth Root",
+      "category": "Utilities",
+      "blurb": "Nth root of a number with verification and integer detection.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "nth_root",
+          "description": "Calculate the nth root of a number. Default is square root (n=2)."
         }
       ],
       "level": 5,
@@ -8742,6 +8854,22 @@
       "hardened": true
     },
     {
+      "slug": "standardform",
+      "name": "Scientific Notation",
+      "category": "Utilities",
+      "blurb": "Convert numbers to scientific and engineering notation.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "standard_form",
+          "description": "Convert a number to scientific and engineering notation."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "seatgeek",
       "name": "Seatgeek",
       "category": "Events & tickets",
@@ -10446,6 +10574,22 @@
       "hardened": true
     },
     {
+      "slug": "trianglesolve",
+      "name": "Triangle Solver",
+      "category": "Utilities",
+      "blurb": "Solve triangles from three side lengths: angles, area, inradius, circumradius.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "triangle_solve",
+          "description": "Solve a triangle given three side lengths. Returns angles, area, perimeter, inradius, circumradius, and type."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "trivia",
       "name": "Trivia",
       "category": "Utilities",
@@ -11164,6 +11308,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "wavelength",
+      "name": "Wavelength Converter",
+      "category": "Utilities",
+      "blurb": "Convert between wavelength and frequency with energy and EM spectrum band.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "wavelength_convert",
+          "description": "Convert between wavelength and frequency. Returns energy and EM spectrum band."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "wayback",

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 495,
-  "toolCount": 1417,
+  "appCount": 505,
+  "toolCount": 1427,
   "categories": [
     "AI",
     "Books",
@@ -80,6 +80,22 @@
         {
           "name": "acronym_generate",
           "description": "Generate an acronym from a phrase, optionally skipping small words."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "sigmoid",
+      "name": "Activation Functions",
+      "category": "Utilities",
+      "blurb": "Compute activation functions (sigmoid, tanh, relu, etc.) and their derivatives.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "sigmoid_calculate",
+          "description": "Compute activation functions (sigmoid, tanh, relu, leaky_relu, elu, swish) and their derivatives."
         }
       ],
       "level": 5,
@@ -328,6 +344,22 @@
         {
           "name": "amiibo_types",
           "description": "List all Amiibo product types (figure, card, yarn, etc.)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "angleconv",
+      "name": "Angle Converter",
+      "category": "Utilities",
+      "blurb": "Convert between degrees, radians, gradians, and turns with trig values.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "angle_convert",
+          "description": "Convert angles between degrees, radians, gradians, and turns. Includes trig values."
         }
       ],
       "level": 5,
@@ -708,6 +740,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "binomprob",
+      "name": "Binomial Probability",
+      "category": "Utilities",
+      "blurb": "Binomial distribution probability, cumulative probabilities, mean, and variance.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "binomial_probability",
+          "description": "Calculate binomial distribution probability P(X=k) and cumulative probabilities for n trials with probability p."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "bitbucket",
@@ -4490,6 +4538,22 @@
       "hardened": true
     },
     {
+      "slug": "interpolate",
+      "name": "Interpolation",
+      "category": "Utilities",
+      "blurb": "Linear interpolation and extrapolation between two points.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "interpolate_calc",
+          "description": "Linear interpolation (or extrapolation) between two points. Returns the y value for a given x."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "ipaddrinfo",
       "name": "IP Address Info",
       "category": "Developer & infra",
@@ -5808,6 +5872,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "modpow",
+      "name": "Modular Arithmetic",
+      "category": "Utilities",
+      "blurb": "Modular exponentiation, modular inverse, and modular reduction.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "modular_arithmetic",
+          "description": "Modular arithmetic operations: modpow (a^b mod m), modinverse (a^-1 mod m), or mod (a mod m)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "monday",
@@ -7454,6 +7534,22 @@
       "hardened": false
     },
     {
+      "slug": "polygon",
+      "name": "Polygon Calculator",
+      "category": "Utilities",
+      "blurb": "Calculate area, perimeter, angles, apothem, and circumradius of regular polygons.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "polygon_calculate",
+          "description": "Calculate properties of a regular polygon: area, perimeter, angles, apothem, circumradius, diagonals."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "postcodes",
       "name": "Postcodes.io",
       "category": "Travel, maps & local",
@@ -7580,6 +7676,22 @@
         {
           "name": "prime_check",
           "description": "Check if a number is prime, get its factorization, and find adjacent primes."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "primefactor",
+      "name": "Prime Factorization",
+      "category": "Utilities",
+      "blurb": "Find the prime factorization of any integer up to one trillion.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "prime_factor",
+          "description": "Find the prime factorization of an integer."
         }
       ],
       "level": 5,
@@ -7866,6 +7978,22 @@
       "hardened": false
     },
     {
+      "slug": "quadratic",
+      "name": "Quadratic Solver",
+      "category": "Utilities",
+      "blurb": "Solve quadratic equations with real or complex roots, discriminant, and vertex.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "quadratic_solve",
+          "description": "Solve a quadratic equation ax^2 + bx + c = 0. Returns roots, discriminant, and vertex."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "quickbooks",
       "name": "Quickbooks",
       "category": "Money & payments",
@@ -8100,6 +8228,22 @@
         {
           "name": "random_user",
           "description": "Generate random user profiles with names, emails, addresses, and photos."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "ratiosimplify",
+      "name": "Ratio Simplifier",
+      "category": "Utilities",
+      "blurb": "Simplify ratios to lowest terms with decimal and percentage forms.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "ratio_simplify",
+          "description": "Simplify a ratio a:b to its lowest terms. Returns decimal and percentage forms."
         }
       ],
       "level": 5,
@@ -11560,6 +11704,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "zscore",
+      "name": "Z-Score Calculator",
+      "category": "Utilities",
+      "blurb": "Calculate z-scores, cumulative probabilities, and percentiles.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "zscore_calculate",
+          "description": "Calculate z-score, cumulative probability, and percentile for a value given mean and standard deviation."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "zenquotes",

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 515,
-  "toolCount": 1437,
+  "appCount": 525,
+  "toolCount": 1447,
   "categories": [
     "AI",
     "Books",
@@ -2134,6 +2134,22 @@
       "hardened": false
     },
     {
+      "slug": "crossproduct",
+      "name": "Cross Product",
+      "category": "Utilities",
+      "blurb": "Cross product of two 3D vectors with magnitude and parallelism check.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "cross_product",
+          "description": "Compute the cross product of two 3D vectors. Returns magnitude and parallelism check."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "crossref",
       "name": "Crossref",
       "category": "Books",
@@ -2782,6 +2798,22 @@
       "hardened": false
     },
     {
+      "slug": "dotproduct",
+      "name": "Dot Product",
+      "category": "Utilities",
+      "blurb": "Dot product of two vectors with angle and orthogonality detection.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "dot_product",
+          "description": "Compute the dot product of two vectors. Returns magnitude, angle, and orthogonality check."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "dropbox",
       "name": "Dropbox",
       "category": "Productivity",
@@ -3240,6 +3272,22 @@
         {
           "name": "excuser_random",
           "description": "Get a random excuse, optionally by category."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "expgrowth",
+      "name": "Exponential Growth",
+      "category": "Utilities",
+      "blurb": "Exponential growth and decay with doubling time and half-life.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "exponential_growth",
+          "description": "Model exponential growth or decay: final = initial * e^(rate*time). Includes doubling time or half-life."
         }
       ],
       "level": 5,
@@ -3850,6 +3898,22 @@
       "hardened": false
     },
     {
+      "slug": "geomseries",
+      "name": "Geometric Series",
+      "category": "Utilities",
+      "blurb": "Finite and infinite sums of geometric series.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "geometric_series",
+          "description": "Calculate finite and infinite sums of a geometric series: a, ar, ar^2, ..."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "geopass",
       "name": "GeoPass",
       "category": "Quality (XPass)",
@@ -4120,6 +4184,22 @@
         {
           "name": "hamming_distance",
           "description": "Calculate Hamming distance between two equal-length strings."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "harmonicseries",
+      "name": "Harmonic Series",
+      "category": "Utilities",
+      "blurb": "Partial sums of the harmonic series with ln approximation.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "harmonic_series",
+          "description": "Calculate partial sum of the harmonic series H(n) = 1 + 1/2 + 1/3 + ... + 1/n."
         }
       ],
       "level": 5,
@@ -7314,6 +7394,22 @@
       "hardened": false
     },
     {
+      "slug": "piapprox",
+      "name": "Pi Approximation",
+      "category": "Utilities",
+      "blurb": "Approximate pi using Leibniz, Nilakantha, and Wallis formulas.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "pi_approx",
+          "description": "Approximate pi using Leibniz, Nilakantha, and Wallis formulas. Compare convergence rates."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "piglatin",
       "name": "Pig Latin Translator",
       "category": "Utilities",
@@ -7588,6 +7684,22 @@
         {
           "name": "poetry_random",
           "description": "Get a random poem from PoetryDB."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "poisson",
+      "name": "Poisson Distribution",
+      "category": "Utilities",
+      "blurb": "Poisson distribution PMF and CDF for modeling rare events.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "poisson_probability",
+          "description": "Calculate Poisson distribution PMF and CDF for k events with rate lambda."
         }
       ],
       "level": 5,
@@ -9926,6 +10038,22 @@
       "hardened": true
     },
     {
+      "slug": "taylor",
+      "name": "Taylor Series",
+      "category": "Utilities",
+      "blurb": "Taylor series approximation for exp, sin, cos, ln(1+x), and atan.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "taylor_expand",
+          "description": "Taylor series approximation for exp, sin, cos, ln(1+x), and atan(x)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "telegram",
       "name": "Telegram",
       "category": "Messaging & email",
@@ -11186,6 +11314,22 @@
       "hardened": false
     },
     {
+      "slug": "variancecalc",
+      "name": "Variance Calculator",
+      "category": "Utilities",
+      "blurb": "Population/sample variance, standard deviation, median, range, and CV.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "variance_calc",
+          "description": "Calculate population/sample variance, standard deviation, median, range, and coefficient of variation."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "vatcomply",
       "name": "VATcomply",
       "category": "Markets & crypto",
@@ -11368,6 +11512,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "weightedmean",
+      "name": "Weighted Mean",
+      "category": "Utilities",
+      "blurb": "Weighted, arithmetic, geometric, and harmonic means of a value set.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "weighted_mean",
+          "description": "Compute weighted, arithmetic, geometric, and harmonic means of a set of values."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "wger",

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -3802,6 +3802,66 @@
       "note": "proportion_solve solves a/b = c/d locally. No API needed.",
       "testedAt": "2026-06-09T12:28:00.000Z",
       "toolsTested": ["proportion_solve"]
+    },
+    "quadratic": {
+      "status": "pass",
+      "note": "quadratic_solve returns roots, discriminant, and vertex. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["quadratic_solve"]
+    },
+    "primefactor": {
+      "status": "pass",
+      "note": "prime_factor returns prime factorization up to 1 trillion. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["prime_factor"]
+    },
+    "zscore": {
+      "status": "pass",
+      "note": "zscore_calculate returns z-score, cumulative probability, percentile. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["zscore_calculate"]
+    },
+    "angleconv": {
+      "status": "pass",
+      "note": "angle_convert converts degrees/radians/gradians/turns with trig values. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["angle_convert"]
+    },
+    "polygon": {
+      "status": "pass",
+      "note": "polygon_calculate returns area, perimeter, angles for regular polygons. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["polygon_calculate"]
+    },
+    "sigmoid": {
+      "status": "pass",
+      "note": "sigmoid_calculate computes activation functions and derivatives. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["sigmoid_calculate"]
+    },
+    "interpolate": {
+      "status": "pass",
+      "note": "interpolate_calc performs linear interpolation/extrapolation. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["interpolate_calc"]
+    },
+    "modpow": {
+      "status": "pass",
+      "note": "modular_arithmetic computes modpow, modinverse, mod. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["modular_arithmetic"]
+    },
+    "ratiosimplify": {
+      "status": "pass",
+      "note": "ratio_simplify reduces ratios to lowest terms. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["ratio_simplify"]
+    },
+    "binomprob": {
+      "status": "pass",
+      "note": "binomial_probability computes PMF and CDF for binomial distribution. Local computation.",
+      "testedAt": "2026-06-09T12:56:00.000Z",
+      "toolsTested": ["binomial_probability"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -3922,6 +3922,66 @@
       "note": "area_calculate computes area/perimeter for circles, rectangles, triangles, etc. Local computation.",
       "testedAt": "2026-06-09T13:05:00.000Z",
       "toolsTested": ["area_calculate"]
+    },
+    "dotproduct": {
+      "status": "pass",
+      "note": "dot_product computes dot product with angle and orthogonality. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["dot_product"]
+    },
+    "crossproduct": {
+      "status": "pass",
+      "note": "cross_product computes 3D cross product with parallelism check. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["cross_product"]
+    },
+    "weightedmean": {
+      "status": "pass",
+      "note": "weighted_mean computes weighted, arithmetic, geometric, harmonic means. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["weighted_mean"]
+    },
+    "variancecalc": {
+      "status": "pass",
+      "note": "variance_calc computes variance, stddev, median, range. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["variance_calc"]
+    },
+    "poisson": {
+      "status": "pass",
+      "note": "poisson_probability computes PMF and CDF for Poisson distribution. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["poisson_probability"]
+    },
+    "expgrowth": {
+      "status": "pass",
+      "note": "exponential_growth models growth/decay with doubling time. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["exponential_growth"]
+    },
+    "geomseries": {
+      "status": "pass",
+      "note": "geometric_series computes finite/infinite sums. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["geometric_series"]
+    },
+    "harmonicseries": {
+      "status": "pass",
+      "note": "harmonic_series computes partial sums with ln approximation. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["harmonic_series"]
+    },
+    "piapprox": {
+      "status": "pass",
+      "note": "pi_approx approximates pi using Leibniz, Nilakantha, Wallis. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["pi_approx"]
+    },
+    "taylor": {
+      "status": "pass",
+      "note": "taylor_expand computes Taylor series for exp, sin, cos, ln1p, atan. Local computation.",
+      "testedAt": "2026-06-09T13:11:00.000Z",
+      "toolsTested": ["taylor_expand"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -3862,6 +3862,66 @@
       "note": "binomial_probability computes PMF and CDF for binomial distribution. Local computation.",
       "testedAt": "2026-06-09T12:56:00.000Z",
       "toolsTested": ["binomial_probability"]
+    },
+    "normaldistr": {
+      "status": "pass",
+      "note": "normal_distribution computes PDF, CDF, percentile for Gaussian distribution. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["normal_distribution"]
+    },
+    "trianglesolve": {
+      "status": "pass",
+      "note": "triangle_solve returns angles, area, inradius, circumradius from three sides. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["triangle_solve"]
+    },
+    "standardform": {
+      "status": "pass",
+      "note": "standard_form converts numbers to scientific and engineering notation. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["standard_form"]
+    },
+    "complexnum": {
+      "status": "pass",
+      "note": "complex_calc performs complex number arithmetic and polar conversion. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["complex_calc"]
+    },
+    "wavelength": {
+      "status": "pass",
+      "note": "wavelength_convert converts wavelength/frequency with energy and spectrum band. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["wavelength_convert"]
+    },
+    "midpoint": {
+      "status": "pass",
+      "note": "midpoint_calc computes midpoint, distance, slope between 2D points. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["midpoint_calc"]
+    },
+    "slopeintercept": {
+      "status": "pass",
+      "note": "slope_intercept finds line equation from two points. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["slope_intercept"]
+    },
+    "logbase": {
+      "status": "pass",
+      "note": "log_base computes logarithm with any base plus ln, log10, log2. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["log_base"]
+    },
+    "nthroot": {
+      "status": "pass",
+      "note": "nth_root calculates nth root with verification. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["nth_root"]
+    },
+    "areacalc": {
+      "status": "pass",
+      "note": "area_calculate computes area/perimeter for circles, rectangles, triangles, etc. Local computation.",
+      "testedAt": "2026-06-09T13:05:00.000Z",
+      "toolsTested": ["area_calculate"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."


### PR DESCRIPTION
## Summary\n\n- **Batch 52**: quadratic, primefactor, zscore, angleconv, polygon\n- **Batch 53**: sigmoid, interpolate, modpow, ratiosimplify, binomprob\n- **Batch 54**: normaldistr, trianglesolve, standardform, complexnum, wavelength\n- **Batch 55**: midpoint, slopeintercept, logbase, nthroot, areacalc\n- **Batch 56**: dotproduct, crossproduct, weightedmean, variancecalc, poisson\n- **Batch 57**: expgrowth, geomseries, harmonicseries, piapprox, taylor\n- All 30 are pure local computation - no API keys, no network calls\n- Each connector has colocated tests (104 tests total, all passing)\n- Catalog updated: 525 apps, 1447 tools\n- Test results updated with pass status for all 30 new apps\n\n## Test plan\n\n- [x] All 30 new test files pass locally (104/104 tests)\n- [x] Regeneration pipeline run in order (tool-index -> depth-ladder -> app-catalog -> brainmap)\n- [x] CI check gates pass (tool-index --check, depth-ladder --check)\n\nhttps://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez