### PR TITLE
Add batch 64: Monte Carlo, DFS, percentile, MST (555 apps)

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 977,
+    "inventory": 981,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 552,
+    "tools": 556,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 552
+      "count": 556
     },
     {
       "id": "rooms",
@@ -5422,6 +5422,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-dfs-packages-mcp-server-src-dfs-tool-ts-no-route",
+      "division": "Tools",
+      "name": "dfs",
+      "kind": "MCP tool",
+      "meaning": "dfs MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/dfs-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-diceware-packages-mcp-server-src-diceware-tool-ts-no-route",
       "division": "Tools",
       "name": "diceware",
@@ -7162,12 +7172,32 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-montecarlo-packages-mcp-server-src-montecarlo-tool-ts-no-route",
+      "division": "Tools",
+      "name": "montecarlo",
+      "kind": "MCP tool",
+      "meaning": "montecarlo MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/montecarlo-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-morse-packages-mcp-server-src-morse-tool-ts-no-route",
       "division": "Tools",
       "name": "morse",
       "kind": "MCP tool",
       "meaning": "morse MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/morse-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-mst-packages-mcp-server-src-mst-tool-ts-no-route",
+      "division": "Tools",
+      "name": "mst",
+      "kind": "MCP tool",
+      "meaning": "mst MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/mst-tool.ts",
       "route": "",
       "tags": []
     },
@@ -7738,6 +7768,16 @@
       "kind": "MCP tool",
       "meaning": "percentage MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/percentage-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-percentile-packages-mcp-server-src-percentile-tool-ts-no-route",
+      "division": "Tools",
+      "name": "percentile",
+      "kind": "MCP tool",
+      "meaning": "percentile MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/percentile-tool.ts",
       "route": "",
       "tags": []
     },
@@ -11076,6 +11116,11 @@
       "packages/mcp-server/src/descriptive-tool.ts"
     ],
     [
+      "dfs",
+      "dfs MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/dfs-tool.ts"
+    ],
+    [
       "diceware",
       "diceware MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/diceware-tool.ts"
@@ -11946,9 +11991,19 @@
       "packages/mcp-server/src/monica-tool.ts"
     ],
     [
+      "montecarlo",
+      "montecarlo MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/montecarlo-tool.ts"
+    ],
+    [
       "morse",
       "morse MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/morse-tool.ts"
+    ],
+    [
+      "mst",
+      "mst MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/mst-tool.ts"
     ],
     [
       "mtg",
@@ -12234,6 +12289,11 @@
       "percentage",
       "percentage MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/percentage-tool.ts"
+    ],
+    [
+      "percentile",
+      "percentile MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/percentile-tool.ts"
     ],
     [
       "permutation",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 552 |
+| Tools | MCP and gateway capabilities available to seats. | 556 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -492,6 +492,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | deepl | deepl MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/deepl-tool.ts |
 | deezer | deezer MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/deezer-tool.ts |
 | descriptive | descriptive MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/descriptive-tool.ts |
+| dfs | dfs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dfs-tool.ts |
 | diceware | diceware MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/diceware-tool.ts |
 | dictionary | dictionary MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/dictionary-tool.ts |
 | difftext | difftext MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/difftext-tool.ts |
@@ -666,7 +667,9 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | modpow | modpow MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/modpow-tool.ts |
 | monday | monday MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/monday-tool.ts |
 | monica | monica MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/monica-tool.ts |
+| montecarlo | montecarlo MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/montecarlo-tool.ts |
 | morse | morse MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/morse-tool.ts |
+| mst | mst MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mst-tool.ts |
 | mtg | mtg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/mtg-tool.ts |
 | multiavatar | multiavatar MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/multiavatar-tool.ts |
 | musicbrainz | musicbrainz MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/musicbrainz-tool.ts |
@@ -724,6 +727,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | passwordgen | passwordgen MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/passwordgen-tool.ts |
 | paypal | paypal MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/paypal-tool.ts |
 | percentage | percentage MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/percentage-tool.ts |
+| percentile | percentile MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/percentile-tool.ts |
 | permutation | permutation MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/permutation-tool.ts |
 | perplexity | perplexity MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/perplexity-tool.ts |
 | phonetic | phonetic MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/phonetic-tool.ts |
@@ -1460,6 +1464,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | deepl | deepl MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/deepl-tool.ts |
 | Tools | MCP tool | deezer | deezer MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/deezer-tool.ts |
 | Tools | MCP tool | descriptive | descriptive MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/descriptive-tool.ts |
+| Tools | MCP tool | dfs | dfs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dfs-tool.ts |
 | Tools | MCP tool | diceware | diceware MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/diceware-tool.ts |
 | Tools | MCP tool | dictionary | dictionary MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/dictionary-tool.ts |
 | Tools | MCP tool | difftext | difftext MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/difftext-tool.ts |
@@ -1634,7 +1639,9 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | modpow | modpow MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/modpow-tool.ts |
 | Tools | MCP tool | monday | monday MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/monday-tool.ts |
 | Tools | MCP tool | monica | monica MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/monica-tool.ts |
+| Tools | MCP tool | montecarlo | montecarlo MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/montecarlo-tool.ts |
 | Tools | MCP tool | morse | morse MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/morse-tool.ts |
+| Tools | MCP tool | mst | mst MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mst-tool.ts |
 | Tools | MCP tool | mtg | mtg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/mtg-tool.ts |
 | Tools | MCP tool | multiavatar | multiavatar MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/multiavatar-tool.ts |
 | Tools | MCP tool | musicbrainz | musicbrainz MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/musicbrainz-tool.ts |
@@ -1692,6 +1699,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | passwordgen | passwordgen MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/passwordgen-tool.ts |
 | Tools | MCP tool | paypal | paypal MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/paypal-tool.ts |
 | Tools | MCP tool | percentage | percentage MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/percentage-tool.ts |
+| Tools | MCP tool | percentile | percentile MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/percentile-tool.ts |
 | Tools | MCP tool | permutation | permutation MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/permutation-tool.ts |
 | Tools | MCP tool | perplexity | perplexity MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/perplexity-tool.ts |
 | Tools | MCP tool | phonetic | phonetic MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/phonetic-tool.ts |

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -2200,6 +2200,26 @@
     }
   },
   {
+    "connector": "dfs",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "diceware",
     "level": 5,
     "levelName": "Agentic",
@@ -5340,7 +5360,47 @@
     }
   },
   {
+    "connector": "montecarlo",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "morse",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "mst",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,
@@ -6401,6 +6461,26 @@
   },
   {
     "connector": "percentage",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "percentile",
     "level": 5,
     "levelName": "Agentic",
     "hardened": false,

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (526 external connectors)
+## Distribution (530 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 487 | 93% |
+| L5 | Agentic | 491 | 93% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 526 (46%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 530 (45%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 487 of 490 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 491 of 494 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -103,6 +103,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `datamuse` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `dblp` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `descriptive` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `dfs` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `diceware` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `difftext` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `digimon` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -196,7 +197,9 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `mhwdb` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `midpoint` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `modpow` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `montecarlo` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `morse` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `mst` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mtg` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `multiavatar` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `mymemory` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -233,6 +236,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `pascaltri` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `passwordgen` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `percentage` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `percentile` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `permutation` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `phonetic` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `piapprox` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -437,6 +441,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `deepl` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `deezer` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `descriptive` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `dfs` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `diceware` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `dictionary` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `difftext` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
@@ -594,7 +599,9 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `mixpanel` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `modpow` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `monday` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `montecarlo` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `morse` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `mst` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `mtg` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `multiavatar` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `musicbrainz` | Yes | - | - | Yes | Yes | no-memory |
@@ -648,6 +655,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `pascaltri` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `passwordgen` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `percentage` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `percentile` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `permutation` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `phonetic` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `piapprox` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -1960,6 +1960,16 @@
     ]
   },
   {
+    "app": "dfs",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "dfs_search",
+        "description": "Depth-first search on a graph. Finds a path, visit order, reachable count, and detects cycles."
+      }
+    ]
+  },
+  {
     "app": "diceware",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4782,12 +4792,32 @@
     ]
   },
   {
+    "app": "montecarlo",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "monte_carlo_estimate",
+        "description": "Monte Carlo estimation: estimate pi or compute a definite integral via random sampling."
+      }
+    ]
+  },
+  {
     "app": "morse",
     "category": "Existing tools (previously unwired)",
     "tools": [
       {
         "name": "morse_convert",
         "description": "Encode text to Morse code or decode Morse code to text."
+      }
+    ]
+  },
+  {
+    "app": "mst",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "mst_find",
+        "description": "Find the minimum spanning tree of a weighted graph using Kruskal's algorithm."
       }
     ]
   },
@@ -5682,6 +5712,16 @@
       {
         "name": "percentage_calc",
         "description": "Perform percentage calculations (of, change, increase, decrease, is_what_percent)."
+      }
+    ]
+  },
+  {
+    "app": "percentile",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "percentile_calc",
+        "description": "Compute percentiles of a dataset (default p5-p99) and optionally find the percentile rank of a given value."
       }
     ]
   },

--- a/packages/mcp-server/src/dfs-tool.test.ts
+++ b/packages/mcp-server/src/dfs-tool.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { dfsSearch } from "./dfs-tool.js";
+
+describe("dfsSearch", () => {
+  const edges = [
+    { from: "A", to: "B" },
+    { from: "A", to: "C" },
+    { from: "B", to: "D" },
+    { from: "C", to: "D" },
+    { from: "D", to: "E" },
+  ];
+
+  it("finds a path to target", async () => {
+    const r = await dfsSearch({ edges, start: "A", target: "E", directed: true }) as any;
+    expect(r.path).not.toBeNull();
+    expect(r.path[0]).toBe("A");
+    expect(r.path[r.path.length - 1]).toBe("E");
+    expect(r.path_length).toBeGreaterThan(0);
+  });
+
+  it("traverses all reachable nodes", async () => {
+    const r = await dfsSearch({ edges, start: "A", directed: true }) as any;
+    expect(r.reachable_count).toBe(5);
+    expect(r.visit_order[0]).toBe("A");
+  });
+
+  it("detects cycles", async () => {
+    const r = await dfsSearch({
+      edges: [{ from: "A", to: "B" }, { from: "B", to: "A" }],
+      start: "A",
+      directed: true,
+    }) as any;
+    expect(r.has_cycle).toBe(true);
+  });
+
+  it("no cycle in a DAG", async () => {
+    const r = await dfsSearch({ edges, start: "A", directed: true }) as any;
+    expect(r.has_cycle).toBe(false);
+  });
+
+  it("returns null path if unreachable", async () => {
+    const r = await dfsSearch({
+      edges: [{ from: "A", to: "B" }, { from: "C", to: "D" }],
+      start: "A",
+      target: "D",
+      directed: true,
+    }) as any;
+    expect(r.path).toBeNull();
+  });
+
+  it("rejects empty edges", async () => {
+    await expect(dfsSearch({ edges: [], start: "A" })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await dfsSearch({ edges: [{ from: "A", to: "B" }], start: "A" }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/dfs-tool.ts
+++ b/packages/mcp-server/src/dfs-tool.ts
@@ -1,0 +1,105 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+interface Edge {
+  from: string;
+  to: string;
+}
+
+export async function dfsSearch(args: Record<string, unknown>) {
+  const edges = args.edges as Edge[];
+  if (!Array.isArray(edges) || edges.length === 0) {
+    throw new Error("edges must be a non-empty array of {from, to} objects.");
+  }
+  if (edges.length > 10000) throw new Error("edges must have 10000 entries or fewer.");
+
+  const start = String(args.start ?? "");
+  if (!start) throw new Error("start node is required.");
+
+  const target = args.target !== undefined ? String(args.target) : null;
+  const directed = args.directed !== false;
+
+  const adj = new Map<string, string[]>();
+  const allNodes = new Set<string>();
+
+  for (const e of edges) {
+    const from = String(e.from);
+    const to = String(e.to);
+    allNodes.add(from);
+    allNodes.add(to);
+    if (!adj.has(from)) adj.set(from, []);
+    adj.get(from)!.push(to);
+    if (!directed) {
+      if (!adj.has(to)) adj.set(to, []);
+      adj.get(to)!.push(from);
+    }
+  }
+
+  if (!allNodes.has(start)) throw new Error(`start node '${start}' not found in graph.`);
+  if (target && !allNodes.has(target)) throw new Error(`target node '${target}' not found in graph.`);
+
+  const visited = new Set<string>();
+  const order: string[] = [];
+  let foundPath: string[] | null = null;
+
+  const dfs = (node: string, path: string[]): boolean => {
+    visited.add(node);
+    order.push(node);
+    const currentPath = [...path, node];
+
+    if (target && node === target) {
+      foundPath = currentPath;
+      return true;
+    }
+
+    for (const neighbor of adj.get(node) ?? []) {
+      if (!visited.has(neighbor)) {
+        if (dfs(neighbor, currentPath)) return true;
+      }
+    }
+    return false;
+  };
+
+  dfs(start, []);
+
+  const hasCycle = (() => {
+    const white = new Set(allNodes);
+    const gray = new Set<string>();
+
+    const detect = (node: string): boolean => {
+      white.delete(node);
+      gray.add(node);
+      for (const neighbor of adj.get(node) ?? []) {
+        if (gray.has(neighbor)) return true;
+        if (white.has(neighbor) && detect(neighbor)) return true;
+      }
+      gray.delete(node);
+      return false;
+    };
+
+    for (const node of allNodes) {
+      if (white.has(node) && detect(node)) return true;
+    }
+    return false;
+  })();
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "DFS finds a path but not necessarily the shortest",
+      "Use bfs_search for shortest unweighted path",
+    ],
+  };
+  const resultPath = foundPath as unknown as string[] | null;
+  return stampMeta({
+    start,
+    target: target ?? "none",
+    directed,
+    nodes_visited: order.length,
+    visit_order: order,
+    path: resultPath,
+    path_length: resultPath ? resultPath.length - 1 : null,
+    reachable_count: visited.size,
+    has_cycle: hasCycle,
+  }, meta);
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -1974,6 +1974,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "dfs",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "dfs_search",
+        "description": "Depth-first search on a graph. Finds a path, visit order, reachable count, and detects cycles."
+      }
+    ]
+  },
+  {
     "app": "diceware",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -4796,12 +4806,32 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "montecarlo",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "monte_carlo_estimate",
+        "description": "Monte Carlo estimation: estimate pi or compute a definite integral via random sampling."
+      }
+    ]
+  },
+  {
     "app": "morse",
     "category": "Existing tools (previously unwired)",
     "tools": [
       {
         "name": "morse_convert",
         "description": "Encode text to Morse code or decode Morse code to text."
+      }
+    ]
+  },
+  {
+    "app": "mst",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "mst_find",
+        "description": "Find the minimum spanning tree of a weighted graph using Kruskal's algorithm."
       }
     ]
   },
@@ -5696,6 +5726,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "percentage_calc",
         "description": "Perform percentage calculations (of, change, increase, decrease, is_what_percent)."
+      }
+    ]
+  },
+  {
+    "app": "percentile",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "percentile_calc",
+        "description": "Compute percentiles of a dataset (default p5-p99) and optionally find the percentile rank of a given value."
       }
     ]
   },

--- a/packages/mcp-server/src/montecarlo-tool.test.ts
+++ b/packages/mcp-server/src/montecarlo-tool.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { monteCarloEstimate } from "./montecarlo-tool.js";
+
+describe("monteCarloEstimate", () => {
+  it("estimates pi", async () => {
+    const r = await monteCarloEstimate({ method: "pi", samples: 100000 }) as any;
+    expect(r.estimate).toBeCloseTo(Math.PI, 1);
+    expect(r.method).toBe("pi");
+    expect(r.samples).toBe(100000);
+    expect(r.points_inside).toBeGreaterThan(0);
+  });
+
+  it("estimates integral of x^2 from 0 to 1", async () => {
+    const r = await monteCarloEstimate({
+      method: "integral",
+      expression: "x*x",
+      a: 0,
+      b: 1,
+      samples: 100000,
+    }) as any;
+    expect(r.estimate).toBeCloseTo(1 / 3, 1);
+    expect(r.method).toBe("integral");
+  });
+
+  it("respects seed for reproducibility", async () => {
+    const r1 = await monteCarloEstimate({ method: "pi", samples: 1000, seed: 42 }) as any;
+    const r2 = await monteCarloEstimate({ method: "pi", samples: 1000, seed: 42 }) as any;
+    expect(r1.estimate).toBe(r2.estimate);
+  });
+
+  it("rejects invalid method", async () => {
+    await expect(monteCarloEstimate({ method: "bogus" })).rejects.toThrow("method must be");
+  });
+
+  it("rejects missing expression for integral", async () => {
+    await expect(monteCarloEstimate({ method: "integral" })).rejects.toThrow("expression");
+  });
+
+  it("stamps meta", async () => {
+    const r = await monteCarloEstimate({ method: "pi", samples: 100 }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/montecarlo-tool.ts
+++ b/packages/mcp-server/src/montecarlo-tool.ts
@@ -1,0 +1,87 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function monteCarloEstimate(args: Record<string, unknown>) {
+  const method = String(args.method ?? "pi").toLowerCase();
+  const samples = Math.min(Math.max(Math.floor(Number(args.samples ?? 10000)), 100), 10000000);
+
+  if (method === "pi") {
+    let inside = 0;
+    let seed = (args.seed !== undefined ? Number(args.seed) : 12345) >>> 0;
+    const lcg = () => { seed = (seed * 1664525 + 1013904223) >>> 0; return seed / 4294967296; };
+
+    for (let i = 0; i < samples; i++) {
+      const x = lcg();
+      const y = lcg();
+      if (x * x + y * y <= 1) inside++;
+    }
+    const estimate = 4 * inside / samples;
+    const error = Math.abs(estimate - Math.PI);
+
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: ["Increase samples for better accuracy", "Error decreases as 1/sqrt(n)"],
+    };
+    return stampMeta({
+      method: "pi",
+      samples,
+      estimate: Math.round(estimate * 1e10) / 1e10,
+      actual: Math.round(Math.PI * 1e10) / 1e10,
+      absolute_error: Math.round(error * 1e10) / 1e10,
+      relative_error_pct: Math.round((error / Math.PI) * 1e8) / 1e6,
+      points_inside: inside,
+    }, meta);
+  }
+
+  if (method === "integral") {
+    const expr = String(args.expression ?? "");
+    if (!expr) throw new Error("expression is required for integral method.");
+    const a = Number(args.a ?? 0);
+    const b = Number(args.b ?? 1);
+    if (!Number.isFinite(a) || !Number.isFinite(b) || a >= b) {
+      throw new Error("a and b must be finite with a < b.");
+    }
+
+    const evaluate = (xVal: number): number => {
+      const sanitized = expr.replace(/\bx\b/g, `(${xVal})`).replace(/\^/g, "**");
+      const allowed = /^[\d+\-*/().eE\s]*$/;
+      if (!allowed.test(sanitized)) throw new Error("Expression contains unsupported characters.");
+      const result = Function(`"use strict"; return (${sanitized})`)();
+      if (typeof result !== "number" || !Number.isFinite(result)) return 0;
+      return result;
+    };
+
+    let seed = (args.seed !== undefined ? Number(args.seed) : 54321) >>> 0;
+    const lcg = () => { seed = (seed * 1664525 + 1013904223) >>> 0; return seed / 4294967296; };
+
+    let sum = 0;
+    let sumSq = 0;
+    for (let i = 0; i < samples; i++) {
+      const x = a + (b - a) * lcg();
+      const val = evaluate(x);
+      sum += val;
+      sumSq += val * val;
+    }
+    const mean = sum / samples;
+    const estimate = (b - a) * mean;
+    const variance = (sumSq / samples - mean * mean) * (b - a) * (b - a) / samples;
+    const stdError = Math.sqrt(Math.max(0, variance));
+
+    const meta: ConnectorMeta = {
+      source: "local-computation",
+      fetched_at: new Date().toISOString(),
+      next_steps: ["Increase samples for tighter confidence interval", "Standard error decreases as 1/sqrt(n)"],
+    };
+    return stampMeta({
+      method: "integral",
+      expression: expr,
+      a,
+      b,
+      samples,
+      estimate: Math.round(estimate * 1e8) / 1e8,
+      std_error: Math.round(stdError * 1e8) / 1e8,
+    }, meta);
+  }
+
+  throw new Error("method must be pi or integral.");
+}

--- a/packages/mcp-server/src/mst-tool.test.ts
+++ b/packages/mcp-server/src/mst-tool.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { mstFind } from "./mst-tool.js";
+
+describe("mstFind", () => {
+  it("finds MST of a simple graph", async () => {
+    const r = await mstFind({
+      edges: [
+        { from: "A", to: "B", weight: 1 },
+        { from: "B", to: "C", weight: 2 },
+        { from: "A", to: "C", weight: 3 },
+      ],
+    }) as any;
+    expect(r.mst_edges).toBe(2);
+    expect(r.total_weight).toBe(3);
+    expect(r.is_connected).toBe(true);
+  });
+
+  it("picks lighter edges", async () => {
+    const r = await mstFind({
+      edges: [
+        { from: "A", to: "B", weight: 10 },
+        { from: "A", to: "B", weight: 1 },
+        { from: "B", to: "C", weight: 5 },
+      ],
+    }) as any;
+    expect(r.total_weight).toBe(6);
+  });
+
+  it("handles disconnected graph", async () => {
+    const r = await mstFind({
+      edges: [
+        { from: "A", to: "B", weight: 1 },
+        { from: "C", to: "D", weight: 2 },
+      ],
+    }) as any;
+    expect(r.is_connected).toBe(false);
+    expect(r.mst_edges).toBe(2);
+  });
+
+  it("single edge", async () => {
+    const r = await mstFind({
+      edges: [{ from: "X", to: "Y", weight: 7 }],
+    }) as any;
+    expect(r.mst_edges).toBe(1);
+    expect(r.total_weight).toBe(7);
+  });
+
+  it("rejects empty edges", async () => {
+    await expect(mstFind({ edges: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await mstFind({
+      edges: [{ from: "A", to: "B", weight: 1 }],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/mst-tool.ts
+++ b/packages/mcp-server/src/mst-tool.ts
@@ -1,0 +1,80 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+interface Edge {
+  from: string;
+  to: string;
+  weight: number;
+}
+
+export async function mstFind(args: Record<string, unknown>) {
+  const edges = args.edges as Edge[];
+  if (!Array.isArray(edges) || edges.length === 0) {
+    throw new Error("edges must be a non-empty array of {from, to, weight} objects.");
+  }
+  if (edges.length > 10000) throw new Error("edges must have 10000 entries or fewer.");
+
+  const allNodes = new Set<string>();
+  for (const e of edges) {
+    allNodes.add(String(e.from));
+    allNodes.add(String(e.to));
+  }
+
+  const parent = new Map<string, string>();
+  const rank = new Map<string, number>();
+  for (const node of allNodes) {
+    parent.set(node, node);
+    rank.set(node, 0);
+  }
+
+  const find = (x: string): string => {
+    if (parent.get(x) !== x) parent.set(x, find(parent.get(x)!));
+    return parent.get(x)!;
+  };
+
+  const union = (a: string, b: string): boolean => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra === rb) return false;
+    const rankA = rank.get(ra)!;
+    const rankB = rank.get(rb)!;
+    if (rankA < rankB) parent.set(ra, rb);
+    else if (rankA > rankB) parent.set(rb, ra);
+    else { parent.set(rb, ra); rank.set(ra, rankA + 1); }
+    return true;
+  };
+
+  const sorted = [...edges]
+    .map((e) => ({ from: String(e.from), to: String(e.to), weight: Number(e.weight) }))
+    .sort((a, b) => a.weight - b.weight);
+
+  const mstEdges: { from: string; to: string; weight: number }[] = [];
+  let totalWeight = 0;
+
+  for (const e of sorted) {
+    if (union(e.from, e.to)) {
+      mstEdges.push(e);
+      totalWeight += e.weight;
+    }
+  }
+
+  const roots = new Set<string>();
+  for (const node of allNodes) roots.add(find(node));
+  const isConnected = roots.size === 1;
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "MST connects all nodes with minimum total edge weight",
+      "If graph is disconnected, result is a minimum spanning forest",
+    ],
+  };
+  return stampMeta({
+    node_count: allNodes.size,
+    input_edges: edges.length,
+    mst_edges: mstEdges.length,
+    total_weight: Math.round(totalWeight * 1e8) / 1e8,
+    is_connected: isConnected,
+    edges: mstEdges,
+  }, meta);
+}

--- a/packages/mcp-server/src/percentile-tool.test.ts
+++ b/packages/mcp-server/src/percentile-tool.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { percentileCalc } from "./percentile-tool.js";
+
+describe("percentileCalc", () => {
+  it("computes default percentiles", async () => {
+    const data = Array.from({ length: 100 }, (_, i) => i + 1);
+    const r = await percentileCalc({ data }) as any;
+    expect(r.percentiles.p50).toBeCloseTo(50.5, 1);
+    expect(r.percentiles.p25).toBeCloseTo(25.75, 1);
+    expect(r.percentiles.p75).toBeCloseTo(75.25, 1);
+  });
+
+  it("computes custom percentiles", async () => {
+    const data = [10, 20, 30, 40, 50];
+    const r = await percentileCalc({ data, percentiles: [0, 50, 100] }) as any;
+    expect(r.percentiles.p0).toBe(10);
+    expect(r.percentiles.p50).toBe(30);
+    expect(r.percentiles.p100).toBe(50);
+  });
+
+  it("finds percentile rank of a value", async () => {
+    const data = Array.from({ length: 100 }, (_, i) => i + 1);
+    const r = await percentileCalc({ data, value: 50 }) as any;
+    expect(r.value_percentile.percentile).toBeCloseTo(49.5, 0);
+  });
+
+  it("handles single element", async () => {
+    const r = await percentileCalc({ data: [42] }) as any;
+    expect(r.percentiles.p50).toBe(42);
+    expect(r.min).toBe(42);
+    expect(r.max).toBe(42);
+  });
+
+  it("rejects empty data", async () => {
+    await expect(percentileCalc({ data: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await percentileCalc({ data: [1, 2, 3] }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/percentile-tool.ts
+++ b/packages/mcp-server/src/percentile-tool.ts
@@ -1,0 +1,58 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function percentileCalc(args: Record<string, unknown>) {
+  const data = args.data as number[];
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error("data must be a non-empty array of numbers.");
+  }
+  if (data.length > 100000) throw new Error("data must have 100000 elements or fewer.");
+
+  const sorted = [...data].sort((a, b) => a - b);
+  const n = sorted.length;
+
+  const getPercentile = (p: number): number => {
+    if (p <= 0) return sorted[0];
+    if (p >= 100) return sorted[n - 1];
+    const rank = (p / 100) * (n - 1);
+    const lower = Math.floor(rank);
+    const upper = Math.ceil(rank);
+    if (lower === upper) return sorted[lower];
+    return sorted[lower] + (rank - lower) * (sorted[upper] - sorted[lower]);
+  };
+
+  const percentiles = args.percentiles as number[] | undefined;
+  const defaultPercentiles = [5, 10, 25, 50, 75, 90, 95, 99];
+  const targets = Array.isArray(percentiles) && percentiles.length > 0
+    ? percentiles.filter((p) => p >= 0 && p <= 100)
+    : defaultPercentiles;
+
+  const results: Record<string, number> = {};
+  for (const p of targets) {
+    results[`p${p}`] = Math.round(getPercentile(p) * 1e8) / 1e8;
+  }
+
+  const value = args.value !== undefined ? Number(args.value) : null;
+  let valuePercentile: number | null = null;
+  if (value !== null && Number.isFinite(value)) {
+    const belowCount = sorted.filter((v) => v < value).length;
+    const equalCount = sorted.filter((v) => v === value).length;
+    valuePercentile = Math.round(((belowCount + equalCount / 2) / n) * 100 * 1e4) / 1e4;
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "p50 is the median",
+      "p25 and p75 define the interquartile range",
+      "Provide a value to find its percentile rank",
+    ],
+  };
+  return stampMeta({
+    n,
+    percentiles: results,
+    value_percentile: valuePercentile !== null ? { value, percentile: valuePercentile } : null,
+    min: sorted[0],
+    max: sorted[n - 1],
+  }, meta);
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -722,6 +722,10 @@ import { convolution } from "./convolution-tool.js";
 import { rleEncodeDecode } from "./rle2-tool.js";
 import { descriptiveStats } from "./descriptive-tool.js";
 import { bfsSearch } from "./bfs-tool.js";
+import { monteCarloEstimate } from "./montecarlo-tool.js";
+import { dfsSearch } from "./dfs-tool.js";
+import { percentileCalc } from "./percentile-tool.js";
+import { mstFind } from "./mst-tool.js";
 
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
@@ -10851,6 +10855,64 @@ export const ADDITIONAL_TOOLS = [
         target: { type: "string", description: "Optional target node to find path to" },
         directed: { type: "boolean", description: "Whether the graph is directed (default true)" },
       }, required: ["edges", "start"],
+    },
+  },
+
+  // ── montecarlo-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "monte_carlo_estimate",
+    description: "Monte Carlo estimation: estimate pi or compute a definite integral via random sampling.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        method: { type: "string", enum: ["pi", "integral"], description: "Estimation method (default pi)" },
+        samples: { type: "integer", description: "Number of random samples (default 10000, max 10000000)" },
+        expression: { type: "string", description: "JS expression in x for integral method" },
+        a: { type: "number", description: "Lower bound for integral" },
+        b: { type: "number", description: "Upper bound for integral" },
+        seed: { type: "integer", description: "Random seed for reproducibility" },
+      }, required: [],
+    },
+  },
+
+  // ── dfs-tool.ts ─────────────────────────────────────────────────────────────
+  {
+    name: "dfs_search",
+    description: "Depth-first search on a graph. Finds a path, visit order, reachable count, and detects cycles.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        edges: { type: "array", items: { type: "object", properties: { from: { type: "string" }, to: { type: "string" } }, required: ["from", "to"] }, description: "Array of edges" },
+        start: { type: "string", description: "Start node" },
+        target: { type: "string", description: "Optional target node" },
+        directed: { type: "boolean", description: "Whether the graph is directed (default true)" },
+      }, required: ["edges", "start"],
+    },
+  },
+
+  // ── percentile-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "percentile_calc",
+    description: "Compute percentiles of a dataset (default p5-p99) and optionally find the percentile rank of a given value.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        data: { type: "array", items: { type: "number" }, description: "Numeric data array" },
+        percentiles: { type: "array", items: { type: "number" }, description: "Percentiles to compute (default [5,10,25,50,75,90,95,99])" },
+        value: { type: "number", description: "Optional value to find its percentile rank" },
+      }, required: ["data"],
+    },
+  },
+
+  // ── mst-tool.ts ─────────────────────────────────────────────────────────────
+  {
+    name: "mst_find",
+    description: "Find the minimum spanning tree of a weighted graph using Kruskal's algorithm.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        edges: { type: "array", items: { type: "object", properties: { from: { type: "string" }, to: { type: "string" }, weight: { type: "number" } }, required: ["from", "to", "weight"] }, description: "Array of weighted edges" },
+      }, required: ["edges"],
     },
   },
 
@@ -22599,6 +22661,12 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   rle_encode_decode:         (args) => rleEncodeDecode(args),
   descriptive_stats:         (args) => descriptiveStats(args),
   bfs_search:                (args) => bfsSearch(args),
+
+  // batch 64: Monte Carlo, DFS, percentile, MST
+  monte_carlo_estimate:      (args) => monteCarloEstimate(args),
+  dfs_search:                (args) => dfsSearch(args),
+  percentile_calc:           (args) => percentileCalc(args),
+  mst_find:                  (args) => mstFind(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate", "fft", "bezier", "rootfind", "matinverse", "ode", "polynomial", "hypothesis", "huffman", "correlation", "bitcount", "runstats", "graph", "convolution", "rle2", "descriptive", "bfs"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate", "fft", "bezier", "rootfind", "matinverse", "ode", "polynomial", "hypothesis", "huffman", "correlation", "bitcount", "runstats", "graph", "convolution", "rle2", "descriptive", "bfs", "montecarlo", "dfs", "percentile", "mst"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -199,6 +199,7 @@ const NAME_OF = {
   ode: "ODE Solver", polynomial: "Polynomial Ops", hypothesis: "Hypothesis Test", huffman: "Huffman Coding",
   correlation: "Correlation", bitcount: "Bit Count", runstats: "Running Stats", graph: "Graph Analyze",
   convolution: "Convolution", rle2: "RLE Numeric", descriptive: "Descriptive Stats", bfs: "BFS Search",
+  montecarlo: "Monte Carlo", dfs: "DFS Search", percentile: "Percentile", mst: "Min Spanning Tree",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -597,6 +598,10 @@ const BLURB_OF = {
   rle2: "Run-length encode or decode numeric arrays for compression analysis.",
   descriptive: "Full descriptive statistics: mean, median, mode, std, skewness, kurtosis, IQR.",
   bfs: "Breadth-first search for shortest unweighted paths and reachability.",
+  montecarlo: "Monte Carlo estimation of pi or definite integrals via random sampling.",
+  dfs: "Depth-first search with path finding, reachability, and cycle detection.",
+  percentile: "Compute percentiles (p5-p99) and find the percentile rank of a value.",
+  mst: "Find the minimum spanning tree of a weighted graph (Kruskal's algorithm).",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -772,6 +777,7 @@ const DOMAIN_OF = {
   ode: "local", polynomial: "local", hypothesis: "local", huffman: "local",
   correlation: "local", bitcount: "local", runstats: "local", graph: "local",
   convolution: "local", rle2: "local", descriptive: "local", bfs: "local",
+  montecarlo: "local", dfs: "local", percentile: "local", mst: "local",
 };
 
 function titleCase(slug) {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 551,
-  "toolCount": 1473,
+  "appCount": 555,
+  "toolCount": 1477,
   "categories": [
     "AI",
     "Books",
@@ -2592,6 +2592,22 @@
         {
           "name": "descriptive_stats",
           "description": "Compute descriptive statistics: mean, median, mode, std, variance, skewness, kurtosis, quartiles, IQR, and more."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "dfs",
+      "name": "DFS Search",
+      "category": "Utilities",
+      "blurb": "Depth-first search with path finding, reachability, and cycle detection.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "dfs_search",
+          "description": "Depth-first search on a graph. Finds a path, visit order, reachable count, and detects cycles."
         }
       ],
       "level": 5,
@@ -6226,6 +6242,22 @@
       "hardened": false
     },
     {
+      "slug": "mst",
+      "name": "Min Spanning Tree",
+      "category": "Utilities",
+      "blurb": "Find the minimum spanning tree of a weighted graph (Kruskal's algorithm).",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "mst_find",
+          "description": "Find the minimum spanning tree of a weighted graph using Kruskal's algorithm."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "miro",
       "name": "Miro",
       "category": "Productivity",
@@ -6388,6 +6420,22 @@
         {
           "name": "mhw_weapons",
           "description": "Browse Monster Hunter World weapons by type."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "montecarlo",
+      "name": "Monte Carlo",
+      "category": "Utilities",
+      "blurb": "Monte Carlo estimation of pi or definite integrals via random sampling.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "monte_carlo_estimate",
+          "description": "Monte Carlo estimation: estimate pi or compute a definite integral via random sampling."
         }
       ],
       "level": 5,
@@ -7660,6 +7708,22 @@
         {
           "name": "percentage_calc",
           "description": "Perform percentage calculations (of, change, increase, decrease, is_what_percent)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "percentile",
+      "name": "Percentile",
+      "category": "Utilities",
+      "blurb": "Compute percentiles (p5-p99) and find the percentile rank of a value.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "percentile_calc",
+          "description": "Compute percentiles of a dataset (default p5-p99) and optionally find the percentile rank of a given value."
         }
       ],
       "level": 5,

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -4138,6 +4138,30 @@
       "note": "bfs_search does breadth-first search for shortest paths and reachability. Local computation.",
       "testedAt": "2026-06-09T18:00:00.000Z",
       "toolsTested": ["bfs_search"]
+    },
+    "montecarlo": {
+      "status": "pass",
+      "note": "monte_carlo_estimate estimates pi or integrals via random sampling. Local computation.",
+      "testedAt": "2026-06-09T19:00:00.000Z",
+      "toolsTested": ["monte_carlo_estimate"]
+    },
+    "dfs": {
+      "status": "pass",
+      "note": "dfs_search does depth-first search with cycle detection. Local computation.",
+      "testedAt": "2026-06-09T19:00:00.000Z",
+      "toolsTested": ["dfs_search"]
+    },
+    "percentile": {
+      "status": "pass",
+      "note": "percentile_calc computes p5-p99 and percentile rank of values. Local computation.",
+      "testedAt": "2026-06-09T19:00:00.000Z",
+      "toolsTested": ["percentile_calc"]
+    },
+    "mst": {
+      "status": "pass",
+      "note": "mst_find computes minimum spanning tree via Kruskal's algorithm. Local computation.",
+      "testedAt": "2026-06-09T19:00:00.000Z",
+      "toolsTested": ["mst_find"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."


### PR DESCRIPTION
## Summary
- **montecarlo-tool**: Monte Carlo estimation of pi or definite integrals via random sampling with reproducible seeds
- **dfs-tool**: Depth-first search on graphs with path finding, visit order, reachability, and cycle detection
- **percentile-tool**: Compute percentiles (p5-p99) and find the percentile rank of any value in a dataset
- **mst-tool**: Minimum spanning tree via Kruskal's algorithm with union-find

All four are local computation connectors (no API keys, no network). 25 tests pass. App count: 555.

## Test plan
- [x] `npx vitest run src/montecarlo-tool.test.ts` - 6 tests pass
- [x] `npx vitest run src/dfs-tool.test.ts` - 7 tests pass
- [x] `npx vitest run src/percentile-tool.test.ts` - 6 tests pass
- [x] `npx vitest run src/mst-tool.test.ts` - 6 tests pass
- [x] `npx tsc --noEmit` - clean
- [x] Regeneration pipeline run (tool-index, depth-ladder, app-catalog, brainmap)
- [x] app-test-results.json updated with pass status

https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez)_