### PR TITLE
ci(mcp): orphan-module gate to block unwired dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,7 @@ jobs:
         run: npm install --no-audit --no-fund
       - name: Typecheck + build
         run: npm run build
+      - name: Orphan-module gate
+        run: npm run check:orphans
       - name: Tests
         run: npm test

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -15526,8 +15526,8 @@
     },
     {
       "source": ".github/workflows/ci.yml",
-      "hash": "ab3e717a4ae9",
-      "bytes": 1663
+      "hash": "ab9a444f7506",
+      "bytes": 1731
     },
     {
       "source": ".github/workflows/brainmap-auto-update.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -30,7 +30,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminSkills.tsx | a3cf298f1eda | 4203 |
 | src/lib/skillLibrary.ts | 3a15b942a827 | 12515 |
 | src/lib/skillLibrarySeeds.ts | 51ca658707f8 | 652 |
-| .github/workflows/ci.yml | ab3e717a4ae9 | 1663 |
+| .github/workflows/ci.yml | ab9a444f7506 | 1731 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | .github/workflows/continuous-improvement-watch.yml | d121a434a464 | 2358 |
 | package.json | adbb13d02beb | 7084 |

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "prepare:wiring": "node scripts/patch-reddit-public-wiring.mjs && node scripts/generate-tool-index.mjs",
+    "check:orphans": "node scripts/check-orphan-modules.mjs",
     "build": "npm run prepare:wiring && npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsc",
     "dev": "npm run prepare:wiring && npm run build --workspace=@unclick/commonsensepass && npm run build --workspace=@unclick/flowpass && npm run build --workspace=@unclick/securitypass && tsx src/index.ts",
     "start": "node dist/index.js",

--- a/packages/mcp-server/scripts/check-orphan-modules.mjs
+++ b/packages/mcp-server/scripts/check-orphan-modules.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Orphan-module gate for the MCP server.
+//
+// Why this exists: CI green only proves "compiles + colocated unit test
+// passes". It never proves a module is reachable from the running server.
+// That gap let ~1,975 unwired "*-calc.ts" modules (57% of src) accumulate -
+// every one passed CI while being dead code (see issue #1440).
+//
+// This script walks the static import graph from the server entrypoints and
+// flags any source module that nothing reachable imports. A baseline allowlist
+// records modules that are unreachable today, so the gate only fails on NEW
+// orphans - it catches the next flood without forcing a big-bang cleanup.
+//
+// No dependencies, no TypeScript parse: a regex import scan is enough because
+// the package is ESM with explicit "./x.js" specifiers.
+
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, "..");
+const srcDir = join(pkgRoot, "src");
+const allowlistPath = join(here, "orphan-modules-allowlist.json");
+
+// Entry roots: anything the published server can start from. Keep this small
+// and explicit; a new genuine entrypoint should be added here on purpose.
+// "index.ts" is the published bin (unclick-mcp); "server.ts" is main/exports.
+const ROOTS = ["index.ts", "server.ts"]
+  .map((r) => join(srcDir, r))
+  .filter((p) => existsSync(p));
+
+// Files that are reachable by means the static scan cannot see (test setup,
+// build tooling) or that are intentionally standalone are excluded from being
+// "candidates" entirely.
+const EXCLUDE_RE = [
+  /\.test\.ts$/,
+  /\.d\.ts$/,
+  /\.generated\.ts$/,
+  /[/\\]__tests__[/\\]/,
+  /[/\\]__mocks__[/\\]/,
+];
+
+function listTsFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...listTsFiles(full));
+    else if (name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+// Resolve an import specifier (as written, e.g. "./x.js" or "./dir") to a
+// concrete source file path, or null if it is not a local source module.
+function resolveSpecifier(fromFile, spec) {
+  if (!spec.startsWith(".")) return null; // bare/package import
+  const base = resolve(dirname(fromFile), spec);
+  const candidates = [
+    base,
+    base.replace(/\.js$/, ".ts"),
+    base.replace(/\.mjs$/, ".ts"),
+    base + ".ts",
+    join(base, "index.ts"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c) && c.endsWith(".ts")) return c;
+  }
+  return null;
+}
+
+const IMPORT_RE =
+  /(?:import|export)\s+(?:[^"';]*?\sfrom\s*)?["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+function importsOf(file) {
+  const text = readFileSync(file, "utf8");
+  const specs = [];
+  let m;
+  while ((m = IMPORT_RE.exec(text)) !== null) {
+    const spec = m[1] ?? m[2];
+    if (spec) specs.push(spec);
+  }
+  return specs;
+}
+
+// BFS over the import graph from the roots.
+const reachable = new Set();
+const queue = [...ROOTS];
+for (const r of ROOTS) reachable.add(r);
+while (queue.length) {
+  const file = queue.pop();
+  for (const spec of importsOf(file)) {
+    const target = resolveSpecifier(file, spec);
+    if (target && !reachable.has(target)) {
+      reachable.add(target);
+      queue.push(target);
+    }
+  }
+}
+
+const allFiles = listTsFiles(srcDir);
+const candidates = allFiles.filter((f) => !EXCLUDE_RE.some((re) => re.test(f)));
+const orphans = candidates
+  .filter((f) => !reachable.has(f))
+  .map((f) => relative(pkgRoot, f).split("\\").join("/"))
+  .sort();
+
+const baseline = existsSync(allowlistPath)
+  ? new Set(JSON.parse(readFileSync(allowlistPath, "utf8")).allow ?? [])
+  : new Set();
+
+const updateMode = process.argv.includes("--update-baseline");
+if (updateMode) {
+  const json = JSON.stringify(
+    {
+      note:
+        "Modules unreachable from server.ts as of baseline. The orphan gate " +
+        "fails only on NEW entries. Shrink this list; do not grow it. See issue #1440.",
+      allow: orphans,
+    },
+    null,
+    2
+  );
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(allowlistPath, json + "\n");
+  console.log(`Baseline written: ${orphans.length} allowed orphan(s).`);
+  process.exit(0);
+}
+
+const newOrphans = orphans.filter((f) => !baseline.has(f));
+const healed = [...baseline].filter((f) => !orphans.includes(f));
+
+console.log(
+  `Orphan-module gate: ${candidates.length} candidate module(s), ` +
+    `${reachable.size} reachable, ${orphans.length} orphan(s) ` +
+    `(${baseline.size} baselined).`
+);
+
+if (healed.length) {
+  console.log(
+    `\nNote: ${healed.length} baselined module(s) are now reachable. ` +
+      `Run "npm run check:orphans -- --update-baseline" to shrink the allowlist.`
+  );
+}
+
+if (newOrphans.length) {
+  console.error(
+    `\n✖ ${newOrphans.length} new orphan module(s) - reachable from nothing the server imports:\n`
+  );
+  for (const f of newOrphans) console.error(`    ${f}`);
+  console.error(
+    `\nWire each into the server (tool-wiring.ts / server.ts) or, if it is a` +
+      ` deliberate standalone entrypoint, add it to ROOTS in ` +
+      `scripts/check-orphan-modules.mjs. Do NOT just append to the baseline.\n`
+  );
+  process.exit(1);
+}
+
+console.log("✔ No new orphan modules.");

--- a/packages/mcp-server/scripts/orphan-modules-allowlist.json
+++ b/packages/mcp-server/scripts/orphan-modules-allowlist.json
@@ -1,0 +1,23 @@
+{
+  "note": "Modules unreachable from server.ts as of baseline. The orphan gate fails only on NEW entries. Shrink this list; do not grow it. See issue #1440.",
+  "allow": [
+    "src/connectors/discogs.ts",
+    "src/connectors/guardian.ts",
+    "src/connectors/lastfm.ts",
+    "src/connectors/newsapi.ts",
+    "src/connectors/ptv.ts",
+    "src/connectors/seatgeek.ts",
+    "src/connectors/ticketmaster.ts",
+    "src/connectors/twitch.ts",
+    "src/connectors/yelp.ts",
+    "src/converter-tools.ts",
+    "src/heartbeat-noop-reasons.ts",
+    "src/local-tools.ts",
+    "src/memory/conflicts.ts",
+    "src/memory/eval-harness.ts",
+    "src/memory/load-events.ts",
+    "src/memory/tenant-settings.ts",
+    "src/reliability.ts",
+    "src/web-tools.ts"
+  ]
+}


### PR DESCRIPTION
## Why

Closes the highest-leverage gap from #1440. CI green only proved *"compiles + colocated unit test passes"* - it never checked whether a module is reachable from the running server. That gap let **~1,975 unwired `*-calc.ts` modules (57% of `packages/mcp-server/src`)** accumulate on PR #1347, every one passing CI while being dead code.

This gate would have blocked that flood at the first commit.

## What it does

A dependency-free import-graph walker (`scripts/check-orphan-modules.mjs`) starts from the server entrypoints (`index.ts` = the `unclick-mcp` bin, `server.ts` = main/exports), follows every `./x.js` import, and flags any source module nothing reachable imports.

- A **baseline allowlist** (`orphan-modules-allowlist.json`) records the **18** modules unreachable in `main` today, so the gate fails **only on NEW orphans** - it stops the next flood without forcing a big-bang cleanup of pre-existing code.
- Runs as a new **"Orphan-module gate"** step after build in the MCP server package CI job, plus an `npm run check:orphans` script for local use.
- `--update-baseline` regenerates the allowlist; the note tells reviewers to **shrink, never grow** it.

## Verification

- ✔ Passes on a clean `main` tree (763 candidates, 747 reachable, 18 baselined).
- ✔ Fails with exit 1 on a planted `src/widget-calc.ts` orphan, naming the file.
- ✔ Passes again once the planted file is removed.

## Scope / safety

- New files + 1 line in `package.json` + 2 lines in `ci.yml`. No product code touched.
- Does not retroactively fail existing PRs on the 18 baselined modules; it only catches *new* unwired modules.
- Deliberately conservative: a genuine new entrypoint is added to `ROOTS` on purpose, not silently baselined.

## Follow-ups (tracked in #1440, not this PR)

- Re-cut PR #1347 clean off `main` (keep the 11 utility modules + wire them in; drop the calc flood).
- Branch-scope gate (file-count vs description), and make the zero-touch scoreboard's "activity ≠ proof" doctrine an enforced check.

Related: #1440 · #1347

https://claude.ai/code/session_01897ub4h75gcod3kQRXTVtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01897ub4h75gcod3kQRXTVtc)_