### PR TITLE
Add batch 63: convolution, RLE numeric, descriptive stats, BFS (551 apps)

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 973,
+    "inventory": 977,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 548,
+    "tools": 552,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 548
+      "count": 552
     },
     {
       "id": "rooms",
@@ -4542,6 +4542,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-bfs-packages-mcp-server-src-bfs-tool-ts-no-route",
+      "division": "Tools",
+      "name": "bfs",
+      "kind": "MCP tool",
+      "meaning": "bfs MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/bfs-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-bgg-packages-mcp-server-src-bgg-tool-ts-no-route",
       "division": "Tools",
       "name": "bgg",
@@ -5142,6 +5152,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-convolution-packages-mcp-server-src-convolution-tool-ts-no-route",
+      "division": "Tools",
+      "name": "convolution",
+      "kind": "MCP tool",
+      "meaning": "convolution MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/convolution-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-copypass-packages-mcp-server-src-copypass-tool-ts-no-route",
       "division": "Tools",
       "name": "copypass",
@@ -5388,6 +5408,16 @@
       "kind": "MCP tool",
       "meaning": "deezer MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/deezer-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-descriptive-packages-mcp-server-src-descriptive-tool-ts-no-route",
+      "division": "Tools",
+      "name": "descriptive",
+      "kind": "MCP tool",
+      "meaning": "descriptive MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/descriptive-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8352,6 +8382,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-rle2-packages-mcp-server-src-rle2-tool-ts-no-route",
+      "division": "Tools",
+      "name": "rle2",
+      "kind": "MCP tool",
+      "meaning": "rle2 MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/rle2-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-robohash-packages-mcp-server-src-robohash-tool-ts-no-route",
       "division": "Tools",
       "name": "robohash",
@@ -10596,6 +10636,11 @@
       "packages/mcp-server/src/bezier-tool.ts"
     ],
     [
+      "bfs",
+      "bfs MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/bfs-tool.ts"
+    ],
+    [
       "bgg",
       "bgg MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/bgg-tool.ts"
@@ -10896,6 +10941,11 @@
       "packages/mcp-server/src/convexhull-tool.ts"
     ],
     [
+      "convolution",
+      "convolution MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/convolution-tool.ts"
+    ],
+    [
       "copypass",
       "copypass MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/copypass-tool.ts"
@@ -11019,6 +11069,11 @@
       "deezer",
       "deezer MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/deezer-tool.ts"
+    ],
+    [
+      "descriptive",
+      "descriptive MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/descriptive-tool.ts"
     ],
     [
       "diceware",
@@ -12499,6 +12554,11 @@
       "ripe",
       "ripe MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/ripe-tool.ts"
+    ],
+    [
+      "rle2",
+      "rle2 MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/rle2-tool.ts"
     ],
     [
       "robohash",
@@ -14384,6 +14444,11 @@
       "bytes": 2561
     },
     {
+      "source": "packages/mcp-server/src/bfs-tool.ts",
+      "hash": "6eff2fdbba8b",
+      "bytes": 2678
+    },
+    {
       "source": "packages/mcp-server/src/bgg-tool.ts",
       "hash": "f7014933783a",
       "bytes": 12903
@@ -14407,11 +14472,6 @@
       "source": "packages/mcp-server/src/binaryconv-tool.ts",
       "hash": "b09d86831da2",
       "bytes": 1337
-    },
-    {
-      "source": "packages/mcp-server/src/binomprob-tool.ts",
-      "hash": "08174a2866e7",
-      "bytes": 1770
     },
     {
       "source": ".github/workflows/apply-migrations.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -203,12 +203,12 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/base64-tool.ts | b93e3d17577c | 1174 |
 | packages/mcp-server/src/baseconvert-tool.ts | bbfa716f0f7c | 1246 |
 | packages/mcp-server/src/bezier-tool.ts | 29ff88e26cbb | 2561 |
+| packages/mcp-server/src/bfs-tool.ts | 6eff2fdbba8b | 2678 |
 | packages/mcp-server/src/bgg-tool.ts | f7014933783a | 12903 |
 | packages/mcp-server/src/bgpview-tool.ts | c97cbd66581b | 2523 |
 | packages/mcp-server/src/bible-tool.ts | 94f62f2fa1c1 | 2338 |
 | packages/mcp-server/src/bibleverse-tool.ts | c5c118d0eb27 | 1698 |
 | packages/mcp-server/src/binaryconv-tool.ts | b09d86831da2 | 1337 |
-| packages/mcp-server/src/binomprob-tool.ts | 08174a2866e7 | 1770 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
 | .github/workflows/autonomous-runner.yml | 942080b620ac | 15338 |
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 548 |
+| Tools | MCP and gateway capabilities available to seats. | 552 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -404,6 +404,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | base64 | base64 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/base64-tool.ts |
 | baseconvert | baseconvert MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/baseconvert-tool.ts |
 | bezier | bezier MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bezier-tool.ts |
+| bfs | bfs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bfs-tool.ts |
 | bgg | bgg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bgg-tool.ts |
 | bgpview | bgpview MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bgpview-tool.ts |
 | bible | bible MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bible-tool.ts |
@@ -464,6 +465,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | contentful | contentful MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/contentful-tool.ts |
 | convertkit | convertkit MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/convertkit-tool.ts |
 | convexhull | convexhull MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/convexhull-tool.ts |
+| convolution | convolution MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/convolution-tool.ts |
 | copypass | copypass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/copypass-tool.ts |
 | corporatebs | corporatebs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/corporatebs-tool.ts |
 | correlation | correlation MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/correlation-tool.ts |
@@ -489,6 +491,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | deckofcards | deckofcards MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/deckofcards-tool.ts |
 | deepl | deepl MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/deepl-tool.ts |
 | deezer | deezer MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/deezer-tool.ts |
+| descriptive | descriptive MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/descriptive-tool.ts |
 | diceware | diceware MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/diceware-tool.ts |
 | dictionary | dictionary MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dictionary-tool.ts |
 | difftext | difftext MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/difftext-tool.ts |
@@ -785,6 +788,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | rickandmorty | rickandmorty MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rickandmorty-tool.ts |
 | riot | riot MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/riot-tool.ts |
 | ripe | ripe MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/ripe-tool.ts |
+| rle2 | rle2 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rle2-tool.ts |
 | robohash | robohash MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/robohash-tool.ts |
 | roman | roman MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/roman-tool.ts |
 | rootfind | rootfind MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rootfind-tool.ts |
@@ -1368,6 +1372,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | base64 | base64 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/base64-tool.ts |
 | Tools | MCP tool | baseconvert | baseconvert MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/baseconvert-tool.ts |
 | Tools | MCP tool | bezier | bezier MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bezier-tool.ts |
+| Tools | MCP tool | bfs | bfs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bfs-tool.ts |
 | Tools | MCP tool | bgg | bgg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bgg-tool.ts |
 | Tools | MCP tool | bgpview | bgpview MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bgpview-tool.ts |
 | Tools | MCP tool | bible | bible MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bible-tool.ts |
@@ -1428,6 +1433,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | contentful | contentful MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/contentful-tool.ts |
 | Tools | MCP tool | convertkit | convertkit MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/convertkit-tool.ts |
 | Tools | MCP tool | convexhull | convexhull MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/convexhull-tool.ts |
+| Tools | MCP tool | convolution | convolution MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/convolution-tool.ts |
 | Tools | MCP tool | copypass | copypass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/copypass-tool.ts |
 | Tools | MCP tool | corporatebs | corporatebs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/corporatebs-tool.ts |
 | Tools | MCP tool | correlation | correlation MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/correlation-tool.ts |
@@ -1453,6 +1459,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | deckofcards | deckofcards MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/deckofcards-tool.ts |
 | Tools | MCP tool | deepl | deepl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/deepl-tool.ts |
 | Tools | MCP tool | deezer | deezer MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/deezer-tool.ts |
+| Tools | MCP tool | descriptive | descriptive MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/descriptive-tool.ts |
 | Tools | MCP tool | diceware | diceware MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/diceware-tool.ts |
 | Tools | MCP tool | dictionary | dictionary MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dictionary-tool.ts |
 | Tools | MCP tool | difftext | difftext MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/difftext-tool.ts |
@@ -1749,6 +1756,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | rickandmorty | rickandmorty MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rickandmorty-tool.ts |
 | Tools | MCP tool | riot | riot MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/riot-tool.ts |
 | Tools | MCP tool | ripe | ripe MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/ripe-tool.ts |
+| Tools | MCP tool | rle2 | rle2 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rle2-tool.ts |
 | Tools | MCP tool | robohash | robohash MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/robohash-tool.ts |
 | Tools | MCP tool | roman | roman MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/roman-tool.ts |
 | Tools | MCP tool | rootfind | rootfind MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rootfind-tool.ts |

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -660,6 +660,26 @@
     }
   },
   {
+    "connector": "bfs",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "bgg",
     "level": 5,
     "levelName": "Agentic",
@@ -1720,6 +1740,26 @@
     }
   },
   {
+    "connector": "convolution",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "corporatebs",
     "level": 5,
     "levelName": "Agentic",
@@ -2130,6 +2170,26 @@
       "hasTimeout": true,
       "handles429": true,
       "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "descriptive",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,
@@ -7408,6 +7468,26 @@
     "capReason": null,
     "signals": {
       "hasTimeout": true,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "rle2",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
       "handles429": false,
       "hasRetry": false,
       "readsErrorBody": false,

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (522 external connectors)
+## Distribution (526 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 483 | 93% |
+| L5 | Agentic | 487 | 93% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 522 (46%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 526 (46%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 483 of 486 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 487 of 490 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -56,6 +56,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `base64` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `baseconvert` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `bezier` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `bfs` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `bgpview` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `bibleverse` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `binaryconv` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -85,6 +86,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `combination` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `complexnum` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `convexhull` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `convolution` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `correlation` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `cosinesim` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `countdowncalc` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -100,6 +102,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `damerau` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `datamuse` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `dblp` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `descriptive` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `diceware` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `difftext` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `digimon` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -262,6 +265,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `regression` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `reversetext` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `ripe` (L5 Agentic): not-hardened, no-rate-limit, no-memory
+- `rle2` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `robohash` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `roman` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `rootfind` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -356,6 +360,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `base64` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `baseconvert` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bezier` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `bfs` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bgg` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `bgpview` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `bible` | Yes | - | - | Yes | Yes | no-memory |
@@ -409,6 +414,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `contentful` | Yes | Yes | - | Yes | Yes |  |
 | L5 Agentic | `convertkit` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `convexhull` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `convolution` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `corporatebs` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `correlation` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `cosinesim` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -430,6 +436,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `deckofcards` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `deepl` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `deezer` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `descriptive` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `diceware` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `dictionary` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `difftext` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -694,6 +701,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `rickandmorty` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `riot` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `ripe` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
+| L5 Agentic | `rle2` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `robohash` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `roman` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `rootfind` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -556,6 +556,16 @@
     ]
   },
   {
+    "app": "bfs",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "bfs_search",
+        "description": "Breadth-first search on a graph. Finds shortest unweighted path, visit order, and reachable node count."
+      }
+    ]
+  },
+  {
     "app": "bgg",
     "category": "Gaming",
     "tools": [
@@ -1556,6 +1566,16 @@
     ]
   },
   {
+    "app": "convolution",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "convolution",
+        "description": "Compute discrete convolution of a signal with a kernel. Supports full, same, and valid modes."
+      }
+    ]
+  },
+  {
     "app": "copypass",
     "category": "CopyPass (copy quality QC, sister to SecurityPass)",
     "tools": [
@@ -1926,6 +1946,16 @@
       {
         "name": "deezer_search_playlist",
         "description": "Search for Deezer playlists."
+      }
+    ]
+  },
+  {
+    "app": "descriptive",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "descriptive_stats",
+        "description": "Compute descriptive statistics: mean, median, mode, std, variance, skewness, kurtosis, quartiles, IQR, and more."
       }
     ]
   },
@@ -6776,6 +6806,16 @@
       {
         "name": "ripe_asn_neighbours",
         "description": "Get peering neighbours for an ASN from RIPE NCC."
+      }
+    ]
+  },
+  {
+    "app": "rle2",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "rle_encode_decode",
+        "description": "Run-length encode a numeric array into runs, or decode runs back to a numeric array."
       }
     ]
   },

--- a/packages/mcp-server/src/bfs-tool.test.ts
+++ b/packages/mcp-server/src/bfs-tool.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { bfsSearch } from "./bfs-tool.js";
+
+describe("bfsSearch", () => {
+  const edges = [
+    { from: "A", to: "B" },
+    { from: "A", to: "C" },
+    { from: "B", to: "D" },
+    { from: "C", to: "D" },
+    { from: "D", to: "E" },
+  ];
+
+  it("finds shortest path", async () => {
+    const r = await bfsSearch({ edges, start: "A", target: "E", directed: true }) as any;
+    expect(r.path).toEqual(["A", "B", "D", "E"]);
+    expect(r.path_length).toBe(3);
+  });
+
+  it("traverses all reachable nodes", async () => {
+    const r = await bfsSearch({ edges, start: "A", directed: true }) as any;
+    expect(r.reachable_count).toBe(5);
+    expect(r.visit_order[0]).toBe("A");
+  });
+
+  it("returns null path if target unreachable", async () => {
+    const r = await bfsSearch({
+      edges: [{ from: "A", to: "B" }, { from: "C", to: "D" }],
+      start: "A",
+      target: "D",
+      directed: true,
+    }) as any;
+    expect(r.path).toBeNull();
+  });
+
+  it("undirected mode", async () => {
+    const r = await bfsSearch({
+      edges: [{ from: "X", to: "Y" }],
+      start: "Y",
+      target: "X",
+      directed: false,
+    }) as any;
+    expect(r.path).toEqual(["Y", "X"]);
+  });
+
+  it("rejects missing start", async () => {
+    await expect(bfsSearch({ edges, start: "Z" })).rejects.toThrow("not found");
+  });
+
+  it("rejects empty edges", async () => {
+    await expect(bfsSearch({ edges: [], start: "A" })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await bfsSearch({ edges: [{ from: "A", to: "B" }], start: "A" }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/bfs-tool.ts
+++ b/packages/mcp-server/src/bfs-tool.ts
@@ -1,0 +1,99 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+interface Edge {
+  from: string;
+  to: string;
+}
+
+export async function bfsSearch(args: Record<string, unknown>) {
+  const edges = args.edges as Edge[];
+  if (!Array.isArray(edges) || edges.length === 0) {
+    throw new Error("edges must be a non-empty array of {from, to} objects.");
+  }
+  if (edges.length > 10000) throw new Error("edges must have 10000 entries or fewer.");
+
+  const start = String(args.start ?? "");
+  if (!start) throw new Error("start node is required.");
+
+  const target = args.target !== undefined ? String(args.target) : null;
+  const directed = args.directed !== false;
+
+  const adj = new Map<string, string[]>();
+  const allNodes = new Set<string>();
+
+  for (const e of edges) {
+    const from = String(e.from);
+    const to = String(e.to);
+    allNodes.add(from);
+    allNodes.add(to);
+    if (!adj.has(from)) adj.set(from, []);
+    adj.get(from)!.push(to);
+    if (!directed) {
+      if (!adj.has(to)) adj.set(to, []);
+      adj.get(to)!.push(from);
+    }
+  }
+
+  if (!allNodes.has(start)) throw new Error(`start node '${start}' not found in graph.`);
+  if (target && !allNodes.has(target)) throw new Error(`target node '${target}' not found in graph.`);
+
+  const visited = new Set<string>();
+  const parent = new Map<string, string | null>();
+  const distance = new Map<string, number>();
+  const order: string[] = [];
+
+  const queue: string[] = [start];
+  visited.add(start);
+  parent.set(start, null);
+  distance.set(start, 0);
+
+  let found = false;
+
+  while (queue.length > 0) {
+    const curr = queue.shift()!;
+    order.push(curr);
+
+    if (target && curr === target) {
+      found = true;
+      break;
+    }
+
+    for (const neighbor of adj.get(curr) ?? []) {
+      if (!visited.has(neighbor)) {
+        visited.add(neighbor);
+        parent.set(neighbor, curr);
+        distance.set(neighbor, (distance.get(curr) ?? 0) + 1);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  let path: string[] | null = null;
+  if (target && found) {
+    path = [];
+    let node: string | null = target;
+    while (node !== null) {
+      path.unshift(node);
+      node = parent.get(node) ?? null;
+    }
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "BFS finds shortest path in unweighted graphs",
+      "Use dijkstra_path for weighted shortest paths",
+    ],
+  };
+  return stampMeta({
+    start,
+    target: target ?? "none",
+    directed,
+    nodes_visited: order.length,
+    visit_order: order,
+    path,
+    path_length: path ? path.length - 1 : null,
+    reachable_count: visited.size,
+  }, meta);
+}

--- a/packages/mcp-server/src/convolution-tool.test.ts
+++ b/packages/mcp-server/src/convolution-tool.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { convolution } from "./convolution-tool.js";
+
+describe("convolution", () => {
+  it("computes full convolution", async () => {
+    const r = await convolution({ signal: [1, 2, 3], kernel: [1, 1] }) as any;
+    expect(r.result).toEqual([1, 3, 5, 3]);
+    expect(r.output_length).toBe(4);
+    expect(r.mode).toBe("full");
+  });
+
+  it("computes same convolution", async () => {
+    const r = await convolution({ signal: [1, 2, 3, 4], kernel: [1, 1, 1], mode: "same" }) as any;
+    expect(r.result.length).toBe(4);
+  });
+
+  it("computes valid convolution", async () => {
+    const r = await convolution({ signal: [1, 2, 3, 4, 5], kernel: [1, 1], mode: "valid" }) as any;
+    expect(r.result).toEqual([3, 5, 7, 9]);
+    expect(r.output_length).toBe(4);
+  });
+
+  it("identity convolution", async () => {
+    const r = await convolution({ signal: [3, 5, 7], kernel: [1] }) as any;
+    expect(r.result).toEqual([3, 5, 7]);
+  });
+
+  it("rejects empty arrays", async () => {
+    await expect(convolution({ signal: [], kernel: [1] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await convolution({ signal: [1], kernel: [1] }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/convolution-tool.ts
+++ b/packages/mcp-server/src/convolution-tool.ts
@@ -1,0 +1,58 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function convolution(args: Record<string, unknown>) {
+  const a = args.signal as number[];
+  const b = args.kernel as number[];
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length === 0 || b.length === 0) {
+    throw new Error("signal and kernel must be non-empty arrays of numbers.");
+  }
+  if (a.length > 50000 || b.length > 50000) {
+    throw new Error("Arrays must have 50000 elements or fewer.");
+  }
+
+  const mode = String(args.mode ?? "full").toLowerCase();
+  if (!["full", "same", "valid"].includes(mode)) {
+    throw new Error("mode must be full, same, or valid.");
+  }
+
+  const fullLen = a.length + b.length - 1;
+  const full: number[] = new Array(fullLen).fill(0);
+  for (let i = 0; i < a.length; i++) {
+    for (let j = 0; j < b.length; j++) {
+      full[i + j] += a[i] * b[j];
+    }
+  }
+
+  for (let i = 0; i < full.length; i++) {
+    full[i] = Math.round(full[i] * 1e10) / 1e10;
+  }
+
+  let result: number[];
+  if (mode === "same") {
+    const start = Math.floor((b.length - 1) / 2);
+    result = full.slice(start, start + a.length);
+  } else if (mode === "valid") {
+    const validLen = Math.abs(a.length - b.length) + 1;
+    const start = Math.min(a.length, b.length) - 1;
+    result = full.slice(start, start + validLen);
+  } else {
+    result = full;
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "full mode returns a.length + b.length - 1 elements",
+      "same mode returns a.length elements centered",
+      "valid mode returns only fully overlapping elements",
+    ],
+  };
+  return stampMeta({
+    signal_length: a.length,
+    kernel_length: b.length,
+    mode,
+    output_length: result.length,
+    result,
+  }, meta);
+}

--- a/packages/mcp-server/src/descriptive-tool.test.ts
+++ b/packages/mcp-server/src/descriptive-tool.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { descriptiveStats } from "./descriptive-tool.js";
+
+describe("descriptiveStats", () => {
+  it("computes mean and median", async () => {
+    const r = await descriptiveStats({ data: [1, 2, 3, 4, 5] }) as any;
+    expect(r.mean).toBe(3);
+    expect(r.median).toBe(3);
+    expect(r.n).toBe(5);
+  });
+
+  it("computes even-length median", async () => {
+    const r = await descriptiveStats({ data: [1, 2, 3, 4] }) as any;
+    expect(r.median).toBe(2.5);
+  });
+
+  it("computes range and sum", async () => {
+    const r = await descriptiveStats({ data: [10, 20, 30] }) as any;
+    expect(r.min).toBe(10);
+    expect(r.max).toBe(30);
+    expect(r.range).toBe(20);
+    expect(r.sum).toBe(60);
+  });
+
+  it("computes std and variance", async () => {
+    const r = await descriptiveStats({ data: [2, 4, 4, 4, 5, 5, 7, 9] }) as any;
+    expect(r.mean).toBe(5);
+    expect(r.variance).toBeCloseTo(4, 4);
+    expect(r.std).toBeCloseTo(2, 4);
+  });
+
+  it("finds mode", async () => {
+    const r = await descriptiveStats({ data: [1, 2, 2, 3, 3, 3] }) as any;
+    expect(r.mode).toEqual([3]);
+  });
+
+  it("rejects empty data", async () => {
+    await expect(descriptiveStats({ data: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await descriptiveStats({ data: [1, 2] }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/descriptive-tool.ts
+++ b/packages/mcp-server/src/descriptive-tool.ts
@@ -1,0 +1,81 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function descriptiveStats(args: Record<string, unknown>) {
+  const data = args.data as number[];
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error("data must be a non-empty array of numbers.");
+  }
+  if (data.length > 100000) throw new Error("data must have 100000 elements or fewer.");
+
+  const n = data.length;
+  const sorted = [...data].sort((a, b) => a - b);
+  const sum = data.reduce((s, v) => s + v, 0);
+  const mean = sum / n;
+
+  const variance = data.reduce((s, v) => s + (v - mean) ** 2, 0) / n;
+  const std = Math.sqrt(variance);
+  const sampleVariance = n > 1 ? data.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1) : 0;
+  const sampleStd = Math.sqrt(sampleVariance);
+
+  const min = sorted[0];
+  const max = sorted[n - 1];
+  const range = max - min;
+
+  const median = n % 2 === 0
+    ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    : sorted[Math.floor(n / 2)];
+
+  const q1Idx = Math.floor(n / 4);
+  const q3Idx = Math.floor(3 * n / 4);
+  const q1 = sorted[q1Idx];
+  const q3 = sorted[q3Idx];
+  const iqr = q3 - q1;
+
+  const freqMap = new Map<number, number>();
+  for (const v of data) freqMap.set(v, (freqMap.get(v) ?? 0) + 1);
+  let maxFreq = 0;
+  const modes: number[] = [];
+  for (const [val, freq] of freqMap) {
+    if (freq > maxFreq) { maxFreq = freq; modes.length = 0; modes.push(val); }
+    else if (freq === maxFreq) modes.push(val);
+  }
+  modes.sort((a, b) => a - b);
+
+  const skewness = n >= 3 && std > 0
+    ? (n / ((n - 1) * (n - 2))) * data.reduce((s, v) => s + ((v - mean) / std) ** 3, 0)
+    : 0;
+
+  const kurtosis = n >= 4 && std > 0
+    ? ((n * (n + 1)) / ((n - 1) * (n - 2) * (n - 3))) *
+      data.reduce((s, v) => s + ((v - mean) / std) ** 4, 0) -
+      (3 * (n - 1) ** 2) / ((n - 2) * (n - 3))
+    : 0;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "Use sample_std for inference about a population",
+      "IQR helps identify outliers (below Q1-1.5*IQR or above Q3+1.5*IQR)",
+    ],
+  };
+  return stampMeta({
+    n,
+    mean: Math.round(mean * 1e8) / 1e8,
+    median,
+    mode: modes.length === n ? null : modes,
+    min,
+    max,
+    range,
+    sum: Math.round(sum * 1e8) / 1e8,
+    variance: Math.round(variance * 1e8) / 1e8,
+    std: Math.round(std * 1e8) / 1e8,
+    sample_variance: Math.round(sampleVariance * 1e8) / 1e8,
+    sample_std: Math.round(sampleStd * 1e8) / 1e8,
+    q1,
+    q3,
+    iqr,
+    skewness: Math.round(skewness * 1e8) / 1e8,
+    kurtosis: Math.round(kurtosis * 1e8) / 1e8,
+  }, meta);
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -570,6 +570,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "bfs",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "bfs_search",
+        "description": "Breadth-first search on a graph. Finds shortest unweighted path, visit order, and reachable node count."
+      }
+    ]
+  },
+  {
     "app": "bgg",
     "category": "Gaming",
     "tools": [
@@ -1570,6 +1580,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "convolution",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "convolution",
+        "description": "Compute discrete convolution of a signal with a kernel. Supports full, same, and valid modes."
+      }
+    ]
+  },
+  {
     "app": "copypass",
     "category": "CopyPass (copy quality QC, sister to SecurityPass)",
     "tools": [
@@ -1940,6 +1960,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "deezer_search_playlist",
         "description": "Search for Deezer playlists."
+      }
+    ]
+  },
+  {
+    "app": "descriptive",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "descriptive_stats",
+        "description": "Compute descriptive statistics: mean, median, mode, std, variance, skewness, kurtosis, quartiles, IQR, and more."
       }
     ]
   },
@@ -6790,6 +6820,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "ripe_asn_neighbours",
         "description": "Get peering neighbours for an ASN from RIPE NCC."
+      }
+    ]
+  },
+  {
+    "app": "rle2",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "rle_encode_decode",
+        "description": "Run-length encode a numeric array into runs, or decode runs back to a numeric array."
       }
     ]
   },

--- a/packages/mcp-server/src/rle2-tool.test.ts
+++ b/packages/mcp-server/src/rle2-tool.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { rleEncodeDecode } from "./rle2-tool.js";
+
+describe("rleEncodeDecode", () => {
+  it("encodes a sequence with repeats", async () => {
+    const r = await rleEncodeDecode({ operation: "encode", data: [1, 1, 1, 2, 2, 3] }) as any;
+    expect(r.runs).toEqual([
+      { value: 1, count: 3 },
+      { value: 2, count: 2 },
+      { value: 3, count: 1 },
+    ]);
+    expect(r.run_count).toBe(3);
+  });
+
+  it("encodes with no repeats", async () => {
+    const r = await rleEncodeDecode({ operation: "encode", data: [1, 2, 3] }) as any;
+    expect(r.run_count).toBe(3);
+    expect(r.compression_ratio).toBeGreaterThan(1);
+  });
+
+  it("decodes runs back to data", async () => {
+    const r = await rleEncodeDecode({
+      operation: "decode",
+      runs: [{ value: 5, count: 3 }, { value: 7, count: 2 }],
+    }) as any;
+    expect(r.data).toEqual([5, 5, 5, 7, 7]);
+    expect(r.output_length).toBe(5);
+  });
+
+  it("round-trips encode then decode", async () => {
+    const original = [4, 4, 4, 9, 9, 1];
+    const encoded = await rleEncodeDecode({ operation: "encode", data: original }) as any;
+    const decoded = await rleEncodeDecode({ operation: "decode", runs: encoded.runs }) as any;
+    expect(decoded.data).toEqual(original);
+  });
+
+  it("rejects empty data", async () => {
+    await expect(rleEncodeDecode({ operation: "encode", data: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await rleEncodeDecode({ operation: "encode", data: [1, 1] }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/rle2-tool.ts
+++ b/packages/mcp-server/src/rle2-tool.ts
@@ -1,0 +1,69 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function rleEncodeDecode(args: Record<string, unknown>) {
+  const operation = String(args.operation ?? "encode").toLowerCase();
+  if (!["encode", "decode"].includes(operation)) {
+    throw new Error("operation must be encode or decode.");
+  }
+
+  if (operation === "encode") {
+    const data = args.data as number[];
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new Error("data must be a non-empty array for encoding.");
+    }
+    if (data.length > 100000) throw new Error("data must have 100000 elements or fewer.");
+
+    const runs: { value: number; count: number }[] = [];
+    let current = data[0];
+    let count = 1;
+    for (let i = 1; i < data.length; i++) {
+      if (data[i] === current) {
+        count++;
+      } else {
+        runs.push({ value: current, count });
+        current = data[i];
+        count = 1;
+      }
+    }
+    runs.push({ value: current, count });
+
+    const ratio = runs.length * 2 / data.length;
+
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: ["Ratio below 1 means RLE compressed effectively", "Works best with many consecutive repeats"],
+    };
+    return stampMeta({
+      operation: "encode",
+      input_length: data.length,
+      run_count: runs.length,
+      compression_ratio: Math.round(ratio * 1e6) / 1e6,
+      runs,
+    }, meta);
+  }
+
+  const runs = args.runs as { value: number; count: number }[];
+  if (!Array.isArray(runs) || runs.length === 0) {
+    throw new Error("runs must be a non-empty array of {value, count} for decoding.");
+  }
+
+  const data: number[] = [];
+  for (const run of runs) {
+    const v = Number(run.value);
+    const c = Math.max(1, Math.floor(Number(run.count)));
+    for (let i = 0; i < c; i++) data.push(v);
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: ["Decoded data restores the original sequence"],
+  };
+  return stampMeta({
+    operation: "decode",
+    run_count: runs.length,
+    output_length: data.length,
+    data,
+  }, meta);
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -718,6 +718,10 @@ import { correlationCalc } from "./correlation-tool.js";
 import { bitCount } from "./bitcount-tool.js";
 import { runningStats } from "./runstats-tool.js";
 import { graphAnalyze } from "./graph-tool.js";
+import { convolution } from "./convolution-tool.js";
+import { rleEncodeDecode } from "./rle2-tool.js";
+import { descriptiveStats } from "./descriptive-tool.js";
+import { bfsSearch } from "./bfs-tool.js";
 
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
@@ -10792,6 +10796,61 @@ export const ADDITIONAL_TOOLS = [
         edges: { type: "array", items: { type: "object", properties: { from: { type: "string" }, to: { type: "string" }, weight: { type: "number" } }, required: ["from", "to"] }, description: "Array of edges" },
         directed: { type: "boolean", description: "Whether the graph is directed (default true)" },
       }, required: ["edges"],
+    },
+  },
+
+  // ── convolution-tool.ts ─────────────────────────────────────────────────────
+  {
+    name: "convolution",
+    description: "Compute discrete convolution of a signal with a kernel. Supports full, same, and valid modes.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        signal: { type: "array", items: { type: "number" }, description: "Input signal array" },
+        kernel: { type: "array", items: { type: "number" }, description: "Convolution kernel array" },
+        mode: { type: "string", enum: ["full", "same", "valid"], description: "Output mode (default full)" },
+      }, required: ["signal", "kernel"],
+    },
+  },
+
+  // ── rle2-tool.ts ────────────────────────────────────────────────────────────
+  {
+    name: "rle_encode_decode",
+    description: "Run-length encode a numeric array into runs, or decode runs back to a numeric array.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        operation: { type: "string", enum: ["encode", "decode"], description: "Operation (default encode)" },
+        data: { type: "array", items: { type: "number" }, description: "Numeric array to encode" },
+        runs: { type: "array", items: { type: "object", properties: { value: { type: "number" }, count: { type: "integer" } } }, description: "Runs to decode" },
+      }, required: ["operation"],
+    },
+  },
+
+  // ── descriptive-tool.ts ─────────────────────────────────────────────────────
+  {
+    name: "descriptive_stats",
+    description: "Compute descriptive statistics: mean, median, mode, std, variance, skewness, kurtosis, quartiles, IQR, and more.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        data: { type: "array", items: { type: "number" }, description: "Numeric data array" },
+      }, required: ["data"],
+    },
+  },
+
+  // ── bfs-tool.ts ─────────────────────────────────────────────────────────────
+  {
+    name: "bfs_search",
+    description: "Breadth-first search on a graph. Finds shortest unweighted path, visit order, and reachable node count.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        edges: { type: "array", items: { type: "object", properties: { from: { type: "string" }, to: { type: "string" } }, required: ["from", "to"] }, description: "Array of edges" },
+        start: { type: "string", description: "Start node" },
+        target: { type: "string", description: "Optional target node to find path to" },
+        directed: { type: "boolean", description: "Whether the graph is directed (default true)" },
+      }, required: ["edges", "start"],
     },
   },
 
@@ -22534,6 +22593,12 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   bit_count:                 (args) => bitCount(args),
   running_stats:             (args) => runningStats(args),
   graph_analyze:             (args) => graphAnalyze(args),
+
+  // batch 63: convolution, RLE encode/decode, descriptive stats, BFS
+  convolution:               (args) => convolution(args),
+  rle_encode_decode:         (args) => rleEncodeDecode(args),
+  descriptive_stats:         (args) => descriptiveStats(args),
+  bfs_search:                (args) => bfsSearch(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate", "fft", "bezier", "rootfind", "matinverse", "ode", "polynomial", "hypothesis", "huffman", "correlation", "bitcount", "runstats", "graph"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate", "fft", "bezier", "rootfind", "matinverse", "ode", "polynomial", "hypothesis", "huffman", "correlation", "bitcount", "runstats", "graph", "convolution", "rle2", "descriptive", "bfs"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -198,6 +198,7 @@ const NAME_OF = {
   rootfind: "Root Finder", matinverse: "Matrix Inverse",
   ode: "ODE Solver", polynomial: "Polynomial Ops", hypothesis: "Hypothesis Test", huffman: "Huffman Coding",
   correlation: "Correlation", bitcount: "Bit Count", runstats: "Running Stats", graph: "Graph Analyze",
+  convolution: "Convolution", rle2: "RLE Numeric", descriptive: "Descriptive Stats", bfs: "BFS Search",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -592,6 +593,10 @@ const BLURB_OF = {
   bitcount: "Count set bits, convert between decimal/binary/hex/octal, detect powers of two.",
   runstats: "Compute sliding-window running mean, std, min, and max over numeric data.",
   graph: "Analyze graph structure: nodes, edges, components, density, and degrees.",
+  convolution: "Compute discrete convolution of a signal with a kernel (full/same/valid).",
+  rle2: "Run-length encode or decode numeric arrays for compression analysis.",
+  descriptive: "Full descriptive statistics: mean, median, mode, std, skewness, kurtosis, IQR.",
+  bfs: "Breadth-first search for shortest unweighted paths and reachability.",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -766,6 +771,7 @@ const DOMAIN_OF = {
   fft: "local", bezier: "local", rootfind: "local", matinverse: "local",
   ode: "local", polynomial: "local", hypothesis: "local", huffman: "local",
   correlation: "local", bitcount: "local", runstats: "local", graph: "local",
+  convolution: "local", rle2: "local", descriptive: "local", bfs: "local",
 };
 
 function titleCase(slug) {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 547,
-  "toolCount": 1469,
+  "appCount": 551,
+  "toolCount": 1473,
   "categories": [
     "AI",
     "Books",
@@ -724,6 +724,22 @@
         {
           "name": "bezier_curve",
           "description": "Compute a Bezier curve from control points with arc length and optional evaluation."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "bfs",
+      "name": "BFS Search",
+      "category": "Utilities",
+      "blurb": "Breadth-first search for shortest unweighted paths and reachability.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "bfs_search",
+          "description": "Breadth-first search on a graph. Finds shortest unweighted path, visit order, and reachable node count."
         }
       ],
       "level": 5,
@@ -2006,6 +2022,22 @@
       "hardened": false
     },
     {
+      "slug": "convolution",
+      "name": "Convolution",
+      "category": "Utilities",
+      "blurb": "Compute discrete convolution of a signal with a kernel (full/same/valid).",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "convolution",
+          "description": "Compute discrete convolution of a signal with a kernel. Supports full, same, and valid modes."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "copypass",
       "name": "CopyPass",
       "category": "Quality (XPass)",
@@ -2548,6 +2580,22 @@
       ],
       "level": 5,
       "hardened": true
+    },
+    {
+      "slug": "descriptive",
+      "name": "Descriptive Stats",
+      "category": "Utilities",
+      "blurb": "Full descriptive statistics: mean, median, mode, std, skewness, kurtosis, IQR.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "descriptive_stats",
+          "description": "Compute descriptive statistics: mean, median, mode, std, variance, skewness, kurtosis, quartiles, IQR, and more."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "diceware",
@@ -9160,6 +9208,22 @@
         {
           "name": "ripe_asn_neighbours",
           "description": "Get peering neighbours for an ASN from RIPE NCC."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "rle2",
+      "name": "RLE Numeric",
+      "category": "Utilities",
+      "blurb": "Run-length encode or decode numeric arrays for compression analysis.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "rle_encode_decode",
+          "description": "Run-length encode a numeric array into runs, or decode runs back to a numeric array."
         }
       ],
       "level": 5,

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -4114,6 +4114,30 @@
       "note": "graph_analyze counts nodes, edges, components, density, degrees. Local computation.",
       "testedAt": "2026-06-09T17:00:00.000Z",
       "toolsTested": ["graph_analyze"]
+    },
+    "convolution": {
+      "status": "pass",
+      "note": "convolution computes discrete signal convolution (full/same/valid modes). Local computation.",
+      "testedAt": "2026-06-09T18:00:00.000Z",
+      "toolsTested": ["convolution"]
+    },
+    "rle2": {
+      "status": "pass",
+      "note": "rle_encode_decode run-length encodes/decodes numeric arrays. Local computation.",
+      "testedAt": "2026-06-09T18:00:00.000Z",
+      "toolsTested": ["rle_encode_decode"]
+    },
+    "descriptive": {
+      "status": "pass",
+      "note": "descriptive_stats computes mean, median, mode, std, skewness, kurtosis, IQR. Local computation.",
+      "testedAt": "2026-06-09T18:00:00.000Z",
+      "toolsTested": ["descriptive_stats"]
+    },
+    "bfs": {
+      "status": "pass",
+      "note": "bfs_search does breadth-first search for shortest paths and reachability. Local computation.",
+      "testedAt": "2026-06-09T18:00:00.000Z",
+      "toolsTested": ["bfs_search"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."


### PR DESCRIPTION
## Summary
- **convolution-tool**: Discrete signal convolution with full, same, and valid output modes
- **rle2-tool**: Run-length encode/decode numeric arrays with compression ratio analysis
- **descriptive-tool**: Full descriptive statistics - mean, median, mode, std, variance, skewness, kurtosis, quartiles, IQR
- **bfs-tool**: Breadth-first search on graphs - shortest unweighted path, visit order, reachability

All four are local computation connectors (no API keys, no network). 26 tests pass. App count: 551.

## Test plan
- [x] `npx vitest run src/convolution-tool.test.ts` - 6 tests pass
- [x] `npx vitest run src/rle2-tool.test.ts` - 6 tests pass
- [x] `npx vitest run src/descriptive-tool.test.ts` - 7 tests pass
- [x] `npx vitest run src/bfs-tool.test.ts` - 7 tests pass
- [x] `npx tsc --noEmit` - clean
- [x] Regeneration pipeline run (tool-index, depth-ladder, app-catalog, brainmap)
- [x] app-test-results.json updated with pass status

https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez)_