### PR TITLE
feat: add batch 60 local connectors (4 new tools) - 539 apps

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 961,
+    "inventory": 965,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 536,
+    "tools": 540,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 536
+      "count": 540
     },
     {
       "id": "rooms",
@@ -4532,6 +4532,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-bezier-packages-mcp-server-src-bezier-tool-ts-no-route",
+      "division": "Tools",
+      "name": "bezier",
+      "kind": "MCP tool",
+      "meaning": "bezier MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/bezier-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-bgg-packages-mcp-server-src-bgg-tool-ts-no-route",
       "division": "Tools",
       "name": "bgg",
@@ -5782,6 +5792,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-fft-packages-mcp-server-src-fft-tool-ts-no-route",
+      "division": "Tools",
+      "name": "fft",
+      "kind": "MCP tool",
+      "meaning": "fft MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/fft-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-fibonacci-packages-mcp-server-src-fibonacci-tool-ts-no-route",
       "division": "Tools",
       "name": "fibonacci",
@@ -6888,6 +6908,16 @@
       "kind": "MCP tool",
       "meaning": "mastodon MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/mastodon-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-matinverse-packages-mcp-server-src-matinverse-tool-ts-no-route",
+      "division": "Tools",
+      "name": "matinverse",
+      "kind": "MCP tool",
+      "meaning": "matinverse MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/matinverse-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8268,6 +8298,16 @@
       "kind": "MCP tool",
       "meaning": "roman MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/roman-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-rootfind-packages-mcp-server-src-rootfind-tool-ts-no-route",
+      "division": "Tools",
+      "name": "rootfind",
+      "kind": "MCP tool",
+      "meaning": "rootfind MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/rootfind-tool.ts",
       "route": "",
       "tags": []
     },
@@ -10471,6 +10511,11 @@
       "packages/mcp-server/src/baseconvert-tool.ts"
     ],
     [
+      "bezier",
+      "bezier MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/bezier-tool.ts"
+    ],
+    [
       "bgg",
       "bgg MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/bgg-tool.ts"
@@ -11096,6 +11141,11 @@
       "packages/mcp-server/src/feedly-tool.ts"
     ],
     [
+      "fft",
+      "fft MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/fft-tool.ts"
+    ],
+    [
       "fibonacci",
       "fibonacci MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/fibonacci-tool.ts"
@@ -11649,6 +11699,11 @@
       "mastodon",
       "mastodon MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/mastodon-tool.ts"
+    ],
+    [
+      "matinverse",
+      "matinverse MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/matinverse-tool.ts"
     ],
     [
       "matrix",
@@ -12339,6 +12394,11 @@
       "roman",
       "roman MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/roman-tool.ts"
+    ],
+    [
+      "rootfind",
+      "rootfind MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/rootfind-tool.ts"
     ],
     [
       "rot13",
@@ -14199,6 +14259,11 @@
       "bytes": 1246
     },
     {
+      "source": "packages/mcp-server/src/bezier-tool.ts",
+      "hash": "29ff88e26cbb",
+      "bytes": 2561
+    },
+    {
       "source": "packages/mcp-server/src/bgg-tool.ts",
       "hash": "f7014933783a",
       "bytes": 12903
@@ -14227,11 +14292,6 @@
       "source": "packages/mcp-server/src/binomprob-tool.ts",
       "hash": "08174a2866e7",
       "bytes": 1770
-    },
-    {
-      "source": "packages/mcp-server/src/bitbucket-tool.ts",
-      "hash": "a6a405951262",
-      "bytes": 4388
     },
     {
       "source": ".github/workflows/apply-migrations.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -202,13 +202,13 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/bandsintown-tool.ts | f56d1929e864 | 4850 |
 | packages/mcp-server/src/base64-tool.ts | b93e3d17577c | 1174 |
 | packages/mcp-server/src/baseconvert-tool.ts | bbfa716f0f7c | 1246 |
+| packages/mcp-server/src/bezier-tool.ts | 29ff88e26cbb | 2561 |
 | packages/mcp-server/src/bgg-tool.ts | f7014933783a | 12903 |
 | packages/mcp-server/src/bgpview-tool.ts | c97cbd66581b | 2523 |
 | packages/mcp-server/src/bible-tool.ts | 94f62f2fa1c1 | 2338 |
 | packages/mcp-server/src/bibleverse-tool.ts | c5c118d0eb27 | 1698 |
 | packages/mcp-server/src/binaryconv-tool.ts | b09d86831da2 | 1337 |
 | packages/mcp-server/src/binomprob-tool.ts | 08174a2866e7 | 1770 |
-| packages/mcp-server/src/bitbucket-tool.ts | a6a405951262 | 4388 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
 | .github/workflows/autonomous-runner.yml | 942080b620ac | 15338 |
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 536 |
+| Tools | MCP and gateway capabilities available to seats. | 540 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -403,6 +403,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | bandsintown | bandsintown MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bandsintown-tool.ts |
 | base64 | base64 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/base64-tool.ts |
 | baseconvert | baseconvert MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/baseconvert-tool.ts |
+| bezier | bezier MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bezier-tool.ts |
 | bgg | bgg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bgg-tool.ts |
 | bgpview | bgpview MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bgpview-tool.ts |
 | bible | bible MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bible-tool.ts |
@@ -528,6 +529,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | fakerapi | fakerapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fakerapi-tool.ts |
 | fakestoreapi | fakestoreapi MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fakestoreapi-tool.ts |
 | feedly | feedly MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/feedly-tool.ts |
+| fft | fft MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fft-tool.ts |
 | fibonacci | fibonacci MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fibonacci-tool.ts |
 | fidelitycopy | fidelitycopy MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fidelitycopy-tool.ts |
 | figma | figma MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/figma-tool.ts |
@@ -639,6 +641,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | markdowntable | markdowntable MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/markdowntable-tool.ts |
 | markov | markov MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/markov-tool.ts |
 | mastodon | mastodon MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mastodon-tool.ts |
+| matinverse | matinverse MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/matinverse-tool.ts |
 | matrix | matrix MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/matrix-tool.ts |
 | matrixdecomp | matrixdecomp MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/matrixdecomp-tool.ts |
 | mcsrvstat | mcsrvstat MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mcsrvstat-tool.ts |
@@ -777,6 +780,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | ripe | ripe MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ripe-tool.ts |
 | robohash | robohash MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/robohash-tool.ts |
 | roman | roman MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/roman-tool.ts |
+| rootfind | rootfind MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rootfind-tool.ts |
 | rot13 | rot13 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rot13-tool.ts |
 | runlength | runlength MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/runlength-tool.ts |
 | runway | runway MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/runway-tool.ts |
@@ -1355,6 +1359,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | bandsintown | bandsintown MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bandsintown-tool.ts |
 | Tools | MCP tool | base64 | base64 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/base64-tool.ts |
 | Tools | MCP tool | baseconvert | baseconvert MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/baseconvert-tool.ts |
+| Tools | MCP tool | bezier | bezier MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bezier-tool.ts |
 | Tools | MCP tool | bgg | bgg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bgg-tool.ts |
 | Tools | MCP tool | bgpview | bgpview MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bgpview-tool.ts |
 | Tools | MCP tool | bible | bible MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bible-tool.ts |
@@ -1480,6 +1485,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | fakerapi | fakerapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fakerapi-tool.ts |
 | Tools | MCP tool | fakestoreapi | fakestoreapi MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fakestoreapi-tool.ts |
 | Tools | MCP tool | feedly | feedly MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/feedly-tool.ts |
+| Tools | MCP tool | fft | fft MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fft-tool.ts |
 | Tools | MCP tool | fibonacci | fibonacci MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fibonacci-tool.ts |
 | Tools | MCP tool | fidelitycopy | fidelitycopy MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fidelitycopy-tool.ts |
 | Tools | MCP tool | figma | figma MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/figma-tool.ts |
@@ -1591,6 +1597,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | markdowntable | markdowntable MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/markdowntable-tool.ts |
 | Tools | MCP tool | markov | markov MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/markov-tool.ts |
 | Tools | MCP tool | mastodon | mastodon MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mastodon-tool.ts |
+| Tools | MCP tool | matinverse | matinverse MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/matinverse-tool.ts |
 | Tools | MCP tool | matrix | matrix MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/matrix-tool.ts |
 | Tools | MCP tool | matrixdecomp | matrixdecomp MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/matrixdecomp-tool.ts |
 | Tools | MCP tool | mcsrvstat | mcsrvstat MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mcsrvstat-tool.ts |
@@ -1729,6 +1736,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | ripe | ripe MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ripe-tool.ts |
 | Tools | MCP tool | robohash | robohash MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/robohash-tool.ts |
 | Tools | MCP tool | roman | roman MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/roman-tool.ts |
+| Tools | MCP tool | rootfind | rootfind MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rootfind-tool.ts |
 | Tools | MCP tool | rot13 | rot13 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rot13-tool.ts |
 | Tools | MCP tool | runlength | runlength MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/runlength-tool.ts |
 | Tools | MCP tool | runway | runway MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/runway-tool.ts |

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -640,6 +640,26 @@
     }
   },
   {
+    "connector": "bezier",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "bgg",
     "level": 5,
     "levelName": "Agentic",
@@ -2860,6 +2880,26 @@
     }
   },
   {
+    "connector": "fft",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "fibonacci",
     "level": 5,
     "levelName": "Agentic",
@@ -4801,6 +4841,26 @@
   },
   {
     "connector": "markov",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "matinverse",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,
@@ -7241,6 +7301,26 @@
   },
   {
     "connector": "roman",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "rootfind",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (510 external connectors)
+## Distribution (514 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 471 | 92% |
+| L5 | Agentic | 475 | 92% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 510 (47%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 514 (47%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 471 of 474 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 475 of 478 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -55,6 +55,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `balldontlie` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `base64` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `baseconvert` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `bezier` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `bgpview` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `bibleverse` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `binaryconv` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -119,6 +120,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `expgrowth` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `fakerapi` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `fakestoreapi` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `fft` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `fibonacci` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `finalspace` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `fishwatch` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -176,6 +178,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `markdown` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `markdowntable` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `markov` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `matinverse` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `matrix` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `matrixdecomp` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mcsrvstat` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -254,6 +257,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `ripe` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `robohash` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `roman` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `rootfind` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `rot13` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `runlength` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `semver` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -343,6 +347,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `bandsintown` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `base64` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `baseconvert` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `bezier` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bgg` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `bgpview` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `bible` | Yes | - | - | Yes | Yes | no-memory |
@@ -454,6 +459,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `expgrowth` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `fakerapi` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `fakestoreapi` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `fft` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `fibonacci` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `figma` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `finalspace` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -552,6 +558,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `markdown` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `markdowntable` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `markov` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `matinverse` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `matrix` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `matrixdecomp` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `mcsrvstat` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -674,6 +681,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `ripe` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `robohash` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `roman` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `rootfind` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `rot13` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `runlength` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `runway` | Yes | - | - | Yes | Yes | no-memory |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -546,6 +546,16 @@
     ]
   },
   {
+    "app": "bezier",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "bezier_curve",
+        "description": "Compute a Bezier curve from control points with arc length and optional evaluation."
+      }
+    ]
+  },
+  {
     "app": "bgg",
     "category": "Gaming",
     "tools": [
@@ -2628,6 +2638,16 @@
     ]
   },
   {
+    "app": "fft",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "fft_transform",
+        "description": "Fast Fourier Transform (Cooley-Tukey radix-2) with optional inverse."
+      }
+    ]
+  },
+  {
     "app": "fibonacci",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4416,6 +4436,16 @@
       {
         "name": "mastodon_action",
         "description": "Perform a Mastodon action: mastodon_post, mastodon_read_timeline, mastodon_reply, mastodon_boost, mastodon_favorite, mastodon_search, mastodon_profile, mastodon_follow, mastodon_notifications."
+      }
+    ]
+  },
+  {
+    "app": "matinverse",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "matrix_inverse",
+        "description": "Compute the inverse and determinant of a square matrix using Gauss-Jordan elimination."
       }
     ]
   },
@@ -6696,6 +6726,16 @@
       {
         "name": "roman_convert",
         "description": "Convert between Roman numerals and decimal numbers."
+      }
+    ]
+  },
+  {
+    "app": "rootfind",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "root_find",
+        "description": "Find roots of a math expression using Newton's method or bisection."
       }
     ]
   },

--- a/packages/mcp-server/src/bezier-tool.test.ts
+++ b/packages/mcp-server/src/bezier-tool.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { bezierCurve } from "./bezier-tool.js";
+
+describe("bezierCurve", () => {
+  it("computes linear Bezier (straight line)", async () => {
+    const r = await bezierCurve({
+      control_points: [[0, 0], [10, 10]],
+      steps: 10,
+    }) as any;
+    expect(r.degree).toBe(1);
+    expect(r.curve[0]).toEqual([0, 0]);
+    expect(r.curve[10]).toEqual([10, 10]);
+    expect(r.curve[5][0]).toBeCloseTo(5, 4);
+  });
+
+  it("computes quadratic Bezier", async () => {
+    const r = await bezierCurve({
+      control_points: [[0, 0], [5, 10], [10, 0]],
+      steps: 2,
+    }) as any;
+    expect(r.degree).toBe(2);
+    expect(r.curve[1][0]).toBeCloseTo(5, 4);
+    expect(r.curve[1][1]).toBeCloseTo(5, 4);
+  });
+
+  it("evaluates at specific t values", async () => {
+    const r = await bezierCurve({
+      control_points: [[0, 0], [10, 0]],
+      eval_at: [0, 0.5, 1],
+    }) as any;
+    expect(r.evaluated[0].x).toBe(0);
+    expect(r.evaluated[1].x).toBe(5);
+    expect(r.evaluated[2].x).toBe(10);
+  });
+
+  it("computes arc length", async () => {
+    const r = await bezierCurve({
+      control_points: [[0, 0], [10, 0]],
+      steps: 100,
+    }) as any;
+    expect(r.arc_length).toBeCloseTo(10, 4);
+  });
+
+  it("rejects fewer than 2 points", async () => {
+    await expect(
+      bezierCurve({ control_points: [[0, 0]] }),
+    ).rejects.toThrow("at least 2");
+  });
+
+  it("stamps meta", async () => {
+    const r = await bezierCurve({
+      control_points: [[0, 0], [1, 1]],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/bezier-tool.ts
+++ b/packages/mcp-server/src/bezier-tool.ts
@@ -1,0 +1,85 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function bezierCurve(args: Record<string, unknown>) {
+  const points = args.control_points as [number, number][];
+  if (!Array.isArray(points) || points.length < 2) {
+    throw new Error("control_points must have at least 2 [x, y] pairs.");
+  }
+  if (points.length > 20) {
+    throw new Error("Maximum 20 control points supported.");
+  }
+
+  const steps = Math.min(Math.max(Number(args.steps ?? 50), 2), 1000);
+
+  const pts = points.map((p) => {
+    if (!Array.isArray(p) || p.length < 2) throw new Error("Each point must be [x, y].");
+    return { x: Number(p[0]), y: Number(p[1]) };
+  });
+
+  const n = pts.length - 1;
+
+  const binomials: number[] = new Array(n + 1);
+  binomials[0] = 1;
+  for (let i = 1; i <= n; i++) {
+    binomials[i] = (binomials[i - 1] * (n - i + 1)) / i;
+  }
+
+  const curve: { x: number; y: number }[] = [];
+  for (let s = 0; s <= steps; s++) {
+    const t = s / steps;
+    let x = 0;
+    let y = 0;
+    for (let i = 0; i <= n; i++) {
+      const basis = binomials[i] * Math.pow(1 - t, n - i) * Math.pow(t, i);
+      x += basis * pts[i].x;
+      y += basis * pts[i].y;
+    }
+    curve.push({
+      x: Math.round(x * 1e6) / 1e6,
+      y: Math.round(y * 1e6) / 1e6,
+    });
+  }
+
+  let arcLength = 0;
+  for (let i = 1; i < curve.length; i++) {
+    arcLength += Math.hypot(curve[i].x - curve[i - 1].x, curve[i].y - curve[i - 1].y);
+  }
+
+  const evalT = args.eval_at;
+  let evaluated: { t: number; x: number; y: number }[] | undefined;
+  if (evalT !== undefined) {
+    const ts = Array.isArray(evalT) ? (evalT as number[]) : [Number(evalT)];
+    evaluated = ts.map((t) => {
+      const tv = Math.max(0, Math.min(1, Number(t)));
+      let x = 0;
+      let y = 0;
+      for (let i = 0; i <= n; i++) {
+        const basis = binomials[i] * Math.pow(1 - tv, n - i) * Math.pow(tv, i);
+        x += basis * pts[i].x;
+        y += basis * pts[i].y;
+      }
+      return {
+        t: tv,
+        x: Math.round(x * 1e6) / 1e6,
+        y: Math.round(y * 1e6) / 1e6,
+      };
+    });
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use eval_at to sample at specific t values", "Use spline_interpolate for data fitting"],
+  };
+  return stampMeta(
+    {
+      degree: n,
+      control_points: pts.map((p) => [p.x, p.y]),
+      steps,
+      curve: curve.map((p) => [p.x, p.y]),
+      arc_length: Math.round(arcLength * 1e6) / 1e6,
+      ...(evaluated ? { evaluated } : {}),
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/fft-tool.test.ts
+++ b/packages/mcp-server/src/fft-tool.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { fftTransform } from "./fft-tool.js";
+
+describe("fftTransform", () => {
+  it("transforms a simple signal", async () => {
+    const r = await fftTransform({ signal: [1, 0, 1, 0] }) as any;
+    expect(r.padded_length).toBe(4);
+    expect(r.real[0]).toBeCloseTo(2, 5);
+    expect(r.magnitudes[0]).toBeCloseTo(2, 5);
+  });
+
+  it("transforms constant signal", async () => {
+    const r = await fftTransform({ signal: [3, 3, 3, 3] }) as any;
+    expect(r.real[0]).toBeCloseTo(12, 5);
+    expect(r.magnitudes[1]).toBeCloseTo(0, 5);
+  });
+
+  it("handles inverse transform of real-only input", async () => {
+    const r = await fftTransform({ signal: [1, 0, 1, 0], inverse: true }) as any;
+    expect(r.inverse).toBe(true);
+    expect(r.padded_length).toBe(4);
+  });
+
+  it("zero-pads to power of 2", async () => {
+    const r = await fftTransform({ signal: [1, 2, 3] }) as any;
+    expect(r.input_length).toBe(3);
+    expect(r.padded_length).toBe(4);
+  });
+
+  it("rejects empty signal", async () => {
+    await expect(fftTransform({ signal: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await fftTransform({ signal: [1, 0] }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/fft-tool.ts
+++ b/packages/mcp-server/src/fft-tool.ts
@@ -1,0 +1,86 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function fftTransform(args: Record<string, unknown>) {
+  const input = args.signal as number[];
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new Error("signal must be a non-empty array of numbers.");
+  }
+
+  let n = 1;
+  while (n < input.length) n *= 2;
+  const re = new Array(n).fill(0);
+  const im = new Array(n).fill(0);
+  for (let i = 0; i < input.length; i++) re[i] = Number(input[i]);
+
+  if (n > 65536) throw new Error("Signal length must be 65536 or fewer (after zero-padding).");
+
+  const inverse = !!args.inverse;
+  const dir = inverse ? -1 : 1;
+
+  for (let i = 0, j = 0; i < n; i++) {
+    if (i < j) {
+      [re[i], re[j]] = [re[j], re[i]];
+      [im[i], im[j]] = [im[j], im[i]];
+    }
+    let bit = n >> 1;
+    while (bit & j) {
+      j ^= bit;
+      bit >>= 1;
+    }
+    j ^= bit;
+  }
+
+  for (let len = 2; len <= n; len *= 2) {
+    const angle = (dir * 2 * Math.PI) / len;
+    const wRe = Math.cos(angle);
+    const wIm = Math.sin(angle);
+    for (let i = 0; i < n; i += len) {
+      let curRe = 1;
+      let curIm = 0;
+      for (let j = 0; j < len / 2; j++) {
+        const uRe = re[i + j];
+        const uIm = im[i + j];
+        const vRe = re[i + j + len / 2] * curRe - im[i + j + len / 2] * curIm;
+        const vIm = re[i + j + len / 2] * curIm + im[i + j + len / 2] * curRe;
+        re[i + j] = uRe + vRe;
+        im[i + j] = uIm + vIm;
+        re[i + j + len / 2] = uRe - vRe;
+        im[i + j + len / 2] = uIm - vIm;
+        const tmpRe = curRe * wRe - curIm * wIm;
+        curIm = curRe * wIm + curIm * wRe;
+        curRe = tmpRe;
+      }
+    }
+  }
+
+  if (inverse) {
+    for (let i = 0; i < n; i++) {
+      re[i] /= n;
+      im[i] /= n;
+    }
+  }
+
+  const magnitudes = re.map((r, i) =>
+    Math.round(Math.sqrt(r * r + im[i] * im[i]) * 1e8) / 1e8,
+  );
+
+  const roundedRe = re.map((v) => Math.round(v * 1e8) / 1e8);
+  const roundedIm = im.map((v) => Math.round(v * 1e8) / 1e8);
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Magnitudes show frequency strength", "Set inverse=true to reconstruct signal from spectrum"],
+  };
+  return stampMeta(
+    {
+      real: roundedRe,
+      imaginary: roundedIm,
+      magnitudes,
+      input_length: input.length,
+      padded_length: n,
+      inverse,
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/matinverse-tool.test.ts
+++ b/packages/mcp-server/src/matinverse-tool.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { matrixInverse } from "./matinverse-tool.js";
+
+describe("matrixInverse", () => {
+  it("inverts 2x2 identity", async () => {
+    const r = await matrixInverse({
+      matrix: [[1, 0], [0, 1]],
+    }) as any;
+    expect(r.inverse).toEqual([[1, 0], [0, 1]]);
+    expect(r.determinant).toBe(1);
+  });
+
+  it("inverts 2x2 matrix", async () => {
+    const r = await matrixInverse({
+      matrix: [[2, 1], [7, 4]],
+    }) as any;
+    expect(r.inverse[0][0]).toBeCloseTo(4, 6);
+    expect(r.inverse[0][1]).toBeCloseTo(-1, 6);
+    expect(r.inverse[1][0]).toBeCloseTo(-7, 6);
+    expect(r.inverse[1][1]).toBeCloseTo(2, 6);
+    expect(r.determinant).toBeCloseTo(1, 6);
+  });
+
+  it("inverts 3x3 matrix", async () => {
+    const r = await matrixInverse({
+      matrix: [
+        [1, 2, 3],
+        [0, 1, 4],
+        [5, 6, 0],
+      ],
+    }) as any;
+    expect(r.size).toBe(3);
+    expect(r.determinant).toBeCloseTo(1, 4);
+  });
+
+  it("rejects singular matrix", async () => {
+    await expect(
+      matrixInverse({ matrix: [[1, 2], [2, 4]] }),
+    ).rejects.toThrow("singular");
+  });
+
+  it("rejects non-square matrix", async () => {
+    await expect(
+      matrixInverse({ matrix: [[1, 2, 3], [4, 5, 6]] }),
+    ).rejects.toThrow("square");
+  });
+
+  it("stamps meta", async () => {
+    const r = await matrixInverse({ matrix: [[2]] }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+    expect(r.inverse[0][0]).toBeCloseTo(0.5, 6);
+  });
+});

--- a/packages/mcp-server/src/matinverse-tool.ts
+++ b/packages/mcp-server/src/matinverse-tool.ts
@@ -1,0 +1,91 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function matrixInverse(args: Record<string, unknown>) {
+  const matrix = args.matrix as number[][];
+  if (!Array.isArray(matrix) || matrix.length === 0) {
+    throw new Error("matrix must be a non-empty 2D array.");
+  }
+  const n = matrix.length;
+  if (n > 50) throw new Error("Maximum matrix size is 50x50.");
+
+  for (const row of matrix) {
+    if (!Array.isArray(row) || row.length !== n) {
+      throw new Error("Matrix must be square with consistent row lengths.");
+    }
+  }
+
+  const aug: number[][] = matrix.map((row, i) => {
+    const identity = new Array(n).fill(0);
+    identity[i] = 1;
+    return [...row.map(Number), ...identity];
+  });
+
+  for (let col = 0; col < n; col++) {
+    let maxRow = col;
+    let maxVal = Math.abs(aug[col][col]);
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(aug[row][col]) > maxVal) {
+        maxVal = Math.abs(aug[row][col]);
+        maxRow = row;
+      }
+    }
+
+    if (maxVal < 1e-12) {
+      throw new Error("Matrix is singular (not invertible).");
+    }
+
+    if (maxRow !== col) {
+      [aug[col], aug[maxRow]] = [aug[maxRow], aug[col]];
+    }
+
+    const pivot = aug[col][col];
+    for (let j = 0; j < 2 * n; j++) {
+      aug[col][j] /= pivot;
+    }
+
+    for (let row = 0; row < n; row++) {
+      if (row !== col) {
+        const factor = aug[row][col];
+        for (let j = 0; j < 2 * n; j++) {
+          aug[row][j] -= factor * aug[col][j];
+        }
+      }
+    }
+  }
+
+  const inverse = aug.map((row) =>
+    row.slice(n).map((v) => Math.round(v * 1e8) / 1e8),
+  );
+
+  let det = 1;
+  const orig: number[][] = matrix.map((row) => [...row.map(Number)]);
+  for (let col = 0; col < n; col++) {
+    let maxRow = col;
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(orig[row][col]) > Math.abs(orig[maxRow][col])) maxRow = row;
+    }
+    if (maxRow !== col) {
+      [orig[col], orig[maxRow]] = [orig[maxRow], orig[col]];
+      det *= -1;
+    }
+    det *= orig[col][col];
+    for (let row = col + 1; row < n; row++) {
+      const factor = orig[row][col] / orig[col][col];
+      for (let j = col; j < n; j++) orig[row][j] -= factor * orig[col][j];
+    }
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Use linear_solve for Ax=b systems", "Use matrix_decomp for LU factorization"],
+  };
+  return stampMeta(
+    {
+      size: n,
+      inverse,
+      determinant: Math.round(det * 1e8) / 1e8,
+    },
+    meta,
+  );
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -560,6 +560,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "bezier",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "bezier_curve",
+        "description": "Compute a Bezier curve from control points with arc length and optional evaluation."
+      }
+    ]
+  },
+  {
     "app": "bgg",
     "category": "Gaming",
     "tools": [
@@ -2642,6 +2652,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "fft",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "fft_transform",
+        "description": "Fast Fourier Transform (Cooley-Tukey radix-2) with optional inverse."
+      }
+    ]
+  },
+  {
     "app": "fibonacci",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4430,6 +4450,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "mastodon_action",
         "description": "Perform a Mastodon action: mastodon_post, mastodon_read_timeline, mastodon_reply, mastodon_boost, mastodon_favorite, mastodon_search, mastodon_profile, mastodon_follow, mastodon_notifications."
+      }
+    ]
+  },
+  {
+    "app": "matinverse",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "matrix_inverse",
+        "description": "Compute the inverse and determinant of a square matrix using Gauss-Jordan elimination."
       }
     ]
   },
@@ -6710,6 +6740,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "roman_convert",
         "description": "Convert between Roman numerals and decimal numbers."
+      }
+    ]
+  },
+  {
+    "app": "rootfind",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "root_find",
+        "description": "Find roots of a math expression using Newton's method or bisection."
       }
     ]
   },

--- a/packages/mcp-server/src/rootfind-tool.test.ts
+++ b/packages/mcp-server/src/rootfind-tool.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { rootFind } from "./rootfind-tool.js";
+
+describe("rootFind", () => {
+  it("finds root of x^2 - 4 via Newton", async () => {
+    const r = await rootFind({ expression: "x^2 - 4", x0: 3 }) as any;
+    expect(r.root).toBeCloseTo(2, 8);
+    expect(r.converged).toBe(true);
+    expect(r.method).toBe("newton");
+  });
+
+  it("finds root of x^3 - 2 via Newton", async () => {
+    const r = await rootFind({ expression: "x^3 - 2", x0: 1.5 }) as any;
+    expect(r.root).toBeCloseTo(Math.cbrt(2), 6);
+    expect(r.converged).toBe(true);
+  });
+
+  it("finds root via bisection", async () => {
+    const r = await rootFind({
+      expression: "x^2 - 2",
+      method: "bisection",
+      a: 0,
+      b: 2,
+    }) as any;
+    expect(r.root).toBeCloseTo(Math.SQRT2, 6);
+    expect(r.converged).toBe(true);
+  });
+
+  it("rejects bisection without sign change", async () => {
+    await expect(
+      rootFind({ expression: "x^2 + 1", method: "bisection", a: 0, b: 2 }),
+    ).rejects.toThrow("opposite signs");
+  });
+
+  it("rejects empty expression", async () => {
+    await expect(rootFind({ expression: "" })).rejects.toThrow("required");
+  });
+
+  it("rejects invalid method", async () => {
+    await expect(
+      rootFind({ expression: "x", method: "secant" }),
+    ).rejects.toThrow("method");
+  });
+
+  it("stamps meta", async () => {
+    const r = await rootFind({ expression: "x - 5", x0: 0 }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/rootfind-tool.ts
+++ b/packages/mcp-server/src/rootfind-tool.ts
@@ -1,0 +1,122 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function rootFind(args: Record<string, unknown>) {
+  const expr = String(args.expression ?? "");
+  if (!expr) throw new Error("expression is required (e.g. 'x^3 - 2*x - 5').");
+
+  const method = String(args.method ?? "newton").toLowerCase();
+  const tol = Number(args.tolerance ?? 1e-10);
+  const maxIter = Math.min(Number(args.max_iterations ?? 100), 10000);
+
+  const evaluate = (val: number): number => {
+    const sanitized = expr
+      .replace(/\bx\b/g, `(${val})`)
+      .replace(/\^/g, "**");
+    const allowed = /^[\d+\-*/().eE\s]*$/;
+    if (!allowed.test(sanitized)) {
+      throw new Error("Expression contains unsupported characters. Use x, numbers, +, -, *, /, ^, ().");
+    }
+    const result = Function(`"use strict"; return (${sanitized})`)();
+    if (typeof result !== "number" || !Number.isFinite(result)) {
+      throw new Error(`Expression evaluated to non-finite at x=${val}.`);
+    }
+    return result;
+  };
+
+  const deriv = (val: number): number => {
+    const h = 1e-8;
+    return (evaluate(val + h) - evaluate(val - h)) / (2 * h);
+  };
+
+  if (method === "newton") {
+    let x = Number(args.x0 ?? 1);
+    if (!Number.isFinite(x)) throw new Error("x0 must be a finite number.");
+
+    const iterations: { i: number; x: number; fx: number }[] = [];
+    let converged = false;
+
+    for (let i = 0; i < maxIter; i++) {
+      const fx = evaluate(x);
+      iterations.push({ i, x: Math.round(x * 1e10) / 1e10, fx: Math.round(fx * 1e10) / 1e10 });
+      if (Math.abs(fx) < tol) {
+        converged = true;
+        break;
+      }
+      const dx = deriv(x);
+      if (Math.abs(dx) < 1e-15) throw new Error("Derivative near zero; Newton's method stuck.");
+      x = x - fx / dx;
+    }
+
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: converged
+        ? ["Verify by evaluating expression at the root"]
+        : ["Try a different x0 or increase max_iterations"],
+    };
+    return stampMeta(
+      {
+        expression: expr,
+        method: "newton",
+        root: Math.round(x * 1e10) / 1e10,
+        f_at_root: Math.round(evaluate(x) * 1e12) / 1e12,
+        converged,
+        iterations_used: iterations.length,
+        history: iterations.slice(0, 20),
+      },
+      meta,
+    );
+  }
+
+  if (method === "bisection") {
+    let a = Number(args.a ?? -10);
+    let b = Number(args.b ?? 10);
+    if (!Number.isFinite(a) || !Number.isFinite(b)) throw new Error("a and b must be finite numbers.");
+    if (a >= b) throw new Error("a must be less than b.");
+
+    let fa = evaluate(a);
+    let fb = evaluate(b);
+    if (fa * fb > 0) throw new Error("f(a) and f(b) must have opposite signs.");
+
+    let converged = false;
+    let mid = (a + b) / 2;
+    let iter = 0;
+
+    for (iter = 0; iter < maxIter; iter++) {
+      mid = (a + b) / 2;
+      const fmid = evaluate(mid);
+      if (Math.abs(fmid) < tol || (b - a) / 2 < tol) {
+        converged = true;
+        break;
+      }
+      if (fa * fmid < 0) {
+        b = mid;
+        fb = fmid;
+      } else {
+        a = mid;
+        fa = fmid;
+      }
+    }
+
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: converged
+        ? ["Use newton method for faster convergence near the root"]
+        : ["Widen the interval or increase max_iterations"],
+    };
+    return stampMeta(
+      {
+        expression: expr,
+        method: "bisection",
+        root: Math.round(mid * 1e10) / 1e10,
+        f_at_root: Math.round(evaluate(mid) * 1e12) / 1e12,
+        converged,
+        iterations_used: iter + 1,
+      },
+      meta,
+    );
+  }
+
+  throw new Error("method must be newton or bisection.");
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -705,6 +705,12 @@ import { linearSolve } from "./linearsolve-tool.js";
 import { numericalDiff } from "./numdiff-tool.js";
 import { numericalIntegrate } from "./numintegrate-tool.js";
 
+// ── batch 60: signal processing, curves, root finding, matrix inverse ──
+import { fftTransform } from "./fft-tool.js";
+import { bezierCurve } from "./bezier-tool.js";
+import { rootFind } from "./rootfind-tool.js";
+import { matrixInverse } from "./matinverse-tool.js";
+
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
   nasaEarthImagery, nasaEpic,
@@ -10612,6 +10618,56 @@ export const ADDITIONAL_TOOLS = [
         method: { type: "string" as const, description: "Method: simpson (default), trapezoid, or midpoint." },
         intervals: { type: "number" as const, description: "Number of intervals (default 1000, max 1000000)." },
       }, required: ["expression", "a", "b"],
+    },
+  },
+
+  // ── fft-tool.ts ──────────────────────────────────────────────────────────────
+  {
+    name: "fft_transform",
+    description: "Fast Fourier Transform (Cooley-Tukey radix-2) with optional inverse.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        signal: { type: "array" as const, description: "Array of real-valued samples.", items: { type: "number" as const } },
+        inverse: { type: "boolean" as const, description: "Perform inverse FFT (default false)." },
+      }, required: ["signal"],
+    },
+  },
+  // ── bezier-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "bezier_curve",
+    description: "Compute a Bezier curve from control points with arc length and optional evaluation.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        control_points: { type: "array" as const, description: "Array of [x, y] control points (at least 2).", items: { type: "array" as const, items: { type: "number" as const } } },
+        steps: { type: "number" as const, description: "Number of curve samples (default 50, max 1000)." },
+        eval_at: { description: "t value(s) in [0,1] to evaluate at. Number or array of numbers." },
+      }, required: ["control_points"],
+    },
+  },
+  // ── rootfind-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "root_find",
+    description: "Find roots of a math expression using Newton's method or bisection.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        expression: { type: "string" as const, description: "Math expression in x (e.g. 'x^2 - 4')." },
+        method: { type: "string" as const, description: "Method: newton (default) or bisection." },
+        x0: { type: "number" as const, description: "Initial guess (Newton, default 1)." },
+        a: { type: "number" as const, description: "Left bound (bisection)." },
+        b: { type: "number" as const, description: "Right bound (bisection)." },
+        tolerance: { type: "number" as const, description: "Convergence tolerance (default 1e-10)." },
+        max_iterations: { type: "number" as const, description: "Max iterations (default 100)." },
+      }, required: ["expression"],
+    },
+  },
+  // ── matinverse-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "matrix_inverse",
+    description: "Compute the inverse and determinant of a square matrix using Gauss-Jordan elimination.",
+    inputSchema: {
+      type: "object" as const, additionalProperties: false, properties: {
+        matrix: { type: "array" as const, description: "Square 2D array of numbers.", items: { type: "array" as const, items: { type: "number" as const } } },
+      }, required: ["matrix"],
     },
   },
 
@@ -22336,6 +22392,12 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   linear_solve:              (args) => linearSolve(args),
   numerical_diff:            (args) => numericalDiff(args),
   numerical_integrate:       (args) => numericalIntegrate(args),
+
+  // batch 60: signal processing, curves, root finding, matrix inverse
+  fft_transform:             (args) => fftTransform(args),
+  bezier_curve:              (args) => bezierCurve(args),
+  root_find:                 (args) => rootFind(args),
+  matrix_inverse:            (args) => matrixInverse(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate", "fft", "bezier", "rootfind", "matinverse"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -194,6 +194,8 @@ const NAME_OF = {
   convexhull: "Convex Hull", knapsack: "Knapsack Solver", spline: "Spline Interpolation",
   dijkstra: "Dijkstra Shortest Path", matrixdecomp: "Matrix Decomposition",
   linearsolve: "Linear Solver", numdiff: "Numerical Differentiation", numintegrate: "Numerical Integration",
+  fft: "FFT (Fast Fourier Transform)", bezier: "Bezier Curve",
+  rootfind: "Root Finder", matinverse: "Matrix Inverse",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -576,6 +578,10 @@ const BLURB_OF = {
   linearsolve: "Solve systems of linear equations Ax = b with partial pivoting.",
   numdiff: "Numerical differentiation using five-point stencil (1st through 4th order).",
   numintegrate: "Numerical integration using Simpson, trapezoid, or midpoint rule.",
+  fft: "Fast Fourier Transform (Cooley-Tukey radix-2) for frequency analysis.",
+  bezier: "Compute Bezier curves from control points with arc length and evaluation.",
+  rootfind: "Find roots of expressions using Newton's method or bisection.",
+  matinverse: "Compute the inverse and determinant of a square matrix.",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -747,6 +753,7 @@ const DOMAIN_OF = {
   expgrowth: "local", geomseries: "local", harmonicseries: "local", piapprox: "local", taylor: "local",
   lcs: "local", toposort: "local", convexhull: "local", knapsack: "local", spline: "local",
   dijkstra: "local", matrixdecomp: "local", linearsolve: "local", numdiff: "local", numintegrate: "local",
+  fft: "local", bezier: "local", rootfind: "local", matinverse: "local",
 };
 
 function titleCase(slug) {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 535,
-  "toolCount": 1457,
+  "appCount": 539,
+  "toolCount": 1461,
   "categories": [
     "AI",
     "Books",
@@ -708,6 +708,22 @@
         {
           "name": "base64_decode",
           "description": "Decode a Base64 string to text."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "bezier",
+      "name": "Bezier Curve",
+      "category": "Utilities",
+      "blurb": "Compute Bezier curves from control points with arc length and evaluation.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "bezier_curve",
+          "description": "Compute a Bezier curve from control points with arc length and optional evaluation."
         }
       ],
       "level": 5,
@@ -3430,6 +3446,22 @@
       "hardened": true
     },
     {
+      "slug": "fft",
+      "name": "FFT (Fast Fourier Transform)",
+      "category": "Utilities",
+      "blurb": "Fast Fourier Transform (Cooley-Tukey radix-2) for frequency analysis.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "fft_transform",
+          "description": "Fast Fourier Transform (Cooley-Tukey radix-2) with optional inverse."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "fibonacci",
       "name": "Fibonacci Generator",
       "category": "Utilities",
@@ -5912,6 +5944,22 @@
         {
           "name": "matrix_decomp",
           "description": "Matrix decomposition and analysis: LU factorization, transpose, trace, or rank."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "matinverse",
+      "name": "Matrix Inverse",
+      "category": "Utilities",
+      "blurb": "Compute the inverse and determinant of a square matrix.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "matrix_inverse",
+          "description": "Compute the inverse and determinant of a square matrix using Gauss-Jordan elimination."
         }
       ],
       "level": 5,
@@ -9032,6 +9080,22 @@
         {
           "name": "roman_convert",
           "description": "Convert between Roman numerals and decimal numbers."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "rootfind",
+      "name": "Root Finder",
+      "category": "Utilities",
+      "blurb": "Find roots of expressions using Newton's method or bisection.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "root_find",
+          "description": "Find roots of a math expression using Newton's method or bisection."
         }
       ],
       "level": 5,

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-09T14:30:00.000Z",
+  "updatedAt": "2026-06-09T15:00:00.000Z",
   "results": {
     "abn": {
       "status": "attention",
@@ -4042,6 +4042,30 @@
       "note": "numerical_integrate computes definite integrals (Simpson/trapezoid/midpoint). Local computation.",
       "testedAt": "2026-06-09T14:30:00.000Z",
       "toolsTested": ["numerical_integrate"]
+    },
+    "fft": {
+      "status": "pass",
+      "note": "fft_transform computes FFT via Cooley-Tukey radix-2 with inverse support. Local computation.",
+      "testedAt": "2026-06-09T15:00:00.000Z",
+      "toolsTested": ["fft_transform"]
+    },
+    "bezier": {
+      "status": "pass",
+      "note": "bezier_curve computes Bezier curves with arc length and evaluation. Local computation.",
+      "testedAt": "2026-06-09T15:00:00.000Z",
+      "toolsTested": ["bezier_curve"]
+    },
+    "rootfind": {
+      "status": "pass",
+      "note": "root_find solves f(x)=0 via Newton or bisection method. Local computation.",
+      "testedAt": "2026-06-09T15:00:00.000Z",
+      "toolsTested": ["root_find"]
+    },
+    "matinverse": {
+      "status": "pass",
+      "note": "matrix_inverse computes inverse and determinant via Gauss-Jordan. Local computation.",
+      "testedAt": "2026-06-09T15:00:00.000Z",
+      "toolsTested": ["matrix_inverse"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."


### PR DESCRIPTION
## Summary

- **Batch 60** (signal processing, geometry, numerical analysis): `fft_transform`, `bezier_curve`, `root_find`, `matrix_inverse`

Catalog: 535 -> 539 apps, 1457 -> 1461 tools. All 25 tests pass, type check clean.

All tools are pure local computation (no API calls, no auth required).

## Test plan

- [x] 25 unit tests across 4 test files (all pass)
- [x] TypeScript type check passes
- [x] Regeneration pipeline run in order
- [x] app-test-results.json updated with pass status for all 4 new apps

https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez)_