### PR TITLE
Seats Compute Layer: WP-1 - Navigation and routing scaffold

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,9 +9,9 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 1025,
-    "source_manifest": 215,
-    "pages": 88,
+    "inventory": 1028,
+    "source_manifest": 218,
+    "pages": 91,
     "tools": 600,
     "rooms": 23,
     "workers": 8
@@ -21,7 +21,7 @@
       "id": "admin-surfaces",
       "name": "Admin surfaces",
       "meaning": "Private operator views and internal control panels.",
-      "count": 52
+      "count": 55
     },
     {
       "id": "public-surfaces",
@@ -349,6 +349,36 @@
       "meaning": "Master heartbeat copy policy for scheduled AI seats.",
       "source": "src/pages/admin/AdminSeatHeartbeat.tsx",
       "route": "/admin/agents/heartbeat",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-seats-api-src-pages-admin-adminseatsapi-tsx-admin-agents-api",
+      "division": "Admin surfaces",
+      "name": "Admin Seats Api",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Seats Api.",
+      "source": "src/pages/admin/AdminSeatsApi.tsx",
+      "route": "/admin/agents/api",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-seats-local-src-pages-admin-adminseatslocal-tsx-admin-agents-local",
+      "division": "Admin surfaces",
+      "name": "Admin Seats Local",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Seats Local.",
+      "source": "src/pages/admin/AdminSeatsLocal.tsx",
+      "route": "/admin/agents/local",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-seats-subscription-src-pages-admin-adminseatssubscription-tsx-admin-agents-subscription",
+      "division": "Admin surfaces",
+      "name": "Admin Seats Subscription",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Seats Subscription.",
+      "source": "src/pages/admin/AdminSeatsSubscription.tsx",
+      "route": "/admin/agents/subscription",
       "tags": []
     },
     {
@@ -10356,10 +10386,28 @@
       "src/pages/admin/AdminActivity.tsx"
     ],
     [
+      "/admin/agents/api",
+      "Admin Seats Api",
+      "Admin surface for Admin Seats Api.",
+      "src/pages/admin/AdminSeatsApi.tsx"
+    ],
+    [
       "/admin/agents/heartbeat",
       "Admin Seat Heartbeat",
       "Master heartbeat copy policy for scheduled AI seats.",
       "src/pages/admin/AdminSeatHeartbeat.tsx"
+    ],
+    [
+      "/admin/agents/local",
+      "Admin Seats Local",
+      "Admin surface for Admin Seats Local.",
+      "src/pages/admin/AdminSeatsLocal.tsx"
+    ],
+    [
+      "/admin/agents/subscription",
+      "Admin Seats Subscription",
+      "Admin surface for Admin Seats Subscription.",
+      "src/pages/admin/AdminSeatsSubscription.tsx"
     ],
     [
       "/admin/agents",
@@ -14260,13 +14308,13 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "ead5f39c080b",
-      "bytes": 16499
+      "hash": "1126750fa6f0",
+      "bytes": 16930
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
-      "hash": "2c6ec8581d6c",
-      "bytes": 25721
+      "hash": "05205988146b",
+      "bytes": 26745
     },
     {
       "source": "src/pages/admin/AdminControlTower.tsx",
@@ -14509,9 +14557,24 @@
       "bytes": 14795
     },
     {
+      "source": "src/pages/admin/AdminSeatsApi.tsx",
+      "hash": "294c1c50b4db",
+      "bytes": 676
+    },
+    {
       "source": "src/pages/admin/AdminSeatHeartbeat.tsx",
       "hash": "f9548c19ddab",
       "bytes": 11641
+    },
+    {
+      "source": "src/pages/admin/AdminSeatsLocal.tsx",
+      "hash": "2337f508e1a3",
+      "bytes": 678
+    },
+    {
+      "source": "src/pages/admin/AdminSeatsSubscription.tsx",
+      "hash": "cf78e7eb577f",
+      "bytes": 718
     },
     {
       "source": "src/pages/admin/AdminAgents.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,8 +22,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | de9f41b265f3 | 4881 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | ead5f39c080b | 16499 |
-| src/pages/admin/AdminShell.tsx | 2c6ec8581d6c | 25721 |
+| src/App.tsx | 1126750fa6f0 | 16930 |
+| src/pages/admin/AdminShell.tsx | 05205988146b | 26745 |
 | src/pages/admin/AdminControlTower.tsx | 2bc870ebf30f | 21782 |
 | src/lib/controltower.ts | c9d18e61e7d8 | 21703 |
 | docs/prd/controltower.md | 83641285316d | 4571 |
@@ -72,7 +72,10 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | seed/skills/write-tests-for-changed-code.skill.md | 0c2617abce77 | 1049 |
 | src/pages/Index.tsx | 87bc594da785 | 1598 |
 | src/pages/admin/AdminActivity.tsx | 48f1919d4056 | 14795 |
+| src/pages/admin/AdminSeatsApi.tsx | 294c1c50b4db | 676 |
 | src/pages/admin/AdminSeatHeartbeat.tsx | f9548c19ddab | 11641 |
+| src/pages/admin/AdminSeatsLocal.tsx | 2337f508e1a3 | 678 |
+| src/pages/admin/AdminSeatsSubscription.tsx | cf78e7eb577f | 718 |
 | src/pages/admin/AdminAgents.tsx | 73353b1405ef | 45563 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 90c9377b4bab | 10945 |
@@ -233,7 +236,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 
 | Division | Meaning | Items |
 | --- | --- | --- |
-| Admin surfaces | Private operator views and internal control panels. | 52 |
+| Admin surfaces | Private operator views and internal control panels. | 55 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
 | Tools | MCP and gateway capabilities available to seats. | 600 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
@@ -279,7 +282,10 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | --- | --- | --- | --- |
 | / | Index | Public home and first explanation of UnClick. | src/pages/Index.tsx |
 | /admin/activity | Admin Activity | Admin surface for Admin Activity. | src/pages/admin/AdminActivity.tsx |
+| /admin/agents/api | Admin Seats Api | Admin surface for Admin Seats Api. | src/pages/admin/AdminSeatsApi.tsx |
 | /admin/agents/heartbeat | Admin Seat Heartbeat | Master heartbeat copy policy for scheduled AI seats. | src/pages/admin/AdminSeatHeartbeat.tsx |
+| /admin/agents/local | Admin Seats Local | Admin surface for Admin Seats Local. | src/pages/admin/AdminSeatsLocal.tsx |
+| /admin/agents/subscription | Admin Seats Subscription | Admin surface for Admin Seats Subscription. | src/pages/admin/AdminSeatsSubscription.tsx |
 | /admin/agents | Admin Agents | Admin surface for Admin Agents. | src/pages/admin/AdminAgents.tsx |
 | /admin/analytics | Admin Analytics | Internal analytics view for platform signals and usage. | src/pages/admin/AdminAnalytics.tsx |
 | /admin/app-testing | Admin App Testing | Admin surface for Admin App Testing. | src/pages/admin/AdminAppTesting.tsx |
@@ -1001,6 +1007,9 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Admin Pinball Wake | PinballWake rooms, wake routes, and automation visibility. | /admin/pinballwake | src/pages/admin/AdminPinballWake.tsx |
 | Admin surfaces | admin page | Admin Projects | Admin surface for Admin Ecosystem Pages. | /admin/projects | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin Seat Heartbeat | Master heartbeat copy policy for scheduled AI seats. | /admin/agents/heartbeat | src/pages/admin/AdminSeatHeartbeat.tsx |
+| Admin surfaces | admin page | Admin Seats Api | Admin surface for Admin Seats Api. | /admin/agents/api | src/pages/admin/AdminSeatsApi.tsx |
+| Admin surfaces | admin page | Admin Seats Local | Admin surface for Admin Seats Local. | /admin/agents/local | src/pages/admin/AdminSeatsLocal.tsx |
+| Admin surfaces | admin page | Admin Seats Subscription | Admin surface for Admin Seats Subscription. | /admin/agents/subscription | src/pages/admin/AdminSeatsSubscription.tsx |
 | Admin surfaces | admin page | Admin Settings | Account and admin configuration. | /admin/settings | src/pages/admin/AdminSettings.tsx |
 | Admin surfaces | admin page | Admin Shell | Admin surface for Admin Shell. | /admin | src/pages/admin/AdminShell.tsx |
 | Admin surfaces | admin page | Admin Skills | Read-only starter pack of UnClick-native skills, native rails, and portable SKILL.md packages. | /admin/skills | src/pages/admin/AdminSkills.tsx |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,9 @@ import AdminActivity from "./pages/admin/AdminActivity.tsx";
 import AdminSettings from "./pages/admin/AdminSettings.tsx";
 import AdminAgentsPage from "./pages/admin/AdminAgents.tsx";
 import AdminSeatHeartbeatPage from "./pages/admin/AdminSeatHeartbeat.tsx";
+import AdminSeatsApi from "./pages/admin/AdminSeatsApi.tsx";
+import AdminSeatsLocal from "./pages/admin/AdminSeatsLocal.tsx";
+import AdminSeatsSubscription from "./pages/admin/AdminSeatsSubscription.tsx";
 import AdminAnalytics from "./pages/admin/AdminAnalytics.tsx";
 import AdminCodebase from "./pages/admin/AdminCodebase.tsx";
 import AdminOrchestratorPage from "./pages/admin/AdminOrchestrator.tsx";
@@ -201,6 +204,9 @@ const App = () => (
             <Route path="autopilot" element={<AdminAutopilot />} />
             <Route path="autopilot/expressbuild" element={<AdminExpressBuild />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
+            <Route path="agents/api" element={<AdminSeatsApi />} />
+            <Route path="agents/local" element={<AdminSeatsLocal />} />
+            <Route path="agents/subscription" element={<AdminSeatsSubscription />} />
             <Route path="agents/heartbeat" element={<AdminSeatHeartbeatPage />} />
             <Route path="workers" element={<AdminWorkers />} />
             <Route path="jobs" element={<AdminJobs />} />

--- a/src/pages/admin/AdminSeatsApi.tsx
+++ b/src/pages/admin/AdminSeatsApi.tsx
@@ -1,0 +1,19 @@
+import { KeyRound } from "lucide-react";
+
+export default function AdminSeatsApi() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <KeyRound className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold tracking-tight">API</h1>
+      </div>
+      <p className="text-muted-foreground">
+        Manage API keys and usage across AI providers. Configure spend limits,
+        smart routing, and escalation rules.
+      </p>
+      <div className="rounded-lg border border-border/40 bg-card/30 p-8 text-center text-sm text-muted-foreground">
+        API tier management coming soon.
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminSeatsLocal.tsx
+++ b/src/pages/admin/AdminSeatsLocal.tsx
@@ -1,0 +1,19 @@
+import { Cpu } from "lucide-react";
+
+export default function AdminSeatsLocal() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Cpu className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold tracking-tight">Local</h1>
+      </div>
+      <p className="text-muted-foreground">
+        Run AI models on your own hardware. Detect local endpoints, manage
+        installed models, and configure routing rules.
+      </p>
+      <div className="rounded-lg border border-border/40 bg-card/30 p-8 text-center text-sm text-muted-foreground">
+        Local tier management coming soon.
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminSeatsSubscription.tsx
+++ b/src/pages/admin/AdminSeatsSubscription.tsx
@@ -1,0 +1,19 @@
+import { CreditCard } from "lucide-react";
+
+export default function AdminSeatsSubscription() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <CreditCard className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold tracking-tight">Subscription</h1>
+      </div>
+      <p className="text-muted-foreground">
+        Manage AI platform subscriptions you already pay for. Connect Claude Pro,
+        ChatGPT Plus, Cursor, Windsurf, and Copilot.
+      </p>
+      <div className="rounded-lg border border-border/40 bg-card/30 p-8 text-center text-sm text-muted-foreground">
+        Subscription tier management coming soon.
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -32,6 +32,7 @@ import {
   BarChart3,
   Bell,
   Code2,
+  Cpu,
   Terminal,
   ChevronRight,
   ChevronDown,
@@ -408,28 +409,56 @@ function MemoryNavItem({ onClick }: { onClick?: () => void }) {
   );
 }
 
+const SEATS_CHILDREN = [
+  { path: "/admin/agents/api",          label: "API",          icon: KeyRound },
+  { path: "/admin/agents/local",        label: "Local",        icon: Cpu },
+  { path: "/admin/agents/subscription", label: "Subscription", icon: CreditCard },
+  { path: "/admin/agents/heartbeat",    label: "Heartbeat",    icon: HeartPulse },
+] as const;
+
 function SeatsNavItem({ onClick }: { onClick?: () => void }) {
   const location = useLocation();
   const isSeats = location.pathname === "/admin/agents" || location.pathname.startsWith("/admin/agents/");
-  const heartbeatActive = location.pathname === "/admin/agents/heartbeat";
 
   return (
     <div>
-      <SurfaceLink path="/admin/agents" label="Seats" icon={SeatsCascadeIcon} onClick={onClick} />
+      <NavLink
+        to="/admin/agents"
+        onClick={onClick}
+        className={() =>
+          `flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+            isSeats
+              ? "bg-primary/10 text-primary"
+              : "text-muted-foreground hover:bg-card/40 hover:text-foreground"
+          }`
+        }
+      >
+        <SeatsCascadeIcon className="h-4 w-4 shrink-0" />
+        <span className="flex-1">Seats</span>
+        {isSeats
+          ? <ChevronDown className="h-3 w-3 shrink-0" />
+          : <ChevronRight className="h-3 w-3 shrink-0" />}
+      </NavLink>
       {isSeats && (
         <div className="ml-7 mt-0.5 flex flex-col gap-0.5">
-          <Link
-            to="/admin/agents/heartbeat"
-            onClick={onClick}
-            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-              heartbeatActive
-                ? "bg-primary/10 text-primary"
-                : "text-muted-foreground hover:bg-card/40 hover:text-body"
-            }`}
-          >
-            <HeartPulse className="h-3 w-3 shrink-0" />
-            Heartbeat
-          </Link>
+          {SEATS_CHILDREN.map(({ path, label, icon: Icon }) => {
+            const active = location.pathname === path;
+            return (
+              <Link
+                key={path}
+                to={path}
+                onClick={onClick}
+                className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-card/40 hover:text-body"
+                }`}
+              >
+                <Icon className="h-3 w-3 shrink-0" />
+                {label}
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Adds three new routes under `/admin/agents`: `/api`, `/local`, `/subscription` for the three compute tiers
- Extends `SeatsNavItem` in the admin sidebar to show four cascading children (API, Local, Subscription, Heartbeat) with Lucide icons and active-state highlighting
- Creates stub pages for all three tiers (`AdminSeatsApi.tsx`, `AdminSeatsLocal.tsx`, `AdminSeatsSubscription.tsx`) that render inside the AdminShell
- Follows the existing `MemoryNavItem` cascade pattern with chevron expand/collapse indicators

## Acceptance criteria

- [x] Route `/admin/agents/api` renders the API stub page within the admin shell
- [x] Route `/admin/agents/local` renders the Local stub page within the admin shell
- [x] Route `/admin/agents/subscription` renders the Subscription stub page within the admin shell
- [x] Sidebar shows all four children (API, Local, Subscription, Heartbeat) under Seats when any `/admin/agents/*` path is active
- [x] Each child has an icon: `KeyRound` (API), `Cpu` (Local), `CreditCard` (Subscription), `HeartPulse` (Heartbeat)
- [x] Active child is highlighted with `bg-primary/10 text-primary`
- [x] Existing Heartbeat route and Seats dashboard remain unchanged
- [x] TypeScript compiles cleanly (`tsc --noEmit` passes)

## Dependencies

None - this is the scaffold that WP-2 through WP-10 build on.

## Test plan

- [ ] Navigate to `/admin/agents` - sidebar expands to show four children
- [ ] Click each child link - correct stub page renders
- [ ] Active child is visually highlighted
- [ ] Navigate away from Seats - children collapse
- [ ] Heartbeat page still works at `/admin/agents/heartbeat`

https://claude.ai/code/session_01PGcK3VZVSNGacuDcLfkPqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGcK3VZVSNGacuDcLfkPqf)_