### PR TITLE
Seats Compute Layer: WP-4 - API usage and spend tracking

### DIFF
--- a/api/seats-api-usage.ts
+++ b/api/seats-api-usage.ts
@@ -1,0 +1,345 @@
+/**
+ * Seats API usage and budget tracking.
+ *
+ * Routes:
+ *   GET  /api/seats-api-usage?action=summary
+ *   POST /api/seats-api-usage?action=log_usage
+ *   POST /api/seats-api-usage?action=set_budget
+ *   POST /api/seats-api-usage?action=delete_budget
+ *   POST /api/seats-api-usage?action=check_budget
+ */
+
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createClient } from "@supabase/supabase-js";
+import {
+  SEATS_API_PRICING,
+  budgetDecision,
+  estimateSeatsApiCostUsd,
+  normalizeSeatsApiBudgetCap,
+  normalizeSeatsApiProvider,
+  normalizeSeatsApiUsageRow,
+  summarizeSeatsApiUsage,
+  type SeatsApiBudgetCap,
+  type SeatsApiUsageInput,
+} from "../src/lib/seatsApiUsage";
+
+type Db = ReturnType<typeof createClient>;
+
+interface SessionUser {
+  id: string;
+  email: string | null;
+}
+
+interface UsageEventRow {
+  id?: string;
+  provider_slug?: string | null;
+  model?: string | null;
+  task_type?: string | null;
+  input_tokens?: number | string | null;
+  output_tokens?: number | string | null;
+  cached_input_tokens?: number | string | null;
+  request_count?: number | string | null;
+  estimated_cost_usd?: number | string | null;
+  created_at?: string | null;
+}
+
+interface BudgetCapRow {
+  id?: string;
+  provider_slug?: string | null;
+  monthly_budget_usd?: number | string | null;
+  warn_at_percent?: number | string | null;
+  throttle_at_percent?: number | string | null;
+  updated_at?: string | null;
+}
+
+function bearerFrom(req: VercelRequest): string {
+  return (req.headers.authorization ?? "").replace(/^Bearer\s+/i, "").trim();
+}
+
+async function resolveSessionUser(
+  token: string,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+): Promise<SessionUser | null> {
+  if (!token) return null;
+  if (token.startsWith("uc_") || token.startsWith("agt_")) return null;
+  try {
+    const scoped = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data, error } = await scoped.auth.getUser(token);
+    if (error || !data?.user) return null;
+    return { id: data.user.id, email: data.user.email ?? null };
+  } catch {
+    return null;
+  }
+}
+
+function bodyObject(body: unknown): Record<string, unknown> {
+  if (typeof body === "string") {
+    try {
+      const parsed = JSON.parse(body) as unknown;
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return body && typeof body === "object" && !Array.isArray(body)
+    ? body as Record<string, unknown>
+    : {};
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function numericValue(value: unknown, fallback = 0): number {
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function optionalNumericValue(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+}
+
+function currentMonthPeriod(now = new Date()) {
+  const periodStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const periodEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+  return {
+    periodStart: periodStart.toISOString(),
+    periodEnd: periodEnd.toISOString(),
+  };
+}
+
+function periodFromQuery(req: VercelRequest) {
+  const defaults = currentMonthPeriod();
+  const rawFrom = Array.isArray(req.query.from) ? req.query.from[0] : req.query.from;
+  const rawTo = Array.isArray(req.query.to) ? req.query.to[0] : req.query.to;
+  const fromDate = rawFrom ? new Date(String(rawFrom)) : null;
+  const toDate = rawTo ? new Date(String(rawTo)) : null;
+  const periodStart = fromDate && Number.isFinite(fromDate.getTime())
+    ? fromDate.toISOString()
+    : defaults.periodStart;
+  const periodEnd = toDate && Number.isFinite(toDate.getTime())
+    ? toDate.toISOString()
+    : defaults.periodEnd;
+  return { periodStart, periodEnd };
+}
+
+function toUsageInput(row: UsageEventRow): SeatsApiUsageInput {
+  return {
+    provider: String(row.provider_slug ?? ""),
+    model: row.model ?? null,
+    inputTokens: numericValue(row.input_tokens),
+    outputTokens: numericValue(row.output_tokens),
+    cachedInputTokens: numericValue(row.cached_input_tokens),
+    requestCount: numericValue(row.request_count, 1),
+    estimatedCostUsd: numericValue(row.estimated_cost_usd),
+  };
+}
+
+function toBudgetCap(row: BudgetCapRow): SeatsApiBudgetCap {
+  return normalizeSeatsApiBudgetCap({
+    provider: String(row.provider_slug ?? ""),
+    monthlyBudgetUsd: row.monthly_budget_usd ?? null,
+    warnAtPercent: row.warn_at_percent ?? 80,
+    throttleAtPercent: row.throttle_at_percent ?? 100,
+  });
+}
+
+async function buildSummary(db: Db, userId: string, periodStart: string, periodEnd: string) {
+  const { data: rows, error: usageError } = await db
+    .from("seats_api_usage_events")
+    .select("provider_slug, model, input_tokens, output_tokens, cached_input_tokens, request_count, estimated_cost_usd, created_at")
+    .eq("user_id", userId)
+    .gte("created_at", periodStart)
+    .lt("created_at", periodEnd)
+    .order("created_at", { ascending: true });
+  if (usageError) throw usageError;
+
+  const { data: budgetRows, error: budgetError } = await db
+    .from("seats_api_budget_caps")
+    .select("provider_slug, monthly_budget_usd, warn_at_percent, throttle_at_percent, updated_at")
+    .eq("user_id", userId)
+    .order("provider_slug", { ascending: true });
+  if (budgetError) throw budgetError;
+
+  const budgets = ((budgetRows ?? []) as BudgetCapRow[]).map(toBudgetCap);
+  const summary = summarizeSeatsApiUsage({
+    periodStart,
+    periodEnd,
+    rows: ((rows ?? []) as UsageEventRow[]).map(toUsageInput),
+    budgets,
+  });
+
+  return { summary, budgets };
+}
+
+async function summaryAction(db: Db, req: VercelRequest, res: VercelResponse, userId: string) {
+  if (req.method !== "GET") return res.status(405).json({ error: "GET required" });
+  const { periodStart, periodEnd } = periodFromQuery(req);
+  if (new Date(periodEnd).getTime() <= new Date(periodStart).getTime()) {
+    return res.status(400).json({ error: "Period end must be after period start" });
+  }
+
+  const { summary } = await buildSummary(db, userId, periodStart, periodEnd);
+  return res.status(200).json({ summary, pricing: SEATS_API_PRICING });
+}
+
+async function logUsageAction(db: Db, req: VercelRequest, res: VercelResponse, userId: string) {
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+  const body = bodyObject(req.body);
+  const provider = stringValue(body.provider ?? body.provider_slug);
+  if (!provider) return res.status(400).json({ error: "provider is required" });
+
+  const metadata = body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
+    ? body.metadata as Record<string, unknown>
+    : {};
+  const usage = normalizeSeatsApiUsageRow({
+    provider,
+    model: stringValue(body.model) || null,
+    inputTokens: numericValue(body.input_tokens ?? body.inputTokens),
+    outputTokens: numericValue(body.output_tokens ?? body.outputTokens),
+    cachedInputTokens: numericValue(body.cached_input_tokens ?? body.cachedInputTokens),
+    requestCount: numericValue(body.request_count ?? body.requestCount, 1),
+    estimatedCostUsd: optionalNumericValue(body.estimated_cost_usd ?? body.estimatedCostUsd),
+  });
+
+  const { data, error } = await db
+    .from("seats_api_usage_events")
+    .insert({
+      user_id: userId,
+      provider_slug: usage.provider,
+      model: usage.model,
+      task_type: stringValue(body.task_type ?? body.taskType) || null,
+      input_tokens: usage.inputTokens,
+      output_tokens: usage.outputTokens,
+      cached_input_tokens: usage.cachedInputTokens,
+      request_count: usage.requestCount,
+      estimated_cost_usd: usage.estimatedCostUsd,
+      metadata,
+    })
+    .select("id, provider_slug, model, task_type, input_tokens, output_tokens, cached_input_tokens, request_count, estimated_cost_usd, created_at")
+    .single();
+  if (error) throw error;
+
+  return res.status(200).json({ event: data, usage });
+}
+
+async function setBudgetAction(db: Db, req: VercelRequest, res: VercelResponse, userId: string) {
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+  const body = bodyObject(req.body);
+  const provider = stringValue(body.provider ?? body.provider_slug);
+  if (!provider) return res.status(400).json({ error: "provider is required" });
+
+  const budget = normalizeSeatsApiBudgetCap({
+    provider,
+    monthlyBudgetUsd: body.monthly_budget_usd ?? body.monthlyBudgetUsd ?? null,
+    warnAtPercent: body.warn_at_percent ?? body.warnAtPercent ?? 80,
+    throttleAtPercent: body.throttle_at_percent ?? body.throttleAtPercent ?? 100,
+  });
+
+  if (!budget.monthlyBudgetUsd || budget.monthlyBudgetUsd <= 0) {
+    return res.status(400).json({ error: "monthly_budget_usd must be greater than 0" });
+  }
+
+  const { data, error } = await db
+    .from("seats_api_budget_caps")
+    .upsert({
+      user_id: userId,
+      provider_slug: budget.provider,
+      monthly_budget_usd: budget.monthlyBudgetUsd,
+      warn_at_percent: budget.warnAtPercent,
+      throttle_at_percent: budget.throttleAtPercent,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: "user_id,provider_slug" })
+    .select("id, provider_slug, monthly_budget_usd, warn_at_percent, throttle_at_percent, updated_at")
+    .single();
+  if (error) throw error;
+
+  return res.status(200).json({ budget: data });
+}
+
+async function deleteBudgetAction(db: Db, req: VercelRequest, res: VercelResponse, userId: string) {
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+  const body = bodyObject(req.body);
+  const provider = normalizeSeatsApiProvider(stringValue(body.provider ?? body.provider_slug));
+  if (!provider) return res.status(400).json({ error: "provider is required" });
+
+  const { error } = await db
+    .from("seats_api_budget_caps")
+    .delete()
+    .eq("user_id", userId)
+    .eq("provider_slug", provider);
+  if (error) throw error;
+
+  return res.status(200).json({ ok: true });
+}
+
+async function checkBudgetAction(db: Db, req: VercelRequest, res: VercelResponse, userId: string) {
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+  const body = bodyObject(req.body);
+  const provider = normalizeSeatsApiProvider(stringValue(body.provider ?? body.provider_slug));
+  if (!provider) return res.status(400).json({ error: "provider is required" });
+
+  const period = currentMonthPeriod();
+  const { summary, budgets } = await buildSummary(db, userId, period.periodStart, period.periodEnd);
+  const providerSummary = summary.providers.find((row) => row.provider === provider);
+  const budget = budgets.find((row) => row.provider === provider) ?? null;
+  const projectedCostUsd = optionalNumericValue(body.projected_cost_usd ?? body.projectedCostUsd)
+    ?? estimateSeatsApiCostUsd({
+      provider,
+      model: stringValue(body.model) || null,
+      inputTokens: numericValue(body.input_tokens ?? body.inputTokens),
+      outputTokens: numericValue(body.output_tokens ?? body.outputTokens),
+      cachedInputTokens: numericValue(body.cached_input_tokens ?? body.cachedInputTokens),
+    });
+
+  return res.status(200).json({
+    provider,
+    currentCostUsd: providerSummary?.estimatedCostUsd ?? 0,
+    projectedCostUsd,
+    decision: budgetDecision(providerSummary?.estimatedCostUsd ?? 0, budget, projectedCostUsd),
+    budget,
+  });
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  if (req.method === "OPTIONS") return res.status(204).end();
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "";
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  if (!supabaseUrl || !serviceRoleKey) {
+    return res.status(500).json({ error: "Database service unavailable" });
+  }
+
+  const caller = await resolveSessionUser(bearerFrom(req), supabaseUrl, serviceRoleKey);
+  if (!caller) return res.status(401).json({ error: "Unauthorized" });
+
+  const db = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const action = String(req.query.action ?? "");
+
+  try {
+    if (action === "summary") return await summaryAction(db, req, res, caller.id);
+    if (action === "log_usage") return await logUsageAction(db, req, res, caller.id);
+    if (action === "set_budget") return await setBudgetAction(db, req, res, caller.id);
+    if (action === "delete_budget") return await deleteBudgetAction(db, req, res, caller.id);
+    if (action === "check_budget") return await checkBudgetAction(db, req, res, caller.id);
+    return res.status(400).json({ error: `Unknown action: ${action}` });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Internal error";
+    console.error(`Seats API usage error (${action}):`, message);
+    return res.status(500).json({ error: message });
+  }
+}

--- a/src/lib/seatsApiUsage.test.ts
+++ b/src/lib/seatsApiUsage.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  budgetDecision,
+  budgetStatus,
+  estimateSeatsApiCostUsd,
+  findSeatsApiPricing,
+  normalizeSeatsApiBudgetCap,
+  normalizeSeatsApiUsageRow,
+  summarizeSeatsApiUsage,
+} from "./seatsApiUsage";
+
+describe("seats API usage accounting", () => {
+  it("estimates provider cost from token counts and cached input", () => {
+    expect(findSeatsApiPricing("anthropic", "claude-sonnet-4.6")?.inputUsdPerMillion).toBe(3);
+    expect(estimateSeatsApiCostUsd({
+      provider: "anthropic",
+      model: "claude-sonnet-4.6",
+      inputTokens: 1_000_000,
+      cachedInputTokens: 200_000,
+      outputTokens: 100_000,
+    })).toBe(3.96);
+  });
+
+  it("uses supplied cost when a caller logs exact billing", () => {
+    expect(normalizeSeatsApiUsageRow({
+      provider: "openai",
+      inputTokens: 10,
+      outputTokens: 20,
+      estimatedCostUsd: 1.234567,
+    }).estimatedCostUsd).toBe(1.2346);
+  });
+
+  it("summarizes spend and budget state by provider", () => {
+    const summary = summarizeSeatsApiUsage({
+      periodStart: "2026-06-01T00:00:00.000Z",
+      periodEnd: "2026-07-01T00:00:00.000Z",
+      rows: [
+        { provider: "openai", model: "gpt-5.4-mini", inputTokens: 1_000_000, outputTokens: 1_000_000 },
+        { provider: "openai", model: "gpt-5.4-mini", inputTokens: 500_000, outputTokens: 0 },
+      ],
+      budgets: [{ provider: "openai", monthlyBudgetUsd: 5, warnAtPercent: 80, throttleAtPercent: 100 }],
+    });
+
+    expect(summary.totals.totalTokens).toBe(2_500_000);
+    expect(summary.providers[0].provider).toBe("openai");
+    expect(summary.providers[0].estimatedCostUsd).toBe(5.625);
+    expect(summary.providers[0].budgetStatus).toBe("over");
+  });
+
+  it("classifies budget status thresholds", () => {
+    expect(budgetStatus(0, null)).toBe("none");
+    expect(budgetStatus(4, { provider: "openai", monthlyBudgetUsd: 10, warnAtPercent: 80, throttleAtPercent: 100 })).toBe("ok");
+    expect(budgetStatus(8, { provider: "openai", monthlyBudgetUsd: 10, warnAtPercent: 80, throttleAtPercent: 100 })).toBe("warning");
+    expect(budgetStatus(10, { provider: "openai", monthlyBudgetUsd: 10, warnAtPercent: 80, throttleAtPercent: 100 })).toBe("over");
+  });
+
+  it("normalizes budget caps and makes projected throttle decisions", () => {
+    const budget = normalizeSeatsApiBudgetCap({
+      provider: "OpenAI",
+      monthlyBudgetUsd: "10.12345",
+      warnAtPercent: "75.54",
+      throttleAtPercent: "90",
+    });
+
+    expect(budget).toEqual({
+      provider: "openai",
+      monthlyBudgetUsd: 10.1235,
+      warnAtPercent: 75.5,
+      throttleAtPercent: 90,
+    });
+    expect(budgetDecision(7, budget, 0.8)).toBe("warn");
+    expect(budgetDecision(8.8, budget, 0.4)).toBe("throttle");
+  });
+});

--- a/src/lib/seatsApiUsage.ts
+++ b/src/lib/seatsApiUsage.ts
@@ -1,0 +1,390 @@
+export type SeatsApiProvider = "anthropic" | "openai" | "google-ai" | "mistral" | "groq" | "perplexity" | "together-ai" | "replicate";
+
+export interface SeatsApiPricing {
+  provider: SeatsApiProvider;
+  model: string;
+  inputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  cachedInputUsdPerMillion?: number;
+  sourceLabel: string;
+}
+
+export interface SeatsApiUsageInput {
+  provider: string;
+  model?: string | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cachedInputTokens?: number | null;
+  requestCount?: number | null;
+  estimatedCostUsd?: number | null;
+}
+
+export interface SeatsApiUsageRow extends Required<Omit<SeatsApiUsageInput, "estimatedCostUsd" | "model">> {
+  model: string | null;
+  estimatedCostUsd: number;
+}
+
+export interface SeatsApiBudgetCap {
+  provider: string;
+  monthlyBudgetUsd: number | null;
+  warnAtPercent: number;
+  throttleAtPercent: number;
+}
+
+export type SeatsApiBudgetDecision = "uncapped" | "ok" | "warn" | "throttle";
+
+export interface SeatsApiProviderSummary {
+  provider: string;
+  label: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  totalTokens: number;
+  requestCount: number;
+  estimatedCostUsd: number;
+  monthlyBudgetUsd: number | null;
+  budgetUsedPercent: number | null;
+  budgetStatus: "none" | "ok" | "warning" | "over";
+}
+
+export interface SeatsApiUsageSummary {
+  periodStart: string;
+  periodEnd: string;
+  totals: {
+    inputTokens: number;
+    outputTokens: number;
+    cachedInputTokens: number;
+    totalTokens: number;
+    requestCount: number;
+    estimatedCostUsd: number;
+  };
+  providers: SeatsApiProviderSummary[];
+}
+
+export const SEATS_API_PROVIDER_LABELS: Record<SeatsApiProvider, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  "google-ai": "Google AI",
+  mistral: "Mistral",
+  groq: "Groq",
+  perplexity: "Perplexity",
+  "together-ai": "Together AI",
+  replicate: "Replicate",
+};
+
+export const SEATS_API_DEFAULT_PROVIDER_ORDER: SeatsApiProvider[] = [
+  "anthropic",
+  "openai",
+  "google-ai",
+  "mistral",
+  "groq",
+  "perplexity",
+  "together-ai",
+  "replicate",
+];
+
+export const SEATS_API_PRICING: SeatsApiPricing[] = [
+  {
+    provider: "anthropic",
+    model: "claude-sonnet-4.6",
+    inputUsdPerMillion: 3,
+    outputUsdPerMillion: 15,
+    cachedInputUsdPerMillion: 0.3,
+    sourceLabel: "Anthropic Claude Sonnet 4.6 standard",
+  },
+  {
+    provider: "anthropic",
+    model: "claude-haiku-4.5",
+    inputUsdPerMillion: 1,
+    outputUsdPerMillion: 5,
+    cachedInputUsdPerMillion: 0.1,
+    sourceLabel: "Anthropic Claude Haiku 4.5 standard",
+  },
+  {
+    provider: "anthropic",
+    model: "claude-opus-4.8",
+    inputUsdPerMillion: 5,
+    outputUsdPerMillion: 25,
+    cachedInputUsdPerMillion: 0.5,
+    sourceLabel: "Anthropic Claude Opus 4.8 standard",
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    inputUsdPerMillion: 0.75,
+    outputUsdPerMillion: 4.5,
+    cachedInputUsdPerMillion: 0.075,
+    sourceLabel: "OpenAI GPT-5.4 mini standard",
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.4",
+    inputUsdPerMillion: 2.5,
+    outputUsdPerMillion: 15,
+    cachedInputUsdPerMillion: 0.25,
+    sourceLabel: "OpenAI GPT-5.4 standard",
+  },
+  {
+    provider: "openai",
+    model: "gpt-5.5",
+    inputUsdPerMillion: 5,
+    outputUsdPerMillion: 30,
+    cachedInputUsdPerMillion: 0.5,
+    sourceLabel: "OpenAI GPT-5.5 standard",
+  },
+  {
+    provider: "google-ai",
+    model: "gemini-3-flash-preview",
+    inputUsdPerMillion: 0.5,
+    outputUsdPerMillion: 3,
+    cachedInputUsdPerMillion: 0.05,
+    sourceLabel: "Google Gemini 3 Flash preview standard",
+  },
+  {
+    provider: "google-ai",
+    model: "gemini-2.5-pro",
+    inputUsdPerMillion: 1.25,
+    outputUsdPerMillion: 10,
+    cachedInputUsdPerMillion: 0.125,
+    sourceLabel: "Google Gemini 2.5 Pro standard under 200k",
+  },
+  {
+    provider: "mistral",
+    model: "mistral-large",
+    inputUsdPerMillion: 2,
+    outputUsdPerMillion: 6,
+    sourceLabel: "Mistral Large standard",
+  },
+];
+
+const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<SeatsApiProvider, string>> = {
+  anthropic: "claude-sonnet-4.6",
+  openai: "gpt-5.4-mini",
+  "google-ai": "gemini-3-flash-preview",
+  mistral: "mistral-large",
+};
+
+export function normalizeSeatsApiProvider(provider: string): string {
+  return provider.trim().toLowerCase();
+}
+
+function normalizeModel(model?: string | null): string | null {
+  const normalized = model?.trim().toLowerCase() ?? "";
+  return normalized || null;
+}
+
+export function coerceNonNegativeNumber(value: unknown, fallback = 0): number {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return fallback;
+  return numeric;
+}
+
+export function labelForSeatsApiProvider(provider: string): string {
+  const normalizedProvider = normalizeSeatsApiProvider(provider);
+  return SEATS_API_PROVIDER_LABELS[normalizedProvider as SeatsApiProvider]
+    ?? normalizedProvider
+      .split(/[-_\s]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+}
+
+export function normalizeSeatsApiBudgetCap(input: {
+  provider: string;
+  monthlyBudgetUsd?: number | string | null;
+  warnAtPercent?: number | string | null;
+  throttleAtPercent?: number | string | null;
+}): SeatsApiBudgetCap {
+  const monthlyBudgetUsd =
+    input.monthlyBudgetUsd === null || input.monthlyBudgetUsd === ""
+      ? null
+      : roundUsd(coerceNonNegativeNumber(input.monthlyBudgetUsd, 0));
+  const warnAtPercent = clampPercent(coerceNonNegativeNumber(input.warnAtPercent, 80), 1, 1000);
+  const throttleAtPercent = Math.max(
+    warnAtPercent,
+    clampPercent(coerceNonNegativeNumber(input.throttleAtPercent, 100), warnAtPercent, 1000),
+  );
+
+  return {
+    provider: normalizeSeatsApiProvider(input.provider),
+    monthlyBudgetUsd,
+    warnAtPercent,
+    throttleAtPercent,
+  };
+}
+
+export function findSeatsApiPricing(provider: string, model?: string | null): SeatsApiPricing | null {
+  const normalizedProvider = normalizeSeatsApiProvider(provider) as SeatsApiProvider;
+  const normalizedModel = normalizeModel(model);
+  const exact = normalizedModel
+    ? SEATS_API_PRICING.find((pricing) => pricing.provider === normalizedProvider && pricing.model === normalizedModel)
+    : null;
+  if (exact) return exact;
+
+  const defaultModel = DEFAULT_MODEL_BY_PROVIDER[normalizedProvider];
+  if (!defaultModel) return null;
+  return SEATS_API_PRICING.find((pricing) => pricing.provider === normalizedProvider && pricing.model === defaultModel) ?? null;
+}
+
+export function estimateSeatsApiCostUsd(input: SeatsApiUsageInput): number {
+  if (typeof input.estimatedCostUsd === "number" && Number.isFinite(input.estimatedCostUsd) && input.estimatedCostUsd >= 0) {
+    return roundUsd(input.estimatedCostUsd);
+  }
+
+  const pricing = findSeatsApiPricing(input.provider, input.model);
+  if (!pricing) return 0;
+
+  const inputTokens = coerceNonNegativeNumber(input.inputTokens);
+  const outputTokens = coerceNonNegativeNumber(input.outputTokens);
+  const cachedInputTokens = coerceNonNegativeNumber(input.cachedInputTokens);
+  const billableInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const cachedRate = pricing.cachedInputUsdPerMillion ?? pricing.inputUsdPerMillion;
+
+  return roundUsd(
+    (billableInputTokens / 1_000_000) * pricing.inputUsdPerMillion
+    + (cachedInputTokens / 1_000_000) * cachedRate
+    + (outputTokens / 1_000_000) * pricing.outputUsdPerMillion,
+  );
+}
+
+export function normalizeSeatsApiUsageRow(input: SeatsApiUsageInput): SeatsApiUsageRow {
+  return {
+    provider: normalizeSeatsApiProvider(input.provider),
+    model: normalizeModel(input.model),
+    inputTokens: Math.round(coerceNonNegativeNumber(input.inputTokens)),
+    outputTokens: Math.round(coerceNonNegativeNumber(input.outputTokens)),
+    cachedInputTokens: Math.round(coerceNonNegativeNumber(input.cachedInputTokens)),
+    requestCount: Math.max(1, Math.round(coerceNonNegativeNumber(input.requestCount, 1))),
+    estimatedCostUsd: estimateSeatsApiCostUsd(input),
+  };
+}
+
+export function budgetStatus(costUsd: number, budget: SeatsApiBudgetCap | null): SeatsApiProviderSummary["budgetStatus"] {
+  if (!budget?.monthlyBudgetUsd || budget.monthlyBudgetUsd <= 0) return "none";
+  const percent = (costUsd / budget.monthlyBudgetUsd) * 100;
+  if (percent >= budget.throttleAtPercent) return "over";
+  if (percent >= budget.warnAtPercent) return "warning";
+  return "ok";
+}
+
+export function budgetDecision(
+  currentCostUsd: number,
+  budget: SeatsApiBudgetCap | null,
+  projectedCostUsd = 0,
+): SeatsApiBudgetDecision {
+  if (!budget?.monthlyBudgetUsd || budget.monthlyBudgetUsd <= 0) return "uncapped";
+  const projectedTotal = currentCostUsd + coerceNonNegativeNumber(projectedCostUsd);
+  const percent = (projectedTotal / budget.monthlyBudgetUsd) * 100;
+  if (percent >= budget.throttleAtPercent) return "throttle";
+  if (percent >= budget.warnAtPercent) return "warn";
+  return "ok";
+}
+
+export function summarizeSeatsApiUsage(params: {
+  periodStart: string;
+  periodEnd: string;
+  rows: SeatsApiUsageInput[];
+  budgets?: SeatsApiBudgetCap[];
+}): SeatsApiUsageSummary {
+  const budgetByProvider = new Map(
+    (params.budgets ?? []).map((budget) => [normalizeSeatsApiProvider(budget.provider), normalizeSeatsApiBudgetCap(budget)]),
+  );
+  const providerMap = new Map<string, SeatsApiProviderSummary>();
+
+  for (const rawRow of params.rows) {
+    const row = normalizeSeatsApiUsageRow(rawRow);
+    const current = providerMap.get(row.provider) ?? {
+      provider: row.provider,
+      label: labelForSeatsApiProvider(row.provider),
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+      totalTokens: 0,
+      requestCount: 0,
+      estimatedCostUsd: 0,
+      monthlyBudgetUsd: budgetByProvider.get(row.provider)?.monthlyBudgetUsd ?? null,
+      budgetUsedPercent: null,
+      budgetStatus: "none" as const,
+    };
+
+    current.inputTokens += row.inputTokens;
+    current.outputTokens += row.outputTokens;
+    current.cachedInputTokens += row.cachedInputTokens;
+    current.totalTokens += row.inputTokens + row.outputTokens;
+    current.requestCount += row.requestCount;
+    current.estimatedCostUsd = roundUsd(current.estimatedCostUsd + row.estimatedCostUsd);
+    providerMap.set(row.provider, current);
+  }
+
+  for (const budget of budgetByProvider.values()) {
+    const provider = normalizeSeatsApiProvider(budget.provider);
+    if (providerMap.has(provider)) continue;
+    providerMap.set(provider, {
+      provider,
+      label: labelForSeatsApiProvider(provider),
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+      totalTokens: 0,
+      requestCount: 0,
+      estimatedCostUsd: 0,
+      monthlyBudgetUsd: budget.monthlyBudgetUsd,
+      budgetUsedPercent: null,
+      budgetStatus: "none",
+    });
+  }
+
+  const providers = [...providerMap.values()].map((summary) => {
+    const budget = budgetByProvider.get(summary.provider) ?? null;
+    const usedPercent = budget?.monthlyBudgetUsd
+      ? roundPercent((summary.estimatedCostUsd / budget.monthlyBudgetUsd) * 100)
+      : null;
+    return {
+      ...summary,
+      monthlyBudgetUsd: budget?.monthlyBudgetUsd ?? summary.monthlyBudgetUsd,
+      budgetUsedPercent: usedPercent,
+      budgetStatus: budgetStatus(summary.estimatedCostUsd, budget),
+    };
+  }).sort((left, right) => {
+    const leftIndex = SEATS_API_DEFAULT_PROVIDER_ORDER.indexOf(left.provider as SeatsApiProvider);
+    const rightIndex = SEATS_API_DEFAULT_PROVIDER_ORDER.indexOf(right.provider as SeatsApiProvider);
+    return (leftIndex === -1 ? 99 : leftIndex) - (rightIndex === -1 ? 99 : rightIndex)
+      || left.label.localeCompare(right.label);
+  });
+
+  const totals = providers.reduce<SeatsApiUsageSummary["totals"]>((acc, provider) => {
+    acc.inputTokens += provider.inputTokens;
+    acc.outputTokens += provider.outputTokens;
+    acc.cachedInputTokens += provider.cachedInputTokens;
+    acc.totalTokens += provider.totalTokens;
+    acc.requestCount += provider.requestCount;
+    acc.estimatedCostUsd = roundUsd(acc.estimatedCostUsd + provider.estimatedCostUsd);
+    return acc;
+  }, {
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+    totalTokens: 0,
+    requestCount: 0,
+    estimatedCostUsd: 0,
+  });
+
+  return {
+    periodStart: params.periodStart,
+    periodEnd: params.periodEnd,
+    totals,
+    providers,
+  };
+}
+
+export function roundUsd(value: number): number {
+  return Math.round(value * 10_000) / 10_000;
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function clampPercent(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.round(value * 10) / 10));
+}

--- a/src/pages/admin/AdminSeatsApiUsage.tsx
+++ b/src/pages/admin/AdminSeatsApiUsage.tsx
@@ -1,0 +1,456 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  DollarSign,
+  Gauge,
+  Loader2,
+  RefreshCw,
+  Save,
+  ShieldAlert,
+  Trash2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { toast } from "@/components/ui/use-toast";
+import { useSession } from "@/lib/auth";
+import {
+  SEATS_API_DEFAULT_PROVIDER_ORDER,
+  labelForSeatsApiProvider,
+  type SeatsApiProviderSummary,
+  type SeatsApiUsageSummary,
+} from "@/lib/seatsApiUsage";
+
+interface UsageSummaryResponse {
+  summary: SeatsApiUsageSummary;
+}
+
+const STATUS_COPY: Record<SeatsApiProviderSummary["budgetStatus"], { label: string; className: string }> = {
+  none: {
+    label: "No cap",
+    className: "border-white/[0.08] bg-white/[0.04] text-[#999]",
+  },
+  ok: {
+    label: "OK",
+    className: "border-emerald-400/20 bg-emerald-400/10 text-emerald-300",
+  },
+  warning: {
+    label: "Warn",
+    className: "border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#E2B93B]",
+  },
+  over: {
+    label: "Throttle",
+    className: "border-red-400/30 bg-red-400/10 text-red-300",
+  },
+};
+
+function emptyProviderSummary(provider: string): SeatsApiProviderSummary {
+  return {
+    provider,
+    label: labelForSeatsApiProvider(provider),
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+    totalTokens: 0,
+    requestCount: 0,
+    estimatedCostUsd: 0,
+    monthlyBudgetUsd: null,
+    budgetUsedPercent: null,
+    budgetStatus: "none",
+  };
+}
+
+function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: value >= 100 ? 2 : 4,
+  }).format(value);
+}
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatMonth(iso: string): string {
+  const date = new Date(iso);
+  if (!Number.isFinite(date.getTime())) return "Current month";
+  return date.toLocaleDateString(undefined, { month: "short", year: "numeric" });
+}
+
+async function usageRequest<T>(
+  action: string,
+  accessToken: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+    ...(options.headers as Record<string, string> | undefined),
+  };
+  const response = await fetch(`/api/seats-api-usage?action=${action}`, {
+    ...options,
+    headers,
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({})) as { error?: string };
+    throw new Error(body.error ?? `Request failed: ${response.status}`);
+  }
+  return await response.json() as T;
+}
+
+function MetricCard({
+  title,
+  value,
+  detail,
+  icon: Icon,
+  tone = "teal",
+}: {
+  title: string;
+  value: string;
+  detail: string;
+  icon: typeof DollarSign;
+  tone?: "teal" | "yellow" | "red";
+}) {
+  const toneClass = tone === "yellow"
+    ? "text-[#E2B93B]"
+    : tone === "red"
+      ? "text-red-300"
+      : "text-[#61C1C4]";
+
+  return (
+    <Card className="border-white/[0.06] bg-white/[0.03]">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-medium uppercase text-[#777]">{title}</p>
+          <Icon className={`h-4 w-4 ${toneClass}`} />
+        </div>
+        <p className="mt-3 text-2xl font-semibold tabular-nums text-white">{value}</p>
+        <p className="mt-1 text-xs text-[#777]">{detail}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatusBadge({ status }: { status: SeatsApiProviderSummary["budgetStatus"] }) {
+  const copy = STATUS_COPY[status];
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${copy.className}`}>
+      {copy.label}
+    </span>
+  );
+}
+
+export function AdminSeatsApiUsagePanel() {
+  const { session, loading: sessionLoading } = useSession();
+  const [summary, setSummary] = useState<SeatsApiUsageSummary | null>(null);
+  const [budgetDrafts, setBudgetDrafts] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [savingProvider, setSavingProvider] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const accessToken = session?.access_token ?? "";
+
+  const loadSummary = useCallback(async () => {
+    if (!accessToken) return;
+    setLoading(true);
+    setError("");
+    try {
+      const response = await usageRequest<UsageSummaryResponse>("summary", accessToken);
+      setSummary(response.summary);
+      const drafts: Record<string, string> = {};
+      for (const provider of SEATS_API_DEFAULT_PROVIDER_ORDER) {
+        drafts[provider] = "";
+      }
+      for (const provider of response.summary.providers) {
+        drafts[provider.provider] = provider.monthlyBudgetUsd ? String(provider.monthlyBudgetUsd) : "";
+      }
+      setBudgetDrafts(drafts);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Could not load API spend";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void loadSummary();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadSummary]);
+
+  const providerRows = useMemo(() => {
+    const byProvider = new Map((summary?.providers ?? []).map((row) => [row.provider, row]));
+    const rows = SEATS_API_DEFAULT_PROVIDER_ORDER.map((provider) => byProvider.get(provider) ?? emptyProviderSummary(provider));
+    for (const row of summary?.providers ?? []) {
+      if (!SEATS_API_DEFAULT_PROVIDER_ORDER.some((provider) => provider === row.provider)) rows.push(row);
+    }
+    return rows;
+  }, [summary]);
+
+  const alertCount = providerRows.filter((row) => row.budgetStatus === "warning" || row.budgetStatus === "over").length;
+  const cappedCount = providerRows.filter((row) => row.monthlyBudgetUsd && row.monthlyBudgetUsd > 0).length;
+  const maxSpend = Math.max(1, ...providerRows.map((row) => row.estimatedCostUsd));
+  const periodLabel = summary ? formatMonth(summary.periodStart) : "Current month";
+
+  async function saveBudget(provider: string) {
+    if (!accessToken) return;
+    const raw = (budgetDrafts[provider] ?? "").trim();
+    const monthlyBudgetUsd = Number(raw);
+    if (!raw || !Number.isFinite(monthlyBudgetUsd) || monthlyBudgetUsd <= 0) {
+      toast({
+        title: "Budget not saved",
+        description: "Enter a monthly cap greater than 0.",
+      });
+      return;
+    }
+
+    setSavingProvider(provider);
+    try {
+      await usageRequest("set_budget", accessToken, {
+        method: "POST",
+        body: JSON.stringify({
+          provider,
+          monthly_budget_usd: monthlyBudgetUsd,
+          warn_at_percent: 80,
+          throttle_at_percent: 100,
+        }),
+      });
+      toast({ title: "Budget saved", description: `${labelForSeatsApiProvider(provider)} cap updated.` });
+      await loadSummary();
+    } catch (err) {
+      toast({
+        title: "Budget not saved",
+        description: err instanceof Error ? err.message : "The budget could not be saved.",
+      });
+    } finally {
+      setSavingProvider(null);
+    }
+  }
+
+  async function removeBudget(provider: string) {
+    if (!accessToken) return;
+    setSavingProvider(provider);
+    try {
+      await usageRequest("delete_budget", accessToken, {
+        method: "POST",
+        body: JSON.stringify({ provider }),
+      });
+      setBudgetDrafts((current) => ({ ...current, [provider]: "" }));
+      toast({ title: "Budget removed", description: `${labelForSeatsApiProvider(provider)} cap cleared.` });
+      await loadSummary();
+    } catch (err) {
+      toast({
+        title: "Budget not removed",
+        description: err instanceof Error ? err.message : "The budget could not be removed.",
+      });
+    } finally {
+      setSavingProvider(null);
+    }
+  }
+
+  if (sessionLoading) {
+    return (
+      <div className="flex items-center gap-2 py-8 text-sm text-[#777]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading session
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <Card className="border-white/[0.06] bg-white/[0.03]">
+        <CardContent className="p-4 text-sm text-[#999]">Sign in to view API spend.</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Usage and spend</h2>
+          <p className="mt-1 text-xs text-[#777]">{periodLabel} API tier accounting</p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => void loadSummary()}
+          disabled={loading}
+          className="border-white/[0.08] bg-white/[0.04] text-[#ddd] hover:bg-white/[0.08] hover:text-white"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-400/20 bg-red-400/10 p-3 text-sm text-red-200">
+          <AlertTriangle className="mt-0.5 h-4 w-4" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-4">
+        <MetricCard
+          title="Spend"
+          value={formatUsd(summary?.totals.estimatedCostUsd ?? 0)}
+          detail="Estimated from logged tokens"
+          icon={DollarSign}
+        />
+        <MetricCard
+          title="Tokens"
+          value={formatCount(summary?.totals.totalTokens ?? 0)}
+          detail={`${formatCount(summary?.totals.cachedInputTokens ?? 0)} cached input`}
+          icon={Activity}
+        />
+        <MetricCard
+          title="Requests"
+          value={formatCount(summary?.totals.requestCount ?? 0)}
+          detail={`${providerRows.length} providers visible`}
+          icon={Gauge}
+        />
+        <MetricCard
+          title="Caps"
+          value={String(cappedCount)}
+          detail={alertCount ? `${alertCount} need attention` : "No active alerts"}
+          icon={ShieldAlert}
+          tone={alertCount ? "red" : "yellow"}
+        />
+      </div>
+
+      <Card className="border-white/[0.06] bg-white/[0.03]">
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="text-sm text-white">Provider spend</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 pt-0">
+          {providerRows.map((row) => {
+            const width = Math.max(2, Math.min(100, (row.estimatedCostUsd / maxSpend) * 100));
+            return (
+              <div key={row.provider} className="grid gap-2 sm:grid-cols-[150px_1fr_90px] sm:items-center">
+                <div className="flex items-center gap-2">
+                  <StatusBadge status={row.budgetStatus} />
+                  <span className="text-sm text-[#ddd]">{row.label}</span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-white/[0.06]">
+                  <div
+                    className="h-full rounded-full bg-[#61C1C4]"
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+                <span className="text-right text-sm tabular-nums text-[#ddd]">{formatUsd(row.estimatedCostUsd)}</span>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/[0.06] bg-white/[0.03]">
+        <CardHeader className="p-4 pb-0">
+          <CardTitle className="text-sm text-white">Budgets by provider</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow className="border-white/[0.06] hover:bg-transparent">
+                <TableHead className="text-[#777]">Provider</TableHead>
+                <TableHead className="text-right text-[#777]">Tokens</TableHead>
+                <TableHead className="text-right text-[#777]">Spend</TableHead>
+                <TableHead className="text-[#777]">Monthly cap</TableHead>
+                <TableHead className="text-[#777]">Status</TableHead>
+                <TableHead className="text-right text-[#777]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {providerRows.map((row) => {
+                const progress = Math.min(100, Math.max(0, row.budgetUsedPercent ?? 0));
+                const isSaving = savingProvider === row.provider;
+                return (
+                  <TableRow key={row.provider} className="border-white/[0.06] hover:bg-white/[0.02]">
+                    <TableCell>
+                      <div>
+                        <p className="text-sm font-medium text-white">{row.label}</p>
+                        <p className="text-[11px] text-[#666]">{formatCount(row.requestCount)} requests</p>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right text-sm tabular-nums text-[#ddd]">
+                      {formatCount(row.totalTokens)}
+                    </TableCell>
+                    <TableCell className="text-right text-sm tabular-nums text-[#ddd]">
+                      {formatUsd(row.estimatedCostUsd)}
+                    </TableCell>
+                    <TableCell className="min-w-[170px]">
+                      <div className="flex items-center gap-2">
+                        <Input
+                          inputMode="decimal"
+                          value={budgetDrafts[row.provider] ?? ""}
+                          onChange={(event) => setBudgetDrafts((current) => ({
+                            ...current,
+                            [row.provider]: event.target.value,
+                          }))}
+                          placeholder="USD"
+                          className="h-8 border-white/[0.08] bg-black/20 text-sm text-white placeholder:text-[#555]"
+                        />
+                      </div>
+                      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
+                        <div
+                          className={row.budgetStatus === "over" ? "h-full rounded-full bg-red-300" : "h-full rounded-full bg-[#E2B93B]"}
+                          style={{ width: `${progress}%` }}
+                        />
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={row.budgetStatus} />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => void saveBudget(row.provider)}
+                          disabled={isSaving}
+                          className="h-8 w-8 border-white/[0.08] bg-white/[0.04] text-[#ddd] hover:bg-white/[0.08] hover:text-white"
+                          title="Save budget"
+                        >
+                          {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => void removeBudget(row.provider)}
+                          disabled={isSaving || !row.monthlyBudgetUsd}
+                          className="h-8 w-8 border-white/[0.08] bg-white/[0.04] text-[#ddd] hover:bg-white/[0.08] hover:text-white"
+                          title="Remove budget"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+export default AdminSeatsApiUsagePanel;

--- a/supabase/migrations/20260609090000_seats_api_usage_spend.sql
+++ b/supabase/migrations/20260609090000_seats_api_usage_spend.sql
@@ -1,0 +1,146 @@
+-- Seats compute API tier usage and budget caps.
+-- Tracks per-user token usage events, estimated spend, and monthly provider caps.
+
+create table if not exists public.seats_api_usage_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider_slug text not null check (length(trim(provider_slug)) > 0),
+  model text,
+  task_type text,
+  input_tokens bigint not null default 0 check (input_tokens >= 0),
+  output_tokens bigint not null default 0 check (output_tokens >= 0),
+  cached_input_tokens bigint not null default 0 check (cached_input_tokens >= 0),
+  request_count integer not null default 1 check (request_count >= 1),
+  estimated_cost_usd numeric(14,6) not null default 0 check (estimated_cost_usd >= 0),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.seats_api_budget_caps (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider_slug text not null check (length(trim(provider_slug)) > 0),
+  monthly_budget_usd numeric(12,2) check (monthly_budget_usd is null or monthly_budget_usd >= 0),
+  warn_at_percent numeric(6,2) not null default 80 check (warn_at_percent > 0 and warn_at_percent <= 1000),
+  throttle_at_percent numeric(6,2) not null default 100 check (throttle_at_percent > 0 and throttle_at_percent <= 1000),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, provider_slug),
+  check (throttle_at_percent >= warn_at_percent)
+);
+
+create index if not exists seats_api_usage_events_user_created_idx
+  on public.seats_api_usage_events (user_id, created_at desc);
+
+create index if not exists seats_api_usage_events_user_provider_created_idx
+  on public.seats_api_usage_events (user_id, provider_slug, created_at desc);
+
+create index if not exists seats_api_budget_caps_user_provider_idx
+  on public.seats_api_budget_caps (user_id, provider_slug);
+
+create or replace function public.seats_api_budget_caps_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists seats_api_budget_caps_updated_at on public.seats_api_budget_caps;
+create trigger seats_api_budget_caps_updated_at
+  before update on public.seats_api_budget_caps
+  for each row execute function public.seats_api_budget_caps_set_updated_at();
+
+alter table public.seats_api_usage_events enable row level security;
+alter table public.seats_api_budget_caps enable row level security;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'seats_api_usage_events'
+      and policyname = 'seats_api_usage_events_select_own'
+  ) then
+    create policy "seats_api_usage_events_select_own"
+      on public.seats_api_usage_events
+      for select using (user_id = auth.uid());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'seats_api_usage_events'
+      and policyname = 'seats_api_usage_events_insert_own'
+  ) then
+    create policy "seats_api_usage_events_insert_own"
+      on public.seats_api_usage_events
+      for insert with check (user_id = auth.uid());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'seats_api_usage_events'
+      and policyname = 'seats_api_usage_events_delete_own'
+  ) then
+    create policy "seats_api_usage_events_delete_own"
+      on public.seats_api_usage_events
+      for delete using (user_id = auth.uid());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'seats_api_budget_caps'
+      and policyname = 'seats_api_budget_caps_select_own'
+  ) then
+    create policy "seats_api_budget_caps_select_own"
+      on public.seats_api_budget_caps
+      for select using (user_id = auth.uid());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'seats_api_budget_caps'
+      and policyname = 'seats_api_budget_caps_insert_own'
+  ) then
+    create policy "seats_api_budget_caps_insert_own"
+      on public.seats_api_budget_caps
+      for insert with check (user_id = auth.uid());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'seats_api_budget_caps'
+      and policyname = 'seats_api_budget_caps_update_own'
+  ) then
+    create policy "seats_api_budget_caps_update_own"
+      on public.seats_api_budget_caps
+      for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'seats_api_budget_caps'
+      and policyname = 'seats_api_budget_caps_delete_own'
+  ) then
+    create policy "seats_api_budget_caps_delete_own"
+      on public.seats_api_budget_caps
+      for delete using (user_id = auth.uid());
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

Adds WP-4 usage and spend tracking for the Seats API tier:

- Adds a shared Seats API accounting library for token totals, cost estimation, provider summaries, budget statuses, and throttle decisions.
- Adds a Supabase migration for per-user `seats_api_usage_events` and `seats_api_budget_caps` tables with RLS.
- Adds `/api/seats-api-usage` actions for monthly summaries, usage logging, budget save/delete, and budget checks.
- Adds `AdminSeatsApiUsagePanel`, a route-ready panel with spend cards, provider spend bars, token counts, and monthly cap controls.

## Acceptance criteria

- User sees token counts and estimated costs per provider through `AdminSeatsApiUsagePanel` once WP-3 mounts it on the API page.
- User can set monthly budget caps per provider.
- API usage events can be logged to Supabase with input, output, cached input tokens, request count, and estimated cost.
- Budget checks return `uncapped`, `ok`, `warn`, or `throttle` so future API call paths can warn or stop before spend exceeds the cap.

## Dependencies

- Depends on WP-3 API credential page and WP-1 route scaffold.
- Built against `main` per the brief because the dependency branches are not merged yet.
- The UI is delivered as a standalone panel instead of editing `AdminSeatsApi.tsx`, so WP-3 can import it cleanly when that page exists on the target branch.

## Proof

- `npx vitest run src/lib/seatsApiUsage.test.ts`
- `npx eslint src/lib/seatsApiUsage.ts src/lib/seatsApiUsage.test.ts src/pages/admin/AdminSeatsApiUsage.tsx api/seats-api-usage.ts`
- `npm run build`
- `npx tsx -e "import('./api/seats-api-usage.ts').then(() => console.log('ok'))"`
- No `packages/mcp-server/**` files touched, so MCP package proof commands were not required.