### PR TITLE
Seats Compute Layer: WP-1 - Scaffold types, constants, and tier utilities

### DIFF
--- a/docs/seats-compute-layer-brief.md
+++ b/docs/seats-compute-layer-brief.md
@@ -1,0 +1,281 @@
+# Seats Compute Layer Brief
+
+Restructure the Seats admin surface from a flat list of AI seats into a
+three-tier compute hub. Each seat belongs to exactly one compute tier:
+
+| Tier | Description | Cost model | Examples |
+|------|-------------|------------|----------|
+| **API** | Cloud endpoints billed per call/token | Pay-per-use | Claude API, OpenAI API, Groq, Replicate |
+| **Local** | On-device or self-hosted compute | Owned (no marginal cost) | Ollama, local GPU, PC-tether agents |
+| **Subscription** | SaaS platform seats with fixed billing | Monthly/annual | Claude Pro, Codex, Windsurf, GitHub Actions |
+
+## Goals
+
+1. Every seat declares its compute tier so routing, cost, and health logic
+   can treat tiers differently.
+2. The admin UI shows seats grouped by tier with tier-specific health and
+   cost summaries.
+3. The routing engine can prefer cheaper tiers when capability is equal.
+4. Backward-compatible: existing seats default to the Subscription tier
+   (the most common case today).
+
+## Architecture changes
+
+### New shared module
+
+`src/lib/seats/compute-tiers.ts` - canonical types, constants, and pure
+utility functions used by both the frontend admin UI and the API routing
+layer.
+
+### Extended types
+
+The existing `AISeat` interface gains a `computeTier` field. The API-side
+`SeatLoadPolicyInput` gains a matching field. A new
+`ComputeTierSummary` type aggregates per-tier stats for the dashboard.
+
+### New UI panels
+
+The admin page gets a tabbed or sectioned layout, one section per tier,
+each with tier-specific health badges and cost indicators.
+
+### Routing extension
+
+`buildSeatLoadRoutingPlan` gains an optional `preferredTier` input so
+callers can bias toward a tier.
+
+## Work packages for 10 builders
+
+### WP-1 - Scaffold (no dependencies)
+
+Core types, constants, and shared utility functions for the three-tier
+model.
+
+**Scope:** Create the shared module that every other WP imports.
+
+**Files:**
+- `src/lib/seats/compute-tiers.ts` - types + constants + pure helpers
+- `src/lib/seats/compute-tiers.test.ts` - unit tests
+- `src/lib/seats/index.ts` - barrel export
+
+**Details:**
+- Define `ComputeTier` union type: `"api" | "local" | "subscription"`
+- Define `ComputeTierMeta` with label, description, icon name, cost model
+  string, and default routing weight
+- Export `COMPUTE_TIER_META` record keyed by tier
+- Export `DEFAULT_COMPUTE_TIER` constant (`"subscription"`)
+- Define `ComputeTierSummary` interface: tier, seat count, eligible count,
+  total weight, avg health score, estimated cost (number or null)
+- Export `classifySeatTier(seat)` pure function that infers tier from
+  provider/device/userAgentHint strings
+- Export `buildTierSummaries(seats, scores)` that groups seats by tier
+  and aggregates
+- All functions must be pure (no side effects, no DOM, no fetch)
+
+**Acceptance criteria:**
+- `npm run test --workspace=@unclick/mcp-server` still passes (no
+  regressions)
+- `npx vitest run src/lib/seats/compute-tiers.test.ts` passes
+- `classifySeatTier` correctly classifies at least: "claude api" -> api,
+  "ollama" -> local, "codex" -> subscription, unknown -> subscription
+- `buildTierSummaries` returns one entry per tier with correct counts
+- No runtime imports from React or browser APIs
+
+---
+
+### WP-2 - Extend AISeat type (depends on WP-1)
+
+Add `computeTier` to the core seat interfaces on both frontend and API
+side.
+
+**Scope:** Wire the new field into existing types without breaking
+current behavior.
+
+**Files:**
+- `src/pages/admin/AdminAgentsSeatUtils.ts` - add `computeTier?` to `AISeat`
+- `api/lib/seat-load-overrides.ts` - add `computeTier?` to `SeatLoadPolicyInput`
+- `src/pages/admin/AdminAgents.tsx` - default each seat in `AI_SEATS` to
+  `"subscription"`
+
+**Details:**
+- Field is optional so old data keeps working
+- `loadSeatOverridesFromStorage` preserves and restores the field
+- `buildSeatOverrideStoragePayload` serializes it
+
+**Acceptance criteria:**
+- Existing tests still pass
+- TypeScript compiles with no new errors
+- Default seats render the same as before (visual no-op)
+
+---
+
+### WP-3 - Tier-aware routing (depends on WP-1)
+
+Extend `buildSeatLoadRoutingPlan` to accept a preferred tier and bias
+weights accordingly.
+
+**Scope:** Backend routing changes only.
+
+**Files:**
+- `api/lib/seat-load-overrides.ts` - add `preferredTier?` to input,
+  apply tier weight bias
+- `api/seat-load-overrides.test.ts` - new test cases
+
+**Details:**
+- When `preferredTier` is set, multiply raw weights of matching seats by
+  1.5 and non-matching by 0.75
+- When unset, behavior is identical to today
+- Add tier to each `SeatLoadRoutingWeight` in the output
+
+**Acceptance criteria:**
+- Existing routing tests still pass
+- New test: with preferred tier "local", local seats get higher weight
+- No behavior change when `preferredTier` is omitted
+
+---
+
+### WP-4 - Tier classification integration (depends on WP-3)
+
+Use `classifySeatTier` inside the routing plan builder so every weight
+row carries its tier.
+
+**Scope:** Wire classification into the routing pipeline.
+
+**Files:**
+- `api/lib/seat-load-overrides.ts` - call `classifySeatTier` during plan
+  build
+- `api/seat-load-overrides.test.ts` - verify tier appears in output
+
+**Acceptance criteria:**
+- Each `SeatLoadRoutingWeight` now includes a `tier` field
+- Classification matches the seat's explicit `computeTier` when set,
+  falls back to inference
+
+---
+
+### WP-5 - Tier cost model (depends on WP-3)
+
+Add per-tier cost estimation to the routing plan output.
+
+**Scope:** Cost math only, no UI.
+
+**Files:**
+- `src/lib/seats/compute-tiers.ts` - add `estimateTierCost(tier, tokens)`
+  pure function
+- `api/lib/seat-load-overrides.ts` - add optional cost fields to plan
+  output
+- Tests for both
+
+**Acceptance criteria:**
+- API tier returns a token-based estimate
+- Local tier returns 0
+- Subscription tier returns null (fixed cost, not per-call)
+- Existing tests still pass
+
+---
+
+### WP-6 - Tier health scoring (depends on WP-1)
+
+Extend seat performance scoring to include tier-level health.
+
+**Scope:** Scoring utilities only.
+
+**Files:**
+- `src/pages/admin/AdminAgentsSeatUtils.ts` - new
+  `buildTierHealthScores(seats, profiles)` function
+- `src/lib/seats/compute-tiers.test.ts` - additional test cases
+
+**Details:**
+- Aggregates per-tier: average score, worst status, count of stale seats
+- Uses existing `buildSeatPerformanceScores` internally
+
+**Acceptance criteria:**
+- Returns one health record per tier
+- Tiers with no seats are omitted
+- Pure function, no side effects
+
+---
+
+### WP-7 - Tier tab UI shell (depends on WP-6)
+
+Replace the flat seat list with a tabbed layout grouped by tier.
+
+**Scope:** UI restructuring.
+
+**Files:**
+- `src/pages/admin/AdminAgents.tsx` - refactor `AISeatsPanel` into
+  `ComputeHubPanel` with three tab sections
+- New `src/pages/admin/TierTab.tsx` component
+
+**Details:**
+- Each tab shows the tier label, seat count badge, and health indicator
+- Seat cards within a tab are the same as today
+- Default tab is Subscription (most seats)
+
+**Acceptance criteria:**
+- Three tabs render: API, Local, Subscription
+- Seats appear under their correct tier
+- Existing seat editing still works
+
+---
+
+### WP-8 - Tier summary cards (depends on WP-7)
+
+Add a summary card at the top of each tier tab showing aggregated stats.
+
+**Scope:** UI components.
+
+**Files:**
+- New `src/pages/admin/TierSummaryCard.tsx`
+- Wire into `TierTab.tsx`
+
+**Details:**
+- Shows: seat count, eligible count, average health score, cost indicator
+- Uses `buildTierSummaries` from WP-1
+
+**Acceptance criteria:**
+- Card renders correct numbers for each tier
+- Cost shows "per-use" / "owned" / "fixed" labels matching tier
+
+---
+
+### WP-9 - Relay tier awareness (depends on WP-1)
+
+Extend seat relay to consider tier when choosing reassignment candidates.
+
+**Scope:** Relay logic only.
+
+**Files:**
+- `src/lib/seatRelay.ts` - add tier preference to `RelayCandidate`
+- `src/lib/seatRelay.test.ts` - new test cases (create if needed)
+
+**Details:**
+- Prefer same-tier reassignment
+- Fall back to any eligible seat if no same-tier candidate
+- No behavior change for items without tier info
+
+**Acceptance criteria:**
+- Same-tier candidates are preferred
+- Cross-tier fallback still works
+- Existing relay tests pass
+
+---
+
+### WP-10 - Integration smoke test (depends on WP-4, WP-9)
+
+End-to-end test that builds a routing plan with mixed-tier seats and
+verifies the full pipeline.
+
+**Scope:** Test-only package.
+
+**Files:**
+- `src/lib/seats/integration.test.ts`
+
+**Details:**
+- Constructs seats across all three tiers
+- Builds a routing plan with preferred tier
+- Verifies tier summaries, cost estimates, and routing weights
+- Verifies relay prefers same-tier
+
+**Acceptance criteria:**
+- Single test file, all assertions pass
+- Exercises WP-1 through WP-9 code paths

--- a/src/lib/seats/compute-tiers.test.ts
+++ b/src/lib/seats/compute-tiers.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifySeatTier,
+  buildTierSummaries,
+  estimateTierCost,
+  COMPUTE_TIERS,
+  COMPUTE_TIER_META,
+  DEFAULT_COMPUTE_TIER,
+  type TierSeatInput,
+  type TierScoreInput,
+} from "./compute-tiers";
+
+describe("classifySeatTier", () => {
+  it("returns explicit computeTier when set", () => {
+    expect(classifySeatTier({ computeTier: "api" })).toBe("api");
+    expect(classifySeatTier({ computeTier: "local" })).toBe("local");
+    expect(classifySeatTier({ computeTier: "subscription" })).toBe("subscription");
+  });
+
+  it("classifies Claude API as api tier", () => {
+    expect(classifySeatTier({ provider: "Claude API" })).toBe("api");
+  });
+
+  it("classifies OpenAI as api tier", () => {
+    expect(classifySeatTier({ provider: "OpenAI" })).toBe("api");
+  });
+
+  it("classifies Groq as api tier", () => {
+    expect(classifySeatTier({ provider: "Groq" })).toBe("api");
+  });
+
+  it("classifies Replicate as api tier", () => {
+    expect(classifySeatTier({ provider: "Replicate" })).toBe("api");
+  });
+
+  it("classifies Anthropic as api tier", () => {
+    expect(classifySeatTier({ userAgentHint: "anthropic-sdk" })).toBe("api");
+  });
+
+  it("classifies Ollama as local tier", () => {
+    expect(classifySeatTier({ provider: "Ollama" })).toBe("local");
+  });
+
+  it("classifies llama.cpp as local tier", () => {
+    expect(classifySeatTier({ device: "llama.cpp server" })).toBe("local");
+  });
+
+  it("classifies LM Studio as local tier", () => {
+    expect(classifySeatTier({ provider: "LM Studio" })).toBe("local");
+  });
+
+  it("classifies local GPU as local tier", () => {
+    expect(classifySeatTier({ device: "local GPU node" })).toBe("local");
+  });
+
+  it("classifies self-hosted as local tier", () => {
+    expect(classifySeatTier({ provider: "self-hosted vLLM" })).toBe("local");
+  });
+
+  it("classifies Codex as subscription tier (default)", () => {
+    expect(classifySeatTier({ provider: "Codex" })).toBe("subscription");
+  });
+
+  it("classifies Windsurf as subscription tier (default)", () => {
+    expect(classifySeatTier({ provider: "Windsurf" })).toBe("subscription");
+  });
+
+  it("classifies unknown provider as subscription tier", () => {
+    expect(classifySeatTier({ provider: "Unknown AI" })).toBe("subscription");
+  });
+
+  it("defaults to subscription when no info provided", () => {
+    expect(classifySeatTier({})).toBe("subscription");
+  });
+
+  it("defaults to subscription for null fields", () => {
+    expect(
+      classifySeatTier({ provider: null, device: null, userAgentHint: null }),
+    ).toBe("subscription");
+  });
+
+  it("explicit computeTier overrides keyword match", () => {
+    expect(
+      classifySeatTier({ computeTier: "subscription", provider: "Ollama" }),
+    ).toBe("subscription");
+  });
+
+  it("ignores invalid explicit computeTier", () => {
+    expect(
+      classifySeatTier({ computeTier: "invalid" as never, provider: "Ollama" }),
+    ).toBe("local");
+  });
+
+  it("uses userAgentHint for classification", () => {
+    expect(classifySeatTier({ userAgentHint: "ollama/0.1" })).toBe("local");
+  });
+
+  it("local keywords take precedence over api keywords", () => {
+    expect(classifySeatTier({ provider: "localhost api" })).toBe("local");
+  });
+});
+
+describe("buildTierSummaries", () => {
+  const seats: TierSeatInput[] = [
+    { id: "s1", provider: "Claude API" },
+    { id: "s2", provider: "OpenAI" },
+    { id: "s3", provider: "Ollama" },
+    { id: "s4", provider: "Codex" },
+    { id: "s5", provider: "Windsurf" },
+  ];
+
+  const scores: TierScoreInput[] = [
+    { id: "s1", score: 90, status: "strong" },
+    { id: "s2", score: 70, status: "watch" },
+    { id: "s3", score: 85, status: "strong" },
+    { id: "s4", score: 60, status: "watch" },
+    { id: "s5", score: 40, status: "stale" },
+  ];
+
+  it("returns one summary per tier that has seats", () => {
+    const summaries = buildTierSummaries(seats, scores);
+    expect(summaries.length).toBe(3);
+    const tiers = summaries.map((s) => s.tier);
+    expect(tiers).toContain("api");
+    expect(tiers).toContain("local");
+    expect(tiers).toContain("subscription");
+  });
+
+  it("counts seats correctly per tier", () => {
+    const summaries = buildTierSummaries(seats, scores);
+    const api = summaries.find((s) => s.tier === "api")!;
+    const local = summaries.find((s) => s.tier === "local")!;
+    const sub = summaries.find((s) => s.tier === "subscription")!;
+    expect(api.seatCount).toBe(2);
+    expect(local.seatCount).toBe(1);
+    expect(sub.seatCount).toBe(2);
+  });
+
+  it("counts eligible seats (strong or watch)", () => {
+    const summaries = buildTierSummaries(seats, scores);
+    const api = summaries.find((s) => s.tier === "api")!;
+    const local = summaries.find((s) => s.tier === "local")!;
+    const sub = summaries.find((s) => s.tier === "subscription")!;
+    expect(api.eligibleCount).toBe(2);
+    expect(local.eligibleCount).toBe(1);
+    expect(sub.eligibleCount).toBe(1);
+  });
+
+  it("calculates average health score", () => {
+    const summaries = buildTierSummaries(seats, scores);
+    const api = summaries.find((s) => s.tier === "api")!;
+    const local = summaries.find((s) => s.tier === "local")!;
+    const sub = summaries.find((s) => s.tier === "subscription")!;
+    expect(api.avgHealthScore).toBe(80);
+    expect(local.avgHealthScore).toBe(85);
+    expect(sub.avgHealthScore).toBe(50);
+  });
+
+  it("sets estimatedCost to 0 for local tier", () => {
+    const summaries = buildTierSummaries(seats, scores);
+    const local = summaries.find((s) => s.tier === "local")!;
+    expect(local.estimatedCost).toBe(0);
+  });
+
+  it("sets estimatedCost to null for non-local tiers", () => {
+    const summaries = buildTierSummaries(seats, scores);
+    const api = summaries.find((s) => s.tier === "api")!;
+    const sub = summaries.find((s) => s.tier === "subscription")!;
+    expect(api.estimatedCost).toBeNull();
+    expect(sub.estimatedCost).toBeNull();
+  });
+
+  it("omits tiers with no seats", () => {
+    const onlySub: TierSeatInput[] = [{ id: "s1", provider: "Codex" }];
+    const subScores: TierScoreInput[] = [{ id: "s1", score: 80, status: "strong" }];
+    const summaries = buildTierSummaries(onlySub, subScores);
+    expect(summaries.length).toBe(1);
+    expect(summaries[0].tier).toBe("subscription");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(buildTierSummaries([], [])).toEqual([]);
+  });
+
+  it("handles seats with no matching scores", () => {
+    const noScoreSeats: TierSeatInput[] = [{ id: "s1", provider: "Ollama" }];
+    const summaries = buildTierSummaries(noScoreSeats, []);
+    expect(summaries.length).toBe(1);
+    expect(summaries[0].avgHealthScore).toBe(0);
+    expect(summaries[0].eligibleCount).toBe(0);
+  });
+
+  it("uses labels from COMPUTE_TIER_META", () => {
+    const summaries = buildTierSummaries(seats, scores);
+    for (const s of summaries) {
+      expect(s.label).toBe(COMPUTE_TIER_META[s.tier].label);
+    }
+  });
+
+  it("respects explicit computeTier on seats", () => {
+    const explicit: TierSeatInput[] = [
+      { id: "s1", computeTier: "api", provider: "Ollama" },
+    ];
+    const explicitScores: TierScoreInput[] = [{ id: "s1", score: 80, status: "strong" }];
+    const summaries = buildTierSummaries(explicit, explicitScores);
+    expect(summaries.length).toBe(1);
+    expect(summaries[0].tier).toBe("api");
+  });
+});
+
+describe("estimateTierCost", () => {
+  it("returns 0 for local tier", () => {
+    expect(estimateTierCost("local", 1_000_000)).toBe(0);
+  });
+
+  it("returns null for subscription tier", () => {
+    expect(estimateTierCost("subscription", 1_000_000)).toBeNull();
+  });
+
+  it("returns per-token cost for api tier", () => {
+    expect(estimateTierCost("api", 1_000_000)).toBe(3.0);
+  });
+
+  it("uses custom cost rate", () => {
+    expect(estimateTierCost("api", 1_000_000, 15.0)).toBe(15.0);
+  });
+
+  it("scales linearly with token count", () => {
+    expect(estimateTierCost("api", 500_000)).toBe(1.5);
+    expect(estimateTierCost("api", 2_000_000)).toBe(6.0);
+  });
+
+  it("returns 0 for zero tokens on api tier", () => {
+    expect(estimateTierCost("api", 0)).toBe(0);
+  });
+});
+
+describe("constants", () => {
+  it("COMPUTE_TIERS has three entries", () => {
+    expect(COMPUTE_TIERS).toHaveLength(3);
+    expect(COMPUTE_TIERS).toEqual(["api", "local", "subscription"]);
+  });
+
+  it("DEFAULT_COMPUTE_TIER is subscription", () => {
+    expect(DEFAULT_COMPUTE_TIER).toBe("subscription");
+  });
+
+  it("COMPUTE_TIER_META has entry for each tier", () => {
+    for (const tier of COMPUTE_TIERS) {
+      const meta = COMPUTE_TIER_META[tier];
+      expect(meta).toBeDefined();
+      expect(meta.label).toBeTruthy();
+      expect(meta.description).toBeTruthy();
+      expect(meta.icon).toBeTruthy();
+      expect(meta.costModel).toBeTruthy();
+      expect(typeof meta.defaultRoutingWeight).toBe("number");
+    }
+  });
+});

--- a/src/lib/seats/compute-tiers.ts
+++ b/src/lib/seats/compute-tiers.ts
@@ -1,0 +1,188 @@
+export type ComputeTier = "api" | "local" | "subscription";
+
+export interface ComputeTierMeta {
+  label: string;
+  description: string;
+  icon: string;
+  costModel: string;
+  defaultRoutingWeight: number;
+}
+
+export const COMPUTE_TIERS: readonly ComputeTier[] = ["api", "local", "subscription"] as const;
+
+export const DEFAULT_COMPUTE_TIER: ComputeTier = "subscription";
+
+export const COMPUTE_TIER_META: Record<ComputeTier, ComputeTierMeta> = {
+  api: {
+    label: "API",
+    description: "Cloud endpoints billed per call or token",
+    icon: "cloud",
+    costModel: "per-use",
+    defaultRoutingWeight: 1.0,
+  },
+  local: {
+    label: "Local",
+    description: "On-device or self-hosted compute",
+    icon: "hard-drive",
+    costModel: "owned",
+    defaultRoutingWeight: 1.2,
+  },
+  subscription: {
+    label: "Subscription",
+    description: "SaaS platform seats with fixed billing",
+    icon: "credit-card",
+    costModel: "fixed",
+    defaultRoutingWeight: 1.0,
+  },
+};
+
+const API_KEYWORDS = [
+  "api",
+  "openai",
+  "anthropic",
+  "claude api",
+  "groq",
+  "replicate",
+  "together",
+  "mistral api",
+  "cohere",
+  "perplexity",
+  "fireworks",
+  "anyscale",
+  "deepinfra",
+];
+
+const LOCAL_KEYWORDS = [
+  "ollama",
+  "llamacpp",
+  "llama.cpp",
+  "local",
+  "localhost",
+  "self-hosted",
+  "on-device",
+  "gpu",
+  "mlx",
+  "gguf",
+  "vllm",
+  "text-generation-webui",
+  "lm studio",
+  "lmstudio",
+  "koboldcpp",
+  "jan.ai",
+  "gpt4all",
+];
+
+export interface SeatTierInput {
+  provider?: string | null;
+  device?: string | null;
+  userAgentHint?: string | null;
+  computeTier?: ComputeTier | null;
+}
+
+export function classifySeatTier(seat: SeatTierInput): ComputeTier {
+  if (seat.computeTier && COMPUTE_TIERS.includes(seat.computeTier)) {
+    return seat.computeTier;
+  }
+
+  const haystack = [seat.provider, seat.device, seat.userAgentHint]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (!haystack) return DEFAULT_COMPUTE_TIER;
+
+  for (const keyword of LOCAL_KEYWORDS) {
+    if (haystack.includes(keyword)) return "local";
+  }
+
+  for (const keyword of API_KEYWORDS) {
+    if (haystack.includes(keyword)) return "api";
+  }
+
+  return DEFAULT_COMPUTE_TIER;
+}
+
+export interface TierSeatInput {
+  id: string;
+  computeTier?: ComputeTier | null;
+  provider?: string | null;
+  device?: string | null;
+  userAgentHint?: string | null;
+  isVirtual?: boolean;
+}
+
+export interface TierScoreInput {
+  id: string;
+  score: number;
+  status: string;
+}
+
+export interface ComputeTierSummary {
+  tier: ComputeTier;
+  label: string;
+  seatCount: number;
+  eligibleCount: number;
+  avgHealthScore: number;
+  estimatedCost: number | null;
+}
+
+export function buildTierSummaries(
+  seats: TierSeatInput[],
+  scores: TierScoreInput[],
+): ComputeTierSummary[] {
+  const scoreById = new Map(scores.map((s) => [s.id, s]));
+
+  const grouped = new Map<ComputeTier, TierSeatInput[]>();
+  for (const seat of seats) {
+    const tier = classifySeatTier(seat);
+    const list = grouped.get(tier);
+    if (list) {
+      list.push(seat);
+    } else {
+      grouped.set(tier, [seat]);
+    }
+  }
+
+  const summaries: ComputeTierSummary[] = [];
+
+  for (const tier of COMPUTE_TIERS) {
+    const tierSeats = grouped.get(tier);
+    if (!tierSeats || tierSeats.length === 0) continue;
+
+    const tierScores = tierSeats
+      .map((s) => scoreById.get(s.id))
+      .filter((s): s is TierScoreInput => s != null);
+
+    const eligibleCount = tierScores.filter(
+      (s) => s.status === "strong" || s.status === "watch",
+    ).length;
+
+    const avgHealthScore =
+      tierScores.length > 0
+        ? Math.round(
+            tierScores.reduce((sum, s) => sum + s.score, 0) / tierScores.length,
+          )
+        : 0;
+
+    summaries.push({
+      tier,
+      label: COMPUTE_TIER_META[tier].label,
+      seatCount: tierSeats.length,
+      eligibleCount,
+      avgHealthScore,
+      estimatedCost: tier === "local" ? 0 : null,
+    });
+  }
+
+  return summaries;
+}
+
+export function estimateTierCost(
+  tier: ComputeTier,
+  tokens: number,
+  costPerMillionTokens = 3.0,
+): number | null {
+  if (tier === "local") return 0;
+  if (tier === "subscription") return null;
+  return (tokens / 1_000_000) * costPerMillionTokens;
+}

--- a/src/lib/seats/index.ts
+++ b/src/lib/seats/index.ts
@@ -1,0 +1,14 @@
+export {
+  type ComputeTier,
+  type ComputeTierMeta,
+  type ComputeTierSummary,
+  type SeatTierInput,
+  type TierSeatInput,
+  type TierScoreInput,
+  COMPUTE_TIERS,
+  COMPUTE_TIER_META,
+  DEFAULT_COMPUTE_TIER,
+  classifySeatTier,
+  buildTierSummaries,
+  estimateTierCost,
+} from "./compute-tiers";


### PR DESCRIPTION
## Summary

- Add the shared foundation module (`src/lib/seats/`) for the three-tier compute hub (API, Local, Subscription) that restructures the Seats admin surface
- Define `ComputeTier` types, `COMPUTE_TIER_META` constants, and pure utility functions: `classifySeatTier()`, `buildTierSummaries()`, `estimateTierCost()`
- Create the full spec brief (`docs/seats-compute-layer-brief.md`) defining all 10 work packages
- 40 unit tests covering classification, aggregation, cost estimation, and constants

## Acceptance criteria

- [x] `npx vitest run src/lib/seats/compute-tiers.test.ts` passes (40/40 tests)
- [x] All existing tests pass (294/294 in `src/lib/`)
- [x] TypeScript compiles with no errors
- [x] `classifySeatTier` correctly classifies: "claude api" -> api, "ollama" -> local, "codex" -> subscription, unknown -> subscription
- [x] `buildTierSummaries` returns one entry per tier with correct counts
- [x] No runtime imports from React or browser APIs - all functions are pure

## Dependencies

- WP-1 has no dependencies (this is the scaffold that WP-2 through WP-10 build on)

## Test plan

- [x] Run `npx vitest run src/lib/seats/compute-tiers.test.ts` - all 40 tests pass
- [x] Run `npx vitest run src/lib/` - all 294 existing tests still pass (no regressions)
- [x] Run `npx tsc --noEmit` - clean TypeScript compilation

https://claude.ai/code/session_01JZSdQ24sDqnqyuUiCX8owH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZSdQ24sDqnqyuUiCX8owH)_