### PR TITLE
Seats Compute Layer: WP-4 - Tier classification integration

### DIFF
--- a/api/lib/seat-load-overrides.ts
+++ b/api/lib/seat-load-overrides.ts
@@ -1,3 +1,5 @@
+import { classifySeatTier, type ComputeTier } from "../../src/lib/seats/compute-tiers";
+
 export type SeatProfileKind = "physical" | "virtual" | "pc_tether";
 export type SeatWorkKind = "brain" | "review" | "fallback";
 export type SeatRoutingPolicy = "auto" | "prefer" | "avoid" | "blocked";
@@ -17,6 +19,9 @@ export interface SeatLoadPolicyInput {
   computedLoad?: unknown;
   routingPolicy?: unknown;
   performanceStatus?: string | null;
+  computeTier?: ComputeTier | null;
+  provider?: string | null;
+  device?: string | null;
 }
 
 export interface BuildSeatLoadRoutingPlanInput {
@@ -25,12 +30,14 @@ export interface BuildSeatLoadRoutingPlanInput {
   staleAfterMs?: number;
   workKind?: SeatWorkKind;
   allowVirtualFallback?: boolean;
+  preferredTier?: ComputeTier | null;
 }
 
 export interface SeatLoadRoutingWeight {
   id: string;
   label: string;
   profile_kind: SeatProfileKind;
+  tier: ComputeTier;
   eligible: boolean;
   weight: number;
   raw_weight: number;
@@ -140,6 +147,11 @@ function applyRoutingPolicy(rawWeight: number, policy: SeatRoutingPolicy): numbe
   return rawWeight;
 }
 
+function applyTierBias(rawWeight: number, seatTier: ComputeTier, preferredTier: ComputeTier | null | undefined): number {
+  if (!preferredTier) return rawWeight;
+  return seatTier === preferredTier ? rawWeight * 1.5 : rawWeight * 0.75;
+}
+
 function normalizeIntegerWeights(rows: SeatLoadRoutingWeight[]): number[] {
   if (rows.length === 0) return [];
 
@@ -175,8 +187,16 @@ export function buildSeatLoadRoutingPlan(input: BuildSeatLoadRoutingPlanInput): 
   const workKind = input.workKind ?? "brain";
   const allowVirtualFallback = input.allowVirtualFallback === true;
 
+  const preferredTier = input.preferredTier ?? null;
+
   const firstPass = input.seats.map((seat): SeatLoadRoutingWeight => {
     const profileKind = inferProfileKind(seat);
+    const tier = classifySeatTier({
+      computeTier: seat.computeTier,
+      provider: seat.provider,
+      device: seat.device,
+      userAgentHint: seat.userAgentHint,
+    });
     const policy = normalizeRoutingPolicy(seat.routingPolicy);
     const latest = latestCheckInAt(seat);
     const fresh = isFresh(latest, nowMs, staleAfterMs);
@@ -211,17 +231,21 @@ export function buildSeatLoadRoutingPlan(input: BuildSeatLoadRoutingPlanInput): 
     }
 
     const raw = rawWeightForSeat(seat, profileKind);
-    const weightedRaw = eligible ? applyRoutingPolicy(raw.raw_weight, policy) : 0;
+    const policyWeighted = eligible ? applyRoutingPolicy(raw.raw_weight, policy) : 0;
+    const weightedRaw = eligible ? applyTierBias(policyWeighted, tier, preferredTier) : 0;
     if (raw.load_source === "manual_override") reasons.push("manual_override");
     if (raw.load_source === "computed_load") reasons.push("computed_load");
     if (raw.load_source === "default_even_split") reasons.push("default_even_split");
     if (policy === "prefer") reasons.push("prefer_policy");
     if (policy === "avoid") reasons.push("avoid_policy");
+    if (preferredTier && tier === preferredTier) reasons.push("preferred_tier");
+    if (preferredTier && tier !== preferredTier) reasons.push("non_preferred_tier");
 
     return {
       id: seat.id,
       label: String(seat.label ?? seat.id),
       profile_kind: profileKind,
+      tier,
       eligible,
       weight: 0,
       raw_weight: weightedRaw,

--- a/api/lib/seat-load-overrides.ts
+++ b/api/lib/seat-load-overrides.ts
@@ -1,4 +1,4 @@
-import { classifySeatTier, type ComputeTier } from "../../src/lib/seats/compute-tiers";
+import { classifySeatTier, type ComputeTier } from "../../src/lib/seats/compute-tiers.js";
 
 export type SeatProfileKind = "physical" | "virtual" | "pc_tether";
 export type SeatWorkKind = "brain" | "review" | "fallback";

--- a/api/seat-load-overrides.test.ts
+++ b/api/seat-load-overrides.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildSeatLoadRoutingPlan,
   type SeatLoadPolicyInput,
+  type SeatLoadRoutingWeight,
 } from "./lib/seat-load-overrides";
 
 const now = new Date("2026-06-02T05:00:00.000Z");
@@ -146,5 +147,177 @@ describe("seat load override routing policy", () => {
       ["physical", true, 60],
       ["virtual-review", true, 40],
     ]);
+  });
+});
+
+describe("tier classification integration", () => {
+  it("every weight row includes a tier field", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "seat-a" }),
+        seat({ id: "seat-b" }),
+      ],
+    });
+
+    for (const row of plan.weights) {
+      expect(row).toHaveProperty("tier");
+      expect(["api", "local", "subscription"]).toContain(row.tier);
+    }
+  });
+
+  it("classifies seat with explicit computeTier", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "api-seat", computeTier: "api" }),
+        seat({ id: "local-seat", computeTier: "local" }),
+        seat({ id: "sub-seat", computeTier: "subscription" }),
+      ],
+    });
+
+    expect(plan.weights.find((r) => r.id === "api-seat")?.tier).toBe("api");
+    expect(plan.weights.find((r) => r.id === "local-seat")?.tier).toBe("local");
+    expect(plan.weights.find((r) => r.id === "sub-seat")?.tier).toBe("subscription");
+  });
+
+  it("infers tier from provider when computeTier is not set", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "ollama-seat", provider: "Ollama" }),
+        seat({ id: "openai-seat", provider: "OpenAI" }),
+        seat({ id: "codex-seat", provider: "Codex" }),
+      ],
+    });
+
+    expect(plan.weights.find((r) => r.id === "ollama-seat")?.tier).toBe("local");
+    expect(plan.weights.find((r) => r.id === "openai-seat")?.tier).toBe("api");
+    expect(plan.weights.find((r) => r.id === "codex-seat")?.tier).toBe("subscription");
+  });
+
+  it("infers tier from userAgentHint", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "local-agent", userAgentHint: "ollama/0.3" }),
+        seat({ id: "api-agent", userAgentHint: "anthropic-sdk/1.0" }),
+      ],
+    });
+
+    expect(plan.weights.find((r) => r.id === "local-agent")?.tier).toBe("local");
+    expect(plan.weights.find((r) => r.id === "api-agent")?.tier).toBe("api");
+  });
+
+  it("infers tier from device field", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "gpu-seat", device: "local GPU node" }),
+      ],
+    });
+
+    expect(plan.weights.find((r) => r.id === "gpu-seat")?.tier).toBe("local");
+  });
+
+  it("defaults unknown seats to subscription tier", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "mystery-seat" }),
+      ],
+    });
+
+    expect(plan.weights.find((r) => r.id === "mystery-seat")?.tier).toBe("subscription");
+  });
+
+  it("explicit computeTier overrides provider inference", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "overridden", computeTier: "api", provider: "Ollama" }),
+      ],
+    });
+
+    expect(plan.weights.find((r) => r.id === "overridden")?.tier).toBe("api");
+  });
+
+  it("virtual seats also get tier classification", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "stale", lastSeenAt: "2026-06-02T03:00:00.000Z" }),
+        seat({ id: "virtual-api", profileKind: "virtual", computeTier: "api" }),
+      ],
+    });
+
+    const virtual = plan.weights.find((r) => r.id === "virtual-api");
+    expect(virtual?.tier).toBe("api");
+  });
+});
+
+describe("preferred tier routing bias", () => {
+  it("boosts weight for seats matching preferredTier", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "local-a", computeTier: "local", manualLoadOverride: 50 }),
+        seat({ id: "sub-a", computeTier: "subscription", manualLoadOverride: 50 }),
+      ],
+      preferredTier: "local",
+    });
+
+    const local = plan.weights.find((r) => r.id === "local-a")!;
+    const sub = plan.weights.find((r) => r.id === "sub-a")!;
+    expect(local.weight).toBeGreaterThan(sub.weight);
+    expect(local.reasons).toContain("preferred_tier");
+    expect(sub.reasons).toContain("non_preferred_tier");
+  });
+
+  it("does not change behavior when preferredTier is omitted", () => {
+    const seatsInput = [
+      seat({ id: "seat-a", manualLoadOverride: 50 }),
+      seat({ id: "seat-b", manualLoadOverride: 50 }),
+    ];
+
+    const withoutPref = buildSeatLoadRoutingPlan({ now, seats: seatsInput });
+    const withNullPref = buildSeatLoadRoutingPlan({ now, seats: seatsInput, preferredTier: null });
+
+    expect(withoutPref.weights.map((r) => [r.id, r.weight])).toEqual(
+      withNullPref.weights.map((r) => [r.id, r.weight]),
+    );
+    expect(withoutPref.weights[0].reasons).not.toContain("preferred_tier");
+    expect(withoutPref.weights[0].reasons).not.toContain("non_preferred_tier");
+  });
+
+  it("applies 1.5x bias for matching tier and 0.75x for non-matching", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "match", computeTier: "api", manualLoadOverride: 40 }),
+        seat({ id: "no-match", computeTier: "subscription", manualLoadOverride: 40 }),
+      ],
+      preferredTier: "api",
+    });
+
+    const match = plan.weights.find((r) => r.id === "match")!;
+    const noMatch = plan.weights.find((r) => r.id === "no-match")!;
+    expect(match.weight).toBeGreaterThan(noMatch.weight);
+    expect(match.raw_weight).toBeCloseTo(40 * 1.5, 1);
+    expect(noMatch.raw_weight).toBeCloseTo(40 * 0.75, 1);
+  });
+
+  it("preserves total weight at 100", () => {
+    const plan = buildSeatLoadRoutingPlan({
+      now,
+      seats: [
+        seat({ id: "a", computeTier: "local" }),
+        seat({ id: "b", computeTier: "api" }),
+        seat({ id: "c", computeTier: "subscription" }),
+      ],
+      preferredTier: "local",
+    });
+
+    expect(plan.total_weight).toBe(100);
   });
 });

--- a/src/lib/seats/compute-tiers.ts
+++ b/src/lib/seats/compute-tiers.ts
@@ -1,0 +1,188 @@
+export type ComputeTier = "api" | "local" | "subscription";
+
+export interface ComputeTierMeta {
+  label: string;
+  description: string;
+  icon: string;
+  costModel: string;
+  defaultRoutingWeight: number;
+}
+
+export const COMPUTE_TIERS: readonly ComputeTier[] = ["api", "local", "subscription"] as const;
+
+export const DEFAULT_COMPUTE_TIER: ComputeTier = "subscription";
+
+export const COMPUTE_TIER_META: Record<ComputeTier, ComputeTierMeta> = {
+  api: {
+    label: "API",
+    description: "Cloud endpoints billed per call or token",
+    icon: "cloud",
+    costModel: "per-use",
+    defaultRoutingWeight: 1.0,
+  },
+  local: {
+    label: "Local",
+    description: "On-device or self-hosted compute",
+    icon: "hard-drive",
+    costModel: "owned",
+    defaultRoutingWeight: 1.2,
+  },
+  subscription: {
+    label: "Subscription",
+    description: "SaaS platform seats with fixed billing",
+    icon: "credit-card",
+    costModel: "fixed",
+    defaultRoutingWeight: 1.0,
+  },
+};
+
+const API_KEYWORDS = [
+  "api",
+  "openai",
+  "anthropic",
+  "claude api",
+  "groq",
+  "replicate",
+  "together",
+  "mistral api",
+  "cohere",
+  "perplexity",
+  "fireworks",
+  "anyscale",
+  "deepinfra",
+];
+
+const LOCAL_KEYWORDS = [
+  "ollama",
+  "llamacpp",
+  "llama.cpp",
+  "local",
+  "localhost",
+  "self-hosted",
+  "on-device",
+  "gpu",
+  "mlx",
+  "gguf",
+  "vllm",
+  "text-generation-webui",
+  "lm studio",
+  "lmstudio",
+  "koboldcpp",
+  "jan.ai",
+  "gpt4all",
+];
+
+export interface SeatTierInput {
+  provider?: string | null;
+  device?: string | null;
+  userAgentHint?: string | null;
+  computeTier?: ComputeTier | null;
+}
+
+export function classifySeatTier(seat: SeatTierInput): ComputeTier {
+  if (seat.computeTier && COMPUTE_TIERS.includes(seat.computeTier)) {
+    return seat.computeTier;
+  }
+
+  const haystack = [seat.provider, seat.device, seat.userAgentHint]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (!haystack) return DEFAULT_COMPUTE_TIER;
+
+  for (const keyword of LOCAL_KEYWORDS) {
+    if (haystack.includes(keyword)) return "local";
+  }
+
+  for (const keyword of API_KEYWORDS) {
+    if (haystack.includes(keyword)) return "api";
+  }
+
+  return DEFAULT_COMPUTE_TIER;
+}
+
+export interface TierSeatInput {
+  id: string;
+  computeTier?: ComputeTier | null;
+  provider?: string | null;
+  device?: string | null;
+  userAgentHint?: string | null;
+  isVirtual?: boolean;
+}
+
+export interface TierScoreInput {
+  id: string;
+  score: number;
+  status: string;
+}
+
+export interface ComputeTierSummary {
+  tier: ComputeTier;
+  label: string;
+  seatCount: number;
+  eligibleCount: number;
+  avgHealthScore: number;
+  estimatedCost: number | null;
+}
+
+export function buildTierSummaries(
+  seats: TierSeatInput[],
+  scores: TierScoreInput[],
+): ComputeTierSummary[] {
+  const scoreById = new Map(scores.map((s) => [s.id, s]));
+
+  const grouped = new Map<ComputeTier, TierSeatInput[]>();
+  for (const seat of seats) {
+    const tier = classifySeatTier(seat);
+    const list = grouped.get(tier);
+    if (list) {
+      list.push(seat);
+    } else {
+      grouped.set(tier, [seat]);
+    }
+  }
+
+  const summaries: ComputeTierSummary[] = [];
+
+  for (const tier of COMPUTE_TIERS) {
+    const tierSeats = grouped.get(tier);
+    if (!tierSeats || tierSeats.length === 0) continue;
+
+    const tierScores = tierSeats
+      .map((s) => scoreById.get(s.id))
+      .filter((s): s is TierScoreInput => s != null);
+
+    const eligibleCount = tierScores.filter(
+      (s) => s.status === "strong" || s.status === "watch",
+    ).length;
+
+    const avgHealthScore =
+      tierScores.length > 0
+        ? Math.round(
+            tierScores.reduce((sum, s) => sum + s.score, 0) / tierScores.length,
+          )
+        : 0;
+
+    summaries.push({
+      tier,
+      label: COMPUTE_TIER_META[tier].label,
+      seatCount: tierSeats.length,
+      eligibleCount,
+      avgHealthScore,
+      estimatedCost: tier === "local" ? 0 : null,
+    });
+  }
+
+  return summaries;
+}
+
+export function estimateTierCost(
+  tier: ComputeTier,
+  tokens: number,
+  costPerMillionTokens = 3.0,
+): number | null {
+  if (tier === "local") return 0;
+  if (tier === "subscription") return null;
+  return (tokens / 1_000_000) * costPerMillionTokens;
+}

--- a/src/lib/seats/index.ts
+++ b/src/lib/seats/index.ts
@@ -1,0 +1,14 @@
+export {
+  type ComputeTier,
+  type ComputeTierMeta,
+  type ComputeTierSummary,
+  type SeatTierInput,
+  type TierSeatInput,
+  type TierScoreInput,
+  COMPUTE_TIERS,
+  COMPUTE_TIER_META,
+  DEFAULT_COMPUTE_TIER,
+  classifySeatTier,
+  buildTierSummaries,
+  estimateTierCost,
+} from "./compute-tiers";


### PR DESCRIPTION
## Summary

- Wire `classifySeatTier` into `buildSeatLoadRoutingPlan` so every `SeatLoadRoutingWeight` row carries a `tier` field (`api` / `local` / `subscription`)
- Classification uses the seat's explicit `computeTier` when set, otherwise infers from `provider` / `device` / `userAgentHint` strings
- Add `preferredTier?` to `BuildSeatLoadRoutingPlanInput` with 1.5x weight bias for matching tier, 0.75x for non-matching (WP-3 prerequisite, included since not yet merged)
- Include WP-1 scaffold (`src/lib/seats/compute-tiers.ts`) as prerequisite since not yet merged

## Dependencies

- **WP-1** (scaffold) - included in this PR since not yet merged into main
- **WP-3** (tier-aware routing) - `preferredTier` bias included in this PR since not yet merged into main
- Once WP-1 and WP-3 merge, the overlapping files can be reconciled

## Acceptance criteria

- [x] Each `SeatLoadRoutingWeight` now includes a `tier` field
- [x] Classification matches the seat's explicit `computeTier` when set, falls back to inference
- [x] Infers correctly: Ollama -> local, OpenAI -> api, Codex -> subscription, unknown -> subscription
- [x] `preferredTier` bias: matching seats get higher weight, non-matching get lower
- [x] No behavior change when `preferredTier` is omitted
- [x] All existing routing tests still pass (7/7)
- [x] 12 new tests pass (8 tier classification + 4 preferred tier bias)
- [x] Full test suite: 1001/1001 pass, TypeScript clean

## Test plan

- [x] `npx vitest run api/seat-load-overrides.test.ts` - 19 tests pass (7 existing + 12 new)
- [x] `npx vitest run api/` - 1001 tests pass (no regressions)
- [x] `npx tsc --noEmit` - clean TypeScript compilation

https://claude.ai/code/session_01JZSdQ24sDqnqyuUiCX8owH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZSdQ24sDqnqyuUiCX8owH)_