### PR TITLE
feat: add batch 58-59 local connectors (10 new tools) - 535 apps

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 956,
+    "inventory": 961,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 531,
+    "tools": 536,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 531
+      "count": 536
     },
     {
       "id": "rooms",
@@ -5412,6 +5412,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-dijkstra-packages-mcp-server-src-dijkstra-tool-ts-no-route",
+      "division": "Tools",
+      "name": "dijkstra",
+      "kind": "MCP tool",
+      "meaning": "dijkstra MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/dijkstra-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-discogs-packages-mcp-server-src-discogs-tool-ts-no-route",
       "division": "Tools",
       "name": "discogs",
@@ -6732,6 +6742,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-linearsolve-packages-mcp-server-src-linearsolve-tool-ts-no-route",
+      "division": "Tools",
+      "name": "linearsolve",
+      "kind": "MCP tool",
+      "meaning": "linearsolve MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/linearsolve-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-logbase-packages-mcp-server-src-logbase-tool-ts-no-route",
       "division": "Tools",
       "name": "logbase",
@@ -6878,6 +6898,16 @@
       "kind": "MCP tool",
       "meaning": "matrix MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/matrix-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-matrixdecomp-packages-mcp-server-src-matrixdecomp-tool-ts-no-route",
+      "division": "Tools",
+      "name": "matrixdecomp",
+      "kind": "MCP tool",
+      "meaning": "matrixdecomp MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/matrixdecomp-tool.ts",
       "route": "",
       "tags": []
     },
@@ -7238,6 +7268,26 @@
       "kind": "MCP tool",
       "meaning": "numbers MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/numbers-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-numdiff-packages-mcp-server-src-numdiff-tool-ts-no-route",
+      "division": "Tools",
+      "name": "numdiff",
+      "kind": "MCP tool",
+      "meaning": "numdiff MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/numdiff-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-numintegrate-packages-mcp-server-src-numintegrate-tool-ts-no-route",
+      "division": "Tools",
+      "name": "numintegrate",
+      "kind": "MCP tool",
+      "meaning": "numintegrate MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/numintegrate-tool.ts",
       "route": "",
       "tags": []
     },
@@ -10861,6 +10911,11 @@
       "packages/mcp-server/src/digitalocean-tool.ts"
     ],
     [
+      "dijkstra",
+      "dijkstra MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/dijkstra-tool.ts"
+    ],
+    [
       "discogs",
       "discogs MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/discogs-tool.ts"
@@ -11521,6 +11576,11 @@
       "packages/mcp-server/src/linear-tool.ts"
     ],
     [
+      "linearsolve",
+      "linearsolve MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/linearsolve-tool.ts"
+    ],
+    [
       "logbase",
       "logbase MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/logbase-tool.ts"
@@ -11594,6 +11654,11 @@
       "matrix",
       "matrix MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/matrix-tool.ts"
+    ],
+    [
+      "matrixdecomp",
+      "matrixdecomp MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/matrixdecomp-tool.ts"
     ],
     [
       "mcsrvstat",
@@ -11774,6 +11839,16 @@
       "numbers",
       "numbers MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/numbers-tool.ts"
+    ],
+    [
+      "numdiff",
+      "numdiff MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/numdiff-tool.ts"
+    ],
+    [
+      "numintegrate",
+      "numintegrate MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/numintegrate-tool.ts"
     ],
     [
       "nvd",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 951,
+    "inventory": 956,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 526,
+    "tools": 531,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 526
+      "count": 531
     },
     {
       "id": "rooms",
@@ -5112,6 +5112,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-convexhull-packages-mcp-server-src-convexhull-tool-ts-no-route",
+      "division": "Tools",
+      "name": "convexhull",
+      "kind": "MCP tool",
+      "meaning": "convexhull MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/convexhull-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-copypass-packages-mcp-server-src-copypass-tool-ts-no-route",
       "division": "Tools",
       "name": "copypass",
@@ -6602,6 +6612,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-knapsack-packages-mcp-server-src-knapsack-tool-ts-no-route",
+      "division": "Tools",
+      "name": "knapsack",
+      "kind": "MCP tool",
+      "meaning": "knapsack MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/knapsack-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-languagetool-packages-mcp-server-src-languagetool-tool-ts-no-route",
       "division": "Tools",
       "name": "languagetool",
@@ -6618,6 +6638,16 @@
       "kind": "MCP tool",
       "meaning": "lastfm MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/lastfm-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-lcs-packages-mcp-server-src-lcs-tool-ts-no-route",
+      "division": "Tools",
+      "name": "lcs",
+      "kind": "MCP tool",
+      "meaning": "lcs MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/lcs-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8482,6 +8512,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-spline-packages-mcp-server-src-spline-tool-ts-no-route",
+      "division": "Tools",
+      "name": "spline",
+      "kind": "MCP tool",
+      "meaning": "spline MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/spline-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-splitwise-packages-mcp-server-src-splitwise-tool-ts-no-route",
       "division": "Tools",
       "name": "splitwise",
@@ -8868,6 +8908,16 @@
       "kind": "MCP tool",
       "meaning": "tomorrowio MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/tomorrowio-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-toposort-packages-mcp-server-src-toposort-tool-ts-no-route",
+      "division": "Tools",
+      "name": "toposort",
+      "kind": "MCP tool",
+      "meaning": "toposort MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/toposort-tool.ts",
       "route": "",
       "tags": []
     },
@@ -10661,6 +10711,11 @@
       "packages/mcp-server/src/convertkit-tool.ts"
     ],
     [
+      "convexhull",
+      "convexhull MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/convexhull-tool.ts"
+    ],
+    [
       "copypass",
       "copypass MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/copypass-tool.ts"
@@ -11406,6 +11461,11 @@
       "packages/mcp-server/src/kling-tool.ts"
     ],
     [
+      "knapsack",
+      "knapsack MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/knapsack-tool.ts"
+    ],
+    [
       "languagetool",
       "languagetool MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/languagetool-tool.ts"
@@ -11414,6 +11474,11 @@
       "lastfm",
       "lastfm MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/lastfm-tool.ts"
+    ],
+    [
+      "lcs",
+      "lcs MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/lcs-tool.ts"
     ],
     [
       "legalpass",
@@ -12346,6 +12411,11 @@
       "packages/mcp-server/src/speedrun-tool.ts"
     ],
     [
+      "spline",
+      "spline MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/spline-tool.ts"
+    ],
+    [
       "splitwise",
       "splitwise MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/splitwise-tool.ts"
@@ -12539,6 +12609,11 @@
       "tomorrowio",
       "tomorrowio MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/tomorrowio-tool.ts"
+    ],
+    [
+      "toposort",
+      "toposort MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/toposort-tool.ts"
     ],
     [
       "trello",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 531 |
+| Tools | MCP and gateway capabilities available to seats. | 536 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -491,6 +491,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | difftext | difftext MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/difftext-tool.ts |
 | digimon | digimon MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/digimon-tool.ts |
 | digitalocean | digitalocean MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/digitalocean-tool.ts |
+| dijkstra | dijkstra MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dijkstra-tool.ts |
 | discogs | discogs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/discogs-tool.ts |
 | discord | discord MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/discord-tool.ts |
 | diseasesh | diseasesh MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/diseasesh-tool.ts |
@@ -623,6 +624,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | lichess | lichess MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lichess-tool.ts |
 | line | line MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/line-tool.ts |
 | linear | linear MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/linear-tool.ts |
+| linearsolve | linearsolve MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/linearsolve-tool.ts |
 | logbase | logbase MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/logbase-tool.ts |
 | lorem | lorem MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lorem-tool.ts |
 | lorem2 | lorem2 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lorem2-tool.ts |
@@ -638,6 +640,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | markov | markov MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/markov-tool.ts |
 | mastodon | mastodon MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mastodon-tool.ts |
 | matrix | matrix MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/matrix-tool.ts |
+| matrixdecomp | matrixdecomp MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/matrixdecomp-tool.ts |
 | mcsrvstat | mcsrvstat MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mcsrvstat-tool.ts |
 | meal | meal MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/meal-tool.ts |
 | mediawiki | mediawiki MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mediawiki-tool.ts |
@@ -674,6 +677,8 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | nthroot | nthroot MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/nthroot-tool.ts |
 | NudgeOnly | NudgeOnly low-token receipt bridge and advisory classifier. | packages/mcp-server/src/nudgeonly-tool.ts |
 | numbers | numbers MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/numbers-tool.ts |
+| numdiff | numdiff MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/numdiff-tool.ts |
+| numintegrate | numintegrate MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/numintegrate-tool.ts |
 | nvd | nvd MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/nvd-tool.ts |
 | oeis | oeis MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/oeis-tool.ts |
 | officialjoke | officialjoke MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/officialjoke-tool.ts |
@@ -1438,6 +1443,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | difftext | difftext MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/difftext-tool.ts |
 | Tools | MCP tool | digimon | digimon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/digimon-tool.ts |
 | Tools | MCP tool | digitalocean | digitalocean MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/digitalocean-tool.ts |
+| Tools | MCP tool | dijkstra | dijkstra MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dijkstra-tool.ts |
 | Tools | MCP tool | discogs | discogs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/discogs-tool.ts |
 | Tools | MCP tool | discord | discord MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/discord-tool.ts |
 | Tools | MCP tool | diseasesh | diseasesh MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/diseasesh-tool.ts |
@@ -1570,6 +1576,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | lichess | lichess MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lichess-tool.ts |
 | Tools | MCP tool | line | line MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/line-tool.ts |
 | Tools | MCP tool | linear | linear MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/linear-tool.ts |
+| Tools | MCP tool | linearsolve | linearsolve MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/linearsolve-tool.ts |
 | Tools | MCP tool | logbase | logbase MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/logbase-tool.ts |
 | Tools | MCP tool | lorem | lorem MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lorem-tool.ts |
 | Tools | MCP tool | lorem2 | lorem2 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lorem2-tool.ts |
@@ -1585,6 +1592,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | markov | markov MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/markov-tool.ts |
 | Tools | MCP tool | mastodon | mastodon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mastodon-tool.ts |
 | Tools | MCP tool | matrix | matrix MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/matrix-tool.ts |
+| Tools | MCP tool | matrixdecomp | matrixdecomp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/matrixdecomp-tool.ts |
 | Tools | MCP tool | mcsrvstat | mcsrvstat MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mcsrvstat-tool.ts |
 | Tools | MCP tool | meal | meal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/meal-tool.ts |
 | Tools | MCP tool | mediawiki | mediawiki MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mediawiki-tool.ts |
@@ -1621,6 +1629,8 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | nthroot | nthroot MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nthroot-tool.ts |
 | Tools | MCP tool | NudgeOnly | NudgeOnly low-token receipt bridge and advisory classifier. | - | packages/mcp-server/src/nudgeonly-tool.ts |
 | Tools | MCP tool | numbers | numbers MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/numbers-tool.ts |
+| Tools | MCP tool | numdiff | numdiff MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/numdiff-tool.ts |
+| Tools | MCP tool | numintegrate | numintegrate MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/numintegrate-tool.ts |
 | Tools | MCP tool | nvd | nvd MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/nvd-tool.ts |
 | Tools | MCP tool | oeis | oeis MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/oeis-tool.ts |
 | Tools | MCP tool | officialjoke | officialjoke MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/officialjoke-tool.ts |

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 526 |
+| Tools | MCP and gateway capabilities available to seats. | 531 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -461,6 +461,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | confluence | confluence MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/confluence-tool.ts |
 | contentful | contentful MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/contentful-tool.ts |
 | convertkit | convertkit MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/convertkit-tool.ts |
+| convexhull | convexhull MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/convexhull-tool.ts |
 | copypass | copypass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/copypass-tool.ts |
 | corporatebs | corporatebs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/corporatebs-tool.ts |
 | cosinesim | cosinesim MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/cosinesim-tool.ts |
@@ -610,8 +611,10 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | keychain | keychain MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/keychain-tool.ts |
 | klaviyo | klaviyo MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/klaviyo-tool.ts |
 | kling | kling MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/kling-tool.ts |
+| knapsack | knapsack MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/knapsack-tool.ts |
 | languagetool | languagetool MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/languagetool-tool.ts |
 | lastfm | lastfm MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lastfm-tool.ts |
+| lcs | lcs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lcs-tool.ts |
 | legalpass | legalpass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/legalpass-tool.ts |
 | lego | lego MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lego-tool.ts |
 | lemonsqueezy | lemonsqueezy MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lemonsqueezy-tool.ts |
@@ -798,6 +801,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | spaceflight | spaceflight MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/spaceflight-tool.ts |
 | spacex | spacex MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/spacex-tool.ts |
 | speedrun | speedrun MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/speedrun-tool.ts |
+| spline | spline MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/spline-tool.ts |
 | splitwise | splitwise MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/splitwise-tool.ts |
 | spotify | spotify MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/spotify-tool.ts |
 | square | square MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/square-tool.ts |
@@ -837,6 +841,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | toilets | toilets MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/toilets-tool.ts |
 | tokencount | tokencount MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tokencount-tool.ts |
 | tomorrowio | tomorrowio MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/tomorrowio-tool.ts |
+| toposort | toposort MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/toposort-tool.ts |
 | trello | trello MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/trello-tool.ts |
 | trianglesolve | trianglesolve MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/trianglesolve-tool.ts |
 | trivia | trivia MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/trivia-tool.ts |
@@ -1403,6 +1408,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | confluence | confluence MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/confluence-tool.ts |
 | Tools | MCP tool | contentful | contentful MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/contentful-tool.ts |
 | Tools | MCP tool | convertkit | convertkit MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/convertkit-tool.ts |
+| Tools | MCP tool | convexhull | convexhull MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/convexhull-tool.ts |
 | Tools | MCP tool | copypass | copypass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/copypass-tool.ts |
 | Tools | MCP tool | corporatebs | corporatebs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/corporatebs-tool.ts |
 | Tools | MCP tool | cosinesim | cosinesim MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/cosinesim-tool.ts |
@@ -1552,8 +1558,10 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | keychain | keychain MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/keychain-tool.ts |
 | Tools | MCP tool | klaviyo | klaviyo MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/klaviyo-tool.ts |
 | Tools | MCP tool | kling | kling MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/kling-tool.ts |
+| Tools | MCP tool | knapsack | knapsack MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/knapsack-tool.ts |
 | Tools | MCP tool | languagetool | languagetool MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/languagetool-tool.ts |
 | Tools | MCP tool | lastfm | lastfm MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lastfm-tool.ts |
+| Tools | MCP tool | lcs | lcs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lcs-tool.ts |
 | Tools | MCP tool | legalpass | legalpass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/legalpass-tool.ts |
 | Tools | MCP tool | lego | lego MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lego-tool.ts |
 | Tools | MCP tool | lemonsqueezy | lemonsqueezy MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lemonsqueezy-tool.ts |
@@ -1740,6 +1748,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | spaceflight | spaceflight MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/spaceflight-tool.ts |
 | Tools | MCP tool | spacex | spacex MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/spacex-tool.ts |
 | Tools | MCP tool | speedrun | speedrun MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/speedrun-tool.ts |
+| Tools | MCP tool | spline | spline MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/spline-tool.ts |
 | Tools | MCP tool | splitwise | splitwise MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/splitwise-tool.ts |
 | Tools | MCP tool | spotify | spotify MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/spotify-tool.ts |
 | Tools | MCP tool | square | square MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/square-tool.ts |
@@ -1779,6 +1788,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | toilets | toilets MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/toilets-tool.ts |
 | Tools | MCP tool | tokencount | tokencount MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tokencount-tool.ts |
 | Tools | MCP tool | tomorrowio | tomorrowio MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/tomorrowio-tool.ts |
+| Tools | MCP tool | toposort | toposort MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/toposort-tool.ts |
 | Tools | MCP tool | trello | trello MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trello-tool.ts |
 | Tools | MCP tool | trianglesolve | trianglesolve MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trianglesolve-tool.ts |
 | Tools | MCP tool | trivia | trivia MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/trivia-tool.ts |

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -1660,6 +1660,26 @@
     }
   },
   {
+    "connector": "convexhull",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "corporatebs",
     "level": 5,
     "levelName": "Agentic",
@@ -4320,6 +4340,26 @@
     }
   },
   {
+    "connector": "knapsack",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "languagetool",
     "level": 5,
     "levelName": "Agentic",
@@ -4351,6 +4391,26 @@
       "handles429": true,
       "hasRetry": true,
       "readsErrorBody": true,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "lcs",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
@@ -7540,6 +7600,26 @@
     }
   },
   {
+    "connector": "spline",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "spotify",
     "level": 5,
     "levelName": "Agentic",
@@ -8191,6 +8271,26 @@
       "handles429": true,
       "hasRetry": false,
       "readsErrorBody": true,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "toposort",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -2180,6 +2180,26 @@
     }
   },
   {
+    "connector": "dijkstra",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "discogs",
     "level": 5,
     "levelName": "Agentic",
@@ -4520,6 +4540,26 @@
     }
   },
   {
+    "connector": "linearsolve",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "logbase",
     "level": 5,
     "levelName": "Agentic",
@@ -4781,6 +4821,26 @@
   },
   {
     "connector": "matrix",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "matrixdecomp",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,
@@ -5421,6 +5481,46 @@
   },
   {
     "connector": "nthroot",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "numdiff",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "numintegrate",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (505 external connectors)
+## Distribution (510 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 466 | 92% |
+| L5 | Agentic | 471 | 92% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 505 (48%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 510 (47%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 466 of 469 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 471 of 474 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -100,6 +100,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `diceware` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `difftext` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `digimon` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `dijkstra` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `diseasesh` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `disneyapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `dogfacts` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -165,6 +166,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `lcs` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `levenshtein` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `libretranslate` (L5 Agentic): not-hardened, no-rate-limit, no-memory
+- `linearsolve` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `logbase` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `lorem2` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `loremname` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -175,6 +177,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `markdowntable` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `markov` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `matrix` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `matrixdecomp` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mcsrvstat` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `mediawiki` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `memegen` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -196,6 +199,8 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `normaldistr` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `npm-registry` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `nthroot` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `numdiff` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `numintegrate` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `oeis` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `officialjoke` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `open-elevation` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -415,6 +420,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `difftext` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `digimon` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `digitalocean` | Yes | - | Yes | Yes | Yes | no-memory |
+| L5 Agentic | `dijkstra` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `discogs` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `diseasesh` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `disneyapi` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -532,6 +538,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `levenshtein` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `libretranslate` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `lichess` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `linearsolve` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `logbase` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `lorem` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `lorem2` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -546,6 +553,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `markdowntable` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `markov` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `matrix` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `matrixdecomp` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `mcsrvstat` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `meal` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `mediawiki` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -578,6 +586,8 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `normaldistr` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `npm-registry` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `nthroot` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `numdiff` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `numintegrate` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `nvd` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `oeis` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `officialjoke` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (500 external connectors)
+## Distribution (505 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 461 | 92% |
+| L5 | Agentic | 466 | 92% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 500 (48%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 505 (48%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 461 of 464 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 466 of 469 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -82,6 +82,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `colr` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `combination` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `complexnum` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `convexhull` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `cosinesim` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `countdowncalc` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `countryflag` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -159,7 +160,9 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `jsoncrack` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `jsonformat` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `jwt` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `knapsack` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `languagetool` (L5 Agentic): not-hardened, 2x-bare-error, no-memory
+- `lcs` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `levenshtein` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `libretranslate` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `logbase` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -258,6 +261,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `sortlines` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `soundex` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `spacex` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `spline` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `stackexchange` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `standardform` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `stapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -273,6 +277,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `timeapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `timezone` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `tokencount` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `toposort` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `trianglesolve` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `tvmaze` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `ukpolice` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -384,6 +389,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `confluence` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `contentful` | Yes | Yes | - | Yes | Yes |  |
 | L5 Agentic | `convertkit` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `convexhull` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `corporatebs` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `cosinesim` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `countdowncalc` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -517,8 +523,10 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `kanye` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `klaviyo` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `kling` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `knapsack` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `languagetool` | - | - | - | Yes | Yes | not-hardened, 2x-bare-error, no-memory |
 | L5 Agentic | `lastfm` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `lcs` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `lego` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `lemonsqueezy` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `levenshtein` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -678,6 +686,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `spaceflight` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `spacex` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `speedrun` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `spline` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `spotify` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `stability` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `stackexchange` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
@@ -711,6 +720,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `toilets` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `tokencount` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `tomorrowio` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `toposort` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `trianglesolve` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `trivia` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `trove` | Yes | - | - | Yes | Yes | no-memory |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1974,6 +1974,16 @@
     ]
   },
   {
+    "app": "dijkstra",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "dijkstra_path",
+        "description": "Find the shortest path between two nodes in a weighted graph (Dijkstra's algorithm)."
+      }
+    ]
+  },
+  {
     "app": "discogs",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4208,6 +4218,16 @@
     ]
   },
   {
+    "app": "linearsolve",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "linear_solve",
+        "description": "Solve a system of linear equations Ax = b using Gaussian elimination with partial pivoting."
+      }
+    ]
+  },
+  {
     "app": "logbase",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4406,6 +4426,16 @@
       {
         "name": "matrix_operate",
         "description": "Perform matrix operations: add, multiply, transpose, or determinant."
+      }
+    ]
+  },
+  {
+    "app": "matrixdecomp",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "matrix_decomp",
+        "description": "Matrix decomposition and analysis: LU factorization, transpose, trace, or rank."
       }
     ]
   },
@@ -4966,6 +4996,26 @@
       {
         "name": "number_random",
         "description": "Get a random number fact."
+      }
+    ]
+  },
+  {
+    "app": "numdiff",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "numerical_diff",
+        "description": "Numerical differentiation of a math expression using five-point stencil (1st-4th order)."
+      }
+    ]
+  },
+  {
+    "app": "numintegrate",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "numerical_integrate",
+        "description": "Numerical integration of a math expression using Simpson's rule, trapezoid, or midpoint method."
       }
     ]
   },

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1526,6 +1526,16 @@
     ]
   },
   {
+    "app": "convexhull",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "convex_hull",
+        "description": "Compute the convex hull of 2D points with area and perimeter."
+      }
+    ]
+  },
+  {
     "app": "copypass",
     "category": "CopyPass (copy quality QC, sister to SecurityPass)",
     "tools": [
@@ -3946,6 +3956,16 @@
     ]
   },
   {
+    "app": "knapsack",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "knapsack_solve",
+        "description": "Solve the 0-1 knapsack problem: pick items to maximize value within a weight capacity."
+      }
+    ]
+  },
+  {
     "app": "languagetool",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -3990,6 +4010,16 @@
       {
         "name": "lastfm_album_info",
         "description": "Get album info from Last.fm."
+      }
+    ]
+  },
+  {
+    "app": "lcs",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "string_lcs",
+        "description": "Find the longest common subsequence of two strings with similarity score."
       }
     ]
   },
@@ -7134,6 +7164,16 @@
     ]
   },
   {
+    "app": "spline",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "spline_interpolate",
+        "description": "Natural cubic spline interpolation through data points, with optional evaluation."
+      }
+    ]
+  },
+  {
     "app": "splitwise",
     "category": "Productivity",
     "tools": [
@@ -7876,6 +7916,16 @@
       {
         "name": "tomorrow_history",
         "description": "Get historical weather data from Tomorrow.io."
+      }
+    ]
+  },
+  {
+    "app": "toposort",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "topo_sort",
+        "description": "Topological sort of a directed graph with cycle detection."
       }
     ]
   },

--- a/packages/mcp-server/src/convexhull-tool.test.ts
+++ b/packages/mcp-server/src/convexhull-tool.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { convexHull } from "./convexhull-tool.js";
+
+describe("convexHull", () => {
+  it("computes hull of a square", async () => {
+    const r = await convexHull({
+      points: [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+        [0.5, 0.5],
+      ],
+    }) as any;
+    expect(r.hull_size).toBe(4);
+    expect(r.area).toBe(1);
+  });
+
+  it("computes hull of a triangle", async () => {
+    const r = await convexHull({
+      points: [
+        [0, 0],
+        [4, 0],
+        [2, 3],
+      ],
+    }) as any;
+    expect(r.hull_size).toBe(3);
+    expect(r.area).toBe(6);
+  });
+
+  it("excludes interior points", async () => {
+    const r = await convexHull({
+      points: [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+        [5, 5],
+        [3, 3],
+        [7, 2],
+      ],
+    }) as any;
+    expect(r.hull_size).toBe(4);
+    expect(r.input_size).toBe(7);
+  });
+
+  it("rejects fewer than 3 points", async () => {
+    await expect(
+      convexHull({ points: [[0, 0], [1, 1]] }),
+    ).rejects.toThrow("at least 3");
+  });
+
+  it("stamps meta", async () => {
+    const r = await convexHull({
+      points: [
+        [0, 0],
+        [1, 0],
+        [0, 1],
+      ],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/convexhull-tool.ts
+++ b/packages/mcp-server/src/convexhull-tool.ts
@@ -1,0 +1,80 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+function cross(o: Point, a: Point, b: Point): number {
+  return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+}
+
+export async function convexHull(args: Record<string, unknown>) {
+  const raw = args.points as unknown[];
+  if (!Array.isArray(raw) || raw.length < 3) {
+    throw new Error("points must be an array of at least 3 [x, y] pairs.");
+  }
+  if (raw.length > 50000) {
+    throw new Error("Maximum 50000 points supported.");
+  }
+
+  const points: Point[] = raw.map((p) => {
+    if (!Array.isArray(p) || p.length < 2) {
+      throw new Error("Each point must be [x, y].");
+    }
+    return { x: Number(p[0]), y: Number(p[1]) };
+  });
+
+  points.sort((a, b) => a.x - b.x || a.y - b.y);
+
+  const lower: Point[] = [];
+  for (const p of points) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+
+  const upper: Point[] = [];
+  for (let i = points.length - 1; i >= 0; i--) {
+    const p = points[i];
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+
+  lower.pop();
+  upper.pop();
+  const hull = lower.concat(upper);
+
+  let area = 0;
+  for (let i = 0; i < hull.length; i++) {
+    const j = (i + 1) % hull.length;
+    area += hull[i].x * hull[j].y;
+    area -= hull[j].x * hull[i].y;
+  }
+  area = Math.abs(area) / 2;
+
+  let perimeter = 0;
+  for (let i = 0; i < hull.length; i++) {
+    const j = (i + 1) % hull.length;
+    perimeter += Math.hypot(hull[j].x - hull[i].x, hull[j].y - hull[i].y);
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use area_calculate for standard shapes", "Use midpoint_calc for center estimation"],
+  };
+  return stampMeta(
+    {
+      hull: hull.map((p) => [p.x, p.y]),
+      hull_size: hull.length,
+      input_size: raw.length,
+      area: Math.round(area * 1e6) / 1e6,
+      perimeter: Math.round(perimeter * 1e6) / 1e6,
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/dijkstra-tool.test.ts
+++ b/packages/mcp-server/src/dijkstra-tool.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { dijkstraPath } from "./dijkstra-tool.js";
+
+describe("dijkstraPath", () => {
+  it("finds shortest path in undirected graph", async () => {
+    const r = await dijkstraPath({
+      source: "A",
+      target: "D",
+      edges: [
+        ["A", "B", 1],
+        ["B", "C", 2],
+        ["A", "C", 4],
+        ["C", "D", 1],
+      ],
+    }) as any;
+    expect(r.distance).toBe(4);
+    expect(r.path).toEqual(["A", "B", "C", "D"]);
+    expect(r.reachable).toBe(true);
+  });
+
+  it("finds shortest path in directed graph", async () => {
+    const r = await dijkstraPath({
+      source: "A",
+      target: "C",
+      directed: true,
+      edges: [
+        ["A", "B", 1],
+        ["B", "C", 1],
+        ["A", "C", 10],
+      ],
+    }) as any;
+    expect(r.distance).toBe(2);
+    expect(r.path).toEqual(["A", "B", "C"]);
+  });
+
+  it("reports unreachable target", async () => {
+    const r = await dijkstraPath({
+      source: "A",
+      target: "C",
+      directed: true,
+      edges: [
+        ["A", "B", 1],
+        ["C", "B", 1],
+      ],
+    }) as any;
+    expect(r.reachable).toBe(false);
+    expect(r.distance).toBeNull();
+  });
+
+  it("rejects negative weights", async () => {
+    await expect(
+      dijkstraPath({
+        source: "A",
+        target: "B",
+        edges: [["A", "B", -1]],
+      }),
+    ).rejects.toThrow("Negative");
+  });
+
+  it("handles same source and target", async () => {
+    const r = await dijkstraPath({
+      source: "A",
+      target: "A",
+      edges: [["A", "B", 5]],
+    }) as any;
+    expect(r.distance).toBe(0);
+    expect(r.path).toEqual(["A"]);
+  });
+
+  it("stamps meta", async () => {
+    const r = await dijkstraPath({
+      source: "A",
+      target: "B",
+      edges: [["A", "B", 1]],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/dijkstra-tool.ts
+++ b/packages/mcp-server/src/dijkstra-tool.ts
@@ -1,0 +1,108 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+interface Edge {
+  to: string;
+  weight: number;
+}
+
+export async function dijkstraPath(args: Record<string, unknown>) {
+  const edges = args.edges as [string, string, number][] | undefined;
+  if (!Array.isArray(edges) || edges.length === 0) {
+    throw new Error("edges must be a non-empty array of [from, to, weight] triples.");
+  }
+  if (edges.length > 50000) {
+    throw new Error("Maximum 50000 edges supported.");
+  }
+
+  const source = String(args.source ?? "");
+  const target = String(args.target ?? "");
+  if (!source) throw new Error("source node is required.");
+  if (!target) throw new Error("target node is required.");
+
+  const adj = new Map<string, Edge[]>();
+  const nodes = new Set<string>();
+
+  for (const edge of edges) {
+    if (!Array.isArray(edge) || edge.length < 3) {
+      throw new Error("Each edge must be [from, to, weight].");
+    }
+    const [from, to, w] = [String(edge[0]), String(edge[1]), Number(edge[2])];
+    if (w < 0) throw new Error("Negative weights are not supported.");
+    nodes.add(from);
+    nodes.add(to);
+    if (!adj.has(from)) adj.set(from, []);
+    adj.get(from)!.push({ to, weight: w });
+    if (!args.directed) {
+      if (!adj.has(to)) adj.set(to, []);
+      adj.get(to)!.push({ to: from, weight: w });
+    }
+  }
+
+  if (!nodes.has(source)) throw new Error(`Source node "${source}" not in graph.`);
+  if (!nodes.has(target)) throw new Error(`Target node "${target}" not in graph.`);
+
+  const dist = new Map<string, number>();
+  const prev = new Map<string, string | null>();
+  const visited = new Set<string>();
+
+  for (const node of nodes) {
+    dist.set(node, Infinity);
+    prev.set(node, null);
+  }
+  dist.set(source, 0);
+
+  while (true) {
+    let u: string | null = null;
+    let minDist = Infinity;
+    for (const node of nodes) {
+      if (!visited.has(node) && dist.get(node)! < minDist) {
+        minDist = dist.get(node)!;
+        u = node;
+      }
+    }
+    if (u === null || u === target) break;
+    visited.add(u);
+
+    for (const edge of adj.get(u) ?? []) {
+      const alt = dist.get(u)! + edge.weight;
+      if (alt < dist.get(edge.to)!) {
+        dist.set(edge.to, alt);
+        prev.set(edge.to, u);
+      }
+    }
+  }
+
+  const distance = dist.get(target)!;
+  const reachable = distance !== Infinity;
+
+  let path: string[] = [];
+  if (reachable) {
+    let node: string | null = target;
+    while (node !== null) {
+      path.unshift(node);
+      node = prev.get(node) ?? null;
+    }
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: reachable
+      ? ["Use topo_sort for DAG ordering", "Use convex_hull for spatial analysis"]
+      : ["Check graph connectivity or add missing edges"],
+  };
+  return stampMeta(
+    {
+      source: source,
+      target,
+      distance: reachable ? Math.round(distance * 1e8) / 1e8 : null,
+      reachable,
+      path,
+      path_length: path.length,
+      node_count: nodes.size,
+      edge_count: edges.length,
+      directed: !!args.directed,
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/knapsack-tool.test.ts
+++ b/packages/mcp-server/src/knapsack-tool.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { knapsackSolve } from "./knapsack-tool.js";
+
+describe("knapsackSolve", () => {
+  it("solves a basic knapsack problem", async () => {
+    const r = await knapsackSolve({
+      capacity: 50,
+      items: [
+        { name: "A", weight: 10, value: 60 },
+        { name: "B", weight: 20, value: 100 },
+        { name: "C", weight: 30, value: 120 },
+      ],
+    }) as any;
+    expect(r.max_value).toBe(220);
+    expect(r.total_weight).toBe(50);
+    expect(r.selected_count).toBe(2);
+  });
+
+  it("selects nothing when items are too heavy", async () => {
+    const r = await knapsackSolve({
+      capacity: 5,
+      items: [
+        { weight: 10, value: 100 },
+        { weight: 20, value: 200 },
+      ],
+    }) as any;
+    expect(r.max_value).toBe(0);
+    expect(r.selected_count).toBe(0);
+  });
+
+  it("selects all items when they fit", async () => {
+    const r = await knapsackSolve({
+      capacity: 100,
+      items: [
+        { weight: 10, value: 10 },
+        { weight: 20, value: 20 },
+        { weight: 30, value: 30 },
+      ],
+    }) as any;
+    expect(r.max_value).toBe(60);
+    expect(r.selected_count).toBe(3);
+  });
+
+  it("rejects empty items", async () => {
+    await expect(
+      knapsackSolve({ capacity: 10, items: [] }),
+    ).rejects.toThrow("non-empty");
+  });
+
+  it("rejects invalid capacity", async () => {
+    await expect(
+      knapsackSolve({ capacity: -1, items: [{ weight: 1, value: 1 }] }),
+    ).rejects.toThrow("positive");
+  });
+
+  it("stamps meta", async () => {
+    const r = await knapsackSolve({
+      capacity: 10,
+      items: [{ weight: 5, value: 10 }],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/knapsack-tool.ts
+++ b/packages/mcp-server/src/knapsack-tool.ts
@@ -1,0 +1,75 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function knapsackSolve(args: Record<string, unknown>) {
+  const capacity = Number(args.capacity);
+  if (!Number.isFinite(capacity) || capacity <= 0) {
+    throw new Error("capacity must be a positive number.");
+  }
+
+  const items = args.items as { name?: string; weight: number; value: number }[];
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error("items must be a non-empty array of { weight, value } objects.");
+  }
+  if (items.length > 500) {
+    throw new Error("Maximum 500 items supported.");
+  }
+
+  const n = items.length;
+  const cap = Math.floor(capacity);
+
+  if (cap > 100000) {
+    throw new Error("capacity must be 100000 or less (integer units).");
+  }
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array(cap + 1).fill(0),
+  );
+
+  for (let i = 1; i <= n; i++) {
+    const w = Math.floor(Number(items[i - 1].weight));
+    const v = Number(items[i - 1].value);
+    for (let j = 0; j <= cap; j++) {
+      dp[i][j] = dp[i - 1][j];
+      if (w <= j && dp[i - 1][j - w] + v > dp[i][j]) {
+        dp[i][j] = dp[i - 1][j - w] + v;
+      }
+    }
+  }
+
+  const selected: number[] = [];
+  let w = cap;
+  for (let i = n; i > 0; i--) {
+    if (dp[i][w] !== dp[i - 1][w]) {
+      selected.unshift(i - 1);
+      w -= Math.floor(Number(items[i - 1].weight));
+    }
+  }
+
+  const totalWeight = selected.reduce(
+    (s, idx) => s + Number(items[idx].weight),
+    0,
+  );
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Adjust capacity or item weights to explore alternatives"],
+  };
+  return stampMeta(
+    {
+      max_value: dp[n][cap],
+      total_weight: totalWeight,
+      capacity,
+      selected_indices: selected,
+      selected_items: selected.map((idx) => ({
+        index: idx,
+        name: items[idx].name ?? `item_${idx}`,
+        weight: Number(items[idx].weight),
+        value: Number(items[idx].value),
+      })),
+      item_count: n,
+      selected_count: selected.length,
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/lcs-tool.test.ts
+++ b/packages/mcp-server/src/lcs-tool.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { stringLcs } from "./lcs-tool.js";
+
+describe("stringLcs", () => {
+  it("finds LCS of two strings", async () => {
+    const r = await stringLcs({ a: "ABCBDAB", b: "BDCAB" }) as any;
+    expect(r.lcs_length).toBe(4);
+    expect(["BCAB", "BDAB"]).toContain(r.lcs);
+  });
+
+  it("returns empty for no common subsequence", async () => {
+    const r = await stringLcs({ a: "abc", b: "xyz" }) as any;
+    expect(r.lcs_length).toBe(0);
+    expect(r.lcs).toBe("");
+    expect(r.similarity).toBe(0);
+  });
+
+  it("handles identical strings", async () => {
+    const r = await stringLcs({ a: "hello", b: "hello" }) as any;
+    expect(r.lcs).toBe("hello");
+    expect(r.lcs_length).toBe(5);
+    expect(r.similarity).toBe(1);
+  });
+
+  it("handles empty strings", async () => {
+    const r = await stringLcs({ a: "", b: "test" }) as any;
+    expect(r.lcs_length).toBe(0);
+  });
+
+  it("rejects strings over 5000 chars", async () => {
+    await expect(
+      stringLcs({ a: "x".repeat(5001), b: "y" }),
+    ).rejects.toThrow("5000");
+  });
+
+  it("stamps meta with local source", async () => {
+    const r = await stringLcs({ a: "ab", b: "b" }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/lcs-tool.ts
+++ b/packages/mcp-server/src/lcs-tool.ts
@@ -1,0 +1,63 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function stringLcs(args: Record<string, unknown>) {
+  const a = String(args.a ?? "");
+  const b = String(args.b ?? "");
+
+  if (a.length > 5000 || b.length > 5000) {
+    throw new Error("Inputs must be 5000 characters or fewer each.");
+  }
+
+  const m = a.length;
+  const n = b.length;
+
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array(n + 1).fill(0),
+  );
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  let lcs = "";
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      lcs = a[i - 1] + lcs;
+      i--;
+      j--;
+    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  const similarity =
+    Math.max(m, n) === 0 ? 1 : dp[m][n] / Math.max(m, n);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use string_distance for edit distance", "Use jaccard_similarity for set-based comparison"],
+  };
+  return stampMeta(
+    {
+      a,
+      b,
+      lcs,
+      lcs_length: dp[m][n],
+      a_length: m,
+      b_length: n,
+      similarity: Math.round(similarity * 1e6) / 1e6,
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/linearsolve-tool.test.ts
+++ b/packages/mcp-server/src/linearsolve-tool.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { linearSolve } from "./linearsolve-tool.js";
+
+describe("linearSolve", () => {
+  it("solves 2x2 system", async () => {
+    const r = await linearSolve({
+      matrix: [
+        [2, 1],
+        [1, 3],
+      ],
+      vector: [5, 10],
+    }) as any;
+    expect(r.solution[0]).toBeCloseTo(1, 6);
+    expect(r.solution[1]).toBeCloseTo(3, 6);
+  });
+
+  it("solves 3x3 system", async () => {
+    const r = await linearSolve({
+      matrix: [
+        [1, 0, 0],
+        [0, 2, 0],
+        [0, 0, 3],
+      ],
+      vector: [5, 8, 9],
+    }) as any;
+    expect(r.solution).toEqual([5, 4, 3]);
+    expect(r.system_size).toBe(3);
+  });
+
+  it("handles partial pivoting", async () => {
+    const r = await linearSolve({
+      matrix: [
+        [0, 1],
+        [1, 0],
+      ],
+      vector: [3, 7],
+    }) as any;
+    expect(r.solution[0]).toBeCloseTo(7, 6);
+    expect(r.solution[1]).toBeCloseTo(3, 6);
+  });
+
+  it("rejects singular system", async () => {
+    await expect(
+      linearSolve({
+        matrix: [
+          [1, 2],
+          [2, 4],
+        ],
+        vector: [3, 6],
+      }),
+    ).rejects.toThrow("singular");
+  });
+
+  it("rejects mismatched dimensions", async () => {
+    await expect(
+      linearSolve({
+        matrix: [[1, 2], [3, 4]],
+        vector: [1],
+      }),
+    ).rejects.toThrow("length");
+  });
+
+  it("stamps meta", async () => {
+    const r = await linearSolve({
+      matrix: [[2]],
+      vector: [6],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+    expect(r.solution[0]).toBe(3);
+  });
+});

--- a/packages/mcp-server/src/linearsolve-tool.ts
+++ b/packages/mcp-server/src/linearsolve-tool.ts
@@ -1,0 +1,80 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function linearSolve(args: Record<string, unknown>) {
+  const A = args.matrix as number[][];
+  const b = args.vector as number[];
+
+  if (!Array.isArray(A) || A.length === 0) {
+    throw new Error("matrix must be a non-empty 2D array (coefficient matrix).");
+  }
+  if (!Array.isArray(b) || b.length === 0) {
+    throw new Error("vector must be a non-empty array (right-hand side).");
+  }
+
+  const n = A.length;
+  if (n > 100) throw new Error("Maximum system size is 100x100.");
+  if (b.length !== n) throw new Error("vector length must equal the number of rows in matrix.");
+
+  for (const row of A) {
+    if (!Array.isArray(row) || row.length !== n) {
+      throw new Error("matrix must be square with consistent row lengths.");
+    }
+  }
+
+  const aug: number[][] = A.map((row, i) => [...row, b[i]]);
+
+  for (let col = 0; col < n; col++) {
+    let maxRow = col;
+    let maxVal = Math.abs(aug[col][col]);
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(aug[row][col]) > maxVal) {
+        maxVal = Math.abs(aug[row][col]);
+        maxRow = row;
+      }
+    }
+
+    if (maxVal < 1e-12) {
+      throw new Error("System is singular or nearly singular (no unique solution).");
+    }
+
+    if (maxRow !== col) {
+      [aug[col], aug[maxRow]] = [aug[maxRow], aug[col]];
+    }
+
+    for (let row = col + 1; row < n; row++) {
+      const factor = aug[row][col] / aug[col][col];
+      for (let j = col; j <= n; j++) {
+        aug[row][j] -= factor * aug[col][j];
+      }
+    }
+  }
+
+  const x = new Array(n).fill(0);
+  for (let i = n - 1; i >= 0; i--) {
+    let sum = aug[i][n];
+    for (let j = i + 1; j < n; j++) {
+      sum -= aug[i][j] * x[j];
+    }
+    x[i] = Math.round((sum / aug[i][i]) * 1e8) / 1e8;
+  }
+
+  const residuals = A.map((row, i) => {
+    const ax = row.reduce((s, v, j) => s + v * x[j], 0);
+    return Math.round((ax - b[i]) * 1e10) / 1e10;
+  });
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use matrix_operate for determinant or inverse", "Use regression_fit for least-squares fitting"],
+  };
+  return stampMeta(
+    {
+      solution: x,
+      system_size: n,
+      residuals,
+      max_residual: Math.max(...residuals.map(Math.abs)),
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/matrixdecomp-tool.test.ts
+++ b/packages/mcp-server/src/matrixdecomp-tool.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { matrixDecomp } from "./matrixdecomp-tool.js";
+
+describe("matrixDecomp", () => {
+  it("computes LU decomposition", async () => {
+    const r = await matrixDecomp({
+      matrix: [
+        [2, 1],
+        [4, 3],
+      ],
+      operation: "lu",
+    }) as any;
+    expect(r.operation).toBe("lu");
+    expect(r.L[1][0]).toBe(2);
+    expect(r.U[0][0]).toBe(2);
+    expect(r.U[1][1]).toBe(1);
+  });
+
+  it("computes transpose", async () => {
+    const r = await matrixDecomp({
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      operation: "transpose",
+    }) as any;
+    expect(r.result.length).toBe(3);
+    expect(r.result[0].length).toBe(2);
+    expect(r.result[0]).toEqual([1, 4]);
+  });
+
+  it("computes trace", async () => {
+    const r = await matrixDecomp({
+      matrix: [
+        [1, 0],
+        [0, 5],
+      ],
+      operation: "trace",
+    }) as any;
+    expect(r.trace).toBe(6);
+  });
+
+  it("computes rank", async () => {
+    const r = await matrixDecomp({
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      operation: "rank",
+    }) as any;
+    expect(r.rank).toBe(2);
+  });
+
+  it("rejects non-square for LU", async () => {
+    await expect(
+      matrixDecomp({ matrix: [[1, 2, 3], [4, 5, 6]], operation: "lu" }),
+    ).rejects.toThrow("square");
+  });
+
+  it("stamps meta", async () => {
+    const r = await matrixDecomp({
+      matrix: [[1]],
+      operation: "trace",
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/matrixdecomp-tool.ts
+++ b/packages/mcp-server/src/matrixdecomp-tool.ts
@@ -1,0 +1,128 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function matrixDecomp(args: Record<string, unknown>) {
+  const matrix = args.matrix as number[][];
+  if (!Array.isArray(matrix) || matrix.length === 0) {
+    throw new Error("matrix must be a non-empty 2D array.");
+  }
+  const m = matrix.length;
+  const n = matrix[0].length;
+  if (m > 100 || n > 100) {
+    throw new Error("Maximum matrix size is 100x100.");
+  }
+  for (const row of matrix) {
+    if (!Array.isArray(row) || row.length !== n) {
+      throw new Error("All rows must have the same length.");
+    }
+  }
+
+  const op = String(args.operation ?? "lu").toLowerCase();
+
+  if (op === "lu") {
+    if (m !== n) throw new Error("LU decomposition requires a square matrix.");
+    const L: number[][] = Array.from({ length: m }, (_, i) =>
+      Array.from({ length: m }, (_, j) => (i === j ? 1 : 0)),
+    );
+    const U: number[][] = matrix.map((r) => [...r]);
+
+    for (let k = 0; k < m; k++) {
+      if (Math.abs(U[k][k]) < 1e-12) {
+        throw new Error("Matrix is singular or nearly singular (zero pivot).");
+      }
+      for (let i = k + 1; i < m; i++) {
+        const factor = U[i][k] / U[k][k];
+        L[i][k] = Math.round(factor * 1e8) / 1e8;
+        for (let j = k; j < m; j++) {
+          U[i][j] -= factor * U[k][j];
+        }
+      }
+    }
+
+    const roundMatrix = (mat: number[][]) =>
+      mat.map((r) => r.map((v) => Math.round(v * 1e8) / 1e8));
+
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: ["Use L and U to solve Ax = b via forward/backward substitution"],
+    };
+    return stampMeta(
+      {
+        operation: "lu",
+        size: `${m}x${n}`,
+        L: roundMatrix(L),
+        U: roundMatrix(U),
+      },
+      meta,
+    );
+  }
+
+  if (op === "transpose") {
+    const T: number[][] = Array.from({ length: n }, (_, i) =>
+      Array.from({ length: m }, (_, j) => matrix[j][i]),
+    );
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: ["Use matrix_operate for multiplication or determinant"],
+    };
+    return stampMeta(
+      { operation: "transpose", input_size: `${m}x${n}`, output_size: `${n}x${m}`, result: T },
+      meta,
+    );
+  }
+
+  if (op === "trace") {
+    if (m !== n) throw new Error("Trace requires a square matrix.");
+    let trace = 0;
+    for (let i = 0; i < m; i++) trace += matrix[i][i];
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: ["Trace equals the sum of eigenvalues"],
+    };
+    return stampMeta(
+      { operation: "trace", size: `${m}x${n}`, trace: Math.round(trace * 1e8) / 1e8 },
+      meta,
+    );
+  }
+
+  if (op === "rank") {
+    const A: number[][] = matrix.map((r) => [...r]);
+    let rank = 0;
+    const rows = A.length;
+    const cols = A[0].length;
+    const usedRows = new Set<number>();
+
+    for (let col = 0; col < cols; col++) {
+      let pivotRow = -1;
+      for (let row = 0; row < rows; row++) {
+        if (!usedRows.has(row) && Math.abs(A[row][col]) > 1e-10) {
+          pivotRow = row;
+          break;
+        }
+      }
+      if (pivotRow === -1) continue;
+      usedRows.add(pivotRow);
+      rank++;
+      const pivotVal = A[pivotRow][col];
+      for (let row = 0; row < rows; row++) {
+        if (row !== pivotRow && Math.abs(A[row][col]) > 1e-10) {
+          const factor = A[row][col] / pivotVal;
+          for (let c = col; c < cols; c++) {
+            A[row][c] -= factor * A[pivotRow][c];
+          }
+        }
+      }
+    }
+
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: ["Full rank means the system has a unique solution"],
+    };
+    return stampMeta({ operation: "rank", size: `${m}x${n}`, rank }, meta);
+  }
+
+  throw new Error(`Unknown operation "${op}". Supported: lu, transpose, trace, rank.`);
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1988,6 +1988,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "dijkstra",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "dijkstra_path",
+        "description": "Find the shortest path between two nodes in a weighted graph (Dijkstra's algorithm)."
+      }
+    ]
+  },
+  {
     "app": "discogs",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4222,6 +4232,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "linearsolve",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "linear_solve",
+        "description": "Solve a system of linear equations Ax = b using Gaussian elimination with partial pivoting."
+      }
+    ]
+  },
+  {
     "app": "logbase",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4420,6 +4440,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "matrix_operate",
         "description": "Perform matrix operations: add, multiply, transpose, or determinant."
+      }
+    ]
+  },
+  {
+    "app": "matrixdecomp",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "matrix_decomp",
+        "description": "Matrix decomposition and analysis: LU factorization, transpose, trace, or rank."
       }
     ]
   },
@@ -4980,6 +5010,26 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "number_random",
         "description": "Get a random number fact."
+      }
+    ]
+  },
+  {
+    "app": "numdiff",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "numerical_diff",
+        "description": "Numerical differentiation of a math expression using five-point stencil (1st-4th order)."
+      }
+    ]
+  },
+  {
+    "app": "numintegrate",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "numerical_integrate",
+        "description": "Numerical integration of a math expression using Simpson's rule, trapezoid, or midpoint method."
       }
     ]
   },

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1540,6 +1540,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "convexhull",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "convex_hull",
+        "description": "Compute the convex hull of 2D points with area and perimeter."
+      }
+    ]
+  },
+  {
     "app": "copypass",
     "category": "CopyPass (copy quality QC, sister to SecurityPass)",
     "tools": [
@@ -3960,6 +3970,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "knapsack",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "knapsack_solve",
+        "description": "Solve the 0-1 knapsack problem: pick items to maximize value within a weight capacity."
+      }
+    ]
+  },
+  {
     "app": "languagetool",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4004,6 +4024,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "lastfm_album_info",
         "description": "Get album info from Last.fm."
+      }
+    ]
+  },
+  {
+    "app": "lcs",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "string_lcs",
+        "description": "Find the longest common subsequence of two strings with similarity score."
       }
     ]
   },
@@ -7148,6 +7178,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "spline",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "spline_interpolate",
+        "description": "Natural cubic spline interpolation through data points, with optional evaluation."
+      }
+    ]
+  },
+  {
     "app": "splitwise",
     "category": "Productivity",
     "tools": [
@@ -7890,6 +7930,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "tomorrow_history",
         "description": "Get historical weather data from Tomorrow.io."
+      }
+    ]
+  },
+  {
+    "app": "toposort",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "topo_sort",
+        "description": "Topological sort of a directed graph with cycle detection."
       }
     ]
   },

--- a/packages/mcp-server/src/numdiff-tool.test.ts
+++ b/packages/mcp-server/src/numdiff-tool.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { numericalDiff } from "./numdiff-tool.js";
+
+describe("numericalDiff", () => {
+  it("computes first derivative of x^2 at x=3", async () => {
+    const r = await numericalDiff({ expression: "x^2", x: 3 }) as any;
+    expect(r.derivative).toBeCloseTo(6, 4);
+    expect(r.f_of_x).toBe(9);
+  });
+
+  it("computes second derivative of x^3 at x=2", async () => {
+    const r = await numericalDiff({ expression: "x^3", x: 2, order: 2 }) as any;
+    expect(r.derivative).toBeCloseTo(12, 0);
+  });
+
+  it("computes derivative of constant", async () => {
+    const r = await numericalDiff({ expression: "5", x: 0 }) as any;
+    expect(Math.abs(r.derivative)).toBeLessThan(0.001);
+  });
+
+  it("handles multiplication", async () => {
+    const r = await numericalDiff({ expression: "3*x + 1", x: 5 }) as any;
+    expect(r.derivative).toBeCloseTo(3, 4);
+  });
+
+  it("rejects empty expression", async () => {
+    await expect(
+      numericalDiff({ expression: "", x: 1 }),
+    ).rejects.toThrow("required");
+  });
+
+  it("rejects invalid order", async () => {
+    await expect(
+      numericalDiff({ expression: "x", x: 1, order: 5 }),
+    ).rejects.toThrow("order");
+  });
+
+  it("stamps meta", async () => {
+    const r = await numericalDiff({ expression: "x", x: 0 }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/numdiff-tool.ts
+++ b/packages/mcp-server/src/numdiff-tool.ts
@@ -1,0 +1,59 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function numericalDiff(args: Record<string, unknown>) {
+  const expr = String(args.expression ?? "");
+  const x = Number(args.x);
+  const h = Number(args.h ?? 1e-7);
+  const order = Number(args.order ?? 1);
+
+  if (!expr) throw new Error("expression is required (e.g. 'x^2 + 3*x').");
+  if (!Number.isFinite(x)) throw new Error("x must be a finite number.");
+  if (h <= 0 || h > 1) throw new Error("h must be between 0 (exclusive) and 1.");
+  if (order < 1 || order > 4) throw new Error("order must be 1, 2, 3, or 4.");
+
+  const evaluate = (val: number): number => {
+    const sanitized = expr
+      .replace(/\bx\b/g, `(${val})`)
+      .replace(/\^/g, "**");
+    const allowed = /^[\d+\-*/().eE\s]*$/;
+    if (!allowed.test(sanitized)) {
+      throw new Error("Expression contains unsupported characters. Use x, numbers, +, -, *, /, ^, ().");
+    }
+    const result = Function(`"use strict"; return (${sanitized})`)();
+    if (typeof result !== "number" || !Number.isFinite(result)) {
+      throw new Error(`Expression evaluated to non-finite at x=${val}.`);
+    }
+    return result;
+  };
+
+  const fx = evaluate(x);
+  let derivative: number;
+
+  if (order === 1) {
+    derivative = (-evaluate(x + 2 * h) + 8 * evaluate(x + h) - 8 * evaluate(x - h) + evaluate(x - 2 * h)) / (12 * h);
+  } else if (order === 2) {
+    derivative = (-evaluate(x + 2 * h) + 16 * evaluate(x + h) - 30 * fx + 16 * evaluate(x - h) - evaluate(x - 2 * h)) / (12 * h * h);
+  } else if (order === 3) {
+    derivative = (evaluate(x + 2 * h) - 2 * evaluate(x + h) + 2 * evaluate(x - h) - evaluate(x - 2 * h)) / (2 * h * h * h);
+  } else {
+    derivative = (evaluate(x + 2 * h) - 4 * evaluate(x + h) + 6 * fx - 4 * evaluate(x - h) + evaluate(x - 2 * h)) / (h * h * h * h);
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use smaller h for better accuracy", "Use taylor_expand for series expansion"],
+  };
+  return stampMeta(
+    {
+      expression: expr,
+      x,
+      h,
+      order,
+      f_of_x: Math.round(fx * 1e10) / 1e10,
+      derivative: Math.round(derivative * 1e8) / 1e8,
+      method: "five-point stencil",
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/numintegrate-tool.test.ts
+++ b/packages/mcp-server/src/numintegrate-tool.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { numericalIntegrate } from "./numintegrate-tool.js";
+
+describe("numericalIntegrate", () => {
+  it("integrates x^2 from 0 to 1 (should be 1/3)", async () => {
+    const r = await numericalIntegrate({
+      expression: "x^2",
+      a: 0,
+      b: 1,
+    }) as any;
+    expect(r.integral).toBeCloseTo(1 / 3, 6);
+  });
+
+  it("integrates constant 5 from 0 to 3 (should be 15)", async () => {
+    const r = await numericalIntegrate({
+      expression: "5",
+      a: 0,
+      b: 3,
+    }) as any;
+    expect(r.integral).toBeCloseTo(15, 6);
+  });
+
+  it("works with trapezoid method", async () => {
+    const r = await numericalIntegrate({
+      expression: "x",
+      a: 0,
+      b: 4,
+      method: "trapezoid",
+    }) as any;
+    expect(r.integral).toBeCloseTo(8, 6);
+  });
+
+  it("works with midpoint method", async () => {
+    const r = await numericalIntegrate({
+      expression: "x",
+      a: 0,
+      b: 2,
+      method: "midpoint",
+    }) as any;
+    expect(r.integral).toBeCloseTo(2, 4);
+  });
+
+  it("rejects a >= b", async () => {
+    await expect(
+      numericalIntegrate({ expression: "x", a: 5, b: 3 }),
+    ).rejects.toThrow("less than");
+  });
+
+  it("rejects invalid method", async () => {
+    await expect(
+      numericalIntegrate({ expression: "x", a: 0, b: 1, method: "rk4" }),
+    ).rejects.toThrow("method");
+  });
+
+  it("stamps meta", async () => {
+    const r = await numericalIntegrate({
+      expression: "1",
+      a: 0,
+      b: 1,
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/numintegrate-tool.ts
+++ b/packages/mcp-server/src/numintegrate-tool.ts
@@ -1,0 +1,74 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function numericalIntegrate(args: Record<string, unknown>) {
+  const expr = String(args.expression ?? "");
+  const a = Number(args.a);
+  const b = Number(args.b);
+  const n = Number(args.intervals ?? 1000);
+  const method = String(args.method ?? "simpson").toLowerCase();
+
+  if (!expr) throw new Error("expression is required (e.g. 'x^2 + 1').");
+  if (!Number.isFinite(a) || !Number.isFinite(b)) throw new Error("a and b must be finite numbers.");
+  if (a >= b) throw new Error("a must be less than b.");
+  if (n < 2 || n > 1000000) throw new Error("intervals must be between 2 and 1000000.");
+  if (!["trapezoid", "simpson", "midpoint"].includes(method)) {
+    throw new Error("method must be trapezoid, simpson, or midpoint.");
+  }
+
+  const evaluate = (val: number): number => {
+    const sanitized = expr
+      .replace(/\bx\b/g, `(${val})`)
+      .replace(/\^/g, "**");
+    const allowed = /^[\d+\-*/().eE\s]*$/;
+    if (!allowed.test(sanitized)) {
+      throw new Error("Expression contains unsupported characters. Use x, numbers, +, -, *, /, ^, ().");
+    }
+    const result = Function(`"use strict"; return (${sanitized})`)();
+    if (typeof result !== "number" || !Number.isFinite(result)) {
+      throw new Error(`Expression evaluated to non-finite at x=${val}.`);
+    }
+    return result;
+  };
+
+  const h = (b - a) / n;
+  let integral: number;
+
+  if (method === "trapezoid") {
+    let sum = (evaluate(a) + evaluate(b)) / 2;
+    for (let i = 1; i < n; i++) {
+      sum += evaluate(a + i * h);
+    }
+    integral = sum * h;
+  } else if (method === "midpoint") {
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+      sum += evaluate(a + (i + 0.5) * h);
+    }
+    integral = sum * h;
+  } else {
+    const steps = n % 2 === 0 ? n : n + 1;
+    const hs = (b - a) / steps;
+    let sum = evaluate(a) + evaluate(b);
+    for (let i = 1; i < steps; i++) {
+      sum += (i % 2 === 0 ? 2 : 4) * evaluate(a + i * hs);
+    }
+    integral = (sum * hs) / 3;
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Increase intervals for better accuracy", "Use numerical_diff for differentiation"],
+  };
+  return stampMeta(
+    {
+      expression: expr,
+      a,
+      b,
+      method,
+      intervals: n,
+      integral: Math.round(integral * 1e8) / 1e8,
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/spline-tool.test.ts
+++ b/packages/mcp-server/src/spline-tool.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { splineInterpolate } from "./spline-tool.js";
+
+describe("splineInterpolate", () => {
+  it("builds cubic spline segments", async () => {
+    const r = await splineInterpolate({
+      points: [
+        [0, 0],
+        [1, 1],
+        [2, 0],
+        [3, 1],
+      ],
+    }) as any;
+    expect(r.segment_count).toBe(3);
+    expect(r.point_count).toBe(4);
+    expect(r.segments.length).toBe(3);
+  });
+
+  it("evaluates at specific x values", async () => {
+    const r = await splineInterpolate({
+      points: [
+        [0, 0],
+        [1, 1],
+        [2, 4],
+      ],
+      eval_at: [0, 1, 2, 0.5],
+    }) as any;
+    expect(r.evaluated.length).toBe(4);
+    expect(r.evaluated[0].y).toBeCloseTo(0, 5);
+    expect(r.evaluated[1].y).toBeCloseTo(1, 5);
+    expect(r.evaluated[2].y).toBeCloseTo(4, 5);
+  });
+
+  it("evaluates a single x value", async () => {
+    const r = await splineInterpolate({
+      points: [
+        [0, 0],
+        [1, 1],
+        [2, 0],
+      ],
+      eval_at: 1,
+    }) as any;
+    expect(r.evaluated[0].y).toBeCloseTo(1, 5);
+  });
+
+  it("rejects fewer than 3 points", async () => {
+    await expect(
+      splineInterpolate({ points: [[0, 0], [1, 1]] }),
+    ).rejects.toThrow("at least 3");
+  });
+
+  it("rejects duplicate x values", async () => {
+    await expect(
+      splineInterpolate({
+        points: [
+          [0, 0],
+          [0, 1],
+          [1, 2],
+        ],
+      }),
+    ).rejects.toThrow("distinct");
+  });
+
+  it("stamps meta", async () => {
+    const r = await splineInterpolate({
+      points: [
+        [0, 0],
+        [1, 1],
+        [2, 0],
+      ],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/spline-tool.ts
+++ b/packages/mcp-server/src/spline-tool.ts
@@ -1,0 +1,106 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function splineInterpolate(args: Record<string, unknown>) {
+  const rawPoints = args.points as [number, number][];
+  if (!Array.isArray(rawPoints) || rawPoints.length < 3) {
+    throw new Error("points must be an array of at least 3 [x, y] pairs.");
+  }
+  if (rawPoints.length > 10000) {
+    throw new Error("Maximum 10000 points supported.");
+  }
+
+  const pts = rawPoints
+    .map((p) => ({ x: Number(p[0]), y: Number(p[1]) }))
+    .sort((a, b) => a.x - b.x);
+
+  for (let i = 1; i < pts.length; i++) {
+    if (pts[i].x === pts[i - 1].x) {
+      throw new Error("All x values must be distinct.");
+    }
+  }
+
+  const n = pts.length - 1;
+  const h: number[] = [];
+  for (let i = 0; i < n; i++) {
+    h.push(pts[i + 1].x - pts[i].x);
+  }
+
+  const alpha: number[] = [0];
+  for (let i = 1; i < n; i++) {
+    alpha.push(
+      (3 / h[i]) * (pts[i + 1].y - pts[i].y) -
+      (3 / h[i - 1]) * (pts[i].y - pts[i - 1].y),
+    );
+  }
+
+  const l = new Array(n + 1).fill(0);
+  const mu = new Array(n + 1).fill(0);
+  const z = new Array(n + 1).fill(0);
+  l[0] = 1;
+
+  for (let i = 1; i < n; i++) {
+    l[i] = 2 * (pts[i + 1].x - pts[i - 1].x) - h[i - 1] * mu[i - 1];
+    mu[i] = h[i] / l[i];
+    z[i] = (alpha[i] - h[i - 1] * z[i - 1]) / l[i];
+  }
+
+  l[n] = 1;
+  const c = new Array(n + 1).fill(0);
+  const b = new Array(n).fill(0);
+  const d = new Array(n).fill(0);
+
+  for (let j = n - 1; j >= 0; j--) {
+    c[j] = z[j] - mu[j] * c[j + 1];
+    b[j] =
+      (pts[j + 1].y - pts[j].y) / h[j] -
+      (h[j] * (c[j + 1] + 2 * c[j])) / 3;
+    d[j] = (c[j + 1] - c[j]) / (3 * h[j]);
+  }
+
+  const evalX = args.eval_at;
+  let evaluated: { x: number; y: number }[] | undefined;
+
+  if (evalX !== undefined) {
+    const xs = Array.isArray(evalX) ? (evalX as number[]) : [Number(evalX)];
+    evaluated = xs.map((x) => {
+      const xn = Number(x);
+      let seg = n - 1;
+      for (let i = 0; i < n; i++) {
+        if (xn <= pts[i + 1].x) {
+          seg = i;
+          break;
+        }
+      }
+      const dx = xn - pts[seg].x;
+      const y =
+        pts[seg].y + b[seg] * dx + c[seg] * dx * dx + d[seg] * dx * dx * dx;
+      return { x: xn, y: Math.round(y * 1e8) / 1e8 };
+    });
+  }
+
+  const segments = [];
+  for (let i = 0; i < n; i++) {
+    segments.push({
+      interval: [pts[i].x, pts[i + 1].x],
+      a: pts[i].y,
+      b: Math.round(b[i] * 1e8) / 1e8,
+      c: Math.round(c[i] * 1e8) / 1e8,
+      d: Math.round(d[i] * 1e8) / 1e8,
+    });
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use eval_at to evaluate the spline at specific x values", "Use interpolate_calc for simple linear interpolation"],
+  };
+  return stampMeta(
+    {
+      point_count: pts.length,
+      segment_count: n,
+      segments,
+      ...(evaluated ? { evaluated } : {}),
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -691,6 +691,13 @@ import { harmonicSeries } from "./harmonicseries-tool.js";
 import { piApprox } from "./piapprox-tool.js";
 import { taylorExpand } from "./taylor-tool.js";
 
+// ── batch 58: algorithms & data structures ──
+import { stringLcs } from "./lcs-tool.js";
+import { topoSort } from "./toposort-tool.js";
+import { convexHull } from "./convexhull-tool.js";
+import { knapsackSolve } from "./knapsack-tool.js";
+import { splineInterpolate } from "./spline-tool.js";
+
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
   nasaEarthImagery, nasaEpic,
@@ -10481,6 +10488,60 @@ export const ADDITIONAL_TOOLS = [
         x: { type: "number" as const, description: "Point to evaluate at." },
         terms: { type: "number" as const, description: "Number of terms (default 10, max 50)." },
       }, required: ["function", "x"],
+    },
+  },
+
+  // ── lcs-tool.ts ──────────────────────────────────────────────────────────────
+  {
+    name: "string_lcs",
+    description: "Find the longest common subsequence of two strings with similarity score.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        a: { type: "string" as const, description: "First string." },
+        b: { type: "string" as const, description: "Second string." },
+      }, required: ["a", "b"],
+    },
+  },
+  // ── toposort-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "topo_sort",
+    description: "Topological sort of a directed graph with cycle detection.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        edges: { type: "array" as const, description: "Array of [from, to] directed edge pairs.", items: { type: "array" as const, items: { type: "string" as const } } },
+      }, required: ["edges"],
+    },
+  },
+  // ── convexhull-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "convex_hull",
+    description: "Compute the convex hull of 2D points with area and perimeter.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        points: { type: "array" as const, description: "Array of [x, y] coordinate pairs.", items: { type: "array" as const, items: { type: "number" as const } } },
+      }, required: ["points"],
+    },
+  },
+  // ── knapsack-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "knapsack_solve",
+    description: "Solve the 0-1 knapsack problem: pick items to maximize value within a weight capacity.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        capacity: { type: "number" as const, description: "Maximum weight capacity (integer units, max 100000)." },
+        items: { type: "array" as const, description: "Array of { name?, weight, value } objects.", items: { type: "object" as const, properties: { name: { type: "string" as const }, weight: { type: "number" as const }, value: { type: "number" as const } }, required: ["weight", "value"] } },
+      }, required: ["capacity", "items"],
+    },
+  },
+  // ── spline-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "spline_interpolate",
+    description: "Natural cubic spline interpolation through data points, with optional evaluation.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        points: { type: "array" as const, description: "Array of [x, y] data points (at least 3, distinct x).", items: { type: "array" as const, items: { type: "number" as const } } },
+        eval_at: { description: "X value(s) to evaluate the spline at. Number or array of numbers." },
+      }, required: ["points"],
     },
   },
 
@@ -22191,6 +22252,13 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
 
   // taylor-tool.ts
   taylor_expand:             (args) => taylorExpand(args),
+
+  // batch 58: algorithms & data structures
+  string_lcs:                (args) => stringLcs(args),
+  topo_sort:                 (args) => topoSort(args),
+  convex_hull:               (args) => convexHull(args),
+  knapsack_solve:            (args) => knapsackSolve(args),
+  spline_interpolate:        (args) => splineInterpolate(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -698,6 +698,13 @@ import { convexHull } from "./convexhull-tool.js";
 import { knapsackSolve } from "./knapsack-tool.js";
 import { splineInterpolate } from "./spline-tool.js";
 
+// ── batch 59: graphs, linear algebra, calculus ──
+import { dijkstraPath } from "./dijkstra-tool.js";
+import { matrixDecomp } from "./matrixdecomp-tool.js";
+import { linearSolve } from "./linearsolve-tool.js";
+import { numericalDiff } from "./numdiff-tool.js";
+import { numericalIntegrate } from "./numintegrate-tool.js";
+
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
   nasaEarthImagery, nasaEpic,
@@ -10542,6 +10549,69 @@ export const ADDITIONAL_TOOLS = [
         points: { type: "array" as const, description: "Array of [x, y] data points (at least 3, distinct x).", items: { type: "array" as const, items: { type: "number" as const } } },
         eval_at: { description: "X value(s) to evaluate the spline at. Number or array of numbers." },
       }, required: ["points"],
+    },
+  },
+
+  // ── dijkstra-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "dijkstra_path",
+    description: "Find the shortest path between two nodes in a weighted graph (Dijkstra's algorithm).",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        source: { type: "string" as const, description: "Source node name." },
+        target: { type: "string" as const, description: "Target node name." },
+        edges: { type: "array" as const, description: "Array of [from, to, weight] triples.", items: { type: "array" as const } },
+        directed: { type: "boolean" as const, description: "Treat graph as directed (default false)." },
+      }, required: ["source", "target", "edges"],
+    },
+  },
+  // ── matrixdecomp-tool.ts ────────────────────────────────────────────────────
+  {
+    name: "matrix_decomp",
+    description: "Matrix decomposition and analysis: LU factorization, transpose, trace, or rank.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        matrix: { type: "array" as const, description: "2D array of numbers (the matrix).", items: { type: "array" as const, items: { type: "number" as const } } },
+        operation: { type: "string" as const, description: "Operation: lu, transpose, trace, or rank (default lu)." },
+      }, required: ["matrix"],
+    },
+  },
+  // ── linearsolve-tool.ts ─────────────────────────────────────────────────────
+  {
+    name: "linear_solve",
+    description: "Solve a system of linear equations Ax = b using Gaussian elimination with partial pivoting.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        matrix: { type: "array" as const, description: "Coefficient matrix A (square, 2D array).", items: { type: "array" as const, items: { type: "number" as const } } },
+        vector: { type: "array" as const, description: "Right-hand side vector b.", items: { type: "number" as const } },
+      }, required: ["matrix", "vector"],
+    },
+  },
+  // ── numdiff-tool.ts ─────────────────────────────────────────────────────────
+  {
+    name: "numerical_diff",
+    description: "Numerical differentiation of a math expression using five-point stencil (1st-4th order).",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        expression: { type: "string" as const, description: "Math expression in x (e.g. 'x^2 + 3*x')." },
+        x: { type: "number" as const, description: "Point to evaluate at." },
+        h: { type: "number" as const, description: "Step size (default 1e-7)." },
+        order: { type: "number" as const, description: "Derivative order: 1, 2, 3, or 4 (default 1)." },
+      }, required: ["expression", "x"],
+    },
+  },
+  // ── numintegrate-tool.ts ────────────────────────────────────────────────────
+  {
+    name: "numerical_integrate",
+    description: "Numerical integration of a math expression using Simpson's rule, trapezoid, or midpoint method.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        expression: { type: "string" as const, description: "Math expression in x (e.g. 'x^2 + 1')." },
+        a: { type: "number" as const, description: "Lower bound of integration." },
+        b: { type: "number" as const, description: "Upper bound of integration." },
+        method: { type: "string" as const, description: "Method: simpson (default), trapezoid, or midpoint." },
+        intervals: { type: "number" as const, description: "Number of intervals (default 1000, max 1000000)." },
+      }, required: ["expression", "a", "b"],
     },
   },
 
@@ -22259,6 +22329,13 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   convex_hull:               (args) => convexHull(args),
   knapsack_solve:            (args) => knapsackSolve(args),
   spline_interpolate:        (args) => splineInterpolate(args),
+
+  // batch 59: graphs, linear algebra, calculus
+  dijkstra_path:             (args) => dijkstraPath(args),
+  matrix_decomp:             (args) => matrixDecomp(args),
+  linear_solve:              (args) => linearSolve(args),
+  numerical_diff:            (args) => numericalDiff(args),
+  numerical_integrate:       (args) => numericalIntegrate(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/packages/mcp-server/src/toposort-tool.test.ts
+++ b/packages/mcp-server/src/toposort-tool.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { topoSort } from "./toposort-tool.js";
+
+describe("topoSort", () => {
+  it("sorts a DAG correctly", async () => {
+    const r = await topoSort({
+      edges: [
+        ["A", "B"],
+        ["A", "C"],
+        ["B", "D"],
+        ["C", "D"],
+      ],
+    }) as any;
+    const sorted = r.sorted as string[];
+    expect(sorted.indexOf("A")).toBeLessThan(sorted.indexOf("B"));
+    expect(sorted.indexOf("A")).toBeLessThan(sorted.indexOf("C"));
+    expect(sorted.indexOf("B")).toBeLessThan(sorted.indexOf("D"));
+    expect(r.has_cycle).toBe(false);
+    expect(r.node_count).toBe(4);
+  });
+
+  it("detects cycles", async () => {
+    const r = await topoSort({
+      edges: [
+        ["A", "B"],
+        ["B", "C"],
+        ["C", "A"],
+      ],
+    }) as any;
+    expect(r.has_cycle).toBe(true);
+    expect((r.cycle_nodes as string[]).length).toBeGreaterThan(0);
+  });
+
+  it("handles linear chain", async () => {
+    const r = await topoSort({
+      edges: [
+        ["1", "2"],
+        ["2", "3"],
+        ["3", "4"],
+      ],
+    }) as any;
+    expect(r.sorted).toEqual(["1", "2", "3", "4"]);
+    expect(r.has_cycle).toBe(false);
+  });
+
+  it("rejects empty edges", async () => {
+    await expect(topoSort({ edges: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await topoSort({ edges: [["a", "b"]] }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/toposort-tool.ts
+++ b/packages/mcp-server/src/toposort-tool.ts
@@ -1,0 +1,72 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function topoSort(args: Record<string, unknown>) {
+  const edges = args.edges as [string, string][] | undefined;
+  if (!Array.isArray(edges) || edges.length === 0) {
+    throw new Error("edges must be a non-empty array of [from, to] pairs.");
+  }
+  if (edges.length > 10000) {
+    throw new Error("Maximum 10000 edges supported.");
+  }
+
+  const adj = new Map<string, string[]>();
+  const inDeg = new Map<string, number>();
+  const nodes = new Set<string>();
+
+  for (const edge of edges) {
+    if (!Array.isArray(edge) || edge.length !== 2) {
+      throw new Error("Each edge must be a [from, to] pair.");
+    }
+    const [from, to] = [String(edge[0]), String(edge[1])];
+    nodes.add(from);
+    nodes.add(to);
+    if (!adj.has(from)) adj.set(from, []);
+    adj.get(from)!.push(to);
+    inDeg.set(to, (inDeg.get(to) ?? 0) + 1);
+    if (!inDeg.has(from)) inDeg.set(from, 0);
+  }
+
+  const queue: string[] = [];
+  for (const node of nodes) {
+    if ((inDeg.get(node) ?? 0) === 0) queue.push(node);
+  }
+  queue.sort();
+
+  const sorted: string[] = [];
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    sorted.push(node);
+    for (const neighbor of adj.get(node) ?? []) {
+      const deg = inDeg.get(neighbor)! - 1;
+      inDeg.set(neighbor, deg);
+      if (deg === 0) {
+        const idx = queue.findIndex((n) => n > neighbor);
+        if (idx === -1) queue.push(neighbor);
+        else queue.splice(idx, 0, neighbor);
+      }
+    }
+  }
+
+  const hasCycle = sorted.length < nodes.size;
+  const cycleNodes = hasCycle
+    ? [...nodes].filter((n) => !sorted.includes(n)).sort()
+    : [];
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: hasCycle
+      ? ["Remove edges causing cycles to get a valid ordering"]
+      : ["Use sorted order for scheduling or dependency resolution"],
+  };
+  return stampMeta(
+    {
+      sorted,
+      node_count: nodes.size,
+      edge_count: edges.length,
+      has_cycle: hasCycle,
+      cycle_nodes: cycleNodes,
+    },
+    meta,
+  );
+}

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -192,6 +192,8 @@ const NAME_OF = {
   piapprox: "Pi Approximation", taylor: "Taylor Series",
   lcs: "LCS (Longest Common Subsequence)", toposort: "Topological Sort",
   convexhull: "Convex Hull", knapsack: "Knapsack Solver", spline: "Spline Interpolation",
+  dijkstra: "Dijkstra Shortest Path", matrixdecomp: "Matrix Decomposition",
+  linearsolve: "Linear Solver", numdiff: "Numerical Differentiation", numintegrate: "Numerical Integration",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -569,6 +571,11 @@ const BLURB_OF = {
   convexhull: "Compute the convex hull of 2D points with area and perimeter.",
   knapsack: "Solve the 0-1 knapsack optimization problem for items with weight and value.",
   spline: "Natural cubic spline interpolation through data points with evaluation.",
+  dijkstra: "Find the shortest path between two nodes in a weighted graph.",
+  matrixdecomp: "Matrix decomposition and analysis: LU, transpose, trace, rank.",
+  linearsolve: "Solve systems of linear equations Ax = b with partial pivoting.",
+  numdiff: "Numerical differentiation using five-point stencil (1st through 4th order).",
+  numintegrate: "Numerical integration using Simpson, trapezoid, or midpoint rule.",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -739,6 +746,7 @@ const DOMAIN_OF = {
   dotproduct: "local", crossproduct: "local", weightedmean: "local", variancecalc: "local", poisson: "local",
   expgrowth: "local", geomseries: "local", harmonicseries: "local", piapprox: "local", taylor: "local",
   lcs: "local", toposort: "local", convexhull: "local", knapsack: "local", spline: "local",
+  dijkstra: "local", matrixdecomp: "local", linearsolve: "local", numdiff: "local", numintegrate: "local",
 };
 
 function titleCase(slug) {

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -190,6 +190,8 @@ const NAME_OF = {
   poisson: "Poisson Distribution", expgrowth: "Exponential Growth",
   geomseries: "Geometric Series", harmonicseries: "Harmonic Series",
   piapprox: "Pi Approximation", taylor: "Taylor Series",
+  lcs: "LCS (Longest Common Subsequence)", toposort: "Topological Sort",
+  convexhull: "Convex Hull", knapsack: "Knapsack Solver", spline: "Spline Interpolation",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -562,6 +564,11 @@ const BLURB_OF = {
   harmonicseries: "Partial sums of the harmonic series with ln approximation.",
   piapprox: "Approximate pi using Leibniz, Nilakantha, and Wallis formulas.",
   taylor: "Taylor series approximation for exp, sin, cos, ln(1+x), and atan.",
+  lcs: "Find the longest common subsequence of two strings with similarity score.",
+  toposort: "Topological sort of a directed graph with cycle detection.",
+  convexhull: "Compute the convex hull of 2D points with area and perimeter.",
+  knapsack: "Solve the 0-1 knapsack optimization problem for items with weight and value.",
+  spline: "Natural cubic spline interpolation through data points with evaluation.",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -731,6 +738,7 @@ const DOMAIN_OF = {
   midpoint: "local", slopeintercept: "local", logbase: "local", nthroot: "local", areacalc: "local",
   dotproduct: "local", crossproduct: "local", weightedmean: "local", variancecalc: "local", poisson: "local",
   expgrowth: "local", geomseries: "local", harmonicseries: "local", piapprox: "local", taylor: "local",
+  lcs: "local", toposort: "local", convexhull: "local", knapsack: "local", spline: "local",
 };
 
 function titleCase(slug) {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 530,
-  "toolCount": 1452,
+  "appCount": 535,
+  "toolCount": 1457,
   "categories": [
     "AI",
     "Books",
@@ -2588,6 +2588,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "dijkstra",
+      "name": "Dijkstra Shortest Path",
+      "category": "Utilities",
+      "blurb": "Find the shortest path between two nodes in a weighted graph.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "dijkstra_path",
+          "description": "Find the shortest path between two nodes in a weighted graph (Dijkstra's algorithm)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "discogs",
@@ -5542,6 +5558,22 @@
       "hardened": false
     },
     {
+      "slug": "linearsolve",
+      "name": "Linear Solver",
+      "category": "Utilities",
+      "blurb": "Solve systems of linear equations Ax = b with partial pivoting.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "linear_solve",
+          "description": "Solve a system of linear equations Ax = b using Gaussian elimination with partial pivoting."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "logbase",
       "name": "Logarithm Calculator",
       "category": "Utilities",
@@ -5864,6 +5896,22 @@
         {
           "name": "matrix_operate",
           "description": "Perform matrix operations: add, multiply, transpose, or determinant."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "matrixdecomp",
+      "name": "Matrix Decomposition",
+      "category": "Utilities",
+      "blurb": "Matrix decomposition and analysis: LU, transpose, trace, rank.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "matrix_decomp",
+          "description": "Matrix decomposition and analysis: LU factorization, transpose, trace, or rank."
         }
       ],
       "level": 5,
@@ -6643,6 +6691,38 @@
         }
       ],
       "level": null,
+      "hardened": false
+    },
+    {
+      "slug": "numdiff",
+      "name": "Numerical Differentiation",
+      "category": "Utilities",
+      "blurb": "Numerical differentiation using five-point stencil (1st through 4th order).",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "numerical_diff",
+          "description": "Numerical differentiation of a math expression using five-point stencil (1st-4th order)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "numintegrate",
+      "name": "Numerical Integration",
+      "category": "Utilities",
+      "blurb": "Numerical integration using Simpson, trapezoid, or midpoint rule.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "numerical_integrate",
+          "description": "Numerical integration of a math expression using Simpson's rule, trapezoid, or midpoint method."
+        }
+      ],
+      "level": 5,
       "hardened": false
     },
     {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 525,
-  "toolCount": 1447,
+  "appCount": 530,
+  "toolCount": 1452,
   "categories": [
     "AI",
     "Books",
@@ -1956,6 +1956,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "convexhull",
+      "name": "Convex Hull",
+      "category": "Utilities",
+      "blurb": "Compute the convex hull of 2D points with area and perimeter.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "convex_hull",
+          "description": "Compute the convex hull of 2D points with area and perimeter."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "copypass",
@@ -5170,6 +5186,22 @@
       "hardened": true
     },
     {
+      "slug": "knapsack",
+      "name": "Knapsack Solver",
+      "category": "Utilities",
+      "blurb": "Solve the 0-1 knapsack optimization problem for items with weight and value.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "knapsack_solve",
+          "description": "Solve the 0-1 knapsack problem: pick items to maximize value within a weight capacity."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "languagetool",
       "name": "LanguageTool",
       "category": "Utilities",
@@ -5228,6 +5260,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "lcs",
+      "name": "LCS (Longest Common Subsequence)",
+      "category": "Utilities",
+      "blurb": "Find the longest common subsequence of two strings with similarity score.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "string_lcs",
+          "description": "Find the longest common subsequence of two strings with similarity score."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "legalpass",
@@ -9566,6 +9614,22 @@
       "hardened": true
     },
     {
+      "slug": "spline",
+      "name": "Spline Interpolation",
+      "category": "Utilities",
+      "blurb": "Natural cubic spline interpolation through data points with evaluation.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "spline_interpolate",
+          "description": "Natural cubic spline interpolation through data points, with optional evaluation."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "splitwise",
       "name": "Splitwise",
       "category": "Money & payments",
@@ -10684,6 +10748,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "toposort",
+      "name": "Topological Sort",
+      "category": "Utilities",
+      "blurb": "Topological sort of a directed graph with cycle detection.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "topo_sort",
+          "description": "Topological sort of a directed graph with cycle detection."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "trello",

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-09T12:28:00.000Z",
+  "updatedAt": "2026-06-09T14:00:00.000Z",
   "results": {
     "abn": {
       "status": "attention",
@@ -3982,6 +3982,36 @@
       "note": "taylor_expand computes Taylor series for exp, sin, cos, ln1p, atan. Local computation.",
       "testedAt": "2026-06-09T13:11:00.000Z",
       "toolsTested": ["taylor_expand"]
+    },
+    "lcs": {
+      "status": "pass",
+      "note": "string_lcs finds longest common subsequence with similarity score. Local computation.",
+      "testedAt": "2026-06-09T14:00:00.000Z",
+      "toolsTested": ["string_lcs"]
+    },
+    "toposort": {
+      "status": "pass",
+      "note": "topo_sort performs topological sorting with cycle detection. Local computation.",
+      "testedAt": "2026-06-09T14:00:00.000Z",
+      "toolsTested": ["topo_sort"]
+    },
+    "convexhull": {
+      "status": "pass",
+      "note": "convex_hull computes convex hull of 2D points with area and perimeter. Local computation.",
+      "testedAt": "2026-06-09T14:00:00.000Z",
+      "toolsTested": ["convex_hull"]
+    },
+    "knapsack": {
+      "status": "pass",
+      "note": "knapsack_solve solves 0-1 knapsack optimization with backtracking. Local computation.",
+      "testedAt": "2026-06-09T14:00:00.000Z",
+      "toolsTested": ["knapsack_solve"]
+    },
+    "spline": {
+      "status": "pass",
+      "note": "spline_interpolate builds natural cubic spline with evaluation. Local computation.",
+      "testedAt": "2026-06-09T14:00:00.000Z",
+      "toolsTested": ["spline_interpolate"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-09T14:00:00.000Z",
+  "updatedAt": "2026-06-09T14:30:00.000Z",
   "results": {
     "abn": {
       "status": "attention",
@@ -4012,6 +4012,36 @@
       "note": "spline_interpolate builds natural cubic spline with evaluation. Local computation.",
       "testedAt": "2026-06-09T14:00:00.000Z",
       "toolsTested": ["spline_interpolate"]
+    },
+    "dijkstra": {
+      "status": "pass",
+      "note": "dijkstra_path finds shortest path in weighted graph. Local computation.",
+      "testedAt": "2026-06-09T14:30:00.000Z",
+      "toolsTested": ["dijkstra_path"]
+    },
+    "matrixdecomp": {
+      "status": "pass",
+      "note": "matrix_decomp performs LU, transpose, trace, rank operations. Local computation.",
+      "testedAt": "2026-06-09T14:30:00.000Z",
+      "toolsTested": ["matrix_decomp"]
+    },
+    "linearsolve": {
+      "status": "pass",
+      "note": "linear_solve solves Ax=b via Gaussian elimination with partial pivoting. Local computation.",
+      "testedAt": "2026-06-09T14:30:00.000Z",
+      "toolsTested": ["linear_solve"]
+    },
+    "numdiff": {
+      "status": "pass",
+      "note": "numerical_diff computes derivatives using five-point stencil. Local computation.",
+      "testedAt": "2026-06-09T14:30:00.000Z",
+      "toolsTested": ["numerical_diff"]
+    },
+    "numintegrate": {
+      "status": "pass",
+      "note": "numerical_integrate computes definite integrals (Simpson/trapezoid/midpoint). Local computation.",
+      "testedAt": "2026-06-09T14:30:00.000Z",
+      "toolsTested": ["numerical_integrate"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."


### PR DESCRIPTION
## Summary

- **Batch 58** (algorithms & data structures): `string_lcs`, `topo_sort`, `convex_hull`, `knapsack_solve`, `spline_interpolate`
- **Batch 59** (graphs, linear algebra, calculus): `dijkstra_path`, `matrix_decomp`, `linear_solve`, `numerical_diff`, `numerical_integrate`

Catalog: 525 -> 535 apps, 1447 -> 1457 tools. All 60 tests pass, type check clean.

All tools are pure local computation (no API calls, no auth required).

## Test plan

- [x] 60 unit tests across 10 test files (all pass)
- [x] TypeScript type check passes
- [x] Regeneration pipeline run in order (tool-index -> depth-ladder -> app-catalog -> brainmap)
- [x] app-test-results.json updated with pass status for all 10 new apps

https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez)_