### PR TITLE
docs: codify "wired or it does not exist" + PR scope rules for the fleet

### DIFF
--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -269,6 +269,10 @@ Before opening a PR:
 
 - Pull from the latest main branch.
 - Keep the change to one chip.
+- Keep the diff proportional to the chip. The `pr-scope-guard` gate fails grossly
+  oversized PRs (stale-base bloat, bulk generation); a genuinely large change
+  carries the `large-change-ok` label. If your "one chip" is touching hundreds of
+  files, the branch is wrong, not the gate.
 - Run the smallest useful verification.
 - Run `/review` when available.
 - Mention whether the change is ship-without-ask, ask-once, or gated.
@@ -279,6 +283,9 @@ Before merging:
 - Checks must be green unless the operator explicitly overrides.
 - Draft PRs must be marked ready by the owner or by explicit instruction.
 - Security, auth, env, migration, and billing changes need operator approval.
+- Shipping proof is a wired, cataloged, TestPass-green surface, not a count of
+  new files, tests, or commits. Activity is not proof (see
+  `docs/autopilot-zero-touch-scoreboard.md`).
 
 ## Current Priority Rule
 

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -15451,8 +15451,8 @@
   "source_manifest": [
     {
       "source": "AUTOPILOT.md",
-      "hash": "190d9db14287",
-      "bytes": 17607
+      "hash": "18863a2e935a",
+      "bytes": 18077
     },
     {
       "source": "FLEET_SYNC.md",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -13,7 +13,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 
 | Source | Hash | Bytes |
 | --- | --- | --- |
-| AUTOPILOT.md | 190d9db14287 | 17607 |
+| AUTOPILOT.md | 18863a2e935a | 18077 |
 | FLEET_SYNC.md | 0768614dd1ed | 14732 |
 | docs/unclick-context-boot-packet.md | d02028751751 | 11234 |
 | docs/agent-observability.md | bffd9f890c75 | 4629 |

--- a/docs/adding-a-connector.md
+++ b/docs/adding-a-connector.md
@@ -54,6 +54,19 @@ See `docs/connector-standard.md` for the full definitions. Summary:
 - **L3 and L4 are opt-in by nature.** Only add them when the connector has a
   stable per-user default (L3) or reads a changeable, user-actionable quantity (L4).
 
+### Non-negotiable: a module must be wired, or it does not exist
+
+L1 means a *callable* endpoint, not a file on disk. Every new module under
+`packages/mcp-server/src` must be reachable from the server (registered in
+`tool-wiring.ts`, imported from `server.ts`). The `check:orphans` CI gate fails
+any module that nothing reachable imports.
+
+Do not bulk-generate standalone modules with colocated tests as a way to show
+progress. A passing unit test on an unwired module is dead code, not a shipped
+feature: in #1347 this pattern produced ~1,975 unreachable `*-calc.ts` modules
+(57% of the package) before anyone noticed (root cause in #1440). One wired,
+cataloged, TestPass-green connector beats a hundred orphan files.
+
 ---
 
 ## 3. The connector template (copy this)


### PR DESCRIPTION
## Why

Third prevention layer from #1440. The orphan gate (#1441) and scope guard (#1443) catch the #1347 failure mode *mechanically* — but this repo is run by a fleet of AI agents, and **the docs are what they actually read**. The calc flood happened in part because the playbook never said "a file is not a feature." This codifies the rule where the fleet will see it.

## Changes (docs only)

**`docs/adding-a-connector.md`** — new subsection in the quality ladder:
> **Non-negotiable: a module must be wired, or it does not exist.** L1 means a *callable* endpoint, not a file on disk... Do not bulk-generate standalone modules with colocated tests as a way to show progress. A passing unit test on an unwired module is dead code, not a shipped feature (in #1347 this produced ~1,975 unreachable `*-calc.ts` modules, 57% of the package).

**`AUTOPILOT.md`** — PR Rules:
- *"Keep the diff proportional to the chip"* — references the `pr-scope-guard` gate and the `large-change-ok` override; "if your one chip is touching hundreds of files, the branch is wrong, not the gate."
- *"Activity is not proof"* — shipping proof is a wired, cataloged, TestPass-green surface, not a count of files/tests/commits. Reinforces the existing zero-touch scoreboard doctrine.

## Scope / safety

- Documentation only (+ brainmap regen, since it inventories these files). No code, no behavior change.
- No em dashes (repo style rule), verified.

Together with #1441 (orphan gate) and #1443 (scope guard), this closes the prevention side of #1440: two mechanical gates plus the written rule the agents read.

Related: #1440 · #1441 · #1443 · #1347

https://claude.ai/code/session_01897ub4h75gcod3kQRXTVtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01897ub4h75gcod3kQRXTVtc)_