### PR TITLE
Seats Compute Layer: WP-7 - Local machine spec recommendations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import AdminActivity from "./pages/admin/AdminActivity.tsx";
 import AdminSettings from "./pages/admin/AdminSettings.tsx";
 import AdminAgentsPage from "./pages/admin/AdminAgents.tsx";
 import AdminSeatHeartbeatPage from "./pages/admin/AdminSeatHeartbeat.tsx";
+import AdminSeatsLocal from "./pages/admin/AdminSeatsLocal.tsx";
 import AdminAnalytics from "./pages/admin/AdminAnalytics.tsx";
 import AdminCodebase from "./pages/admin/AdminCodebase.tsx";
 import AdminOrchestratorPage from "./pages/admin/AdminOrchestrator.tsx";
@@ -201,6 +202,7 @@ const App = () => (
             <Route path="autopilot" element={<AdminAutopilot />} />
             <Route path="autopilot/expressbuild" element={<AdminExpressBuild />} />
             <Route path="agents"     element={<AdminAgentsPage />} />
+            <Route path="agents/local" element={<AdminSeatsLocal />} />
             <Route path="agents/heartbeat" element={<AdminSeatHeartbeatPage />} />
             <Route path="workers" element={<AdminWorkers />} />
             <Route path="jobs" element={<AdminJobs />} />

--- a/src/lib/localComputeRecommendations.test.ts
+++ b/src/lib/localComputeRecommendations.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyVramTier,
+  describeModelFit,
+  modelById,
+  rankModelsForHardware,
+  recommendModelsByTask,
+  type LocalHardwareProfile,
+} from "./localComputeRecommendations";
+
+const baseHardware: LocalHardwareProfile = {
+  ramGb: 32,
+  cpuCores: 12,
+  gpuName: "RTX 4070",
+  gpuVendor: "NVIDIA",
+  vramGb: 12,
+  webGpuSupported: true,
+};
+
+describe("local compute recommendations", () => {
+  it("classifies the expected VRAM tiers", () => {
+    expect(classifyVramTier(4)?.label).toBe("4GB tier");
+    expect(classifyVramTier(8)?.label).toBe("8GB tier");
+    expect(classifyVramTier(12)?.label).toBe("12GB tier");
+    expect(classifyVramTier(16)?.label).toBe("16GB tier");
+    expect(classifyVramTier(24)?.label).toBe("24GB+ tier");
+  });
+
+  it("flags models that do not fit the detected GPU", () => {
+    const fit = describeModelFit(modelById("llama-3.1-70b-q4"), baseHardware);
+
+    expect(fit.status).toBe("blocked");
+    expect(fit.reason).toContain("Needs ~40GB VRAM");
+    expect(fit.reason).toContain("you have 12GB");
+  });
+
+  it("keeps CPU-friendly embedding models viable without GPU VRAM", () => {
+    const recommendations = recommendModelsByTask({
+      ...baseHardware,
+      gpuName: null,
+      gpuVendor: null,
+      vramGb: null,
+      webGpuSupported: false,
+    });
+
+    expect(recommendations.embeddings.model.id).toBe("bge-m3");
+    expect(recommendations.embeddings.fit.status).toBe("fits");
+  });
+
+  it("recommends compact code models for 8GB VRAM", () => {
+    const ranked = rankModelsForHardware({ ...baseHardware, vramGb: 8 }, "code");
+
+    expect(ranked[0].model.id).toBe("qwen-2.5-coder-7b-q4");
+    expect(ranked[0].fit.status).toBe("fits");
+    expect(ranked.some((entry) => entry.model.id === "codestral-22b-q4" && entry.fit.status === "blocked")).toBe(true);
+  });
+});

--- a/src/lib/localComputeRecommendations.ts
+++ b/src/lib/localComputeRecommendations.ts
@@ -1,0 +1,415 @@
+export type LocalComputeTask = "chat" | "code" | "embeddings" | "ocr";
+
+export interface LocalHardwareProfile {
+  ramGb: number | null;
+  cpuCores: number | null;
+  gpuName: string | null;
+  gpuVendor: string | null;
+  vramGb: number | null;
+  webGpuSupported: boolean;
+}
+
+export interface LocalModelCatalogEntry {
+  id: string;
+  label: string;
+  family: string;
+  parameterSize: string;
+  quantization: string;
+  tasks: LocalComputeTask[];
+  minRamGb: number;
+  minVramGb: number;
+  recommendedVramGb: number;
+  qualityScore: number;
+  localPrivacyScore: number;
+  cpuFriendly: boolean;
+  speedByVram: Record<number, string>;
+  notes: string;
+}
+
+export interface ModelFitResult {
+  status: "fits" | "borderline" | "blocked" | "unknown";
+  label: string;
+  reason: string;
+}
+
+export interface ModelRecommendation {
+  task: LocalComputeTask;
+  model: LocalModelCatalogEntry;
+  fit: ModelFitResult;
+  estimatedSpeed: string;
+}
+
+export const LOCAL_COMPUTE_TASK_LABELS: Record<LocalComputeTask, string> = {
+  chat: "Chat",
+  code: "Code",
+  embeddings: "Embeddings",
+  ocr: "OCR",
+};
+
+export const VRAM_TIERS = [
+  {
+    minGb: 0,
+    maxGb: 3.9,
+    label: "CPU or tiny GPU",
+    guidance: "Use embeddings, OCR helpers, and tiny 1B-3B quantized chat models.",
+  },
+  {
+    minGb: 4,
+    maxGb: 7.9,
+    label: "4GB tier",
+    guidance: "3B-7B quantized models only. Keep context windows modest.",
+  },
+  {
+    minGb: 8,
+    maxGb: 11.9,
+    label: "8GB tier",
+    guidance: "7B-8B models comfortably, with some 13B quantized models at smaller context.",
+  },
+  {
+    minGb: 12,
+    maxGb: 15.9,
+    label: "12GB tier",
+    guidance: "13B models are reasonable. Some 30B-class quantized models may fit with care.",
+  },
+  {
+    minGb: 16,
+    maxGb: 23.9,
+    label: "16GB tier",
+    guidance: "30B-class quantized models are practical. 70B is possible only with heavy quantization.",
+  },
+  {
+    minGb: 24,
+    maxGb: Number.POSITIVE_INFINITY,
+    label: "24GB+ tier",
+    guidance: "70B-class quantized models become realistic for local chat and reasoning.",
+  },
+] as const;
+
+export const LOCAL_MODEL_CATALOG: LocalModelCatalogEntry[] = [
+  {
+    id: "llama-3.2-3b-q4",
+    label: "Llama 3.2 3B Q4",
+    family: "Llama",
+    parameterSize: "3B",
+    quantization: "Q4",
+    tasks: ["chat"],
+    minRamGb: 8,
+    minVramGb: 0,
+    recommendedVramGb: 4,
+    qualityScore: 58,
+    localPrivacyScore: 95,
+    cpuFriendly: true,
+    speedByVram: { 0: "8-14 tok/s CPU", 4: "28-45 tok/s", 8: "45-70 tok/s" },
+    notes: "Best tiny fallback when no GPU VRAM is available.",
+  },
+  {
+    id: "llama-3.1-8b-q4",
+    label: "Llama 3.1 8B Q4",
+    family: "Llama",
+    parameterSize: "8B",
+    quantization: "Q4",
+    tasks: ["chat"],
+    minRamGb: 16,
+    minVramGb: 5,
+    recommendedVramGb: 8,
+    qualityScore: 78,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 4: "8-14 tok/s partial GPU", 8: "24-40 tok/s", 12: "34-55 tok/s", 16: "45-70 tok/s" },
+    notes: "Default local chat choice for 8GB+ GPUs.",
+  },
+  {
+    id: "qwen-2.5-7b-instruct-q4",
+    label: "Qwen 2.5 7B Instruct Q4",
+    family: "Qwen",
+    parameterSize: "7B",
+    quantization: "Q4",
+    tasks: ["chat", "code"],
+    minRamGb: 16,
+    minVramGb: 5,
+    recommendedVramGb: 8,
+    qualityScore: 81,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 4: "8-13 tok/s partial GPU", 8: "24-38 tok/s", 12: "34-52 tok/s", 16: "44-66 tok/s" },
+    notes: "Strong general model that also handles coding tasks.",
+  },
+  {
+    id: "qwen-2.5-coder-7b-q4",
+    label: "Qwen 2.5 Coder 7B Q4",
+    family: "Qwen Coder",
+    parameterSize: "7B",
+    quantization: "Q4",
+    tasks: ["code"],
+    minRamGb: 16,
+    minVramGb: 5,
+    recommendedVramGb: 8,
+    qualityScore: 86,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 4: "7-12 tok/s partial GPU", 8: "22-36 tok/s", 12: "32-50 tok/s", 16: "40-62 tok/s" },
+    notes: "Best compact coding default for laptops and small desktops.",
+  },
+  {
+    id: "deepseek-coder-v2-lite-q4",
+    label: "DeepSeek Coder V2 Lite Q4",
+    family: "DeepSeek Coder",
+    parameterSize: "16B MoE",
+    quantization: "Q4",
+    tasks: ["code"],
+    minRamGb: 24,
+    minVramGb: 10,
+    recommendedVramGb: 12,
+    qualityScore: 90,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 12: "16-28 tok/s", 16: "24-38 tok/s", 24: "34-52 tok/s" },
+    notes: "Higher quality code model for 12GB+ GPUs.",
+  },
+  {
+    id: "codestral-22b-q4",
+    label: "Codestral 22B Q4",
+    family: "Codestral",
+    parameterSize: "22B",
+    quantization: "Q4",
+    tasks: ["code"],
+    minRamGb: 32,
+    minVramGb: 14,
+    recommendedVramGb: 16,
+    qualityScore: 92,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 16: "12-24 tok/s", 24: "22-36 tok/s" },
+    notes: "Excellent code choice when a 16GB+ GPU is available.",
+  },
+  {
+    id: "mistral-small-24b-q4",
+    label: "Mistral Small 24B Q4",
+    family: "Mistral",
+    parameterSize: "24B",
+    quantization: "Q4",
+    tasks: ["chat"],
+    minRamGb: 32,
+    minVramGb: 14,
+    recommendedVramGb: 16,
+    qualityScore: 89,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 16: "12-22 tok/s", 24: "20-34 tok/s" },
+    notes: "Quality local chat for 16GB cards.",
+  },
+  {
+    id: "llama-3.1-70b-q4",
+    label: "Llama 3.1 70B Q4",
+    family: "Llama",
+    parameterSize: "70B",
+    quantization: "Q4",
+    tasks: ["chat"],
+    minRamGb: 64,
+    minVramGb: 40,
+    recommendedVramGb: 48,
+    qualityScore: 96,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 24: "2-5 tok/s split/offload", 48: "8-16 tok/s" },
+    notes: "Only sensible on large GPUs or multi-GPU rigs.",
+  },
+  {
+    id: "nomic-embed-text",
+    label: "Nomic Embed Text",
+    family: "Nomic",
+    parameterSize: "137M",
+    quantization: "FP16/Q8",
+    tasks: ["embeddings"],
+    minRamGb: 4,
+    minVramGb: 0,
+    recommendedVramGb: 0,
+    qualityScore: 82,
+    localPrivacyScore: 98,
+    cpuFriendly: true,
+    speedByVram: { 0: "250-700 docs/min CPU", 4: "900+ docs/min" },
+    notes: "Default local embedding choice for privacy-first RAG.",
+  },
+  {
+    id: "bge-m3",
+    label: "BGE-M3",
+    family: "BGE",
+    parameterSize: "568M",
+    quantization: "FP16/Q8",
+    tasks: ["embeddings"],
+    minRamGb: 8,
+    minVramGb: 0,
+    recommendedVramGb: 4,
+    qualityScore: 90,
+    localPrivacyScore: 98,
+    cpuFriendly: true,
+    speedByVram: { 0: "90-260 docs/min CPU", 4: "500+ docs/min", 8: "850+ docs/min" },
+    notes: "High quality multilingual embeddings and retrieval.",
+  },
+  {
+    id: "paddleocr-vl-0.9b",
+    label: "PaddleOCR-VL 0.9B",
+    family: "PaddleOCR",
+    parameterSize: "0.9B",
+    quantization: "FP16/Q8",
+    tasks: ["ocr"],
+    minRamGb: 8,
+    minVramGb: 0,
+    recommendedVramGb: 4,
+    qualityScore: 84,
+    localPrivacyScore: 98,
+    cpuFriendly: true,
+    speedByVram: { 0: "2-6 pages/min CPU", 4: "10-24 pages/min", 8: "20-38 pages/min" },
+    notes: "Document OCR and layout extraction for local ingestion.",
+  },
+  {
+    id: "llava-7b-q4",
+    label: "LLaVA 7B Q4",
+    family: "LLaVA",
+    parameterSize: "7B",
+    quantization: "Q4",
+    tasks: ["ocr"],
+    minRamGb: 16,
+    minVramGb: 6,
+    recommendedVramGb: 8,
+    qualityScore: 76,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 8: "4-9 images/min", 12: "8-15 images/min", 16: "12-22 images/min" },
+    notes: "Useful for visual question answering, not a dedicated OCR engine.",
+  },
+  {
+    id: "minicpm-v-8b-q4",
+    label: "MiniCPM-V 8B Q4",
+    family: "MiniCPM-V",
+    parameterSize: "8B",
+    quantization: "Q4",
+    tasks: ["ocr"],
+    minRamGb: 16,
+    minVramGb: 7,
+    recommendedVramGb: 8,
+    qualityScore: 82,
+    localPrivacyScore: 95,
+    cpuFriendly: false,
+    speedByVram: { 8: "5-10 images/min", 12: "9-16 images/min", 16: "14-24 images/min" },
+    notes: "Compact vision model for OCR-like extraction and image understanding.",
+  },
+];
+
+export function coerceHardwareNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return null;
+  return Math.round(numeric * 10) / 10;
+}
+
+export function classifyVramTier(vramGb: number | null) {
+  if (vramGb === null) return null;
+  return VRAM_TIERS.find((tier) => vramGb >= tier.minGb && vramGb <= tier.maxGb) ?? VRAM_TIERS[0];
+}
+
+export function describeModelFit(
+  model: LocalModelCatalogEntry,
+  hardware: LocalHardwareProfile,
+): ModelFitResult {
+  const ramGb = coerceHardwareNumber(hardware.ramGb);
+  const vramGb = coerceHardwareNumber(hardware.vramGb);
+
+  if (vramGb !== null && vramGb < model.minVramGb) {
+    return {
+      status: "blocked",
+      label: "Won't fit",
+      reason: `Needs ~${model.minVramGb}GB VRAM, you have ${vramGb}GB.`,
+    };
+  }
+
+  if (ramGb !== null && ramGb < model.minRamGb) {
+    return {
+      status: "blocked",
+      label: "Needs more RAM",
+      reason: `Needs ${model.minRamGb}GB system RAM, detected ${ramGb}GB.`,
+    };
+  }
+
+  if (vramGb === null && (model.cpuFriendly || model.minVramGb === 0)) {
+    return {
+      status: "fits",
+      label: "CPU capable",
+      reason: model.recommendedVramGb > 0
+        ? `Runs without dedicated VRAM, but ${model.recommendedVramGb}GB VRAM is better.`
+        : "Runs locally without dedicated GPU VRAM.",
+    };
+  }
+
+  if (vramGb === null) {
+    return {
+      status: "unknown",
+      label: "Needs VRAM input",
+      reason: `Enter GPU VRAM to verify fit. Needs at least ${model.minVramGb}GB VRAM.`,
+    };
+  }
+
+  if (vramGb < model.recommendedVramGb) {
+    return {
+      status: "borderline",
+      label: "Tight fit",
+      reason: `Can run with quantization, but ${model.recommendedVramGb}GB VRAM is recommended.`,
+    };
+  }
+
+  return {
+    status: "fits",
+    label: "Fits",
+    reason: `Fits this ${classifyVramTier(vramGb)?.label ?? "GPU"} profile.`,
+  };
+}
+
+export function estimateModelSpeed(model: LocalModelCatalogEntry, vramGb: number | null): string {
+  const tiers = Object.keys(model.speedByVram)
+    .map(Number)
+    .sort((left, right) => left - right);
+  if (tiers.length === 0) return "Speed varies by runtime";
+
+  const effectiveVram = vramGb ?? 0;
+  const tier = [...tiers].reverse().find((candidate) => effectiveVram >= candidate) ?? tiers[0];
+  return model.speedByVram[tier] ?? "Speed varies by runtime";
+}
+
+export function rankModelsForHardware(
+  hardware: LocalHardwareProfile,
+  task?: LocalComputeTask,
+): ModelRecommendation[] {
+  const fitRank: Record<ModelFitResult["status"], number> = {
+    fits: 0,
+    borderline: 1,
+    unknown: 2,
+    blocked: 3,
+  };
+
+  return LOCAL_MODEL_CATALOG
+    .filter((model) => !task || model.tasks.includes(task))
+    .map((model) => ({
+      task: task ?? model.tasks[0],
+      model,
+      fit: describeModelFit(model, hardware),
+      estimatedSpeed: estimateModelSpeed(model, hardware.vramGb),
+    }))
+    .sort((left, right) => {
+      const fitDelta = fitRank[left.fit.status] - fitRank[right.fit.status];
+      if (fitDelta !== 0) return fitDelta;
+      return right.model.qualityScore - left.model.qualityScore;
+    });
+}
+
+export function recommendModelsByTask(hardware: LocalHardwareProfile): Record<LocalComputeTask, ModelRecommendation> {
+  return {
+    chat: rankModelsForHardware(hardware, "chat")[0],
+    code: rankModelsForHardware(hardware, "code")[0],
+    embeddings: rankModelsForHardware(hardware, "embeddings")[0],
+    ocr: rankModelsForHardware(hardware, "ocr")[0],
+  };
+}
+
+export function modelById(modelId: string): LocalModelCatalogEntry {
+  return LOCAL_MODEL_CATALOG.find((model) => model.id === modelId) ?? LOCAL_MODEL_CATALOG[0];
+}

--- a/src/pages/admin/AdminSeatsLocal.tsx
+++ b/src/pages/admin/AdminSeatsLocal.tsx
@@ -1,0 +1,545 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Brain,
+  CheckCircle2,
+  Code2,
+  Cpu,
+  Database,
+  Gauge,
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  ScanText,
+  Search,
+  Server,
+  SlidersHorizontal,
+  Zap,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  LOCAL_COMPUTE_TASK_LABELS,
+  LOCAL_MODEL_CATALOG,
+  classifyVramTier,
+  coerceHardwareNumber,
+  describeModelFit,
+  estimateModelSpeed,
+  modelById,
+  rankModelsForHardware,
+  recommendModelsByTask,
+  type LocalComputeTask,
+  type LocalHardwareProfile,
+  type ModelFitResult,
+  type ModelRecommendation,
+} from "@/lib/localComputeRecommendations";
+
+interface WebGpuAdapterInfo {
+  vendor?: string;
+  architecture?: string;
+  device?: string;
+  description?: string;
+}
+
+interface WebGpuAdapter {
+  requestAdapterInfo?: () => Promise<WebGpuAdapterInfo>;
+  info?: WebGpuAdapterInfo;
+}
+
+interface NavigatorWithLocalHardware extends Navigator {
+  deviceMemory?: number;
+  gpu?: {
+    requestAdapter: () => Promise<WebGpuAdapter | null>;
+  };
+}
+
+const EMPTY_HARDWARE: LocalHardwareProfile = {
+  ramGb: null,
+  cpuCores: null,
+  gpuName: null,
+  gpuVendor: null,
+  vramGb: null,
+  webGpuSupported: false,
+};
+
+const TASK_ICONS: Record<LocalComputeTask, typeof Brain> = {
+  chat: Brain,
+  code: Code2,
+  embeddings: Database,
+  ocr: ScanText,
+};
+
+const FIT_BADGE_CLASS: Record<ModelFitResult["status"], string> = {
+  fits: "border-emerald-400/30 bg-emerald-400/10 text-emerald-200",
+  borderline: "border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#E2B93B]",
+  blocked: "border-red-400/30 bg-red-400/10 text-red-200",
+  unknown: "border-white/[0.10] bg-white/[0.05] text-[#aaa]",
+};
+
+function formatGb(value: number | null): string {
+  return value === null ? "Unknown" : `${value}GB`;
+}
+
+function numberInputValue(value: string): number | null {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+}
+
+function joinGpuName(info: WebGpuAdapterInfo | null): string | null {
+  if (!info) return null;
+  const name = info.description?.trim();
+  if (name) return name;
+  const parts = [info.vendor, info.architecture, info.device]
+    .map((part) => part?.trim())
+    .filter(Boolean);
+  return parts.length ? parts.join(" ") : "WebGPU adapter detected";
+}
+
+function FitBadge({ fit }: { fit: ModelFitResult }) {
+  return (
+    <Badge variant="outline" className={FIT_BADGE_CLASS[fit.status]}>
+      {fit.label}
+    </Badge>
+  );
+}
+
+function SpecTile({
+  label,
+  value,
+  detail,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  icon: typeof Cpu;
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-medium uppercase text-[#777]">{label}</p>
+        <Icon className="h-4 w-4 text-[#61C1C4]" />
+      </div>
+      <p className="mt-3 text-xl font-semibold text-white">{value}</p>
+      <p className="mt-1 text-xs leading-5 text-[#777]">{detail}</p>
+    </div>
+  );
+}
+
+function TaskRecommendationCard({ recommendation }: { recommendation: ModelRecommendation }) {
+  const Icon = TASK_ICONS[recommendation.task];
+  const quality = Math.min(100, Math.max(0, recommendation.model.qualityScore));
+
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-black/20 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon className="h-4 w-4 shrink-0 text-[#61C1C4]" />
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase text-[#777]">
+              {LOCAL_COMPUTE_TASK_LABELS[recommendation.task]}
+            </p>
+            <p className="mt-1 truncate text-sm font-semibold text-white">{recommendation.model.label}</p>
+          </div>
+        </div>
+        <FitBadge fit={recommendation.fit} />
+      </div>
+      <div className="mt-4 grid gap-2 text-xs text-[#999]">
+        <div className="flex justify-between gap-3">
+          <span>Quality</span>
+          <span className="tabular-nums text-[#ddd]">{recommendation.model.qualityScore}/100</span>
+        </div>
+        <Progress value={quality} className="h-1.5 bg-white/[0.06]" />
+        <div className="flex justify-between gap-3">
+          <span>Estimated speed</span>
+          <span className="text-right text-[#ddd]">{recommendation.estimatedSpeed}</span>
+        </div>
+        <p className="leading-5 text-[#777]">{recommendation.fit.reason}</p>
+      </div>
+    </div>
+  );
+}
+
+function ModelRequirementPanel({
+  modelId,
+  hardware,
+}: {
+  modelId: string;
+  hardware: LocalHardwareProfile;
+}) {
+  const model = modelById(modelId);
+  const fit = describeModelFit(model, hardware);
+  const speed = estimateModelSpeed(model, hardware.vramGb);
+
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-black/20 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-white">{model.label}</p>
+          <p className="mt-1 text-xs text-[#777]">
+            {model.family} {model.parameterSize} {model.quantization}
+          </p>
+        </div>
+        <FitBadge fit={fit} />
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <div>
+          <p className="text-[11px] uppercase text-[#666]">Minimum</p>
+          <p className="mt-1 text-sm text-[#ddd]">{model.minRamGb}GB RAM, {model.minVramGb}GB VRAM</p>
+        </div>
+        <div>
+          <p className="text-[11px] uppercase text-[#666]">Recommended</p>
+          <p className="mt-1 text-sm text-[#ddd]">{model.recommendedVramGb}GB VRAM</p>
+        </div>
+        <div>
+          <p className="text-[11px] uppercase text-[#666]">Throughput</p>
+          <p className="mt-1 text-sm text-[#ddd]">{speed}</p>
+        </div>
+      </div>
+      <p className="mt-4 text-xs leading-5 text-[#777]">{fit.reason}</p>
+    </div>
+  );
+}
+
+function RankedModelRow({ recommendation }: { recommendation: ModelRecommendation }) {
+  return (
+    <div className="grid gap-2 rounded-lg border border-white/[0.06] bg-black/20 p-3 sm:grid-cols-[1fr_90px_150px] sm:items-center">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-white">{recommendation.model.label}</p>
+        <p className="mt-1 text-[11px] text-[#777]">
+          {recommendation.model.tasks.map((task) => LOCAL_COMPUTE_TASK_LABELS[task]).join(", ")}
+        </p>
+      </div>
+      <div className="text-sm tabular-nums text-[#ddd]">
+        {recommendation.model.qualityScore}/100
+      </div>
+      <div className="flex items-center justify-between gap-2 sm:justify-end">
+        <span className="text-xs text-[#777]">{recommendation.estimatedSpeed}</span>
+        <FitBadge fit={recommendation.fit} />
+      </div>
+    </div>
+  );
+}
+
+function useMachineSpecs() {
+  const [hardware, setHardware] = useState<LocalHardwareProfile>(EMPTY_HARDWARE);
+  const [detecting, setDetecting] = useState(false);
+  const [error, setError] = useState("");
+
+  const detect = useCallback(async () => {
+    if (typeof navigator === "undefined") return;
+
+    setDetecting(true);
+    setError("");
+    const nav = navigator as NavigatorWithLocalHardware;
+    let gpuInfo: WebGpuAdapterInfo | null = null;
+    let webGpuSupported = false;
+
+    try {
+      if (nav.gpu?.requestAdapter) {
+        const adapter = await nav.gpu.requestAdapter();
+        webGpuSupported = Boolean(adapter);
+        if (adapter?.requestAdapterInfo) {
+          gpuInfo = await adapter.requestAdapterInfo();
+        } else {
+          gpuInfo = adapter?.info ?? null;
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "WebGPU detection failed");
+    } finally {
+      setHardware({
+        ramGb: coerceHardwareNumber(nav.deviceMemory),
+        cpuCores: coerceHardwareNumber(nav.hardwareConcurrency),
+        gpuName: joinGpuName(gpuInfo),
+        gpuVendor: gpuInfo?.vendor ?? null,
+        vramGb: null,
+        webGpuSupported,
+      });
+      setDetecting(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void detect();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [detect]);
+
+  return { hardware, detecting, error, detect };
+}
+
+export default function AdminSeatsLocal() {
+  const { hardware, detecting, error, detect } = useMachineSpecs();
+  const [manualVram, setManualVram] = useState("");
+  const [calculatorVram, setCalculatorVram] = useState("12");
+  const [selectedModelId, setSelectedModelId] = useState(LOCAL_MODEL_CATALOG[0].id);
+  const [taskFilter, setTaskFilter] = useState<LocalComputeTask>("chat");
+
+  const effectiveVram = numberInputValue(manualVram);
+  const calculatorVramGb = numberInputValue(calculatorVram);
+
+  const effectiveHardware = useMemo<LocalHardwareProfile>(() => ({
+    ...hardware,
+    vramGb: effectiveVram,
+  }), [effectiveVram, hardware]);
+
+  const calculatorHardware = useMemo<LocalHardwareProfile>(() => ({
+    ...hardware,
+    vramGb: calculatorVramGb,
+  }), [calculatorVramGb, hardware]);
+
+  const recommendations = useMemo(() => recommendModelsByTask(effectiveHardware), [effectiveHardware]);
+  const vramTier = classifyVramTier(effectiveHardware.vramGb);
+  const rankedForTask = useMemo(
+    () => rankModelsForHardware(calculatorHardware, taskFilter).slice(0, 6),
+    [calculatorHardware, taskFilter],
+  );
+  const blockedModels = useMemo(
+    () => rankModelsForHardware(effectiveHardware)
+      .filter((entry) => entry.fit.status === "blocked")
+      .slice(0, 4),
+    [effectiveHardware],
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-heading">Local compute</h1>
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-body">
+            Hardware estimates and model fit guidance for running UnClick locally.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => void detect()}
+          disabled={detecting}
+          className="border-white/[0.08] bg-white/[0.04] text-[#ddd] hover:bg-white/[0.08] hover:text-white"
+        >
+          {detecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          Refresh specs
+        </Button>
+      </header>
+
+      <Card className="border-white/[0.06] bg-white/[0.03]">
+        <CardHeader className="p-4 pb-2">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <CardTitle className="text-base text-white">Detected machine spec</CardTitle>
+              <p className="mt-1 text-xs leading-5 text-[#777]">
+                Browser APIs are estimates. Treat RAM, CPU, GPU, and VRAM as planning signals.
+              </p>
+            </div>
+            <Badge variant="outline" className="border-[#E2B93B]/30 bg-[#E2B93B]/10 text-[#E2B93B]">
+              Estimate
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4 p-4 pt-2">
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg border border-[#E2B93B]/20 bg-[#E2B93B]/10 p-3 text-sm text-[#E2B93B]">
+              <AlertTriangle className="mt-0.5 h-4 w-4" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <div className="grid gap-3 md:grid-cols-4">
+            <SpecTile
+              label="RAM"
+              value={formatGb(hardware.ramGb)}
+              detail="From navigator.deviceMemory when available."
+              icon={HardDrive}
+            />
+            <SpecTile
+              label="CPU"
+              value={hardware.cpuCores === null ? "Unknown" : `${hardware.cpuCores} cores`}
+              detail="From navigator.hardwareConcurrency."
+              icon={Cpu}
+            />
+            <SpecTile
+              label="GPU"
+              value={hardware.gpuName ?? "Unknown"}
+              detail={hardware.webGpuSupported ? "WebGPU adapter detected." : "WebGPU unavailable or blocked."}
+              icon={Server}
+            />
+            <div className="rounded-lg border border-white/[0.06] bg-white/[0.03] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <Label htmlFor="manual-vram" className="text-xs font-medium uppercase text-[#777]">
+                  GPU VRAM
+                </Label>
+                <Gauge className="h-4 w-4 text-[#61C1C4]" />
+              </div>
+              <Input
+                id="manual-vram"
+                inputMode="decimal"
+                value={manualVram}
+                onChange={(event) => setManualVram(event.target.value)}
+                placeholder="Enter GB"
+                className="mt-3 h-9 border-white/[0.08] bg-black/30 text-white placeholder:text-[#555]"
+              />
+              <p className="mt-2 text-xs leading-5 text-[#777]">
+                Browsers do not expose exact VRAM, so enter your card size for precise fit checks.
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-white/[0.06] bg-black/20 p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              {vramTier ? (
+                <>
+                  <CheckCircle2 className="h-4 w-4 text-emerald-300" />
+                  <span className="text-sm font-medium text-white">{vramTier.label}</span>
+                  <span className="text-sm text-[#777]">{vramTier.guidance}</span>
+                </>
+              ) : (
+                <>
+                  <Search className="h-4 w-4 text-[#E2B93B]" />
+                  <span className="text-sm font-medium text-white">Enter GPU VRAM to classify the local tier.</span>
+                  <span className="text-sm text-[#777]">CPU-friendly embedding and OCR options are still shown.</span>
+                </>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Smart recommendations</h2>
+            <p className="mt-1 text-xs text-[#777]">Best local model by task for the detected and entered hardware.</p>
+          </div>
+          <Badge variant="outline" className="border-white/[0.08] bg-white/[0.04] text-[#aaa]">
+            Data driven catalog
+          </Badge>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {(["chat", "code", "embeddings", "ocr"] as LocalComputeTask[]).map((task) => (
+            <TaskRecommendationCard key={task} recommendation={recommendations[task]} />
+          ))}
+        </div>
+      </section>
+
+      <Card className="border-white/[0.06] bg-white/[0.03]">
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <AlertTriangle className="h-4 w-4 text-[#E2B93B]" />
+            Fit warnings
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-4 pt-2">
+          {blockedModels.length === 0 ? (
+            <p className="text-sm text-[#777]">No blocked high-interest models for the current hardware input.</p>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2">
+              {blockedModels.map((entry) => (
+                <div key={entry.model.id} className="rounded-lg border border-red-400/20 bg-red-400/10 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{entry.model.label}</p>
+                      <p className="mt-1 text-xs text-red-100">{entry.fit.reason}</p>
+                    </div>
+                    <FitBadge fit={entry.fit} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/[0.06] bg-white/[0.03]">
+        <CardHeader className="p-4 pb-2">
+          <CardTitle className="flex items-center gap-2 text-base text-white">
+            <SlidersHorizontal className="h-4 w-4 text-[#61C1C4]" />
+            Cooking calculator
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 p-4 pt-2">
+          <div className="grid gap-4 lg:grid-cols-[1fr_220px]">
+            <div className="space-y-2">
+              <Label htmlFor="model-select" className="text-xs uppercase text-[#777]">Model</Label>
+              <Select value={selectedModelId} onValueChange={setSelectedModelId}>
+                <SelectTrigger id="model-select" className="border-white/[0.08] bg-black/30 text-white">
+                  <SelectValue placeholder="Choose a model" />
+                </SelectTrigger>
+                <SelectContent>
+                  {LOCAL_MODEL_CATALOG.map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      {model.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="calculator-vram" className="text-xs uppercase text-[#777]">GPU VRAM</Label>
+              <Input
+                id="calculator-vram"
+                inputMode="decimal"
+                value={calculatorVram}
+                onChange={(event) => setCalculatorVram(event.target.value)}
+                className="border-white/[0.08] bg-black/30 text-white"
+              />
+            </div>
+          </div>
+
+          <ModelRequirementPanel modelId={selectedModelId} hardware={calculatorHardware} />
+
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-white">Best models for entered VRAM</p>
+                <p className="mt-1 text-xs text-[#777]">Sorted by fit first, then quality score.</p>
+              </div>
+              <Select value={taskFilter} onValueChange={(value) => setTaskFilter(value as LocalComputeTask)}>
+                <SelectTrigger className="w-[180px] border-white/[0.08] bg-black/30 text-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(["chat", "code", "embeddings", "ocr"] as LocalComputeTask[]).map((task) => (
+                    <SelectItem key={task} value={task}>
+                      {LOCAL_COMPUTE_TASK_LABELS[task]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid gap-2">
+              {rankedForTask.map((recommendation) => (
+                <RankedModelRow key={recommendation.model.id} recommendation={recommendation} />
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="rounded-lg border border-[#61C1C4]/20 bg-[#61C1C4]/10 p-4">
+        <div className="flex items-start gap-3">
+          <Zap className="mt-0.5 h-4 w-4 text-[#61C1C4]" />
+          <p className="text-sm leading-6 text-[#bdecee]">
+            Use local first for embeddings and OCR when privacy matters. Escalate large reasoning or vision work to API or subscription tiers when the model fit is blocked.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds WP-7 local machine spec detection and smart recommendations for the Seats Local page:

- Adds `AdminSeatsLocal.tsx` with detected hardware cards, manual VRAM input, per-task recommendations, fit warnings, and a two-way Cooking Calculator.
- Adds a data-driven local model catalog and recommendation engine in `localComputeRecommendations.ts`.
- Adds focused tests for VRAM tiers, blocked model warnings, CPU-friendly embedding recommendations, and 8GB code model ranking.
- Adds a minimal `/admin/agents/local` route so this branch can be tested directly while WP-1/WP-6 are still unmerged.

## Acceptance criteria

- Page shows detected hardware specs using browser APIs: `navigator.deviceMemory`, `navigator.hardwareConcurrency`, and WebGPU adapter detection where available.
- Hardware values are clearly treated as estimates, with manual VRAM input for accurate fit checks.
- Page recommends models for chat, code, embeddings, and OCR based on the detected or entered hardware.
- Models that do not fit are flagged with reasons such as `Needs ~40GB VRAM, you have 12GB.`
- Cooking Calculator works both directions: model to hardware requirements and entered VRAM to ranked model list.

## Dependencies

- WP-7 depends on WP-6. WP-6 is not merged, so this was built against current `main` per the brief.
- WP-1 route/sidebar scaffold is also not merged on `main`; this PR only adds a minimal direct route for branch testing and does not change the Seats sidebar.
- A separate draft WP-7 PR (#1413, `seats-compute/wp-7-local-specs`) appeared after this work had started. This PR does not modify or overwrite that branch.

## Proof

- `npx vitest run src/lib/localComputeRecommendations.test.ts`
- `npx eslint src/lib/localComputeRecommendations.ts src/lib/localComputeRecommendations.test.ts src/pages/admin/AdminSeatsLocal.tsx src/App.tsx`
- `npm run build`
- Browser smoke: `http://127.0.0.1:5178/admin/agents/local` redirects in a clean browser to `/login?next=%2Fadmin%2Fagents%2Flocal`, as expected for an auth-protected admin route.
- No `packages/mcp-server/**` files touched, so MCP package proof commands were not required.