### PR TITLE
fix: add timeout guards to 8 connectors with unguarded fetch calls

### DIFF
--- a/packages/mcp-server/src/deepl-tool.ts
+++ b/packages/mcp-server/src/deepl-tool.ts
@@ -141,9 +141,22 @@ export async function deeplListLanguages(args: Record<string, unknown>): Promise
   if (typeof _creds !== "object" || "not_connected" in _creds) return _creds as NotConnectedResult;
   const { key, base } = _creds;
   const type = String(args.type ?? "target");
-  const res = await fetch(`${base}/languages?type=${encodeURIComponent(type)}`, {
-    headers: { "DeepL-Auth-Key": key },
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEEPL_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${base}/languages?type=${encodeURIComponent(type)}`, {
+      headers: { "DeepL-Auth-Key": key },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`DeepL request timed out after ${DEEPL_TIMEOUT_MS}ms.`);
+    }
+    throw new Error(`DeepL network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
   const data = await res.json() as unknown[];
   if (!res.ok) throw new Error(`DeepL error (${res.status})`);
   return { type, count: data.length, languages: data };
@@ -159,7 +172,19 @@ export async function deeplTranslateDocument(args: Record<string, unknown>): Pro
   if (!targetLang)  throw new Error("target_lang is required.");
 
   // Fetch the document
-  const docRes = await fetch(documentUrl);
+  const dlController = new AbortController();
+  const dlTimer = setTimeout(() => dlController.abort(), DEEPL_TIMEOUT_MS);
+  let docRes: Response;
+  try {
+    docRes = await fetch(documentUrl, { signal: dlController.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`Document download timed out after ${DEEPL_TIMEOUT_MS}ms.`);
+    }
+    throw new Error(`Failed to fetch document: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(dlTimer);
+  }
   if (!docRes.ok) throw new Error(`Failed to fetch document_url: HTTP ${docRes.status}`);
   const docBlob = await docRes.blob();
   const filename = args.filename ? String(args.filename) : documentUrl.split("/").pop() ?? "document.pdf";
@@ -170,11 +195,24 @@ export async function deeplTranslateDocument(args: Record<string, unknown>): Pro
   if (args.source_lang) form.append("source_lang", String(args.source_lang).toUpperCase());
   if (args.formality)   form.append("formality", String(args.formality));
 
-  const uploadRes = await fetch(`${base}/document`, {
-    method: "POST",
-    headers: { "DeepL-Auth-Key": key },
-    body: form,
-  });
+  const upController = new AbortController();
+  const upTimer = setTimeout(() => upController.abort(), DEEPL_TIMEOUT_MS);
+  let uploadRes: Response;
+  try {
+    uploadRes = await fetch(`${base}/document`, {
+      method: "POST",
+      headers: { "DeepL-Auth-Key": key },
+      body: form,
+      signal: upController.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`DeepL document upload timed out after ${DEEPL_TIMEOUT_MS}ms.`);
+    }
+    throw new Error(`DeepL upload error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(upTimer);
+  }
   const uploadData = await uploadRes.json() as { document_id?: string; document_key?: string; message?: string };
   if (!uploadRes.ok) throw new Error(`DeepL document upload error (${uploadRes.status}): ${uploadData.message ?? "unknown error"}`);
 

--- a/packages/mcp-server/src/ebay-tool.ts
+++ b/packages/mcp-server/src/ebay-tool.ts
@@ -196,6 +196,9 @@ export async function ebayGetCategories(args: Record<string, unknown>): Promise<
 
   const url = `https://api.ebay.com/commerce/taxonomy/v1/category_tree/${encodeURIComponent(category_tree_id)}`;
 
+  const EBAY_TIMEOUT_MS = Number(process.env.EBAY_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), EBAY_TIMEOUT_MS);
   let response: Response;
   try {
     response = await fetch(url, {
@@ -203,9 +206,15 @@ export async function ebayGetCategories(args: Record<string, unknown>): Promise<
         Authorization:           `Bearer ${tokenResult}`,
         "X-EBAY-C-MARKETPLACE-ID": cfg.marketplace ?? "EBAY_US",
       },
+      signal: controller.signal,
     });
   } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `eBay category tree request timed out after ${EBAY_TIMEOUT_MS}ms.` };
+    }
     return { error: `Network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
   }
 
   if (response.status === 429) {

--- a/packages/mcp-server/src/keychain-tool.ts
+++ b/packages/mcp-server/src/keychain-tool.ts
@@ -29,11 +29,25 @@ async function sbFetch(
   headers:  Record<string, string>,
   body?:    unknown
 ): Promise<{ ok: boolean; status: number; data: unknown }> {
-  const res = await fetch(url, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  const KEYCHAIN_TIMEOUT_MS = Number(process.env.KEYCHAIN_TIMEOUT_MS) || 15000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), KEYCHAIN_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`Keychain request timed out after ${KEYCHAIN_TIMEOUT_MS}ms.`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
   let data: unknown;
   try { data = await res.json(); } catch { data = null; }
   return { ok: res.ok, status: res.status, data };

--- a/packages/mcp-server/src/nudgeonly-tool.ts
+++ b/packages/mcp-server/src/nudgeonly-tool.ts
@@ -673,15 +673,29 @@ function bridgeStatus(
 }
 
 async function openRouterPost<T>(apiKey: string, path: string, body: unknown): Promise<T> {
-  const res = await fetch(`${OPENROUTER_BASE}${path}`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-      "X-OpenRouter-Title": NUDGEONLY_POLICY.official_name,
-    },
-    body: JSON.stringify(body),
-  });
+  const NUDGEONLY_TIMEOUT_MS = Number(process.env.NUDGEONLY_TIMEOUT_MS) || 30000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), NUDGEONLY_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${OPENROUTER_BASE}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "X-OpenRouter-Title": NUDGEONLY_POLICY.official_name,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`OpenRouter NudgeOnlyAPI request timed out after ${NUDGEONLY_TIMEOUT_MS}ms.`);
+    }
+    throw new Error(`OpenRouter NudgeOnlyAPI network error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
 
   const data = await res.json() as Record<string, unknown>;
   if (!res.ok) {

--- a/packages/mcp-server/src/sloppass-tool.ts
+++ b/packages/mcp-server/src/sloppass-tool.ts
@@ -33,14 +33,28 @@ function getApiKey(): string | NotConnectedResult {
 async function callApi(body: Record<string, unknown>): Promise<unknown> {
   const apiKey = getApiKey();
   if (typeof apiKey !== "string") return apiKey;
-  const response = await fetch(`${getApiBase()}/api/sloppass?action=run`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(body),
-  });
+  const SLOPPASS_TIMEOUT_MS = Number(process.env.SLOPPASS_TIMEOUT_MS) || 30000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SLOPPASS_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${getApiBase()}/api/sloppass?action=run`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `SlopPass API request timed out after ${SLOPPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `SlopPass network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await response.text();
   let parsed: unknown = text;
   try {
@@ -156,9 +170,23 @@ async function fetchGithubPrDiff(target: Record<string, unknown>): Promise<
   const resolved = resolveGithubPrDiffTarget(target);
   if ("error" in resolved) return resolved;
 
-  const response = await fetch(resolved.diffUrl, {
-    headers: { Accept: "text/plain" },
-  });
+  const SLOPPASS_TIMEOUT_MS = Number(process.env.SLOPPASS_TIMEOUT_MS) || 30000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SLOPPASS_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(resolved.diffUrl, {
+      headers: { Accept: "text/plain" },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `GitHub PR diff download timed out after ${SLOPPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `GitHub PR diff fetch failed: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const diff = await response.text();
   if (!response.ok) {
     return { error: `GitHub PR diff fetch failed (HTTP ${response.status})` };

--- a/packages/mcp-server/src/stability-tool.ts
+++ b/packages/mcp-server/src/stability-tool.ts
@@ -290,7 +290,20 @@ export async function stabilityImageToImage(args: Record<string, unknown>): Prom
   const samples = Math.min(10, Math.max(1, Number(args.samples ?? 1)));
 
   // Fetch the source image
-  const imgRes = await fetch(imageUrl);
+  const STABILITY_TIMEOUT_MS = Number(process.env.STABILITY_TIMEOUT_MS) || 60000;
+  const dlController = new AbortController();
+  const dlTimer = setTimeout(() => dlController.abort(), STABILITY_TIMEOUT_MS);
+  let imgRes: Response;
+  try {
+    imgRes = await fetch(imageUrl, { signal: dlController.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`Image download timed out after ${STABILITY_TIMEOUT_MS}ms.`);
+    }
+    throw new Error(`Failed to fetch image: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(dlTimer);
+  }
   if (!imgRes.ok) throw new Error(`Failed to fetch image_url: HTTP ${imgRes.status}`);
   const imgBlob = await imgRes.blob();
 
@@ -336,7 +349,20 @@ export async function stabilityUpscale(args: Record<string, unknown>): Promise<u
   requireStabilitySpendAllowed("upscale", engineId, apiKey);
 
   // Fetch source image
-  const imgRes = await fetch(imageUrl);
+  const STABILITY_TIMEOUT_MS = Number(process.env.STABILITY_TIMEOUT_MS) || 60000;
+  const dlController = new AbortController();
+  const dlTimer = setTimeout(() => dlController.abort(), STABILITY_TIMEOUT_MS);
+  let imgRes: Response;
+  try {
+    imgRes = await fetch(imageUrl, { signal: dlController.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(`Image download timed out after ${STABILITY_TIMEOUT_MS}ms.`);
+    }
+    throw new Error(`Failed to fetch image: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    clearTimeout(dlTimer);
+  }
   if (!imgRes.ok) throw new Error(`Failed to fetch image_url: HTTP ${imgRes.status}`);
   const imgBlob = await imgRes.blob();
 

--- a/packages/mcp-server/src/testpass-tool.ts
+++ b/packages/mcp-server/src/testpass-tool.ts
@@ -23,12 +23,27 @@ function parseTextBody(text: string): unknown {
   try { return text ? JSON.parse(text) : null; } catch { return text; }
 }
 
+const TESTPASS_TIMEOUT_MS = Number(process.env.TESTPASS_TIMEOUT_MS) || 30000;
+
 async function fetchJson(path: string): Promise<{ ok: boolean; status: number; body: unknown } | NotConnectedResult> {
   const apiKey = getApiKey();
   if (typeof apiKey !== "string") return apiKey;
-  const res = await fetch(`${API_BASE}${path}`, {
-    headers: { Authorization: `Bearer ${apiKey}` },
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TESTPASS_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}${path}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { ok: false, status: 0, body: { error: `TestPass request timed out after ${TESTPASS_TIMEOUT_MS}ms.` } };
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   return { ok: res.ok, status: res.status, body: parseTextBody(text) };
 }
@@ -55,14 +70,27 @@ export async function testpassRun(args: Record<string, unknown>): Promise<unknow
   };
   requestBody[UUID_RE.test(packId) ? "pack_id" : "pack_slug"] = packId;
   if (taskId) requestBody.task_id = taskId;
-  const res = await fetch(`${API_BASE}/api/testpass?action=start_run`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(requestBody),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TESTPASS_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/api/testpass?action=start_run`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `TestPass start_run timed out after ${TESTPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `TestPass network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   const body = parseTextBody(text);
   if (!res.ok) return { error: `testpass start_run failed (HTTP ${res.status})`, body };
@@ -85,10 +113,22 @@ export async function testpassReportHtml(args: Record<string, unknown>): Promise
 
   const apiKey = getApiKey();
   if (typeof apiKey !== "string") return apiKey;
-  const res = await fetch(
-    `${API_BASE}/api/testpass?action=report_html&run_id=${encodeURIComponent(runId)}`,
-    { headers: { Authorization: `Bearer ${apiKey}` } },
-  );
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TESTPASS_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(
+      `${API_BASE}/api/testpass?action=report_html&run_id=${encodeURIComponent(runId)}`,
+      { headers: { Authorization: `Bearer ${apiKey}` }, signal: controller.signal },
+    );
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `TestPass report_html timed out after ${TESTPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `TestPass network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   if (!res.ok) {
     const body = parseTextBody(text);
@@ -155,14 +195,27 @@ export async function testpassSavePack(args: Record<string, unknown>): Promise<u
 
   const apiKey = getApiKey();
   if (typeof apiKey !== "string") return apiKey;
-  const res = await fetch(`${API_BASE}/api/testpass?action=save_pack`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({ pack_id: packId, pack_yaml: yaml }),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TESTPASS_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/api/testpass?action=save_pack`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ pack_id: packId, pack_yaml: yaml }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `TestPass save_pack timed out after ${TESTPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `TestPass network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   const body = parseTextBody(text);
   if (!res.ok) return { error: `testpass save_pack failed (HTTP ${res.status})`, body };
@@ -187,14 +240,27 @@ export async function testpassEditItem(args: Record<string, unknown>): Promise<u
 
   const apiKey = getApiKey();
   if (typeof apiKey !== "string") return apiKey;
-  const res = await fetch(`${API_BASE}/api/testpass?action=edit_item`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(payload),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TESTPASS_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/api/testpass?action=edit_item`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `TestPass edit_item timed out after ${TESTPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `TestPass network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   const body = parseTextBody(text);
   if (!res.ok) return { error: `testpass edit_item failed (HTTP ${res.status})`, body };

--- a/packages/mcp-server/src/uxpass-tool.ts
+++ b/packages/mcp-server/src/uxpass-tool.ts
@@ -78,20 +78,35 @@ function getApiKey(): string | NotConnectedResult {
   return key;
 }
 
+const UXPASS_TIMEOUT_MS = Number(process.env.UXPASS_TIMEOUT_MS) || 30000;
+
 async function callApi(
   pathAndQuery: string,
   init: { method?: string; body?: unknown } = {},
 ): Promise<unknown> {
   const apiKey = getApiKey();
   if (typeof apiKey !== "string") return apiKey;
-  const res = await fetch(`${API_BASE}/api/uxpass${pathAndQuery}`, {
-    method: init.method ?? "GET",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UXPASS_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/api/uxpass${pathAndQuery}`, {
+      method: init.method ?? "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `UXPass request timed out after ${UXPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `UXPass network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   let body: unknown = text;
   try {
@@ -324,10 +339,22 @@ export async function uxpassReportHtml(args: Record<string, unknown>): Promise<u
   if (!runId) return { error: "run_id is required" };
   const apiKey = getApiKey();
   if (typeof apiKey !== "string") return apiKey;
-  const res = await fetch(
-    `${API_BASE}/api/uxpass?action=report_html&run_id=${encodeURIComponent(runId)}`,
-    { headers: { Authorization: `Bearer ${apiKey}` } },
-  );
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UXPASS_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(
+      `${API_BASE}/api/uxpass?action=report_html&run_id=${encodeURIComponent(runId)}`,
+      { headers: { Authorization: `Bearer ${apiKey}` }, signal: controller.signal },
+    );
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { error: `UXPass report_html timed out after ${UXPASS_TIMEOUT_MS}ms.` };
+    }
+    return { error: `UXPass network error: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
   const text = await res.text();
   if (!res.ok) {
     let body: unknown = text;


### PR DESCRIPTION
## Summary

- Adds AbortController timeout guards to all unguarded `fetch()` calls across 8 connector files
- Follow-up to PR #1325 which fixed the highest-risk connectors (telegram, reddit, openai)
- Each connector now uses its standard timeout env var or a sensible default, preventing indefinite hangs on secondary fetch calls (file uploads, downloads, diff fetches, API calls)

### Files fixed

| Connector | Unguarded calls fixed | Default timeout |
|---|---|---|
| `deepl-tool.ts` | Language list, document download, document upload | 15s |
| `stability-tool.ts` | Image downloads in image-to-image and upscale | 60s |
| `ebay-tool.ts` | Category tree fetch | 15s |
| `keychain-tool.ts` | Central `sbFetch` helper (all Supabase calls) | 15s |
| `sloppass-tool.ts` | API call + GitHub PR diff download | 30s |
| `testpass-tool.ts` | All 5 fetch sites (fetchJson + 3 direct POSTs) | 30s |
| `uxpass-tool.ts` | `callApi` helper + `report_html` direct fetch | 30s |
| `nudgeonly-tool.ts` | OpenRouter API call | 30s |

## Test plan

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Full MCP package test suite passes (7/7)
- [ ] Verify Vercel preview builds successfully

https://claude.ai/code/session_01CrhBpQte6phT1Wug18ZNTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrhBpQte6phT1Wug18ZNTo)_