### PR TITLE
Seats Compute Layer: WP-5 - API smart routing controls

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,9 +9,9 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 1041,
-    "source_manifest": 215,
-    "pages": 88,
+    "inventory": 1042,
+    "source_manifest": 216,
+    "pages": 89,
     "tools": 616,
     "rooms": 23,
     "workers": 8
@@ -21,7 +21,7 @@
       "id": "admin-surfaces",
       "name": "Admin surfaces",
       "meaning": "Private operator views and internal control panels.",
-      "count": 52
+      "count": 53
     },
     {
       "id": "public-surfaces",
@@ -349,6 +349,16 @@
       "meaning": "Master heartbeat copy policy for scheduled AI seats.",
       "source": "src/pages/admin/AdminSeatHeartbeat.tsx",
       "route": "/admin/agents/heartbeat",
+      "tags": []
+    },
+    {
+      "id": "admin-surfaces-admin-page-admin-seats-api-src-pages-admin-adminseatsapi-tsx-admin-agents-api",
+      "division": "Admin surfaces",
+      "name": "Admin Seats Api",
+      "kind": "admin page",
+      "meaning": "Admin surface for Admin Seats Api.",
+      "source": "src/pages/admin/AdminSeatsApi.tsx",
+      "route": "/admin/agents/api",
       "tags": []
     },
     {
@@ -10516,6 +10526,12 @@
       "src/pages/admin/AdminActivity.tsx"
     ],
     [
+      "/admin/agents/api",
+      "Admin Seats Api",
+      "Admin surface for Admin Seats Api.",
+      "src/pages/admin/AdminSeatsApi.tsx"
+    ],
+    [
       "/admin/agents/heartbeat",
       "Admin Seat Heartbeat",
       "Master heartbeat copy policy for scheduled AI seats.",
@@ -14500,13 +14516,13 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "ead5f39c080b",
-      "bytes": 16499
+      "hash": "ddb17c641cf6",
+      "bytes": 16628
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
-      "hash": "2c6ec8581d6c",
-      "bytes": 25721
+      "hash": "31a1bb5406a6",
+      "bytes": 26047
     },
     {
       "source": "src/pages/admin/AdminControlTower.tsx",
@@ -14747,6 +14763,11 @@
       "source": "src/pages/admin/AdminActivity.tsx",
       "hash": "48f1919d4056",
       "bytes": 14795
+    },
+    {
+      "source": "src/pages/admin/AdminSeatsApi.tsx",
+      "hash": "8852181e8d5a",
+      "bytes": 22139
     },
     {
       "source": "src/pages/admin/AdminSeatHeartbeat.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,8 +22,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | de9f41b265f3 | 4881 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | ead5f39c080b | 16499 |
-| src/pages/admin/AdminShell.tsx | 2c6ec8581d6c | 25721 |
+| src/App.tsx | ddb17c641cf6 | 16628 |
+| src/pages/admin/AdminShell.tsx | 31a1bb5406a6 | 26047 |
 | src/pages/admin/AdminControlTower.tsx | 2bc870ebf30f | 21782 |
 | src/lib/controltower.ts | c9d18e61e7d8 | 21703 |
 | docs/prd/controltower.md | 83641285316d | 4571 |
@@ -72,6 +72,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | seed/skills/write-tests-for-changed-code.skill.md | 0c2617abce77 | 1049 |
 | src/pages/Index.tsx | 87bc594da785 | 1598 |
 | src/pages/admin/AdminActivity.tsx | 48f1919d4056 | 14795 |
+| src/pages/admin/AdminSeatsApi.tsx | 8852181e8d5a | 22139 |
 | src/pages/admin/AdminSeatHeartbeat.tsx | f9548c19ddab | 11641 |
 | src/pages/admin/AdminAgents.tsx | 73353b1405ef | 45563 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
@@ -233,7 +234,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 
 | Division | Meaning | Items |
 | --- | --- | --- |
-| Admin surfaces | Private operator views and internal control panels. | 52 |
+| Admin surfaces | Private operator views and internal control panels. | 53 |
 | Public surfaces | Public product, docs, marketplace, and user-facing routes. | 36 |
 | Tools | MCP and gateway capabilities available to seats. | 616 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
@@ -279,6 +280,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | --- | --- | --- | --- |
 | / | Index | Public home and first explanation of UnClick. | src/pages/Index.tsx |
 | /admin/activity | Admin Activity | Admin surface for Admin Activity. | src/pages/admin/AdminActivity.tsx |
+| /admin/agents/api | Admin Seats Api | Admin surface for Admin Seats Api. | src/pages/admin/AdminSeatsApi.tsx |
 | /admin/agents/heartbeat | Admin Seat Heartbeat | Master heartbeat copy policy for scheduled AI seats. | src/pages/admin/AdminSeatHeartbeat.tsx |
 | /admin/agents | Admin Agents | Admin surface for Admin Agents. | src/pages/admin/AdminAgents.tsx |
 | /admin/analytics | Admin Analytics | Internal analytics view for platform signals and usage. | src/pages/admin/AdminAnalytics.tsx |
@@ -1017,6 +1019,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Admin surfaces | admin page | Admin Pinball Wake | PinballWake rooms, wake routes, and automation visibility. | /admin/pinballwake | src/pages/admin/AdminPinballWake.tsx |
 | Admin surfaces | admin page | Admin Projects | Admin surface for Admin Ecosystem Pages. | /admin/projects | src/pages/admin/AdminEcosystemPages.tsx |
 | Admin surfaces | admin page | Admin Seat Heartbeat | Master heartbeat copy policy for scheduled AI seats. | /admin/agents/heartbeat | src/pages/admin/AdminSeatHeartbeat.tsx |
+| Admin surfaces | admin page | Admin Seats Api | Admin surface for Admin Seats Api. | /admin/agents/api | src/pages/admin/AdminSeatsApi.tsx |
 | Admin surfaces | admin page | Admin Settings | Account and admin configuration. | /admin/settings | src/pages/admin/AdminSettings.tsx |
 | Admin surfaces | admin page | Admin Shell | Admin surface for Admin Shell. | /admin | src/pages/admin/AdminShell.tsx |
 | Admin surfaces | admin page | Admin Skills | Read-only starter pack of UnClick-native skills, native rails, and portable SKILL.md packages. | /admin/skills | src/pages/admin/AdminSkills.tsx |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import AdminActivity from "./pages/admin/AdminActivity.tsx";
 import AdminSettings from "./pages/admin/AdminSettings.tsx";
 import AdminAgentsPage from "./pages/admin/AdminAgents.tsx";
 import AdminSeatHeartbeatPage from "./pages/admin/AdminSeatHeartbeat.tsx";
+import AdminSeatsApi from "./pages/admin/AdminSeatsApi.tsx";
 import AdminAnalytics from "./pages/admin/AdminAnalytics.tsx";
 import AdminCodebase from "./pages/admin/AdminCodebase.tsx";
 import AdminOrchestratorPage from "./pages/admin/AdminOrchestrator.tsx";
@@ -201,6 +202,7 @@ const App = () => (
             <Route path="autopilot" element={<AdminAutopilot />} />
             <Route path="autopilot/expressbuild" element={<AdminExpressBuild />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
+            <Route path="agents/api" element={<AdminSeatsApi />} />
             <Route path="agents/heartbeat" element={<AdminSeatHeartbeatPage />} />
             <Route path="workers" element={<AdminWorkers />} />
             <Route path="jobs" element={<AdminJobs />} />

--- a/src/pages/admin/AdminSeatsApi.tsx
+++ b/src/pages/admin/AdminSeatsApi.tsx
@@ -1,0 +1,510 @@
+import { useCallback, useEffect, useState } from "react";
+import { useToast } from "@/hooks/use-toast";
+import { useSession } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  KeyRound,
+  Loader2,
+  Save,
+  RotateCcw,
+  ChevronUp,
+  ChevronDown,
+  Trash2,
+  Plus,
+  Zap,
+  ArrowRightLeft,
+  Layers,
+} from "lucide-react";
+
+const API_KEY_STORAGE = "unclick_api_key";
+
+function getApiKey(): string {
+  try {
+    return localStorage.getItem(API_KEY_STORAGE) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+type TaskType = "chat" | "code" | "embeddings" | "vision" | "ocr";
+
+const TASK_TYPES: { id: TaskType; label: string; description: string }[] = [
+  { id: "chat", label: "Chat", description: "General conversation and reasoning" },
+  { id: "code", label: "Code", description: "Code generation, review, and debugging" },
+  { id: "embeddings", label: "Embeddings", description: "Text embeddings for search and RAG" },
+  { id: "vision", label: "Vision", description: "Image understanding and analysis" },
+  { id: "ocr", label: "OCR", description: "Document text extraction" },
+];
+
+interface ModelDef {
+  id: string;
+  provider: string;
+  label: string;
+  capabilities: TaskType[];
+  batchEligible: boolean;
+  tier: "frontier" | "mid" | "fast" | "embed";
+}
+
+const MODEL_CATALOG: ModelDef[] = [
+  { id: "anthropic:claude-opus-4", provider: "Anthropic", label: "Claude Opus 4", capabilities: ["chat", "code", "vision"], batchEligible: true, tier: "frontier" },
+  { id: "anthropic:claude-sonnet-4", provider: "Anthropic", label: "Claude Sonnet 4", capabilities: ["chat", "code", "vision"], batchEligible: true, tier: "mid" },
+  { id: "anthropic:claude-haiku-4", provider: "Anthropic", label: "Claude Haiku 4", capabilities: ["chat", "code"], batchEligible: true, tier: "fast" },
+  { id: "openai:gpt-4o", provider: "OpenAI", label: "GPT-4o", capabilities: ["chat", "code", "vision", "ocr"], batchEligible: true, tier: "frontier" },
+  { id: "openai:gpt-4o-mini", provider: "OpenAI", label: "GPT-4o Mini", capabilities: ["chat", "code", "vision"], batchEligible: true, tier: "fast" },
+  { id: "openai:o3", provider: "OpenAI", label: "o3", capabilities: ["chat", "code"], batchEligible: false, tier: "frontier" },
+  { id: "openai:text-embedding-3-large", provider: "OpenAI", label: "text-embedding-3-large", capabilities: ["embeddings"], batchEligible: true, tier: "embed" },
+  { id: "openai:text-embedding-3-small", provider: "OpenAI", label: "text-embedding-3-small", capabilities: ["embeddings"], batchEligible: true, tier: "embed" },
+  { id: "google:gemini-2.5-pro", provider: "Google", label: "Gemini 2.5 Pro", capabilities: ["chat", "code", "vision", "ocr"], batchEligible: false, tier: "frontier" },
+  { id: "google:gemini-2.5-flash", provider: "Google", label: "Gemini 2.5 Flash", capabilities: ["chat", "code", "vision"], batchEligible: false, tier: "fast" },
+  { id: "cohere:command-r-plus", provider: "Cohere", label: "Command R+", capabilities: ["chat", "code"], batchEligible: false, tier: "mid" },
+  { id: "cohere:embed-english-v3", provider: "Cohere", label: "Embed English v3", capabilities: ["embeddings"], batchEligible: false, tier: "embed" },
+  { id: "mistral:mistral-large", provider: "Mistral", label: "Mistral Large", capabilities: ["chat", "code", "vision"], batchEligible: false, tier: "mid" },
+  { id: "mistral:codestral", provider: "Mistral", label: "Codestral", capabilities: ["code"], batchEligible: false, tier: "mid" },
+];
+
+type BatchMode = "off" | "non-urgent" | "all-background";
+
+interface RoutingConfig {
+  taskDefaults: Record<TaskType, string>;
+  escalationChain: string[];
+  batchEnabled: boolean;
+  batchMode: BatchMode;
+}
+
+const EMPTY_CONFIG: RoutingConfig = {
+  taskDefaults: {
+    chat: "",
+    code: "",
+    embeddings: "",
+    vision: "",
+    ocr: "",
+  },
+  escalationChain: [],
+  batchEnabled: false,
+  batchMode: "non-urgent",
+};
+
+const SETTINGS_KEY = "compute_routing";
+
+function modelsForTask(task: TaskType): ModelDef[] {
+  return MODEL_CATALOG.filter((m) => m.capabilities.includes(task));
+}
+
+function modelLabel(id: string): string {
+  return MODEL_CATALOG.find((m) => m.id === id)?.label ?? id;
+}
+
+function modelProvider(id: string): string {
+  return MODEL_CATALOG.find((m) => m.id === id)?.provider ?? "";
+}
+
+function tierBadgeClass(tier: ModelDef["tier"]): string {
+  switch (tier) {
+    case "frontier": return "bg-amber-500/15 text-amber-400 border-amber-500/25";
+    case "mid": return "bg-blue-500/15 text-blue-400 border-blue-500/25";
+    case "fast": return "bg-green-500/15 text-green-400 border-green-500/25";
+    case "embed": return "bg-purple-500/15 text-purple-400 border-purple-500/25";
+  }
+}
+
+export default function AdminSeatsApi() {
+  const { toast } = useToast();
+  const { session } = useSession();
+  const [apiKey] = useState<string>(getApiKey);
+  const [config, setConfig] = useState<RoutingConfig>(EMPTY_CONFIG);
+  const [savedConfig, setSavedConfig] = useState<RoutingConfig>(EMPTY_CONFIG);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const hasUnsavedChanges = JSON.stringify(config) !== JSON.stringify(savedConfig);
+
+  const effectiveToken = apiKey || session?.access_token || "";
+
+  const loadConfig = useCallback(async () => {
+    if (!effectiveToken) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const res = await fetch("/api/memory-admin?action=tenant_settings_get", {
+        headers: { Authorization: `Bearer ${effectiveToken}` },
+      });
+      if (res.ok) {
+        const body = (await res.json()) as { data?: Record<string, unknown> };
+        const stored = body.data?.[SETTINGS_KEY];
+        if (stored && typeof stored === "object") {
+          const parsed = stored as Partial<RoutingConfig>;
+          const merged: RoutingConfig = {
+            taskDefaults: { ...EMPTY_CONFIG.taskDefaults, ...parsed.taskDefaults },
+            escalationChain: Array.isArray(parsed.escalationChain) ? parsed.escalationChain : [],
+            batchEnabled: Boolean(parsed.batchEnabled),
+            batchMode: (parsed.batchMode as BatchMode) || "non-urgent",
+          };
+          setConfig(merged);
+          setSavedConfig(merged);
+        }
+      }
+    } catch {
+      toast({ title: "Failed to load routing config", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  }, [effectiveToken, toast]);
+
+  useEffect(() => {
+    void loadConfig();
+  }, [loadConfig]);
+
+  const saveConfig = async () => {
+    if (!effectiveToken) {
+      toast({ title: "API key required", description: "Add your UnClick API key on the You page first.", variant: "destructive" });
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=tenant_settings_set", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${effectiveToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ key: SETTINGS_KEY, value: config }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? "Save failed");
+      }
+      setSavedConfig(config);
+      toast({ title: "Routing config saved" });
+    } catch (err) {
+      toast({ title: "Save failed", description: (err as Error).message, variant: "destructive" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const resetConfig = () => {
+    setConfig(savedConfig);
+  };
+
+  const setTaskDefault = (task: TaskType, modelId: string) => {
+    setConfig((prev) => ({
+      ...prev,
+      taskDefaults: { ...prev.taskDefaults, [task]: modelId },
+    }));
+  };
+
+  const addEscalationStep = (modelId: string) => {
+    if (!modelId || config.escalationChain.includes(modelId)) return;
+    setConfig((prev) => ({
+      ...prev,
+      escalationChain: [...prev.escalationChain, modelId],
+    }));
+  };
+
+  const removeEscalationStep = (index: number) => {
+    setConfig((prev) => ({
+      ...prev,
+      escalationChain: prev.escalationChain.filter((_, i) => i !== index),
+    }));
+  };
+
+  const moveEscalationStep = (index: number, direction: "up" | "down") => {
+    setConfig((prev) => {
+      const chain = [...prev.escalationChain];
+      const target = direction === "up" ? index - 1 : index + 1;
+      if (target < 0 || target >= chain.length) return prev;
+      [chain[index], chain[target]] = [chain[target], chain[index]];
+      return { ...prev, escalationChain: chain };
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  const chatCodeModels = MODEL_CATALOG.filter(
+    (m) => (m.capabilities.includes("chat") || m.capabilities.includes("code")) && !config.escalationChain.includes(m.id),
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="mb-2 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-primary/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-primary">
+            <KeyRound className="h-3.5 w-3.5" />
+            Seats / API
+          </div>
+          <h1 className="text-2xl font-semibold tracking-tight text-heading">Smart Routing</h1>
+          <p className="mt-1 max-w-2xl text-sm text-body">
+            Configure how tasks are routed to AI models. Set defaults per task type, build escalation chains, and enable batch pricing.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasUnsavedChanges && (
+            <Button variant="outline" size="sm" onClick={resetConfig} className="gap-1.5">
+              <RotateCcw className="h-3.5 w-3.5" />
+              Reset
+            </Button>
+          )}
+          <Button
+            size="sm"
+            onClick={saveConfig}
+            disabled={saving || !hasUnsavedChanges}
+            className="gap-1.5"
+          >
+            {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+            {saving ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      </header>
+
+      {/* Task Defaults */}
+      <section className="space-y-4 rounded-lg border border-border/30 bg-card/10 p-4">
+        <div className="flex items-center gap-2">
+          <Layers className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold text-heading">Default Model per Task Type</h2>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Choose which model handles each category of work by default. Tasks without a default use the first model in your escalation chain.
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {TASK_TYPES.map(({ id, label, description }) => {
+            const available = modelsForTask(id);
+            return (
+              <div key={id} className="rounded-md border border-border/30 bg-background/30 p-3">
+                <label className="text-xs font-semibold text-heading" htmlFor={`task-${id}`}>
+                  {label}
+                </label>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">{description}</p>
+                <select
+                  id={`task-${id}`}
+                  value={config.taskDefaults[id]}
+                  onChange={(e) => setTaskDefault(id, e.target.value)}
+                  className="mt-2 block w-full rounded-md border border-border/40 bg-background px-3 py-2 text-sm text-body outline-none focus:border-primary/50"
+                >
+                  <option value="">No default</option>
+                  {available.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.label} ({m.provider})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Escalation Chain */}
+      <section className="space-y-4 rounded-lg border border-border/30 bg-card/10 p-4">
+        <div className="flex items-center gap-2">
+          <ArrowRightLeft className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold text-heading">Escalation Chain</h2>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          When a task exceeds the current model's capability (too complex, too long, or fails), it escalates to the next model in the chain. Order from cheapest/fastest to most capable.
+        </p>
+
+        {config.escalationChain.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border/40 bg-background/20 p-4 text-center">
+            <p className="text-xs text-muted-foreground">
+              No escalation chain configured. Add models below to build one.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            {config.escalationChain.map((modelId, index) => {
+              const model = MODEL_CATALOG.find((m) => m.id === modelId);
+              return (
+                <div
+                  key={modelId}
+                  className="flex items-center gap-2 rounded-md border border-border/30 bg-background/30 px-3 py-2"
+                >
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-bold text-primary">
+                    {index + 1}
+                  </span>
+                  <div className="flex-1">
+                    <span className="text-sm font-medium text-heading">{model?.label ?? modelId}</span>
+                    <span className="ml-2 text-xs text-muted-foreground">{modelProvider(modelId)}</span>
+                  </div>
+                  {model && (
+                    <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${tierBadgeClass(model.tier)}`}>
+                      {model.tier}
+                    </span>
+                  )}
+                  {model?.batchEligible && (
+                    <span className="rounded-full border border-cyan-500/25 bg-cyan-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-cyan-400">
+                      batch
+                    </span>
+                  )}
+                  <div className="flex items-center gap-0.5">
+                    <button
+                      type="button"
+                      onClick={() => moveEscalationStep(index, "up")}
+                      disabled={index === 0}
+                      className="rounded p-1 text-muted-foreground transition-colors hover:bg-card/40 hover:text-body disabled:opacity-30"
+                      title="Move up"
+                    >
+                      <ChevronUp className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => moveEscalationStep(index, "down")}
+                      disabled={index === config.escalationChain.length - 1}
+                      className="rounded p-1 text-muted-foreground transition-colors hover:bg-card/40 hover:text-body disabled:opacity-30"
+                      title="Move down"
+                    >
+                      <ChevronDown className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeEscalationStep(index)}
+                      className="rounded p-1 text-muted-foreground transition-colors hover:bg-red-500/20 hover:text-red-400"
+                      title="Remove"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {chatCodeModels.length > 0 && (
+          <div className="flex items-center gap-2">
+            <select
+              id="add-escalation"
+              defaultValue=""
+              onChange={(e) => {
+                addEscalationStep(e.target.value);
+                e.target.value = "";
+              }}
+              className="flex-1 rounded-md border border-border/40 bg-background px-3 py-2 text-sm text-body outline-none focus:border-primary/50"
+            >
+              <option value="" disabled>
+                Add model to chain...
+              </option>
+              {chatCodeModels.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label} ({m.provider}) - {m.tier}
+                </option>
+              ))}
+            </select>
+            <Plus className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </div>
+        )}
+
+        {config.escalationChain.length >= 2 && (
+          <div className="rounded-md border border-border/20 bg-primary/5 px-3 py-2">
+            <p className="text-xs text-body">
+              <strong className="text-heading">Flow:</strong>{" "}
+              {config.escalationChain.map((id) => modelLabel(id)).join(" → ")}
+            </p>
+          </div>
+        )}
+      </section>
+
+      {/* Batch API */}
+      <section className="space-y-4 rounded-lg border border-border/30 bg-card/10 p-4">
+        <div className="flex items-center gap-2">
+          <Zap className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold text-heading">Batch API</h2>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Batch APIs process requests asynchronously at reduced cost. Anthropic offers 50% off for batch requests. Enable this to automatically route eligible non-urgent tasks through batch endpoints.
+        </p>
+
+        <div className="flex items-center justify-between rounded-md border border-border/30 bg-background/30 p-3">
+          <div>
+            <p className="text-sm font-medium text-heading">Enable batch routing</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Route eligible tasks through batch APIs for up to 50% cost savings
+            </p>
+          </div>
+          <Switch
+            checked={config.batchEnabled}
+            onCheckedChange={(checked) =>
+              setConfig((prev) => ({ ...prev, batchEnabled: checked }))
+            }
+          />
+        </div>
+
+        {config.batchEnabled && (
+          <div className="space-y-3">
+            <label className="text-xs font-semibold text-heading" htmlFor="batch-mode">
+              Batch scope
+            </label>
+            <select
+              id="batch-mode"
+              value={config.batchMode}
+              onChange={(e) =>
+                setConfig((prev) => ({ ...prev, batchMode: e.target.value as BatchMode }))
+              }
+              className="block w-full rounded-md border border-border/40 bg-background px-3 py-2 text-sm text-body outline-none focus:border-primary/50"
+            >
+              <option value="non-urgent">Non-urgent tasks only (recommended)</option>
+              <option value="all-background">All background/automated tasks</option>
+            </select>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="rounded-md border border-border/30 bg-background/20 p-3">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Eligible models</p>
+                <p className="mt-1 text-sm font-semibold text-heading">
+                  {MODEL_CATALOG.filter((m) => m.batchEligible).length}
+                </p>
+              </div>
+              <div className="rounded-md border border-border/30 bg-background/20 p-3">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Max savings</p>
+                <p className="mt-1 text-sm font-semibold text-heading">50%</p>
+              </div>
+              <div className="rounded-md border border-border/30 bg-background/20 p-3">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Latency</p>
+                <p className="mt-1 text-sm font-semibold text-heading">Up to 24h</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Model catalog reference */}
+      <section className="space-y-3 rounded-md border border-border/20 bg-card/5 p-3">
+        <h3 className="text-xs font-semibold text-heading">Model Reference</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border/20">
+                <th className="pb-2 pr-4 text-left font-semibold text-muted-foreground">Model</th>
+                <th className="pb-2 pr-4 text-left font-semibold text-muted-foreground">Provider</th>
+                <th className="pb-2 pr-4 text-left font-semibold text-muted-foreground">Tier</th>
+                <th className="pb-2 pr-4 text-left font-semibold text-muted-foreground">Tasks</th>
+                <th className="pb-2 text-left font-semibold text-muted-foreground">Batch</th>
+              </tr>
+            </thead>
+            <tbody>
+              {MODEL_CATALOG.map((m) => (
+                <tr key={m.id} className="border-b border-border/10">
+                  <td className="py-1.5 pr-4 font-medium text-body">{m.label}</td>
+                  <td className="py-1.5 pr-4 text-muted-foreground">{m.provider}</td>
+                  <td className="py-1.5 pr-4">
+                    <span className={`rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${tierBadgeClass(m.tier)}`}>
+                      {m.tier}
+                    </span>
+                  </td>
+                  <td className="py-1.5 pr-4 text-muted-foreground">{m.capabilities.join(", ")}</td>
+                  <td className="py-1.5 text-muted-foreground">{m.batchEligible ? "Yes" : "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminShell.tsx
+++ b/src/pages/admin/AdminShell.tsx
@@ -408,28 +408,38 @@ function MemoryNavItem({ onClick }: { onClick?: () => void }) {
   );
 }
 
+const SEATS_CHILDREN = [
+  { path: "/admin/agents/api",       label: "API",       icon: KeyRound   },
+  { path: "/admin/agents/heartbeat", label: "Heartbeat", icon: HeartPulse },
+] as const;
+
 function SeatsNavItem({ onClick }: { onClick?: () => void }) {
   const location = useLocation();
   const isSeats = location.pathname === "/admin/agents" || location.pathname.startsWith("/admin/agents/");
-  const heartbeatActive = location.pathname === "/admin/agents/heartbeat";
 
   return (
     <div>
       <SurfaceLink path="/admin/agents" label="Seats" icon={SeatsCascadeIcon} onClick={onClick} />
       {isSeats && (
         <div className="ml-7 mt-0.5 flex flex-col gap-0.5">
-          <Link
-            to="/admin/agents/heartbeat"
-            onClick={onClick}
-            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-              heartbeatActive
-                ? "bg-primary/10 text-primary"
-                : "text-muted-foreground hover:bg-card/40 hover:text-body"
-            }`}
-          >
-            <HeartPulse className="h-3 w-3 shrink-0" />
-            Heartbeat
-          </Link>
+          {SEATS_CHILDREN.map(({ path, label, icon: Icon }) => {
+            const active = location.pathname === path;
+            return (
+              <Link
+                key={path}
+                to={path}
+                onClick={onClick}
+                className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-card/40 hover:text-body"
+                }`}
+              >
+                <Icon className="h-3 w-3 shrink-0" />
+                {label}
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Adds smart routing configuration page at `/admin/agents/api` for the API compute tier
- Default model selection per task type (chat, code, embeddings, vision, OCR) from a data-driven model catalog
- Escalation chain builder - ordered list of models from cheapest/fastest to most capable, with reorder and remove controls
- Batch API toggle with scope control (non-urgent only vs all background tasks) - surfaces 50% savings on eligible providers
- Model reference table showing tier, capabilities, and batch eligibility across 14 models from 5 providers
- Config persists to `tenant_settings` via the existing `memory-admin` API (`compute_routing` key)
- Includes route (`/admin/agents/api`) and sidebar nav entry under Seats

## Files changed

| File | Change |
|------|--------|
| `src/pages/admin/AdminSeatsApi.tsx` | **New** - Smart routing controls page |
| `src/App.tsx` | Import + route for `/admin/agents/api` |
| `src/pages/admin/AdminShell.tsx` | Extended `SeatsNavItem` with API child link |
| `docs/UnClick-brainmap.generated.*` | Regenerated after new file |

## Dependencies

- **WP-1** (nav scaffold) - provides the full route structure and all 4 sidebar children. This PR includes minimal routing for the API page only; WP-1 adds Local, Subscription alongside it.
- **WP-3** (API credentials) - will add the credential list/management section above this routing section in the same page. When WP-3 merges, the two sections should be combined in `AdminSeatsApi.tsx`.

## Acceptance criteria

- [x] User can configure default models per task type (chat, code, embeddings, vision, OCR)
- [x] User can build and reorder an escalation chain
- [x] User can enable/disable batch API routing with scope selection
- [x] Config persists across sessions via tenant_settings
- [x] Save/Reset buttons with unsaved-changes detection
- [x] Model catalog is data-driven (not hardcoded per-dropdown)
- [x] TypeScript compiles cleanly
- [x] Production build succeeds
- [x] Brainmap check passes

https://claude.ai/code/session_01DpQQNnBsXzG7wTKmAQp7XF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpQQNnBsXzG7wTKmAQp7XF)_