### PR TITLE
fix(ci): harden scope guard for dependency bumps and pre-gate branches

### DIFF
--- a/.github/workflows/pr-scope-guard.yml
+++ b/.github/workflows/pr-scope-guard.yml
@@ -29,4 +29,9 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: node scripts/check-pr-scope.mjs
+        run: |
+          if [ -f scripts/check-pr-scope.mjs ]; then
+            node scripts/check-pr-scope.mjs
+          else
+            echo "scripts/check-pr-scope.mjs not present on this PR branch (it predates the scope guard); skipping. Rebase on main to enable the check."
+          fi

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16531,8 +16531,8 @@
     },
     {
       "source": ".github/workflows/pr-scope-guard.yml",
-      "hash": "fb2678102ed6",
-      "bytes": 1038
+      "hash": "a130d252be9c",
+      "bytes": 1286
     },
     {
       "source": ".github/workflows/publish-channel-package.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -229,7 +229,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/event-wake-router.yml | bfd53e324bb4 | 1453 |
 | .github/workflows/fleet-throughput-watch.yml | c5a08f4edf9b | 930 |
 | .github/workflows/openhands-test-mode.yml | 9aaef5273976 | 1137 |
-| .github/workflows/pr-scope-guard.yml | fb2678102ed6 | 1038 |
+| .github/workflows/pr-scope-guard.yml | a130d252be9c | 1286 |
 | .github/workflows/publish-channel-package.yml | 5c9197848ca9 | 8046 |
 | .github/workflows/publish-mcp-package.yml | c029877aab11 | 6427 |
 | .github/workflows/publish-standalone-mcps.yml | ddd200e03a08 | 7228 |

--- a/scripts/check-pr-scope.mjs
+++ b/scripts/check-pr-scope.mjs
@@ -46,15 +46,28 @@ function sh(cmd) {
   return execSync(cmd, { encoding: "utf8" }).trim();
 }
 
+// Lock files and generated artifacts are legitimately huge but are not
+// reviewed line by line, so they must not trip the guard. Excluding them is
+// what lets a dependency bump (a massive package-lock.json diff) or a
+// brainmap regeneration through.
+const IGNORE_RE =
+  /(^|\/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$|\.generated\.(json|md|ts)$/;
+
 let fileCount = 0;
 let additions = 0;
+let ignoredFiles = 0;
 try {
-  const names = sh(`git diff --name-only ${base}...${head}`);
-  fileCount = names ? names.split("\n").length : 0;
   // numstat: "<added>\t<deleted>\t<path>" per file ("-" for binary).
   const numstat = sh(`git diff --numstat ${base}...${head}`);
   for (const line of numstat.split("\n").filter(Boolean)) {
-    const added = line.split("\t")[0];
+    const parts = line.split("\t");
+    const added = parts[0];
+    const path = parts.slice(2).join("\t");
+    if (IGNORE_RE.test(path)) {
+      ignoredFiles++;
+      continue;
+    }
+    fileCount++;
     if (added !== "-") additions += Number(added) || 0;
   }
 } catch (err) {
@@ -75,7 +88,8 @@ if (additions > MAX_ADDITIONS)
 
 console.log(
   `PR scope guard: ${fileCount} files changed, ${additions} insertions ` +
-    `(limits: ${MAX_FILES} files / ${MAX_ADDITIONS} insertions).`
+    `(${ignoredFiles} lock/generated file(s) excluded; ` +
+    `limits: ${MAX_FILES} files / ${MAX_ADDITIONS} insertions).`
 );
 
 if (violations.length === 0) {


### PR DESCRIPTION
## Why

Two flaws in the PR scope guard (#1443) surfaced the first time it ran on a real dependency bump (dependabot PR #1436, zod 3→4):

1. **`MODULE_NOT_FOUND`.** The `pull_request` workflow correctly runs from `main`, but it executed `scripts/check-pr-scope.mjs` from the **PR's checked-out head**. Any branch created *before* the gate merged doesn't have that script, so the job crashed instead of checking anything. This would break the guard on every pre-existing open PR.
2. **Lock-file false positive.** A dependency bump's `package-lock.json` diff is tens of thousands of lines, but it isn't reviewed line by line. Counting it toward the insertion limit would fail every dependabot PR.

## Fix

- **Workflow:** skip gracefully when `scripts/check-pr-scope.mjs` is absent (branch predates the gate), instead of crashing. Such PRs pick the check up once rebased on `main`.
- **Script:** exclude `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` and `*.generated.*` from both the file and insertion counts. The real bloat signal (hand-written/source files) is what remains.

## Verification (local)

- A diff that is **only** a 3,000-line lock file → counted as **0 insertions, 0 files** (excluded), passes even at limit 1.
- The absent-script path prints a skip message and exits 0.
- The genuine-bloat path still fails (limits unchanged: 500 files / 50,000 insertions on non-generated files).

Follow-up to #1443 / #1440. Unblocks the scope-guard check on #1436 and every future dependency bump.

https://claude.ai/code/session_01897ub4h75gcod3kQRXTVtc

---
_Generated by [Claude Code](https://claude.ai/code/session_01897ub4h75gcod3kQRXTVtc)_