### PR TITLE
Seats Compute Layer: WP-2 - dashboard summary strip

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -14755,8 +14755,8 @@
     },
     {
       "source": "src/pages/admin/AdminAgents.tsx",
-      "hash": "73353b1405ef",
-      "bytes": 45563
+      "hash": "f35f07da7bc1",
+      "bytes": 48860
     },
     {
       "source": "src/pages/admin/AdminAnalytics.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -73,7 +73,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Index.tsx | 87bc594da785 | 1598 |
 | src/pages/admin/AdminActivity.tsx | 48f1919d4056 | 14795 |
 | src/pages/admin/AdminSeatHeartbeat.tsx | f9548c19ddab | 11641 |
-| src/pages/admin/AdminAgents.tsx | 73353b1405ef | 45563 |
+| src/pages/admin/AdminAgents.tsx | f35f07da7bc1 | 48860 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 90c9377b4bab | 10945 |
 | src/pages/admin/AdminTools.tsx | 5d2838bcd848 | 6470 |

--- a/src/pages/admin/AdminAgents.test.ts
+++ b/src/pages/admin/AdminAgents.test.ts
@@ -59,6 +59,10 @@ describe("AdminAgents seat check-ins", () => {
 
     expect(screen.getByRole("heading", { name: "Seats" })).toBeInTheDocument();
     expect(screen.getByText("AI Seats")).toBeInTheDocument();
+    expect(screen.getByText("Compute tiers")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open API compute tier" })).toHaveAttribute("href", "/admin/agents/api");
+    expect(screen.getByRole("link", { name: "Open Local compute tier" })).toHaveAttribute("href", "/admin/agents/local");
+    expect(screen.getByRole("link", { name: "Open Subscription compute tier" })).toHaveAttribute("href", "/admin/agents/subscription");
     expect(screen.getByText("Performance monitor")).toBeInTheDocument();
     expect(screen.getByText("Cycle share")).toBeInTheDocument();
     expect(screen.getByText("Fungible mode")).toBeInTheDocument();

--- a/src/pages/admin/AdminAgents.tsx
+++ b/src/pages/admin/AdminAgents.tsx
@@ -11,6 +11,11 @@ import {
   Check,
   AlertTriangle,
   Save,
+  ArrowRight,
+  Cpu,
+  CreditCard,
+  KeyRound,
+  type LucideIcon,
 } from "lucide-react";
 import {
   AGENT_TEMPLATES,
@@ -64,6 +69,50 @@ interface AgentDetail {
   tools: Array<{ connector_id: string; is_enabled: boolean }>;
   memory_scope: Array<{ memory_layer: string; is_enabled: boolean }>;
 }
+
+interface ComputeTierSummary {
+  id: string;
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  count: string;
+  metric: string;
+  status: string;
+  accent: string;
+}
+
+const COMPUTE_TIER_SUMMARIES: ComputeTierSummary[] = [
+  {
+    id: "api",
+    label: "API",
+    href: "/admin/agents/api",
+    icon: KeyRound,
+    count: "0 active providers",
+    metric: "$0 this month",
+    status: "Not configured",
+    accent: "border-sky-400/30 bg-sky-400/10 text-sky-300",
+  },
+  {
+    id: "local",
+    label: "Local",
+    href: "/admin/agents/local",
+    icon: Cpu,
+    count: "0 local models",
+    metric: "No endpoint detected",
+    status: "Not configured",
+    accent: "border-emerald-400/30 bg-emerald-400/10 text-emerald-300",
+  },
+  {
+    id: "subscription",
+    label: "Subscription",
+    href: "/admin/agents/subscription",
+    icon: CreditCard,
+    count: "0 platforms",
+    metric: "No subscription linked",
+    status: "Not configured",
+    accent: "border-violet-400/30 bg-violet-400/10 text-violet-300",
+  },
+];
 
 const ROLE_OPTIONS = [
   { value: "researcher", label: "Researcher" },
@@ -226,8 +275,56 @@ export default function AdminAgentsPage() {
         </p>
       </header>
 
+      <ComputeTierSummaryStrip />
+
       <AISeatsPanel />
     </div>
+  );
+}
+
+function ComputeTierSummaryStrip() {
+  return (
+    <section aria-label="Compute tier overview" className="space-y-3">
+      <div className="flex flex-col gap-1 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-heading">Compute tiers</h2>
+          <p className="text-xs text-muted-foreground">
+            Route work across API keys, local hardware, and existing subscriptions.
+          </p>
+        </div>
+        <span className="text-[11px] text-muted-foreground">Summary data lands with the tier pages.</span>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        {COMPUTE_TIER_SUMMARIES.map((tier) => {
+          const Icon = tier.icon;
+          return (
+            <a
+              key={tier.id}
+              href={tier.href}
+              className="group flex min-h-[136px] flex-col justify-between rounded-lg border border-border/40 bg-card/20 p-4 transition-colors hover:border-primary/40 hover:bg-primary/5"
+              aria-label={`Open ${tier.label} compute tier`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-md border ${tier.accent}`}>
+                    <Icon className="h-4 w-4" />
+                  </span>
+                  <div className="min-w-0">
+                    <h3 className="truncate text-sm font-semibold text-heading">{tier.label}</h3>
+                    <p className="truncate text-xs text-muted-foreground">{tier.count}</p>
+                  </div>
+                </div>
+                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-heading" />
+              </div>
+              <div className="pt-4">
+                <p className="text-lg font-semibold text-heading">{tier.metric}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{tier.status}</p>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds a compute-tier overview strip to the top of the Seats dashboard.
- Adds API, Local, and Subscription cards with zero-state counts, key metrics, status text, and links to the future sub-pages.
- Leaves the existing AI Seats management surface unchanged.
- Adds focused test coverage for the three card links.
- Regenerates the UnClick brainmap entry for `AdminAgents.tsx` after the source change.

## Acceptance criteria
- [x] Dashboard shows three clickable cards for API, Local, and Subscription.
- [x] Cards link to `/admin/agents/api`, `/admin/agents/local`, and `/admin/agents/subscription`.
- [x] Cards gracefully show `Not configured` zero states until the tier pages wire real data.
- [x] Existing seat management content continues to render unchanged.

## Dependencies
- Depends on WP-1 for the actual route and sidebar scaffold.
- Built against `main` because WP-1 is still in draft and not merged yet.

## Verification
- `npx vitest run src/pages/admin/AdminAgents.test.ts`
- `npm run brainmap:check`
- `npm run build`
- Browser smoke: local `/admin/agents` reaches the expected sign-in gate while unauthenticated, with no browser console errors before the auth gate.

## MCP proof commands
- Not required. This PR does not touch `packages/mcp-server/**`.