### PR TITLE
Seats Compute Layer: WP-9 - subscription platform management

### DIFF
--- a/src/pages/admin/AdminSeatsSubscription.tsx
+++ b/src/pages/admin/AdminSeatsSubscription.tsx
@@ -1,0 +1,630 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useToast } from "@/hooks/use-toast";
+import { useSession } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import {
+  generateConfig,
+  platformFilename,
+  platformHasConfigFile,
+  platformLabel,
+  type BusinessContextEntry,
+  type Platform,
+} from "@/lib/configGenerator";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Copy,
+  CreditCard,
+  Download,
+  ExternalLink,
+  FileText,
+  Loader2,
+  RefreshCw,
+  Settings2,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
+
+const API_KEY_STORAGE = "unclick_api_key";
+const PLATFORM_STORAGE = "unclick_platform";
+const SERVER_URL = "https://unclick.world/api/mcp";
+const PLATFORMS: Platform[] = ["claude-code", "cursor", "windsurf", "copilot", "chatgpt"];
+
+interface ConnectionStatus {
+  connected: boolean;
+  last_seen: string | null;
+  cloud_sync: boolean;
+  schema_installed?: boolean;
+}
+
+interface GeneratedConfigResponse {
+  content: string;
+  filename: string;
+  instructions: string;
+  generated_at: string;
+}
+
+interface PlatformGuide {
+  planExamples: string;
+  included: string;
+  metered: string;
+  whereToCheck: string;
+  setup: string[];
+}
+
+const PLATFORM_GUIDES: Record<Platform, PlatformGuide> = {
+  "claude-code": {
+    planExamples: "Claude Pro, Max 5x, Max 20x, Team",
+    included:
+      "Human-in-session Claude app and Claude Code use draw from the subscription usage pool.",
+    metered:
+      "API calls, long-running automation, and background work should be treated as programmatic usage.",
+    whereToCheck: "Claude account usage page and Claude Code plan status.",
+    setup: [
+      "Install Claude Code and sign in with the account that owns the subscription.",
+      "Add the UnClick MCP server to Claude Code.",
+      "Save CLAUDE.md at each project root when you want startup memory loaded from a file.",
+      "Open a fresh Claude Code session and confirm UnClick memory loads before the first answer.",
+    ],
+  },
+  cursor: {
+    planExamples: "Cursor Pro, Pro+, Ultra, Team",
+    included:
+      "Tab completion and agent usage allowances live inside the Cursor subscription.",
+    metered:
+      "Heavy agent work, premium model choices, and background agents can consume included usage or require paid overage.",
+    whereToCheck: "Cursor dashboard and editor usage notifications.",
+    setup: [
+      "Open Cursor settings and go to Tools and MCP.",
+      "Add the UnClick MCP server using the generated Cursor rule file.",
+      "Save .cursor/rules/unclick.mdc inside the project.",
+      "Restart Cursor and start a new chat to confirm UnClick memory loads.",
+    ],
+  },
+  windsurf: {
+    planExamples: "Windsurf Free, Pro, Max, Teams, Enterprise",
+    included:
+      "Cascade prompt quota or credits are allocated by plan and reset on the provider billing cycle.",
+    metered:
+      "Premium models, extra quota, and team add-on credits are tracked separately by Windsurf.",
+    whereToCheck: "Windsurf Settings, Plan Info, and the Windsurf billing page.",
+    setup: [
+      "Open Windsurf settings, then Cascade, then MCP Servers.",
+      "Add the UnClick MCP server.",
+      "Save .windsurfrules at the project root.",
+      "Restart Windsurf and ask Cascade to load memory from UnClick.",
+    ],
+  },
+  copilot: {
+    planExamples: "Copilot Pro, Pro+, Business, Enterprise",
+    included:
+      "IDE completions and Copilot Chat features are covered by the selected Copilot plan and monthly AI credit rules.",
+    metered:
+      "Premium models, agent sessions, and cloud agent usage can consume monthly credits or trigger separate billing.",
+    whereToCheck: "GitHub Copilot usage and billing settings.",
+    setup: [
+      "Open VS Code settings and find MCP Servers.",
+      "Add the UnClick MCP server to the workspace.",
+      "Save .github/copilot-instructions.md in the repo.",
+      "Reload VS Code and start Copilot Chat with the workspace open.",
+    ],
+  },
+  chatgpt: {
+    planExamples: "ChatGPT Plus, Pro, Team, Enterprise",
+    included:
+      "Interactive ChatGPT sessions and connected MCP tools run inside the ChatGPT product experience.",
+    metered:
+      "OpenAI API usage is billed and managed separately from ChatGPT subscriptions.",
+    whereToCheck: "ChatGPT plan settings and OpenAI Platform billing.",
+    setup: [
+      "Open ChatGPT connector settings for MCP tools.",
+      "Add the UnClick MCP server.",
+      "Start a fresh chat and ask ChatGPT to load memory from UnClick.",
+      "Use the API tier for background jobs that should run without an active human chat.",
+    ],
+  },
+};
+
+function getStoredPlatform(): Platform {
+  try {
+    const value = localStorage.getItem(PLATFORM_STORAGE);
+    if (value && PLATFORMS.includes(value as Platform)) return value as Platform;
+  } catch {
+    /* ignore */
+  }
+  return "claude-code";
+}
+
+function getApiKey(): string {
+  try {
+    return localStorage.getItem(API_KEY_STORAGE) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function planStatus(connection: ConnectionStatus | null): string {
+  if (!connection?.connected) return "Unknown until connected";
+  return "Plan not exposed by provider API";
+}
+
+export default function AdminSeatsSubscription() {
+  const { toast } = useToast();
+  const { session } = useSession();
+  const [apiKey] = useState<string>(getApiKey);
+  const [platform, setPlatform] = useState<Platform>(getStoredPlatform);
+  const [connection, setConnection] = useState<ConnectionStatus | null>(null);
+  const [loadingConnection, setLoadingConnection] = useState(true);
+  const [businessContext, setBusinessContext] = useState<BusinessContextEntry[]>([]);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [serverConfig, setServerConfig] = useState<GeneratedConfigResponse | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  const selectedGuide = PLATFORM_GUIDES[platform];
+  const previewLocal = useMemo(
+    () => generateConfig(platform, businessContext),
+    [platform, businessContext]
+  );
+  const activeConfig = serverConfig
+    ? { content: serverConfig.content, filename: serverConfig.filename }
+    : { content: previewLocal.content, filename: previewLocal.filename };
+  const connectedCount = connection?.connected ? 1 : 0;
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(PLATFORM_STORAGE, platform);
+    } catch {
+      /* ignore */
+    }
+  }, [platform]);
+
+  useEffect(() => {
+    const effectiveToken = apiKey || session?.access_token || "";
+    let cancelled = false;
+
+    (async () => {
+      setLoadingConnection(Boolean(effectiveToken));
+      try {
+        const requests: Promise<Response>[] = [fetch("/api/memory-admin?action=business_context")];
+        if (effectiveToken) {
+          requests.unshift(
+            fetch("/api/memory-admin?action=admin_check_connection", {
+              headers: { Authorization: `Bearer ${effectiveToken}` },
+            })
+          );
+        }
+
+        const responses = await Promise.all(requests);
+        const [connRes, bcRes] = effectiveToken ? responses : [null, responses[0]];
+
+        if (!cancelled && connRes?.ok) {
+          setConnection((await connRes.json()) as ConnectionStatus);
+        }
+        if (!cancelled && bcRes.ok) {
+          const body = (await bcRes.json()) as { data: BusinessContextEntry[] };
+          setBusinessContext(body.data ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          toast({
+            title: "Could not refresh subscription status",
+            description: (err as Error).message,
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (!cancelled) setLoadingConnection(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiKey, session?.access_token, toast]);
+
+  const checkConnection = async () => {
+    const effectiveToken = apiKey || session?.access_token || "";
+    if (!effectiveToken) {
+      toast({
+        title: "API key required",
+        description: "Add your UnClick API key on the You page first.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setLoadingConnection(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=admin_check_connection", {
+        headers: { Authorization: `Bearer ${effectiveToken}` },
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Connection check failed (${res.status})`);
+      }
+      setConnection((await res.json()) as ConnectionStatus);
+      toast({ title: "Connection checked", description: "UnClick status is up to date." });
+    } catch (err) {
+      toast({
+        title: "Connection check failed",
+        description: (err as Error).message,
+        variant: "destructive",
+      });
+    } finally {
+      setLoadingConnection(false);
+    }
+  };
+
+  const regenerateFromServer = async () => {
+    if (!apiKey) {
+      toast({
+        title: "API key required",
+        description: "Server-side generation needs your UnClick API key.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setGenerating(true);
+    try {
+      const res = await fetch(
+        `/api/memory-admin?action=admin_generate_config&platform=${platform}`,
+        { headers: { Authorization: `Bearer ${apiKey}` } }
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? "Generation failed");
+      }
+      setServerConfig((await res.json()) as GeneratedConfigResponse);
+      setPreviewOpen(true);
+    } catch (err) {
+      toast({
+        title: "Could not generate config",
+        description: (err as Error).message,
+        variant: "destructive",
+      });
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handlePreview = async () => {
+    setPreviewOpen(true);
+    if (apiKey) await regenerateFromServer();
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(activeConfig.content);
+      toast({ title: "Copied", description: `${activeConfig.filename} copied to clipboard.` });
+    } catch {
+      toast({ title: "Copy failed", variant: "destructive" });
+    }
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([activeConfig.content], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = activeConfig.filename.split("/").pop() ?? "config.md";
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <div className="mb-2 inline-flex items-center gap-2 rounded-md border border-primary/25 bg-primary/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-primary">
+          <CreditCard className="h-3.5 w-3.5" />
+          Seats / Subscription
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight text-heading">Subscriptions</h1>
+        <p className="mt-1 max-w-2xl text-sm text-body">
+          Manage Claude Code, Cursor, Windsurf, Copilot, and ChatGPT subscription paths for
+          interactive work while keeping background automation routed deliberately.
+        </p>
+      </header>
+
+      <section className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Connected platforms</h2>
+            <p className="mt-1 text-xs text-white/60">
+              UnClick checks its MCP connection once. Provider subscription plans are shown when
+              the platform exposes them, otherwise this page shows where to verify the plan.
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={checkConnection} disabled={loadingConnection}>
+            <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${loadingConnection ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
+
+        <div className="mt-5 grid gap-3 lg:grid-cols-5">
+          {PLATFORMS.map((item) => {
+            const isSelected = item === platform;
+            const isConnected = item === platform && connection?.connected;
+            return (
+              <button
+                key={item}
+                type="button"
+                onClick={() => {
+                  setPlatform(item);
+                  setPreviewOpen(false);
+                  setServerConfig(null);
+                }}
+                className={`min-h-[148px] rounded-lg border p-4 text-left transition-colors ${
+                  isSelected
+                    ? "border-[#61C1C4] bg-[#61C1C4]/10"
+                    : "border-white/[0.08] bg-white/[0.02] hover:border-[#61C1C4]/40"
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-semibold text-white">{platformLabel(item)}</p>
+                  {isConnected ? (
+                    <CheckCircle2 className="h-4 w-4 text-[#61C1C4]" />
+                  ) : (
+                    <XCircle className="h-4 w-4 text-white/30" />
+                  )}
+                </div>
+                <p className="mt-3 text-[11px] uppercase tracking-wider text-white/35">Status</p>
+                <p className="mt-1 text-xs text-white/70">
+                  {item === platform && loadingConnection ? "Checking..." : isConnected ? "Connected" : "Not set up"}
+                </p>
+                <p className="mt-3 text-[11px] uppercase tracking-wider text-white/35">Plan</p>
+                <p className="mt-1 text-xs text-white/70">
+                  {item === platform ? planStatus(connection) : "Select to inspect"}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+            <p className="text-[11px] uppercase tracking-wider text-white/40">Selected platform</p>
+            <p className="mt-1 text-sm font-medium text-white">{platformLabel(platform)}</p>
+          </div>
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+            <p className="text-[11px] uppercase tracking-wider text-white/40">Connection</p>
+            <p className="mt-1 flex items-center gap-1.5 text-sm font-medium text-white">
+              {loadingConnection ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin text-white/40" />
+                  Checking...
+                </>
+              ) : connection?.connected ? (
+                <>
+                  <CheckCircle2 className="h-3.5 w-3.5 text-[#61C1C4]" />
+                  Connected
+                </>
+              ) : (
+                <>
+                  <XCircle className="h-3.5 w-3.5 text-[#E2B93B]" />
+                  Not connected
+                </>
+              )}
+            </p>
+            {connection?.last_seen && (
+              <p className="mt-1 text-[11px] text-white/40">
+                Last seen {formatRelative(connection.last_seen)}
+              </p>
+            )}
+          </div>
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+            <p className="text-[11px] uppercase tracking-wider text-white/40">Server</p>
+            <code className="mt-1 block truncate font-mono text-[11px] text-white">
+              {SERVER_URL}
+            </code>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#61C1C4]/10">
+              <Settings2 className="h-4 w-4 text-[#61C1C4]" />
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-white">
+                Setup wizard for {platformLabel(platform)}
+              </h2>
+              <p className="mt-1 text-xs text-white/60">
+                Follow these steps after confirming the subscription account in the provider app.
+              </p>
+            </div>
+          </div>
+
+          <ol className="mt-5 space-y-3">
+            {selectedGuide.setup.map((step, index) => (
+              <li key={step} className="flex gap-3">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-[#61C1C4]/30 bg-[#61C1C4]/10 text-xs font-semibold text-[#61C1C4]">
+                  {index + 1}
+                </span>
+                <p className="pt-0.5 text-sm text-white/75">{step}</p>
+              </li>
+            ))}
+          </ol>
+
+          <div className="mt-5 flex flex-wrap gap-2">
+            <Link
+              to="/memory/connect"
+              className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.02] px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:border-[#61C1C4]/40 hover:text-white"
+            >
+              Open setup guide
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Link>
+            <Button variant="outline" size="sm" onClick={checkConnection} disabled={loadingConnection}>
+              Check connection
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[#E2B93B]/25 bg-[#E2B93B]/[0.05] p-6">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 text-[#E2B93B]" />
+            <div>
+              <h2 className="text-sm font-semibold text-white">Subscription economics</h2>
+              <p className="mt-1 text-xs font-semibold text-[#E2B93B]">
+                Background automation is metered separately from your subscription.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 space-y-3 text-xs leading-relaxed text-white/70">
+            <p>
+              Use subscriptions for interactive work: a human is present, the provider app is open,
+              and UnClick is supplying context through MCP.
+            </p>
+            <p>
+              Use the API tier for unattended jobs, batch processing, scheduled agents, retries,
+              and anything expected to run after you leave the chat.
+            </p>
+            <p>
+              Use the Local tier for private embeddings, OCR, cheap drafts, and workloads that
+              should stay on your own machine.
+            </p>
+          </div>
+          <div className="mt-5 rounded-lg border border-white/[0.06] bg-black/20 p-4 text-xs text-white/70">
+            <p className="font-semibold text-white">Current selection</p>
+            <p className="mt-1">{selectedGuide.included}</p>
+            <p className="mt-2">{selectedGuide.metered}</p>
+            <p className="mt-2 text-white/45">Verify plan details in {selectedGuide.whereToCheck}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#61C1C4]/10">
+              <Sparkles className="h-4 w-4 text-[#61C1C4]" />
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-white">Plan guide</h2>
+              <p className="mt-1 text-xs text-white/60">
+                Plan detection depends on provider APIs. When no plan API is available, UnClick
+                keeps the plan field explicit instead of guessing.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-5 space-y-4 text-xs">
+            <div>
+              <p className="text-[11px] uppercase tracking-wider text-white/40">
+                Common {platformLabel(platform)} tiers
+              </p>
+              <p className="mt-1 text-white/75">{selectedGuide.planExamples}</p>
+            </div>
+            <div>
+              <p className="text-[11px] uppercase tracking-wider text-white/40">
+                Best route by work type
+              </p>
+              <div className="mt-2 grid gap-2">
+                {[
+                  ["Interactive answer", "Subscription"],
+                  ["Background batch", "API"],
+                  ["Embeddings and OCR", "Local"],
+                  ["Provider billing reports", "Provider dashboard"],
+                ].map(([label, value]) => (
+                  <div
+                    key={label}
+                    className="flex items-center justify-between rounded-md border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+                  >
+                    <span className="text-white/60">{label}</span>
+                    <span className="font-medium text-white">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-3">
+              <p className="text-white/70">
+                {connectedCount} subscription platform connected through UnClick. More platforms can
+                use the same MCP server once the provider app is configured.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
+          <h2 className="text-sm font-semibold text-white">Config files</h2>
+          <p className="mt-1 text-xs text-white/60">
+            {platformHasConfigFile(platform)
+              ? "Preview, copy, or download the platform-specific file that tells the app to load UnClick first."
+              : `${platformLabel(platform)} loads context through the MCP connector. No local config file is needed.`}
+          </p>
+
+          {platformHasConfigFile(platform) ? (
+            <>
+              <div className="mt-4 flex flex-wrap items-center gap-2 text-xs">
+                <FileText className="h-4 w-4 text-white/40" />
+                <span className="text-white/50">File:</span>
+                <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[11px] text-[#61C1C4]">
+                  {platformFilename(platform)}
+                </code>
+                {serverConfig && (
+                  <span className="text-white/40">
+                    Generated {formatRelative(serverConfig.generated_at)}
+                  </span>
+                )}
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button variant="outline" size="sm" onClick={handlePreview}>
+                  {previewOpen ? "Refresh preview" : "Preview"}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={regenerateFromServer}
+                  disabled={generating || !apiKey}
+                >
+                  <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${generating ? "animate-spin" : ""}`} />
+                  Regenerate
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleCopy}>
+                  <Copy className="mr-1.5 h-3.5 w-3.5" />
+                  Copy
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleDownload}>
+                  <Download className="mr-1.5 h-3.5 w-3.5" />
+                  Download
+                </Button>
+              </div>
+
+              {previewOpen && (
+                <div className="mt-4 overflow-hidden rounded-md border border-white/[0.06] bg-black/40">
+                  <div className="border-b border-white/[0.06] px-3 py-2 font-mono text-[11px] text-white/40">
+                    {activeConfig.filename}
+                  </div>
+                  <pre className="max-h-[420px] overflow-auto p-3 font-mono text-[11px] leading-relaxed text-white/90">
+                    {activeConfig.content}
+                  </pre>
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="mt-4 rounded-md border border-white/[0.06] bg-white/[0.02] p-4 text-xs text-white/70">
+              Once the UnClick MCP server is added in {platformLabel(platform)} settings, identity,
+              facts, and session history load at the start of every conversation.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -2,8 +2,6 @@
  * AdminSettings - Settings surface (/admin/settings)
  *
  * Grouped sections (top to bottom):
- *   - Connection      platform picker + connection status
- *   - AI Config       generated config file preview / download
  *   - Memory Loading  auto-load toggle (tenant_settings.autoload)
  *   - Isolation       single-memory-tool guidance
  *   - Danger Zone     clear / export
@@ -11,9 +9,7 @@
  *
  * Controls hit /api/memory-admin with the user's API key:
  *   tenant_settings_get / tenant_settings_set for the auto-load toggle,
- *   admin_check_connection for live connection status,
- *   admin_generate_config for server-side config regeneration,
- *   business_context + configGenerator for the local preview.
+ *   admin_bug_reports for the support log.
  *
  * Rendered inside AdminShell's <Outlet>, so we emit plain content only.
  */
@@ -25,49 +21,18 @@ import { useSession, signOut } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import {
-  generateConfig,
-  platformFilename,
-  platformHasConfigFile,
-  platformLabel,
-  type BusinessContextEntry,
-  type Platform,
-} from "@/lib/configGenerator";
-import {
   Settings as SettingsIcon,
   CheckCircle2,
-  XCircle,
-  Copy,
-  Download,
-  RefreshCw,
   AlertTriangle,
   Bug,
   ChevronDown,
   ChevronUp,
-  FileText,
   Loader2,
   ShieldCheck,
 } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 
 const API_KEY_STORAGE = "unclick_api_key";
-const PLATFORM_STORAGE = "unclick_platform";
-const PLATFORMS: Platform[] = ["claude-code", "cursor", "windsurf", "copilot", "chatgpt"];
-
-const SERVER_URL = "https://unclick.world/api/mcp";
-
-interface ConnectionStatus {
-  connected: boolean;
-  last_seen: string | null;
-  cloud_sync: boolean;
-  schema_installed?: boolean;
-}
-
-interface GeneratedConfigResponse {
-  content: string;
-  filename: string;
-  instructions: string;
-  generated_at: string;
-}
 
 interface BugReport {
   id: string;
@@ -77,16 +42,6 @@ interface BugReport {
   status: string;
   created_at: string;
   updated_at?: string | null;
-}
-
-function getStoredPlatform(): Platform {
-  try {
-    const v = localStorage.getItem(PLATFORM_STORAGE);
-    if (v && PLATFORMS.includes(v as Platform)) return v as Platform;
-  } catch {
-    /* ignore */
-  }
-  return "claude-code";
 }
 
 function getApiKey(): string {
@@ -114,20 +69,11 @@ export default function AdminSettings() {
   const { session } = useSession();
   const navigate = useNavigate();
   const [apiKey] = useState<string>(getApiKey);
-  const [platform, setPlatform] = useState<Platform>(getStoredPlatform);
-
-  const [connection, setConnection] = useState<ConnectionStatus | null>(null);
-  const [loadingConnection, setLoadingConnection] = useState(true);
 
   const [autoload, setAutoload] = useState(false);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [autoloadSaving, setAutoloadSaving] = useState(false);
-
-  const [businessContext, setBusinessContext] = useState<BusinessContextEntry[]>([]);
-  const [previewOpen, setPreviewOpen] = useState(false);
-  const [serverConfig, setServerConfig] = useState<GeneratedConfigResponse | null>(null);
-  const [generating, setGenerating] = useState(false);
 
   const [howToCheckOpen, setHowToCheckOpen] = useState(false);
   const [bugReports, setBugReports] = useState<BugReport[]>([]);
@@ -158,14 +104,6 @@ export default function AdminSettings() {
   const [unenrolling, setUnenrolling]           = useState(false);
 
   useEffect(() => {
-    try {
-      localStorage.setItem(PLATFORM_STORAGE, platform);
-    } catch {
-      /* ignore */
-    }
-  }, [platform]);
-
-  useEffect(() => {
     (async () => {
       const { data } = await supabase.auth.mfa.listFactors();
       const verified = data?.totp?.find((f) => f.status === "verified");
@@ -176,24 +114,22 @@ export default function AdminSettings() {
 
   useEffect(() => {
     const effectiveToken = apiKey || session?.access_token || "";
-    if (!effectiveToken) {
-      setLoadingConnection(false);
-      setSettingsLoaded(true);
-      return;
-    }
     let cancelled = false;
+    if (!effectiveToken) {
+      Promise.resolve().then(() => {
+        if (!cancelled) setSettingsLoaded(true);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
     (async () => {
       const authHeader = { Authorization: `Bearer ${effectiveToken}` };
       try {
-        const [connRes, settingsRes, bcRes, bugsRes] = await Promise.all([
-          fetch("/api/memory-admin?action=admin_check_connection", { headers: authHeader }),
+        const [settingsRes, bugsRes] = await Promise.all([
           fetch("/api/memory-admin?action=tenant_settings_get", { headers: authHeader }),
-          fetch("/api/memory-admin?action=business_context"),
           fetch("/api/memory-admin?action=admin_bug_reports&limit=5", { headers: authHeader }),
         ]);
-        if (!cancelled && connRes.ok) {
-          setConnection((await connRes.json()) as ConnectionStatus);
-        }
         if (!cancelled) {
           if (settingsRes.ok) {
             const body = (await settingsRes.json()) as { data?: Record<string, unknown> };
@@ -204,10 +140,6 @@ export default function AdminSettings() {
             setSettingsError(body.error ?? `Settings request failed (${settingsRes.status})`);
           }
           setSettingsLoaded(true);
-        }
-        if (!cancelled && bcRes.ok) {
-          const body = (await bcRes.json()) as { data: BusinessContextEntry[] };
-          setBusinessContext(body.data ?? []);
         }
         if (!cancelled) {
           if (bugsRes.ok) {
@@ -224,8 +156,6 @@ export default function AdminSettings() {
           setSettingsError((err as Error).message);
           setSettingsLoaded(true);
         }
-      } finally {
-        if (!cancelled) setLoadingConnection(false);
       }
     })();
     return () => {
@@ -274,62 +204,6 @@ export default function AdminSettings() {
     } finally {
       setAutoloadSaving(false);
     }
-  };
-
-  const previewLocal = generateConfig(platform, businessContext);
-
-  const regenerateFromServer = async () => {
-    if (!apiKey) return;
-    setGenerating(true);
-    try {
-      const res = await fetch(
-        `/api/memory-admin?action=admin_generate_config&platform=${platform}`,
-        { headers: { Authorization: `Bearer ${apiKey}` } }
-      );
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? "Generation failed");
-      }
-      setServerConfig((await res.json()) as GeneratedConfigResponse);
-    } catch (err) {
-      toast({
-        title: "Could not generate config",
-        description: (err as Error).message,
-        variant: "destructive",
-      });
-    } finally {
-      setGenerating(false);
-    }
-  };
-
-  const handlePreview = async () => {
-    setPreviewOpen(true);
-    if (apiKey) await regenerateFromServer();
-  };
-
-  const activeConfig = serverConfig
-    ? { content: serverConfig.content, filename: serverConfig.filename }
-    : { content: previewLocal.content, filename: previewLocal.filename };
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(activeConfig.content);
-      toast({ title: "Copied", description: `${activeConfig.filename} copied to clipboard.` });
-    } catch {
-      toast({ title: "Copy failed", variant: "destructive" });
-    }
-  };
-
-  const handleDownload = () => {
-    const blob = new Blob([activeConfig.content], { type: "text/markdown" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = activeConfig.filename.split("/").pop() ?? "config.md";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
   };
 
   const handleClearMemory = () => {
@@ -460,156 +334,13 @@ export default function AdminSettings() {
         </div>
         <div>
           <h1 className="text-2xl font-semibold tracking-tight text-white">Settings</h1>
-          <p className="text-sm text-white/50">Manage how UnClick connects to your AI tool.</p>
+          <p className="text-sm text-white/50">
+            Manage memory loading, account safety, and support.
+          </p>
         </div>
       </div>
 
       <div className="space-y-6">
-        {/* CONNECTION */}
-        <section className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
-          <h2 className="text-sm font-semibold text-white">Connection</h2>
-          <p className="mt-1 text-xs text-white/60">
-            Pick which AI tool you use. Setup steps and config-file format follow your choice.
-          </p>
-
-          <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
-            {PLATFORMS.map((p) => (
-              <button
-                key={p}
-                type="button"
-                onClick={() => setPlatform(p)}
-                className={`rounded-md border px-3 py-2 text-sm transition-colors ${
-                  platform === p
-                    ? "border-[#61C1C4] bg-[#61C1C4]/10 text-white"
-                    : "border-white/[0.08] bg-white/[0.02] text-white/70 hover:border-[#61C1C4]/40 hover:text-white"
-                }`}
-              >
-                {platformLabel(p)}
-              </button>
-            ))}
-          </div>
-
-          <div className="mt-5 grid gap-3 sm:grid-cols-2">
-            <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4 text-xs">
-              <p className="text-[11px] uppercase tracking-wider text-white/40">Status</p>
-              <p className="mt-1 flex items-center gap-1.5 text-sm font-medium text-white">
-                {loadingConnection ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 animate-spin text-white/40" />
-                    Checking...
-                  </>
-                ) : connection?.connected ? (
-                  <>
-                    <CheckCircle2 className="h-3.5 w-3.5 text-[#61C1C4]" />
-                    Connected
-                  </>
-                ) : (
-                  <>
-                    <XCircle className="h-3.5 w-3.5 text-[#E2B93B]" />
-                    Not connected
-                  </>
-                )}
-              </p>
-              {connection?.last_seen && (
-                <p className="mt-1 text-[11px] text-white/40">
-                  Last seen {formatRelative(connection.last_seen)}
-                </p>
-              )}
-            </div>
-            <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4 text-xs">
-              <p className="text-[11px] uppercase tracking-wider text-white/40">Server</p>
-              <code className="mt-1 block truncate font-mono text-[11px] text-white">
-                {SERVER_URL}
-              </code>
-            </div>
-          </div>
-
-          <div className="mt-4">
-            <Link
-              to="/memory/connect"
-              className="inline-flex items-center gap-1.5 text-xs font-medium text-[#61C1C4] hover:underline"
-            >
-              View setup steps for {platformLabel(platform)}
-            </Link>
-          </div>
-        </section>
-
-        {/* AI CONFIG */}
-        <section className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
-          <h2 className="text-sm font-semibold text-white">Your AI Config</h2>
-          <p className="mt-1 text-xs text-white/60">
-            {platformHasConfigFile(platform)
-              ? "UnClick can generate a config file for your AI tool so it knows who you are from the first message."
-              : `${platformLabel(platform)} loads your identity automatically via UnClick. No config file needed.`}
-          </p>
-
-          {platformHasConfigFile(platform) ? (
-            <>
-              <div className="mt-4 space-y-3 text-xs">
-                <div className="flex flex-wrap items-center gap-2">
-                  <FileText className="h-4 w-4 text-white/40" />
-                  <span className="text-white/50">Config file type:</span>
-                  <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[11px] text-[#61C1C4]">
-                    {platformFilename(platform)}
-                  </code>
-                  <span className="text-white/40">(auto-selected from your platform choice)</span>
-                </div>
-                {serverConfig && (
-                  <p className="text-white/40">
-                    Last generated {formatRelative(serverConfig.generated_at)} for{" "}
-                    {platformLabel(platform)}.
-                  </p>
-                )}
-              </div>
-
-              <div className="mt-4 flex flex-wrap gap-2">
-                <Button variant="outline" size="sm" onClick={handlePreview}>
-                  {previewOpen ? "Refresh preview" : "Preview"}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={regenerateFromServer}
-                  disabled={generating || !apiKey}
-                >
-                  <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${generating ? "animate-spin" : ""}`} />
-                  Regenerate
-                </Button>
-                <Button variant="outline" size="sm" onClick={handleCopy}>
-                  <Copy className="mr-1.5 h-3.5 w-3.5" />
-                  Copy
-                </Button>
-                <Button variant="outline" size="sm" onClick={handleDownload}>
-                  <Download className="mr-1.5 h-3.5 w-3.5" />
-                  Download
-                </Button>
-              </div>
-
-              {previewOpen && (
-                <div className="mt-4 rounded-md border border-white/[0.06] bg-black/40">
-                  <div className="border-b border-white/[0.06] px-3 py-2 font-mono text-[11px] text-white/40">
-                    {activeConfig.filename}
-                  </div>
-                  <pre className="max-h-[420px] overflow-auto p-3 font-mono text-[11px] leading-relaxed text-white/90">
-                    {activeConfig.content}
-                  </pre>
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="mt-4 rounded-md border border-white/[0.06] bg-white/[0.02] p-4 text-xs text-white/70">
-              <p>
-                Once the UnClick MCP server is added in {platformLabel(platform)}'s settings, your
-                identity, facts, and session history are pulled in automatically at the start of
-                every conversation. Nothing to install, nothing to paste.
-              </p>
-              <p className="mt-2 text-white/40">
-                See setup steps via "View setup steps for {platformLabel(platform)}" above.
-              </p>
-            </div>
-          )}
-        </section>
-
         {/* MEMORY LOADING */}
         <section className="rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
           <h2 className="text-sm font-semibold text-white">Memory Loading</h2>


### PR DESCRIPTION
## Summary
- Adds `AdminSeatsSubscription.tsx` with platform selection, UnClick connection refresh, setup steps, subscription plan guidance, and config preview, copy, download, and server regeneration through the existing config generator.
- Removes the migrated Connection and AI Config sections from `AdminSettings.tsx`, leaving memory loading, isolation, MFA, danger zone, and support.

## Acceptance criteria
- [x] Platform management functions moved to the Subscription page.
- [x] Connection status uses the existing `admin_check_connection` action.
- [x] Config preview, copy, download, and regeneration reuse `configGenerator.ts` and the existing memory admin endpoint.
- [x] Settings no longer shows the migrated Connection or AI Config sections.
- [x] Economics guidance explains interactive subscription use, API use, local use, and the required warning: Background automation is metered separately from your subscription.
- [x] Setup wizard steps are included for Claude Code, Cursor, Windsurf, Copilot, and ChatGPT.

## Dependencies
- Depends on WP-1 for the `/admin/agents/subscription` route and sidebar scaffold.
- WP-1 is not merged into `main` yet, so this branch is built against `main` and only adds the page plus the Settings migration.

## Validation
- `npx eslint src/pages/admin/AdminSeatsSubscription.tsx src/pages/admin/AdminSettings.tsx`
- `npm run build:dev`
- `npx tsc -p tsconfig.app.json --noEmit` was attempted, but the repo currently has unrelated pre-existing type errors in files such as `src/components/ArenaNav.tsx`, `src/components/ui/chart.tsx`, `src/pages/admin/AdminBrainmap.tsx`, and `src/pages/admin/AdminShell.tsx`.

## MCP package proof
- Not run. This WP does not touch `packages/mcp-server/**`.