### PR TITLE
fix(memory): surface recent session stubs in load_memory lite mode

### DIFF
--- a/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/response-bounds.test.ts
@@ -10,7 +10,7 @@ import {
 const long = (prefix: string, size: number) => `${prefix} ${"x".repeat(size)}`;
 
 describe("strict-client memory response bounds", () => {
-  test("load_memory compact mode skips session bodies and keeps payload small", () => {
+  test("load_memory compact mode surfaces session stubs, skips bodies, and keeps payload small", () => {
     const raw = {
       business_context: Array.from({ length: 20 }, (_, i) => ({
         category: "rule",
@@ -45,8 +45,33 @@ describe("strict-client memory response bounds", () => {
 
     const compact = compactStartupContextForStrictClients(raw);
     const text = JSON.stringify(compact);
-    assert.ok(text.length < 8000, `payload was ${text.length} chars`);
-    assert.equal((compact as { recent_sessions: unknown[] }).recent_sessions.length, 0);
+    // Lite stays under the strict-client budget AND stays smaller than the
+    // full-body (non-lite) payload, proving bodies are skipped, not dumped. The
+    // non-session baseline for this extreme synthetic input is already ~8KB, so
+    // the bounded stubs add only a few hundred chars on top.
+    const fullBody = JSON.stringify(compactStartupContextForStrictClients(raw, true));
+    assert.ok(text.length < 9500, `payload was ${text.length} chars`);
+    assert.ok(text.length < fullBody.length, `lite (${text.length}) should be smaller than full bodies (${fullBody.length})`);
+    // Lite mode surfaces compact session stubs (so the latest threads stay
+    // visible) but omits the heavier bodies and keeps the payload small.
+    const recentSessions = (compact as { recent_sessions: Array<Record<string, unknown>> }).recent_sessions;
+    assert.equal(recentSessions.length, 3);
+    for (const stub of recentSessions) {
+      assert.ok(stub.session_id, "stub keeps session_id");
+      assert.ok(stub.created_at, "stub keeps created_at");
+      assert.ok(
+        typeof stub.summary === "string" && (stub.summary as string).length < 200,
+        "stub summary is a short headline, not a full body"
+      );
+      assert.equal("decisions" in stub, false, "lite stub omits decisions body");
+      assert.equal("open_loops" in stub, false, "lite stub omits open_loops body");
+      assert.equal("topics" in stub, false, "lite stub omits topics body");
+    }
+    assert.equal(
+      (compact as { response_bounds: { recent_sessions_bodies_included: boolean } }).response_bounds
+        .recent_sessions_bodies_included,
+      false
+    );
 
     const profileCard = (compact as { profile_card: { source_receipts: Array<{ redaction_state?: string }> } }).profile_card;
     assert.ok(profileCard);

--- a/packages/mcp-server/src/memory/handlers.ts
+++ b/packages/mcp-server/src/memory/handlers.ts
@@ -432,7 +432,9 @@ function buildMemoryProfileCard(params: {
 
   const sessionHealth = params.includeSessionSummaries
     ? `${Math.min(params.sessions.length, 3)} of ${params.sessions.length} recent session summaries returned`
-    : "Recent session bodies omitted in lite mode";
+    : params.sessions.length > 0
+      ? `${Math.min(params.sessions.length, 3)} of ${params.sessions.length} recent session stubs returned; bodies omitted in lite mode (call load_memory lite=false for full bodies)`
+      : "No recent sessions in window";
 
   return {
     profile_summary: profileSummary,
@@ -558,26 +560,39 @@ export function compactStartupContextForStrictClients(
     const r = asRecord(row) ?? {};
     return { slug: r.slug, title: typeof r.title === "string" ? capText(r.title, 60) : r.title, category: r.category, tags: compactStringArray(r.tags, 3, 32), updated_at: r.updated_at };
   });
-  out.recent_sessions = includeSessionSummaries
-    ? sessions.slice(0, 3).map((row) => {
-        const r = asRecord(row) ?? {};
-        return {
-          session_id: r.session_id,
-          platform: r.platform,
-          summary: typeof r.summary === "string" ? capText(r.summary, 350) : r.summary,
-          decisions: compactStringArray(r.decisions),
-          open_loops: compactStringArray(r.open_loops),
-          topics: compactStringArray(r.topics),
-          created_at: r.created_at,
-        };
-      })
-    : [];
+  // Lite mode skips the heavier session *bodies* (decisions/open_loops/topics)
+  // and tightens the summary, but still surfaces a compact stub per recent
+  // session. Returning [] here (the previous behavior) hid even the existence
+  // and headline of the latest cross-session threads from the default load
+  // path, so an agent answering "what is the latest" could not see them or know
+  // to fetch full bodies via load_memory(lite=false) / search_memory.
+  out.recent_sessions = sessions.slice(0, 3).map((row) => {
+    const r = asRecord(row) ?? {};
+    if (includeSessionSummaries) {
+      return {
+        session_id: r.session_id,
+        platform: r.platform,
+        summary: typeof r.summary === "string" ? capText(r.summary, 350) : r.summary,
+        decisions: compactStringArray(r.decisions),
+        open_loops: compactStringArray(r.open_loops),
+        topics: compactStringArray(r.topics),
+        created_at: r.created_at,
+      };
+    }
+    return {
+      session_id: r.session_id,
+      platform: r.platform,
+      summary: typeof r.summary === "string" ? capText(r.summary, 140) : r.summary,
+      created_at: r.created_at,
+    };
+  });
   out.retrieval_plan = buildMemoryRetrievalPlan();
   out.response_bounds = {
     compact: true,
     business_context_returned: compactBusiness.length,
     knowledge_library_returned: Math.min(library.length, 6),
-    recent_sessions_returned: includeSessionSummaries ? Math.min(sessions.length, 3) : 0,
+    recent_sessions_returned: Math.min(sessions.length, 3),
+    recent_sessions_bodies_included: includeSessionSummaries,
     recent_sessions_available_in_loaded_window: sessions.length,
     active_facts_returned: Math.min(startupFacts.length, 12),
     active_facts_available_in_loaded_window: facts.length,


### PR DESCRIPTION
## What and why

While diagnosing cross-platform context + orchestrator continuity, `load_memory` was asked "what is the latest conversation" and returned **zero recent sessions**, even though several recent cross-session threads existed. They were only reachable via `read_orchestrator_context`.

Root cause: `compactStartupContextForStrictClients` in `packages/mcp-server/src/memory/handlers.ts` hard-coded `recent_sessions` to `[]` in **lite mode** (the default), and `recent_sessions_returned` to `0`. But `load_memory`'s own documented contract for `lite` is *"skips session summary **bodies**"* — not "drop the sessions entirely." So the default load path hid even the existence and headline of the newest threads.

## The fix

- **Lite mode now returns a compact stub per recent session** (`session_id`, `platform`, a short summary headline capped at 140 chars, `created_at`), while still omitting the heavier bodies (`decisions` / `open_loops` / `topics`). This keeps the strict-client payload small while making the latest threads visible and reachable (`load_memory(lite=false)` / `search_memory`).
- Adds `recent_sessions_bodies_included` to `response_bounds` so callers can tell stubs from full bodies, and fixes `recent_sessions_returned` to report the actual count in both modes.
- Updates the `memory_health` line to point at `lite=false` for full bodies.

## Measurements (synthetic worst-case test input)

| Payload | Size |
|---|---|
| Non-session baseline | ~8,059 chars |
| Lite + stubs (new default) | 8,880 chars |
| Full bodies (`lite=false`) | 11,230 chars |

The old test bound (`< 8000`) was pinned to the exact empty-sessions output, so it sat on the boundary. Re-based to `< 9500` (passes stubs, still catches a full-body leak at 11,230) and added a **relative guard** asserting the lite payload stays smaller than the full-body payload — more robust than a lone magic number.

## Tests

- `cd packages/mcp-server && npx tsx --test src/memory/__tests__/*.test.ts` → **206 pass / 0 fail** (55 suites).
- `npx tsc --noEmit` → **0 errors**.
- Updated `response-bounds.test.ts` to assert lite surfaces 3 stubs, each keeping `session_id`/`created_at`/short summary and omitting `decisions`/`open_loops`/`topics`.

## Scope / safety

Isolated to the MCP `load_memory` compaction layer. No website/API consumer depends on lite returning empty sessions (the `list_recent_sessions` admin tool and raw context assembly read the RPC directly). No in-flight PR touches this function.

https://claude.ai/code/session_0114pV7ATWwjtFnwoRXSJPSk

---
_Generated by [Claude Code](https://claude.ai/code/session_0114pV7ATWwjtFnwoRXSJPSk)_