### PR TITLE
Add batch 66: k-means, Bellman-Ford, Floyd-Warshall, reservoir sampling (563 apps)

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,10 +9,10 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 985,
+    "inventory": 989,
     "source_manifest": 215,
     "pages": 88,
-    "tools": 560,
+    "tools": 564,
     "rooms": 23,
     "workers": 8
   },
@@ -33,7 +33,7 @@
       "id": "tools",
       "name": "Tools",
       "meaning": "MCP and gateway capabilities available to seats.",
-      "count": 560
+      "count": 564
     },
     {
       "id": "rooms",
@@ -4542,6 +4542,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-bellmanford-packages-mcp-server-src-bellmanford-tool-ts-no-route",
+      "division": "Tools",
+      "name": "bellmanford",
+      "kind": "MCP tool",
+      "meaning": "bellmanford MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/bellmanford-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-bezier-packages-mcp-server-src-bezier-tool-ts-no-route",
       "division": "Tools",
       "name": "bezier",
@@ -5932,6 +5942,16 @@
       "tags": []
     },
     {
+      "id": "tools-mcp-tool-floydwarshall-packages-mcp-server-src-floydwarshall-tool-ts-no-route",
+      "division": "Tools",
+      "name": "floydwarshall",
+      "kind": "MCP tool",
+      "meaning": "floydwarshall MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/floydwarshall-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
       "id": "tools-mcp-tool-flyio-packages-mcp-server-src-flyio-tool-ts-no-route",
       "division": "Tools",
       "name": "flyio",
@@ -6748,6 +6768,16 @@
       "kind": "MCP tool",
       "meaning": "kling MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/kling-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-kmeans-packages-mcp-server-src-kmeans-tool-ts-no-route",
+      "division": "Tools",
+      "name": "kmeans",
+      "kind": "MCP tool",
+      "meaning": "kmeans MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/kmeans-tool.ts",
       "route": "",
       "tags": []
     },
@@ -8398,6 +8428,16 @@
       "kind": "MCP tool",
       "meaning": "resend MCP capability, available through the UnClick tool gateway.",
       "source": "packages/mcp-server/src/resend-tool.ts",
+      "route": "",
+      "tags": []
+    },
+    {
+      "id": "tools-mcp-tool-reservoir-packages-mcp-server-src-reservoir-tool-ts-no-route",
+      "division": "Tools",
+      "name": "reservoir",
+      "kind": "MCP tool",
+      "meaning": "reservoir MCP capability, available through the UnClick tool gateway.",
+      "source": "packages/mcp-server/src/reservoir-tool.ts",
       "route": "",
       "tags": []
     },
@@ -10716,6 +10756,11 @@
       "packages/mcp-server/src/baseconvert-tool.ts"
     ],
     [
+      "bellmanford",
+      "bellmanford MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/bellmanford-tool.ts"
+    ],
+    [
       "bezier",
       "bezier MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/bezier-tool.ts"
@@ -11411,6 +11456,11 @@
       "packages/mcp-server/src/flowpass-tool.ts"
     ],
     [
+      "floydwarshall",
+      "floydwarshall MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/floydwarshall-tool.ts"
+    ],
+    [
       "flyio",
       "flyio MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/flyio-tool.ts"
@@ -11819,6 +11869,11 @@
       "kling",
       "kling MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/kling-tool.ts"
+    ],
+    [
+      "kmeans",
+      "kmeans MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/kmeans-tool.ts"
     ],
     [
       "knapsack",
@@ -12644,6 +12699,11 @@
       "resend",
       "resend MCP capability, available through the UnClick tool gateway.",
       "packages/mcp-server/src/resend-tool.ts"
+    ],
+    [
+      "reservoir",
+      "reservoir MCP capability, available through the UnClick tool gateway.",
+      "packages/mcp-server/src/reservoir-tool.ts"
     ],
     [
       "restcountries",
@@ -14564,6 +14624,11 @@
       "bytes": 1246
     },
     {
+      "source": "packages/mcp-server/src/bellmanford-tool.ts",
+      "hash": "baef494b3f6a",
+      "bytes": 2955
+    },
+    {
       "source": "packages/mcp-server/src/bezier-tool.ts",
       "hash": "29ff88e26cbb",
       "bytes": 2561
@@ -14587,11 +14652,6 @@
       "source": "packages/mcp-server/src/bible-tool.ts",
       "hash": "94f62f2fa1c1",
       "bytes": 2338
-    },
-    {
-      "source": "packages/mcp-server/src/bibleverse-tool.ts",
-      "hash": "c5c118d0eb27",
-      "bytes": 1698
     },
     {
       "source": ".github/workflows/apply-migrations.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -203,12 +203,12 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/bandsintown-tool.ts | f56d1929e864 | 4850 |
 | packages/mcp-server/src/base64-tool.ts | b93e3d17577c | 1174 |
 | packages/mcp-server/src/baseconvert-tool.ts | bbfa716f0f7c | 1246 |
+| packages/mcp-server/src/bellmanford-tool.ts | baef494b3f6a | 2955 |
 | packages/mcp-server/src/bezier-tool.ts | 29ff88e26cbb | 2561 |
 | packages/mcp-server/src/bfs-tool.ts | 6eff2fdbba8b | 2678 |
 | packages/mcp-server/src/bgg-tool.ts | f7014933783a | 12903 |
 | packages/mcp-server/src/bgpview-tool.ts | c97cbd66581b | 2523 |
 | packages/mcp-server/src/bible-tool.ts | 94f62f2fa1c1 | 2338 |
-| packages/mcp-server/src/bibleverse-tool.ts | c5c118d0eb27 | 1698 |
 | .github/workflows/apply-migrations.yml | d2ee87e75e7f | 1529 |
 | .github/workflows/auto-close-fishbowl-todo.yml | d11ec31e1d22 | 11599 |
 | .github/workflows/autonomous-runner.yml | 942080b620ac | 15338 |
@@ -235,7 +235,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 52 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
-| Tools | MCP and gateway capabilities available to seats. | 560 |
+| Tools | MCP and gateway capabilities available to seats. | 564 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
 | Passes and gates | Quality, proof, safety, and fidelity checks. | 17 |
@@ -404,6 +404,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | bandsintown | bandsintown MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bandsintown-tool.ts |
 | base64 | base64 MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/base64-tool.ts |
 | baseconvert | baseconvert MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/baseconvert-tool.ts |
+| bellmanford | bellmanford MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bellmanford-tool.ts |
 | bezier | bezier MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bezier-tool.ts |
 | bfs | bfs MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bfs-tool.ts |
 | bgg | bgg MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/bgg-tool.ts |
@@ -543,6 +544,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | finalspace | finalspace MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/finalspace-tool.ts |
 | fishwatch | fishwatch MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/fishwatch-tool.ts |
 | flowpass | flowpass MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/flowpass-tool.ts |
+| floydwarshall | floydwarshall MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/floydwarshall-tool.ts |
 | flyio | flyio MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/flyio-tool.ts |
 | flyover | flyover MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/flyover-tool.ts |
 | foodish | foodish MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/foodish-tool.ts |
@@ -625,6 +627,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | keychain | keychain MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/keychain-tool.ts |
 | klaviyo | klaviyo MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/klaviyo-tool.ts |
 | kling | kling MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/kling-tool.ts |
+| kmeans | kmeans MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/kmeans-tool.ts |
 | knapsack | knapsack MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/knapsack-tool.ts |
 | languagetool | languagetool MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/languagetool-tool.ts |
 | lastfm | lastfm MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/lastfm-tool.ts |
@@ -790,6 +793,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | replicate | replicate MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/replicate-tool.ts |
 | reqres | reqres MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/reqres-tool.ts |
 | resend | resend MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/resend-tool.ts |
+| reservoir | reservoir MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/reservoir-tool.ts |
 | restcountries | restcountries MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/restcountries-tool.ts |
 | reversetext | reversetext MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/reversetext-tool.ts |
 | rickandmorty | rickandmorty MCP capability, available through the UnClick tool gateway. | packages/mcp-server/src/rickandmorty-tool.ts |
@@ -1380,6 +1384,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | bandsintown | bandsintown MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bandsintown-tool.ts |
 | Tools | MCP tool | base64 | base64 MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/base64-tool.ts |
 | Tools | MCP tool | baseconvert | baseconvert MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/baseconvert-tool.ts |
+| Tools | MCP tool | bellmanford | bellmanford MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bellmanford-tool.ts |
 | Tools | MCP tool | bezier | bezier MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bezier-tool.ts |
 | Tools | MCP tool | bfs | bfs MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bfs-tool.ts |
 | Tools | MCP tool | bgg | bgg MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/bgg-tool.ts |
@@ -1519,6 +1524,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | finalspace | finalspace MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/finalspace-tool.ts |
 | Tools | MCP tool | fishwatch | fishwatch MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/fishwatch-tool.ts |
 | Tools | MCP tool | flowpass | flowpass MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/flowpass-tool.ts |
+| Tools | MCP tool | floydwarshall | floydwarshall MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/floydwarshall-tool.ts |
 | Tools | MCP tool | flyio | flyio MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/flyio-tool.ts |
 | Tools | MCP tool | flyover | flyover MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/flyover-tool.ts |
 | Tools | MCP tool | foodish | foodish MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/foodish-tool.ts |
@@ -1601,6 +1607,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | keychain | keychain MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/keychain-tool.ts |
 | Tools | MCP tool | klaviyo | klaviyo MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/klaviyo-tool.ts |
 | Tools | MCP tool | kling | kling MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/kling-tool.ts |
+| Tools | MCP tool | kmeans | kmeans MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/kmeans-tool.ts |
 | Tools | MCP tool | knapsack | knapsack MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/knapsack-tool.ts |
 | Tools | MCP tool | languagetool | languagetool MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/languagetool-tool.ts |
 | Tools | MCP tool | lastfm | lastfm MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/lastfm-tool.ts |
@@ -1766,6 +1773,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Tools | MCP tool | replicate | replicate MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/replicate-tool.ts |
 | Tools | MCP tool | reqres | reqres MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/reqres-tool.ts |
 | Tools | MCP tool | resend | resend MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/resend-tool.ts |
+| Tools | MCP tool | reservoir | reservoir MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/reservoir-tool.ts |
 | Tools | MCP tool | restcountries | restcountries MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/restcountries-tool.ts |
 | Tools | MCP tool | reversetext | reversetext MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/reversetext-tool.ts |
 | Tools | MCP tool | rickandmorty | rickandmorty MCP capability, available through the UnClick tool gateway. | - | packages/mcp-server/src/rickandmorty-tool.ts |

--- a/docs/connector-depth-ladder.json
+++ b/docs/connector-depth-ladder.json
@@ -660,6 +660,26 @@
     }
   },
   {
+    "connector": "bellmanford",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "bezier",
     "level": 5,
     "levelName": "Agentic",
@@ -3120,6 +3140,26 @@
     }
   },
   {
+    "connector": "floydwarshall",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
     "connector": "flyio",
     "level": 5,
     "levelName": "Agentic",
@@ -4611,6 +4651,26 @@
       "handles429": true,
       "hasRetry": true,
       "readsErrorBody": true,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "kmeans",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
+      "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,
       "memoryAware": false,
@@ -7510,6 +7570,26 @@
       "hasTimeout": true,
       "handles429": true,
       "hasRetry": true,
+      "readsErrorBody": false,
+      "bareStatusErrors": 0,
+      "errorStyleClean": true,
+      "memoryAware": false,
+      "proactive": false,
+      "agentic": true,
+      "sourceStamped": true
+    }
+  },
+  {
+    "connector": "reservoir",
+    "level": 5,
+    "levelName": "Agentic",
+    "hardened": false,
+    "cappedByDesign": false,
+    "capReason": null,
+    "signals": {
+      "hasTimeout": false,
+      "handles429": false,
+      "hasRetry": false,
       "readsErrorBody": false,
       "bareStatusErrors": 0,
       "errorStyleClean": true,

--- a/docs/connector-depth-ladder.md
+++ b/docs/connector-depth-ladder.md
@@ -14,17 +14,17 @@ Graded against the house standard in [`docs/connector-standard.md`](./connector-
 | L4 | Proactive | Can emit a signal or wake, not only answer on demand. |
 | L5 | Agentic | Stamps source and freshness on the result and hands the agent its next step. |
 
-## Distribution (534 external connectors)
+## Distribution (538 external connectors)
 
 | Level | Name | Connectors | Share |
 |:-----:|------|-----------:|------:|
-| L5 | Agentic | 495 | 93% |
+| L5 | Agentic | 499 | 93% |
 | L4 | Proactive | 0 | 0% |
 | L3 | Memory-aware | 0 | 0% |
 | L2 | Reliable | 36 | 7% |
 | L1 | Wrapper | 3 | 1% |
 
-**Hardened (reliability bar met): 241 of 534 (45%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
+**Hardened (reliability bar met): 241 of 538 (45%).** Depth and hardening are independent: a connector can be agentic yet not hardened.
 
 ### Capped at L2 by design (36)
 
@@ -34,7 +34,7 @@ The L5 markers (source + freshness, then a next-step handoff) describe a **data 
 - **write/send** (write/send tool, no data to stamp): `line`, `postmark`, `pushover`, `resend`, `sendgrid`, `telegram`, `whatsapp`
 - **generation** (model output, not a fetched source): `perplexity`
 
-**L5-reachable connectors at L5: 495 of 498 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
+**L5-reachable connectors at L5: 499 of 502 (99%).** The remaining 0 L2 rows are genuine upgrade candidates.
 
 ### Climbed in depth but not yet hardened
 
@@ -56,6 +56,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `balldontlie` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `base64` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `baseconvert` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `bellmanford` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `bezier` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `bfs` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `bgpview` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -131,6 +132,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `fibonacci` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `finalspace` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `fishwatch` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
+- `floydwarshall` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `flyover` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `foodish` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
 - `freetogame` (L5 Agentic): not-hardened, 1x-bare-error, no-memory
@@ -174,6 +176,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `jsoncrack` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `jsonformat` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `jwt` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `kmeans` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `knapsack` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `languagetool` (L5 Agentic): not-hardened, 2x-bare-error, no-memory
 - `lcs` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -270,6 +273,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 - `readability` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `regexr` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `regression` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
+- `reservoir` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `reversetext` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
 - `ripe` (L5 Agentic): not-hardened, no-rate-limit, no-memory
 - `rle2` (L5 Agentic): not-hardened, no-timeout, no-rate-limit, no-memory
@@ -368,6 +372,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `bandsintown` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `base64` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `baseconvert` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
+| L5 Agentic | `bellmanford` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bezier` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bfs` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `bgg` | Yes | - | - | Yes | Yes | no-memory |
@@ -491,6 +496,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `figma` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `finalspace` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
 | L5 Agentic | `fishwatch` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
+| L5 Agentic | `floydwarshall` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `flyio` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `flyover` | - | - | - | Yes | Yes | not-hardened, no-rate-limit, no-memory |
 | L5 Agentic | `foodish` | - | - | - | Yes | Yes | not-hardened, 1x-bare-error, no-memory |
@@ -566,6 +572,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `kanye` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `klaviyo` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `kling` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `kmeans` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `knapsack` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `languagetool` | - | - | - | Yes | Yes | not-hardened, 2x-bare-error, no-memory |
 | L5 Agentic | `lastfm` | Yes | - | - | Yes | Yes | no-memory |
@@ -711,6 +718,7 @@ These reached L3+ capability but have not met the L2 reliability bar. Hardening 
 | L5 Agentic | `render` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `replicate` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `reqres` | Yes | - | - | Yes | Yes | no-memory |
+| L5 Agentic | `reservoir` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `restcountries` | Yes | - | - | Yes | Yes | no-memory |
 | L5 Agentic | `reversetext` | - | - | - | Yes | Yes | not-hardened, no-timeout, no-rate-limit, no-memory |
 | L5 Agentic | `rickandmorty` | Yes | - | - | Yes | Yes | no-memory |

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -556,6 +556,16 @@
     ]
   },
   {
+    "app": "bellmanford",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "bellman_ford",
+        "description": "Find shortest paths from a source node using Bellman-Ford (handles negative edge weights)."
+      }
+    ]
+  },
+  {
     "app": "bezier",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -2838,6 +2848,16 @@
     ]
   },
   {
+    "app": "floydwarshall",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "floyd_warshall",
+        "description": "Compute all-pairs shortest paths using Floyd-Warshall."
+      }
+    ]
+  },
+  {
     "app": "flyio",
     "category": "Dev / Cloud",
     "tools": [
@@ -4092,6 +4112,16 @@
       {
         "name": "kling_get_task",
         "description": "Check the status of a Kling AI video generation task."
+      }
+    ]
+  },
+  {
+    "app": "kmeans",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "kmeans_cluster",
+        "description": "Partition points into k clusters using the k-means algorithm."
       }
     ]
   },
@@ -6770,6 +6800,16 @@
       {
         "name": "resend_list_domains",
         "description": "List domains configured in Resend."
+      }
+    ]
+  },
+  {
+    "app": "reservoir",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "reservoir_sample",
+        "description": "Select k random items from a list with equal probability using reservoir sampling."
       }
     ]
   },

--- a/packages/mcp-server/src/bellmanford-tool.test.ts
+++ b/packages/mcp-server/src/bellmanford-tool.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { bellmanFord } from "./bellmanford-tool.js";
+
+describe("bellmanFord", () => {
+  it("finds shortest paths with positive weights", async () => {
+    const r = await bellmanFord({
+      edges: [
+        { from: "A", to: "B", weight: 4 },
+        { from: "A", to: "C", weight: 2 },
+        { from: "C", to: "B", weight: 1 },
+      ],
+      start: "A",
+      target: "B",
+    }) as any;
+    expect(r.path).toEqual(["A", "C", "B"]);
+    expect(r.path_weight).toBe(3);
+  });
+
+  it("handles negative weights", async () => {
+    const r = await bellmanFord({
+      edges: [
+        { from: "A", to: "B", weight: 5 },
+        { from: "A", to: "C", weight: 2 },
+        { from: "C", to: "B", weight: -1 },
+      ],
+      start: "A",
+      target: "B",
+    }) as any;
+    expect(r.path_weight).toBe(1);
+    expect(r.has_negative_cycle).toBe(false);
+  });
+
+  it("detects negative cycle", async () => {
+    const r = await bellmanFord({
+      edges: [
+        { from: "A", to: "B", weight: 1 },
+        { from: "B", to: "C", weight: -3 },
+        { from: "C", to: "A", weight: 1 },
+      ],
+      start: "A",
+    }) as any;
+    expect(r.has_negative_cycle).toBe(true);
+  });
+
+  it("returns null path for unreachable target", async () => {
+    const r = await bellmanFord({
+      edges: [
+        { from: "A", to: "B", weight: 1 },
+        { from: "C", to: "D", weight: 2 },
+      ],
+      start: "A",
+      target: "D",
+    }) as any;
+    expect(r.path).toBeNull();
+  });
+
+  it("stamps meta", async () => {
+    const r = await bellmanFord({
+      edges: [{ from: "A", to: "B", weight: 1 }],
+      start: "A",
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/bellmanford-tool.ts
+++ b/packages/mcp-server/src/bellmanford-tool.ts
@@ -1,0 +1,102 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+interface WeightedEdge {
+  from: string;
+  to: string;
+  weight: number;
+}
+
+export async function bellmanFord(args: Record<string, unknown>) {
+  const edges = args.edges as WeightedEdge[];
+  if (!Array.isArray(edges) || edges.length === 0) {
+    throw new Error("edges must be a non-empty array of {from, to, weight} objects.");
+  }
+  if (edges.length > 10000) throw new Error("edges must have 10000 entries or fewer.");
+
+  const start = String(args.start ?? "");
+  if (!start) throw new Error("start node is required.");
+
+  const target = args.target !== undefined ? String(args.target) : null;
+
+  const allNodes = new Set<string>();
+  for (const e of edges) {
+    allNodes.add(String(e.from));
+    allNodes.add(String(e.to));
+  }
+
+  if (!allNodes.has(start)) throw new Error(`start node '${start}' not found in graph.`);
+  if (target && !allNodes.has(target)) throw new Error(`target node '${target}' not found in graph.`);
+
+  const dist = new Map<string, number>();
+  const prev = new Map<string, string | null>();
+  for (const n of allNodes) {
+    dist.set(n, Infinity);
+    prev.set(n, null);
+  }
+  dist.set(start, 0);
+
+  const n = allNodes.size;
+
+  for (let i = 0; i < n - 1; i++) {
+    let updated = false;
+    for (const e of edges) {
+      const from = String(e.from);
+      const to = String(e.to);
+      const w = Number(e.weight);
+      const d = dist.get(from)!;
+      if (d < Infinity && d + w < dist.get(to)!) {
+        dist.set(to, d + w);
+        prev.set(to, from);
+        updated = true;
+      }
+    }
+    if (!updated) break;
+  }
+
+  let hasNegativeCycle = false;
+  for (const e of edges) {
+    const from = String(e.from);
+    const to = String(e.to);
+    const w = Number(e.weight);
+    if (dist.get(from)! < Infinity && dist.get(from)! + w < dist.get(to)!) {
+      hasNegativeCycle = true;
+      break;
+    }
+  }
+
+  let path: string[] | null = null;
+  let pathWeight: number | null = null;
+  if (target && !hasNegativeCycle && dist.get(target)! < Infinity) {
+    path = [];
+    let cur: string | null = target;
+    while (cur !== null) {
+      path.unshift(cur);
+      cur = prev.get(cur) ?? null;
+    }
+    pathWeight = dist.get(target)!;
+  }
+
+  const distances: Record<string, number | null> = {};
+  for (const [node, d] of dist) {
+    distances[node] = d === Infinity ? null : Math.round(d * 1e8) / 1e8;
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "Bellman-Ford handles negative edge weights (unlike Dijkstra)",
+      "If has_negative_cycle is true, shortest distances are unreliable",
+    ],
+  };
+  return stampMeta({
+    start,
+    target: target ?? "none",
+    node_count: n,
+    edge_count: edges.length,
+    has_negative_cycle: hasNegativeCycle,
+    distances,
+    path,
+    path_weight: pathWeight !== null ? Math.round(pathWeight * 1e8) / 1e8 : null,
+  }, meta);
+}

--- a/packages/mcp-server/src/floydwarshall-tool.test.ts
+++ b/packages/mcp-server/src/floydwarshall-tool.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { floydWarshall } from "./floydwarshall-tool.js";
+
+describe("floydWarshall", () => {
+  it("computes all-pairs shortest paths", async () => {
+    const r = await floydWarshall({
+      edges: [
+        { from: "A", to: "B", weight: 1 },
+        { from: "B", to: "C", weight: 2 },
+        { from: "A", to: "C", weight: 10 },
+      ],
+    }) as any;
+    expect(r.distance_matrix["A"]["C"]).toBe(3);
+    expect(r.distance_matrix["A"]["B"]).toBe(1);
+    expect(r.node_count).toBe(3);
+  });
+
+  it("handles undirected graph", async () => {
+    const r = await floydWarshall({
+      edges: [
+        { from: "A", to: "B", weight: 5 },
+        { from: "B", to: "C", weight: 3 },
+      ],
+      directed: false,
+    }) as any;
+    expect(r.distance_matrix["C"]["A"]).toBe(8);
+    expect(r.directed).toBe(false);
+  });
+
+  it("returns null for unreachable pairs", async () => {
+    const r = await floydWarshall({
+      edges: [
+        { from: "A", to: "B", weight: 1 },
+        { from: "C", to: "D", weight: 2 },
+      ],
+    }) as any;
+    expect(r.distance_matrix["A"]["C"]).toBeNull();
+  });
+
+  it("detects negative cycle", async () => {
+    const r = await floydWarshall({
+      edges: [
+        { from: "A", to: "B", weight: 1 },
+        { from: "B", to: "C", weight: -3 },
+        { from: "C", to: "A", weight: 1 },
+      ],
+    }) as any;
+    expect(r.has_negative_cycle).toBe(true);
+  });
+
+  it("stamps meta", async () => {
+    const r = await floydWarshall({
+      edges: [{ from: "A", to: "B", weight: 1 }],
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/floydwarshall-tool.ts
+++ b/packages/mcp-server/src/floydwarshall-tool.ts
@@ -1,0 +1,136 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+interface WeightedEdge {
+  from: string;
+  to: string;
+  weight: number;
+}
+
+export async function floydWarshall(args: Record<string, unknown>) {
+  const edges = args.edges as WeightedEdge[];
+  if (!Array.isArray(edges) || edges.length === 0) {
+    throw new Error("edges must be a non-empty array of {from, to, weight} objects.");
+  }
+  if (edges.length > 10000) throw new Error("edges must have 10000 entries or fewer.");
+
+  const directed = args.directed !== false;
+
+  const allNodes = new Set<string>();
+  for (const e of edges) {
+    allNodes.add(String(e.from));
+    allNodes.add(String(e.to));
+  }
+
+  const nodes = Array.from(allNodes).sort();
+  const n = nodes.length;
+  if (n > 500) throw new Error("graph must have 500 or fewer nodes for Floyd-Warshall.");
+
+  const idx = new Map<string, number>();
+  nodes.forEach((node, i) => idx.set(node, i));
+
+  const dist: number[][] = Array.from({ length: n }, () => new Array(n).fill(Infinity));
+  const next: (number | null)[][] = Array.from({ length: n }, () => new Array(n).fill(null));
+
+  for (let i = 0; i < n; i++) {
+    dist[i][i] = 0;
+    next[i][i] = i;
+  }
+
+  for (const e of edges) {
+    const u = idx.get(String(e.from))!;
+    const v = idx.get(String(e.to))!;
+    const w = Number(e.weight);
+    if (w < dist[u][v]) {
+      dist[u][v] = w;
+      next[u][v] = v;
+    }
+    if (!directed && w < dist[v][u]) {
+      dist[v][u] = w;
+      next[v][u] = u;
+    }
+  }
+
+  for (let k = 0; k < n; k++) {
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        if (dist[i][k] + dist[k][j] < dist[i][j]) {
+          dist[i][j] = dist[i][k] + dist[k][j];
+          next[i][j] = next[i][k];
+        }
+      }
+    }
+  }
+
+  let hasNegativeCycle = false;
+  for (let i = 0; i < n; i++) {
+    if (dist[i][i] < 0) { hasNegativeCycle = true; break; }
+  }
+
+  const distanceMatrix: Record<string, Record<string, number | null>> = {};
+  for (let i = 0; i < n; i++) {
+    const row: Record<string, number | null> = {};
+    for (let j = 0; j < n; j++) {
+      row[nodes[j]] = dist[i][j] === Infinity ? null : Math.round(dist[i][j] * 1e8) / 1e8;
+    }
+    distanceMatrix[nodes[i]] = row;
+  }
+
+  const reconstructPath = (from: string, to: string): string[] | null => {
+    const u = idx.get(from)!;
+    const v = idx.get(to)!;
+    if (next[u][v] === null) return null;
+    const path = [from];
+    let cur = u;
+    while (cur !== v) {
+      cur = next[cur][v]!;
+      if (cur === null) return null;
+      path.push(nodes[cur]);
+      if (path.length > n) return null;
+    }
+    return path;
+  };
+
+  let samplePath: { from: string; to: string; path: string[]; weight: number } | null = null;
+  if (n >= 2) {
+    let bestFrom = 0;
+    let bestTo = 1;
+    let bestDist = Infinity;
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        if (i !== j && dist[i][j] < bestDist && dist[i][j] > 0) {
+          bestDist = dist[i][j];
+          bestFrom = i;
+          bestTo = j;
+        }
+      }
+    }
+    if (bestDist < Infinity) {
+      const p = reconstructPath(nodes[bestFrom], nodes[bestTo]);
+      if (p) {
+        samplePath = {
+          from: nodes[bestFrom],
+          to: nodes[bestTo],
+          path: p,
+          weight: Math.round(bestDist * 1e8) / 1e8,
+        };
+      }
+    }
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "Floyd-Warshall computes ALL pairs shortest paths in O(V^3)",
+      "Use Dijkstra or Bellman-Ford for single-source queries on large graphs",
+    ],
+  };
+  return stampMeta({
+    node_count: n,
+    edge_count: edges.length,
+    directed,
+    has_negative_cycle: hasNegativeCycle,
+    distance_matrix: distanceMatrix,
+    shortest_path_sample: samplePath,
+  }, meta);
+}

--- a/packages/mcp-server/src/kmeans-tool.test.ts
+++ b/packages/mcp-server/src/kmeans-tool.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { kmeansCluster } from "./kmeans-tool.js";
+
+describe("kmeansCluster", () => {
+  it("clusters 2D points", async () => {
+    const r = await kmeansCluster({
+      points: [[0,0],[1,0],[0,1],[10,10],[11,10],[10,11]],
+      k: 2,
+    }) as any;
+    expect(r.k).toBe(2);
+    expect(r.cluster_sizes).toHaveLength(2);
+    expect(r.cluster_sizes[0] + r.cluster_sizes[1]).toBe(6);
+    expect(r.centroids).toHaveLength(2);
+    expect(r.assignments).toHaveLength(6);
+  });
+
+  it("clusters 1D points", async () => {
+    const r = await kmeansCluster({
+      points: [[1],[2],[3],[100],[101],[102]],
+      k: 2,
+    }) as any;
+    expect(r.dimensions).toBe(1);
+    expect(r.point_count).toBe(6);
+  });
+
+  it("k=1 puts all in one cluster", async () => {
+    const r = await kmeansCluster({
+      points: [[1,2],[3,4],[5,6]],
+      k: 1,
+    }) as any;
+    expect(r.cluster_sizes).toEqual([3]);
+  });
+
+  it("rejects empty points", async () => {
+    await expect(kmeansCluster({ points: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await kmeansCluster({
+      points: [[1],[2],[3]],
+      k: 2,
+    }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/kmeans-tool.ts
+++ b/packages/mcp-server/src/kmeans-tool.ts
@@ -1,0 +1,94 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function kmeansCluster(args: Record<string, unknown>) {
+  const points = args.points as number[][];
+  if (!Array.isArray(points) || points.length === 0) {
+    throw new Error("points must be a non-empty array of numeric vectors.");
+  }
+  if (points.length > 10000) throw new Error("points must have 10000 entries or fewer.");
+
+  const dim = points[0].length;
+  if (dim === 0) throw new Error("point dimensions must be at least 1.");
+  for (const p of points) {
+    if (!Array.isArray(p) || p.length !== dim) {
+      throw new Error("all points must have the same number of dimensions.");
+    }
+  }
+
+  const k = typeof args.k === "number" ? args.k : 3;
+  if (k < 1 || k > points.length) throw new Error("k must be between 1 and the number of points.");
+
+  const maxIter = typeof args.max_iterations === "number" ? args.max_iterations : 100;
+
+  const centroids: number[][] = [];
+  const used = new Set<number>();
+  while (centroids.length < k) {
+    const idx = Math.floor(Math.random() * points.length);
+    if (!used.has(idx)) {
+      used.add(idx);
+      centroids.push([...points[idx]]);
+    }
+  }
+
+  let assignments = new Array(points.length).fill(0);
+  let iters = 0;
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    iters++;
+    const newAssignments = points.map((p) => {
+      let best = 0;
+      let bestDist = Infinity;
+      for (let c = 0; c < k; c++) {
+        let dist = 0;
+        for (let d = 0; d < dim; d++) dist += (p[d] - centroids[c][d]) ** 2;
+        if (dist < bestDist) { bestDist = dist; best = c; }
+      }
+      return best;
+    });
+
+    let changed = false;
+    for (let i = 0; i < points.length; i++) {
+      if (newAssignments[i] !== assignments[i]) { changed = true; break; }
+    }
+    assignments = newAssignments;
+
+    for (let c = 0; c < k; c++) {
+      const members = points.filter((_, i) => assignments[i] === c);
+      if (members.length > 0) {
+        for (let d = 0; d < dim; d++) {
+          centroids[c][d] = members.reduce((s, p) => s + p[d], 0) / members.length;
+        }
+      }
+    }
+
+    if (!changed) break;
+  }
+
+  const clusterSizes = new Array(k).fill(0);
+  for (const a of assignments) clusterSizes[a]++;
+
+  let totalInertia = 0;
+  for (let i = 0; i < points.length; i++) {
+    const c = assignments[i];
+    for (let d = 0; d < dim; d++) totalInertia += (points[i][d] - centroids[c][d]) ** 2;
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "Lower inertia indicates tighter clusters",
+      "Try different k values to find the best fit (elbow method)",
+    ],
+  };
+  return stampMeta({
+    k,
+    dimensions: dim,
+    point_count: points.length,
+    iterations_run: iters,
+    centroids: centroids.map(c => c.map(v => Math.round(v * 1e6) / 1e6)),
+    cluster_sizes: clusterSizes,
+    assignments,
+    inertia: Math.round(totalInertia * 1e6) / 1e6,
+  }, meta);
+}

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -570,6 +570,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "bellmanford",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "bellman_ford",
+        "description": "Find shortest paths from a source node using Bellman-Ford (handles negative edge weights)."
+      }
+    ]
+  },
+  {
     "app": "bezier",
     "category": "Existing tools (previously unwired)",
     "tools": [
@@ -2852,6 +2862,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     ]
   },
   {
+    "app": "floydwarshall",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "floyd_warshall",
+        "description": "Compute all-pairs shortest paths using Floyd-Warshall."
+      }
+    ]
+  },
+  {
     "app": "flyio",
     "category": "Dev / Cloud",
     "tools": [
@@ -4106,6 +4126,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "kling_get_task",
         "description": "Check the status of a Kling AI video generation task."
+      }
+    ]
+  },
+  {
+    "app": "kmeans",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "kmeans_cluster",
+        "description": "Partition points into k clusters using the k-means algorithm."
       }
     ]
   },
@@ -6784,6 +6814,16 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
       {
         "name": "resend_list_domains",
         "description": "List domains configured in Resend."
+      }
+    ]
+  },
+  {
+    "app": "reservoir",
+    "category": "Existing tools (previously unwired)",
+    "tools": [
+      {
+        "name": "reservoir_sample",
+        "description": "Select k random items from a list with equal probability using reservoir sampling."
       }
     ]
   },

--- a/packages/mcp-server/src/reservoir-tool.test.ts
+++ b/packages/mcp-server/src/reservoir-tool.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { reservoirSample } from "./reservoir-tool.js";
+
+describe("reservoirSample", () => {
+  it("samples k items from array", async () => {
+    const r = await reservoirSample({
+      items: [1,2,3,4,5,6,7,8,9,10],
+      k: 3,
+    }) as any;
+    expect(r.sample_size).toBe(3);
+    expect(r.sample).toHaveLength(3);
+    expect(r.total_items).toBe(10);
+  });
+
+  it("samples single item by default", async () => {
+    const r = await reservoirSample({
+      items: ["a", "b", "c"],
+    }) as any;
+    expect(r.sample_size).toBe(1);
+    expect(r.sample).toHaveLength(1);
+  });
+
+  it("returns deterministic results with seed", async () => {
+    const r1 = await reservoirSample({ items: [1,2,3,4,5], k: 2, seed: 42 }) as any;
+    const r2 = await reservoirSample({ items: [1,2,3,4,5], k: 2, seed: 42 }) as any;
+    expect(r1.sample).toEqual(r2.sample);
+  });
+
+  it("rejects k > items.length", async () => {
+    await expect(reservoirSample({ items: [1,2], k: 5 })).rejects.toThrow("exceed");
+  });
+
+  it("rejects empty items", async () => {
+    await expect(reservoirSample({ items: [] })).rejects.toThrow("non-empty");
+  });
+
+  it("stamps meta", async () => {
+    const r = await reservoirSample({ items: [1,2,3], k: 1 }) as any;
+    expect(r.unclick_meta.source).toBe("local-computation");
+  });
+});

--- a/packages/mcp-server/src/reservoir-tool.ts
+++ b/packages/mcp-server/src/reservoir-tool.ts
@@ -1,0 +1,56 @@
+import { stampMeta, ConnectorMeta } from "./connector-meta.js";
+
+export async function reservoirSample(args: Record<string, unknown>) {
+  const items = args.items as unknown[];
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error("items must be a non-empty array.");
+  }
+  if (items.length > 100000) throw new Error("items must have 100000 entries or fewer.");
+
+  const k = typeof args.k === "number" ? args.k : 1;
+  if (k < 1) throw new Error("k must be at least 1.");
+  if (k > items.length) throw new Error("k must not exceed the number of items.");
+
+  const seed = typeof args.seed === "number" ? args.seed : null;
+
+  let rng: () => number;
+  if (seed !== null) {
+    let s = seed | 0;
+    rng = () => {
+      s = (s * 1664525 + 1013904223) & 0x7fffffff;
+      return s / 0x7fffffff;
+    };
+  } else {
+    rng = Math.random;
+  }
+
+  const reservoir: { item: unknown; original_index: number }[] = [];
+  for (let i = 0; i < k; i++) {
+    reservoir.push({ item: items[i], original_index: i });
+  }
+
+  let replacements = 0;
+  for (let i = k; i < items.length; i++) {
+    const j = Math.floor(rng() * (i + 1));
+    if (j < k) {
+      reservoir[j] = { item: items[i], original_index: i };
+      replacements++;
+    }
+  }
+
+  const meta: ConnectorMeta = {
+    source: "local-computation",
+    fetched_at: new Date().toISOString(),
+    next_steps: [
+      "Each item has equal probability k/n of being in the sample",
+      "Use a fixed seed for reproducible results",
+    ],
+  };
+  return stampMeta({
+    total_items: items.length,
+    sample_size: k,
+    seeded: seed !== null,
+    replacements_made: replacements,
+    sample: reservoir,
+  }, meta);
+}

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -732,6 +732,11 @@ import { astarPath } from "./astar-tool.js";
 import { simplexSolve } from "./simplex-tool.js";
 import { hungarianAssign } from "./hungarian-tool.js";
 
+import { kmeansCluster } from "./kmeans-tool.js";
+import { bellmanFord } from "./bellmanford-tool.js";
+import { floydWarshall } from "./floydwarshall-tool.js";
+import { reservoirSample } from "./reservoir-tool.js";
+
 import {
   nasaApod, nasaAsteroids, nasaMarsPhotos,
   nasaEarthImagery, nasaEpic,
@@ -10974,6 +10979,61 @@ export const ADDITIONAL_TOOLS = [
         cost_matrix: { type: "array", items: { type: "array", items: { type: "number" } }, description: "NxN cost matrix" },
         maximize: { type: "boolean", description: "Maximize instead of minimize (default false)" },
       }, required: ["cost_matrix"],
+    },
+  },
+
+  // ── kmeans-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "kmeans_cluster",
+    description: "Partition points into k clusters using the k-means algorithm.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        points: { type: "array", items: { type: "array", items: { type: "number" } }, description: "Array of numeric vectors (all same dimension)" },
+        k: { type: "number", description: "Number of clusters (default 3)" },
+        max_iterations: { type: "number", description: "Max iterations (default 100)" },
+      }, required: ["points"],
+    },
+  },
+
+  // ── bellmanford-tool.ts ────────────────────────────────────────────────────────
+  {
+    name: "bellman_ford",
+    description: "Find shortest paths from a source node using Bellman-Ford (handles negative edge weights).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        edges: { type: "array", items: { type: "object", properties: { from: { type: "string" }, to: { type: "string" }, weight: { type: "number" } }, required: ["from", "to", "weight"] }, description: "Array of weighted directed edges" },
+        start: { type: "string", description: "Start node" },
+        target: { type: "string", description: "Optional target node for path reconstruction" },
+      }, required: ["edges", "start"],
+    },
+  },
+
+  // ── floydwarshall-tool.ts ──────────────────────────────────────────────────────
+  {
+    name: "floyd_warshall",
+    description: "Compute all-pairs shortest paths using Floyd-Warshall.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        edges: { type: "array", items: { type: "object", properties: { from: { type: "string" }, to: { type: "string" }, weight: { type: "number" } }, required: ["from", "to", "weight"] }, description: "Array of weighted edges" },
+        directed: { type: "boolean", description: "Treat as directed graph (default true)" },
+      }, required: ["edges"],
+    },
+  },
+
+  // ── reservoir-tool.ts ──────────────────────────────────────────────────────────
+  {
+    name: "reservoir_sample",
+    description: "Select k random items from a list with equal probability using reservoir sampling.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        items: { type: "array", items: {}, description: "Array of items to sample from" },
+        k: { type: "number", description: "Number of items to sample (default 1)" },
+        seed: { type: "number", description: "Optional seed for reproducible results" },
+      }, required: ["items"],
     },
   },
 
@@ -22734,6 +22794,12 @@ export const ADDITIONAL_HANDLERS: Record<string, (args: Record<string, unknown>)
   astar_path:                (args) => astarPath(args),
   simplex_solve:             (args) => simplexSolve(args),
   hungarian_assign:          (args) => hungarianAssign(args),
+
+  // batch 66: k-means, Bellman-Ford, Floyd-Warshall, reservoir sampling
+  kmeans_cluster:            (args) => kmeansCluster(args),
+  bellman_ford:              (args) => bellmanFord(args),
+  floyd_warshall:            (args) => floydWarshall(args),
+  reservoir_sample:          (args) => reservoirSample(args),
 
   // nasa-tool.ts
   nasa_apod:               (args) => nasaApod(args),

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -44,7 +44,7 @@ bucket("Events & tickets", ["ticketmaster", "seatgeek", "eventbrite", "bandsinto
 bucket("Content & CMS", ["contentful", "webflow", "wordpress", "ghost"]);
 bucket("Books", ["openlibrary", "bible", "openlib2", "bibleverse", "mediawiki", "jisho", "poetrydb", "crossref", "arxiv", "openalex", "dblp", "gutendex"]);
 bucket("Images", ["unsplash", "giphy", "dogceo", "picsum", "randomfox", "dogapi", "catapi", "placekitten", "shibe", "cataas", "dummyimage", "avatarapi", "robohash", "countryflag", "colr", "imgflip", "httpcat", "multiavatar", "placebear", "memegen", "randomduck", "httpdog", "thecolorapi", "placehold"]);
-bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate", "fft", "bezier", "rootfind", "matinverse", "ode", "polynomial", "hypothesis", "huffman", "correlation", "bitcount", "runstats", "graph", "convolution", "rle2", "descriptive", "bfs", "montecarlo", "dfs", "percentile", "mst", "pagerank", "astar", "simplex", "hungarian"]);
+bucket("Utilities", ["calculator", "color", "datetime", "numbers", "random", "text", "trivia", "unit-converter", "dictionary", "joke", "chucknorris", "catfacts", "deckofcards", "adviceslip", "agify", "quotable", "bored", "affirmation", "tarot", "superhero", "zenquotes", "kanye", "dadjoke", "uselessfacts", "corporatebs", "yesno", "evilinsult", "lorem", "github-emoji", "excuser", "dogfacts", "emojihub", "iseven", "tacofancy", "funtranslations", "datamuse", "urbandictionary", "genderize", "nationalize", "opentriviadb", "diceware", "colornames", "officialjoke", "newton", "timeapi", "languagetool", "mymemory", "iban", "libretranslate", "colorconvert", "lorem2", "wordcount", "roman", "morse", "loremname", "textstats", "timezone", "fibonacci", "primecheck", "sortlines", "countdowncalc", "emojilookup", "natoalphabet", "tempconvert", "textwrap", "braille", "piglatin", "rot13", "reversetext", "palindrome", "acronymgen", "wordfreq", "markdowntable", "runlength", "luhn", "charcodes", "soundex", "frequency", "entropy", "ngram", "camelsnake", "metaphone", "tfidf", "readability", "tokencount", "crc32", "jaccard", "hamming", "cosinesim", "damerau", "markov", "vigenere", "atbash", "railfence", "phonetic", "matrix", "setops", "collatz", "pascaltri", "histogram", "regression", "baseconvert", "gcd", "permutation", "combination", "proportion", "quadratic", "primefactor", "zscore", "angleconv", "polygon", "sigmoid", "interpolate", "modpow", "ratiosimplify", "binomprob", "normaldistr", "trianglesolve", "standardform", "complexnum", "wavelength", "midpoint", "slopeintercept", "logbase", "nthroot", "areacalc", "dotproduct", "crossproduct", "weightedmean", "variancecalc", "poisson", "expgrowth", "geomseries", "harmonicseries", "piapprox", "taylor", "lcs", "toposort", "convexhull", "knapsack", "spline", "dijkstra", "matrixdecomp", "linearsolve", "numdiff", "numintegrate", "fft", "bezier", "rootfind", "matinverse", "ode", "polynomial", "hypothesis", "huffman", "correlation", "bitcount", "runstats", "graph", "convolution", "rle2", "descriptive", "bfs", "montecarlo", "dfs", "percentile", "mst", "pagerank", "astar", "simplex", "hungarian", "kmeans", "bellmanford", "floydwarshall", "reservoir"]);
 bucket("Quality (XPass)", ["testpass", "copypass", "uxpass", "seopass", "sloppass", "legalpass", "compliancepass", "flowpass", "commonsensepass", "fidelitycopy", "igniteonly", "nudgeonly", "pushonly", "qc", "geopass", "securitypass", "xpass-aggregated-verdict"]);
 
 // ─── Display-name casing fixes (fallback is Title Case of the slug) ────────────
@@ -201,6 +201,7 @@ const NAME_OF = {
   convolution: "Convolution", rle2: "RLE Numeric", descriptive: "Descriptive Stats", bfs: "BFS Search",
   montecarlo: "Monte Carlo", dfs: "DFS Search", percentile: "Percentile", mst: "Min Spanning Tree",
   pagerank: "PageRank", astar: "A* Pathfinding", simplex: "Simplex LP", hungarian: "Hungarian Assignment",
+  kmeans: "K-Means Clustering", bellmanford: "Bellman-Ford", floydwarshall: "Floyd-Warshall", reservoir: "Reservoir Sampling",
 };
 
 // ─── Better one-line blurbs for popular apps (fallback is the app's first tool) ─
@@ -607,6 +608,10 @@ const BLURB_OF = {
   astar: "Find the shortest path on a 2D grid using the A* algorithm.",
   simplex: "Solve linear programming problems (maximize subject to constraints) via simplex.",
   hungarian: "Optimally assign workers to tasks using the Hungarian algorithm.",
+  kmeans: "Partition data points into k clusters using the k-means algorithm.",
+  bellmanford: "Single-source shortest paths with negative edge weight support (Bellman-Ford).",
+  floydwarshall: "All-pairs shortest paths via Floyd-Warshall algorithm.",
+  reservoir: "Select k random items from a list with equal probability (reservoir sampling).",
 };
 
 // Keep every blurb a short, single-line sentence (the safety net for any new
@@ -784,6 +789,7 @@ const DOMAIN_OF = {
   convolution: "local", rle2: "local", descriptive: "local", bfs: "local",
   montecarlo: "local", dfs: "local", percentile: "local", mst: "local",
   pagerank: "local", astar: "local", simplex: "local", hungarian: "local",
+  kmeans: "local", bellmanford: "local", floydwarshall: "local", reservoir: "local",
 };
 
 function titleCase(slug) {

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "static",
-  "appCount": 559,
-  "toolCount": 1481,
+  "appCount": 563,
+  "toolCount": 1485,
   "categories": [
     "AI",
     "Books",
@@ -724,6 +724,22 @@
         {
           "name": "base64_decode",
           "description": "Decode a Base64 string to text."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "bellmanford",
+      "name": "Bellman-Ford",
+      "category": "Utilities",
+      "blurb": "Single-source shortest paths with negative edge weight support (Bellman-Ford).",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "bellman_ford",
+          "description": "Find shortest paths from a source node using Bellman-Ford (handles negative edge weights)."
         }
       ],
       "level": 5,
@@ -3730,6 +3746,22 @@
       "hardened": false
     },
     {
+      "slug": "floydwarshall",
+      "name": "Floyd-Warshall",
+      "category": "Utilities",
+      "blurb": "All-pairs shortest paths via Floyd-Warshall algorithm.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "floyd_warshall",
+          "description": "Compute all-pairs shortest paths using Floyd-Warshall."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
       "slug": "flyio",
       "name": "Fly.io",
       "category": "Developer & infra",
@@ -5308,6 +5340,22 @@
         {
           "name": "jwt_decode",
           "description": "Decode a JWT token to inspect header and payload claims (does NOT verify signature)."
+        }
+      ],
+      "level": 5,
+      "hardened": false
+    },
+    {
+      "slug": "kmeans",
+      "name": "K-Means Clustering",
+      "category": "Utilities",
+      "blurb": "Partition data points into k clusters using the k-means algorithm.",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "kmeans_cluster",
+          "description": "Partition points into k clusters using the k-means algorithm."
         }
       ],
       "level": 5,
@@ -9204,6 +9252,22 @@
       ],
       "level": 2,
       "hardened": true
+    },
+    {
+      "slug": "reservoir",
+      "name": "Reservoir Sampling",
+      "category": "Utilities",
+      "blurb": "Select k random items from a list with equal probability (reservoir sampling).",
+      "domain": "local",
+      "toolCount": 1,
+      "tools": [
+        {
+          "name": "reservoir_sample",
+          "description": "Select k random items from a list with equal probability using reservoir sampling."
+        }
+      ],
+      "level": 5,
+      "hardened": false
     },
     {
       "slug": "restcountries",

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -4186,6 +4186,30 @@
       "note": "hungarian_assign optimally assigns workers to tasks. Local computation.",
       "testedAt": "2026-06-09T00:45:00.000Z",
       "toolsTested": ["hungarian_assign"]
+    },
+    "kmeans": {
+      "status": "pass",
+      "note": "kmeans_cluster partitions points into k clusters. Local computation.",
+      "testedAt": "2026-06-09T00:52:00.000Z",
+      "toolsTested": ["kmeans_cluster"]
+    },
+    "bellmanford": {
+      "status": "pass",
+      "note": "bellman_ford finds shortest paths with negative weight support. Local computation.",
+      "testedAt": "2026-06-09T00:52:00.000Z",
+      "toolsTested": ["bellman_ford"]
+    },
+    "floydwarshall": {
+      "status": "pass",
+      "note": "floyd_warshall computes all-pairs shortest paths. Local computation.",
+      "testedAt": "2026-06-09T00:52:00.000Z",
+      "toolsTested": ["floyd_warshall"]
+    },
+    "reservoir": {
+      "status": "pass",
+      "note": "reservoir_sample selects k random items with equal probability. Local computation.",
+      "testedAt": "2026-06-09T00:52:00.000Z",
+      "toolsTested": ["reservoir_sample"]
     }
   },
   "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."


### PR DESCRIPTION
## Summary\n- Add 4 new local computation connectors: k-means clustering, Bellman-Ford shortest path (negative weights), Floyd-Warshall all-pairs shortest paths, reservoir sampling\n- All tools have full test suites (21 tests passing), type-checked, wired into catalog\n- App count: 559 -> 563, tool count: 1481 -> 1485\n\n## Test plan\n- [x] All 21 new tests pass locally\n- [x] TypeScript type check clean\n- [x] Regeneration pipeline run successfully\n- [ ] CI: MCP server package\n- [ ] CI: Website (root package)\n- [ ] CI: TestPass smoke run\n\nhttps://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfzJ3q2P3ECgBQDAWEjNez)_