### PR TITLE
Apps page truth pass: honest icons, internet filter, full blurbs, proven connect wizard, AppTesting false-positive audit

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -110,6 +110,8 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { encrypt as keychainEncrypt, hashKeyFull as keychainHashKeyFull } from "../packages/mcp-server/src/keychain-crypto.js";
+import { testCredential as keychainTestCredential } from "../packages/mcp-server/src/keychain-tool.js";
 import { evaluateFishbowlCompletionPolicy } from "./lib/fishbowl-completion-policy.js";
 import { inferFishbowlJobPipeline } from "./lib/fishbowl-job-pipeline.js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
@@ -5295,6 +5297,80 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           );
         if (upErr) throw upErr;
         return res.status(200).json({ success: true, disabled_apps: disabled });
+      }
+
+      // Connect an app from the admin Apps page: live-test the credential against
+      // the platform's test endpoint FIRST, store it (keychain-compatible
+      // encryption into platform_credentials) only when the test passes. A
+      // platform without a usable test endpoint is stored but reported as
+      // unproven (ok: null) so the UI never shows a green tick without proof.
+      case "admin_connect_app": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const platform = typeof body.platform === "string" ? body.platform.trim().toLowerCase() : "";
+        const credential = typeof body.credential === "string" ? body.credential.trim() : "";
+        const apiKey = typeof body.api_key === "string" ? body.api_key.trim() : "";
+        const label = typeof body.label === "string" && body.label.trim() ? body.label.trim() : "default";
+        if (!platform) return res.status(400).json({ error: "platform is required" });
+        if (!credential) return res.status(400).json({ error: "credential is required" });
+        if (!apiKey) return res.status(400).json({ error: "api_key is required for encryption" });
+        if (keychainHashKeyFull(apiKey) !== tenant.apiKeyHash) {
+          return res.status(403).json({ error: "api_key does not match your account." });
+        }
+
+        const { data: connRows } = await supabase
+          .from("platform_connectors")
+          .select("id, name, test_endpoint")
+          .eq("id", platform)
+          .limit(1);
+        const connectorRow = (connRows ?? [])[0] as { id: string; name: string; test_endpoint: string | null } | undefined;
+        if (!connectorRow) return res.status(404).json({ error: `Unknown platform "${platform}".` });
+
+        const test = await keychainTestCredential(platform, credential, connectorRow.test_endpoint ?? null);
+
+        if (!test.passed) {
+          // Live test failed: store nothing, surface the provider's verdict.
+          return res.status(200).json({
+            ok: false,
+            platform,
+            tested: !test.skipped,
+            status_code: test.status_code ?? null,
+            message: test.message,
+          });
+        }
+
+        const enc = keychainEncrypt(credential, apiKey);
+        const now = new Date().toISOString();
+        const { error: connErr } = await supabase
+          .from("platform_credentials")
+          .upsert(
+            {
+              key_hash: tenant.apiKeyHash,
+              platform,
+              label,
+              encrypted_value: enc.encrypted_value,
+              iv: enc.iv,
+              auth_tag: enc.auth_tag,
+              is_valid: true,
+              // Only a real probe earns a test stamp. A skipped test stays null
+              // so the UI shows "Key saved", not a false "Connected".
+              last_tested_at: test.skipped ? null : now,
+              created_at: now,
+            },
+            { onConflict: "key_hash,platform,label" },
+          );
+        if (connErr) throw connErr;
+
+        return res.status(200).json({
+          ok: test.skipped ? null : true,
+          platform,
+          tested: !test.skipped,
+          tested_at: test.skipped ? null : now,
+          message: test.message,
+        });
       }
 
       case "admin_update_fact": {

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -15821,13 +15821,13 @@
     },
     {
       "source": "src/pages/admin/AdminAppTesting.tsx",
-      "hash": "90c9377b4bab",
-      "bytes": 10945
+      "hash": "5ba37cf2abff",
+      "bytes": 11567
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",
-      "hash": "5d2838bcd848",
-      "bytes": 6470
+      "hash": "e837ee6a6e33",
+      "bytes": 7846
     },
     {
       "source": "src/pages/admin/AdminAuditLog.tsx",
@@ -16011,13 +16011,13 @@
     },
     {
       "source": "src/pages/AppDetail.tsx",
-      "hash": "5d2ee9cd8690",
-      "bytes": 5401
+      "hash": "ce60db85ef41",
+      "bytes": 6592
     },
     {
       "source": "src/pages/Apps.tsx",
-      "hash": "1ccab2a4ccad",
-      "bytes": 2647
+      "hash": "f2fab29b2942",
+      "bytes": 3137
     },
     {
       "source": "src/pages/AuthCallback.tsx",
@@ -16381,8 +16381,8 @@
     },
     {
       "source": "packages/mcp-server/src/animechan-tool.ts",
-      "hash": "f77b9af84d81",
-      "bytes": 1735
+      "hash": "52c851f21185",
+      "bytes": 1856
     },
     {
       "source": "packages/mcp-server/src/anthropic-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -85,8 +85,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminSeatsSubscription.tsx | 8511bc4559db | 25328 |
 | src/pages/admin/AdminAgents.tsx | a37a2518aa57 | 49158 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
-| src/pages/admin/AdminAppTesting.tsx | 90c9377b4bab | 10945 |
-| src/pages/admin/AdminTools.tsx | 5d2838bcd848 | 6470 |
+| src/pages/admin/AdminAppTesting.tsx | 5ba37cf2abff | 11567 |
+| src/pages/admin/AdminTools.tsx | e837ee6a6e33 | 7846 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
 | src/pages/admin/AdminEcosystemPages.tsx | a43f559b89c3 | 13821 |
@@ -123,8 +123,8 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminUsers.tsx | 222654ee0f22 | 866 |
 | src/pages/admin/AdminXGate.tsx | 193295e6e4dc | 26811 |
 | src/pages/admin/AdminYou.tsx | a0e051f56e86 | 63243 |
-| src/pages/AppDetail.tsx | 5d2ee9cd8690 | 5401 |
-| src/pages/Apps.tsx | 1ccab2a4ccad | 2647 |
+| src/pages/AppDetail.tsx | ce60db85ef41 | 6592 |
+| src/pages/Apps.tsx | f2fab29b2942 | 3137 |
 | src/pages/AuthCallback.tsx | c7dba82923b5 | 4875 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
 | src/pages/Connect.tsx | 4879515ad320 | 29609 |
@@ -197,7 +197,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | packages/mcp-server/src/amber-tool.ts | 635b10e30a39 | 7078 |
 | packages/mcp-server/src/amiibo-tool.ts | 81076c40936a | 2101 |
 | packages/mcp-server/src/angleconv-tool.ts | 6e8ddaf9344f | 1663 |
-| packages/mcp-server/src/animechan-tool.ts | f77b9af84d81 | 1735 |
+| packages/mcp-server/src/animechan-tool.ts | 52c851f21185 | 1856 |
 | packages/mcp-server/src/anthropic-tool.ts | 72906c764b43 | 9657 |
 | packages/mcp-server/src/aoe2-tool.ts | 13377d4c8ad0 | 3685 |
 | packages/mcp-server/src/apifootball-tool.ts | ff6ec8c8d646 | 3682 |

--- a/docs/adding-a-connector.md
+++ b/docs/adding-a-connector.md
@@ -202,6 +202,7 @@ Only after the connector file **and its test** exist, regenerate in this order:
 cd packages/mcp-server && node scripts/generate-tool-index.mjs   # tool surface
 node scripts/connector-depth-ladder.mjs                          # quality grades (depends on the test existing)
 cd ../.. && node scripts/generate-app-catalog.mjs                # Apps catalog (depends on the ladder)
+node scripts/generate-connector-setup.mjs                        # connect-wizard setup data (when CONNECTOR_SETUP changed)
 node scripts/UnClick-brainmap.mjs                                # brainmap (hashes EVERY source file)
 ```
 
@@ -209,6 +210,13 @@ Why the order: the depth ladder marks a connector "hardened/L5" only if its
 colocated test exists; the app catalog reads the ladder's level; the brainmap
 records a content hash of every file (so it goes stale on **any** edit,
 including docs). If you skip a regen, a `--check` guard fails in CI.
+
+The app catalog also derives each app's `network` field (offline / online /
+hybrid) by scanning the connector source for `fetch(`: no fetch and no brand
+domain = offline; no fetch but a real domain (URL-builder apps) = hybrid;
+anything that fetches = online. In `DOMAIN_OF`, the special value `"local"`
+means "no brand site": it is emitted as `domain: null` so the icon falls back
+to the letter chip instead of asking the favicon service for a bogus host.
 
 ---
 
@@ -257,6 +265,6 @@ are doing the full OAuth flow. Confirm the slug is not already in
 - [ ] `connector-setup.ts`: `CONNECTOR_SETUP` row
 - [ ] `generate-app-catalog.mjs`: category bucket (+ name/blurb/domain)
 - [ ] (optional) L3 registry / L4 signal
-- [ ] Regenerate in order: tool-index -> ladder -> app-catalog -> brainmap
+- [ ] Regenerate in order: tool-index -> ladder -> app-catalog -> connector-setup -> brainmap
 - [ ] `tsc` + MCP `test` chain + `brainmap:check` + app-catalog `--check` + frontend catalog tests
 - [ ] Branch, push, draft PR, auto-merge

--- a/packages/mcp-server/src/animechan-tool.ts
+++ b/packages/mcp-server/src/animechan-tool.ts
@@ -1,7 +1,9 @@
 import { stampMeta } from "./connector-meta.js";
 
 const UA = "UnClick-MCP/1.0";
-const BASE = "https://animechan.io/api/v1";
+// The v1 API lives at api.animechan.io/v1; animechan.io itself is the website
+// and answers /api/v1/* with a 404 page.
+const BASE = "https://api.animechan.io/v1";
 const TIMEOUT_MS = 10_000;
 
 async function fetchJson(url: string): Promise<unknown> {

--- a/packages/mcp-server/src/bored-tool.test.ts
+++ b/packages/mcp-server/src/bored-tool.test.ts
@@ -35,4 +35,20 @@ describe("bored connector resilience (L2)", () => {
     expect(r.activity).toBe("Learn a new recipe");
     expect(r.unclick_meta).toBeDefined();
   });
+
+  it("hits the App Brewery /random and /filter paths (old /api/activity is gone)", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: unknown) => ({
+      ok: true, status: 200,
+      json: async () => [{ activity: "Go hiking", type: "recreational" }],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const r = await boredByType({ type: "recreational" }) as Record<string, unknown>;
+    expect(fetchMock.mock.calls[0][0]).toBe("https://bored-api.appbrewery.com/filter?type=recreational");
+    // /filter returns an array; the tool wraps it so unclick_meta has a home.
+    expect(r.count).toBe(1);
+    expect(Array.isArray(r.activities)).toBe(true);
+
+    await boredRandom({});
+    expect(fetchMock.mock.calls[1][0]).toBe("https://bored-api.appbrewery.com/random");
+  });
 });

--- a/packages/mcp-server/src/bored-tool.ts
+++ b/packages/mcp-server/src/bored-tool.ts
@@ -1,10 +1,11 @@
 // Bored API - activity suggestions.
 // No API key required - completely free and open.
-// Base URL: https://bored-api.appbrewery.com/api/
+// Base URL: https://bored-api.appbrewery.com/ (the App Brewery mirror serves
+// /random and /filter; the old boredapi.com /api/activity paths are gone)
 
 import { stampMeta } from "./connector-meta.js";
 
-const BASE = "https://bored-api.appbrewery.com/api";
+const BASE = "https://bored-api.appbrewery.com";
 const TIMEOUT_MS = Number(process.env.BORED_TIMEOUT_MS) || 10000;
 
 async function boredFetch<T>(path: string): Promise<T> {
@@ -37,9 +38,15 @@ async function boredFetch<T>(path: string): Promise<T> {
 
 const META = { source: "bored-api.appbrewery.com" };
 
+// /filter returns an array of matching activities; /random returns one object.
+function wrapActivities(data: unknown): unknown {
+  if (Array.isArray(data)) return { count: data.length, activities: data };
+  return data;
+}
+
 export async function boredRandom(_args: Record<string, unknown>): Promise<unknown> {
   try {
-    const data = await boredFetch("/activity");
+    const data = await boredFetch("/random");
     return stampMeta(data, { ...META, fetched_at: new Date().toISOString(), next_steps: ["Use bored_by_type to filter activities by type.", "Use bored_by_participants to filter by participant count."] });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
@@ -50,8 +57,8 @@ export async function boredByType(args: Record<string, unknown>): Promise<unknow
   const type = String(args.type ?? "").toLowerCase();
   if (!type) return { error: "type is required (education, recreational, social, diy, charity, cooking, relaxation, music, busywork)." };
   try {
-    const data = await boredFetch(`/activity?type=${encodeURIComponent(type)}`);
-    return stampMeta(data, { ...META, fetched_at: new Date().toISOString(), next_steps: ["Use bored_random for any activity."] });
+    const data = await boredFetch(`/filter?type=${encodeURIComponent(type)}`);
+    return stampMeta(wrapActivities(data), { ...META, fetched_at: new Date().toISOString(), next_steps: ["Use bored_random for any activity."] });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }
@@ -61,8 +68,8 @@ export async function boredByParticipants(args: Record<string, unknown>): Promis
   const participants = Number(args.participants ?? 0);
   if (!participants || participants < 1) return { error: "participants is required (positive integer)." };
   try {
-    const data = await boredFetch(`/activity?participants=${participants}`);
-    return stampMeta(data, { ...META, fetched_at: new Date().toISOString(), next_steps: ["Use bored_by_type to filter by activity type."] });
+    const data = await boredFetch(`/filter?participants=${participants}`);
+    return stampMeta(wrapActivities(data), { ...META, fetched_at: new Date().toISOString(), next_steps: ["Use bored_by_type to filter by activity type."] });
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
   }

--- a/packages/mcp-server/src/isup-tool.ts
+++ b/packages/mcp-server/src/isup-tool.ts
@@ -7,7 +7,11 @@ export async function isupCheck(args: Record<string, unknown>) {
   const domain = String(args.domain ?? "").trim();
   if (!domain) return { error: "domain is required" };
   const url = `${BASE}/${encodeURIComponent(domain)}.json`;
-  const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT) });
+  // isitup.org rejects requests without a custom User-Agent (returns 404).
+  const res = await fetch(url, {
+    headers: { "User-Agent": "UnClickMCP/1.0 (https://unclick.world)" },
+    signal: AbortSignal.timeout(TIMEOUT),
+  });
   if (!res.ok) throw new Error(`isitup.org ${res.status}`);
   const data = await res.json();
   return stampMeta(data, {

--- a/packages/mcp-server/src/keychain-tool.ts
+++ b/packages/mcp-server/src/keychain-tool.ts
@@ -251,7 +251,9 @@ interface TestResult {
   auth_method:    string;
 }
 
-async function testCredential(
+// Exported so the web admin connect flow (api/memory-admin admin_connect_app)
+// can run the exact same live proof before storing a credential.
+export async function testCredential(
   platform:     string,
   credential:   string,
   testEndpoint: string | null

--- a/packages/mcp-server/src/numbers-tool.ts
+++ b/packages/mcp-server/src/numbers-tool.ts
@@ -1,8 +1,8 @@
 // Numbers API integration - interesting facts about numbers, dates, and years.
 // No authentication required - completely free and open.
-// Base URL: https://numbersapi.com/
+// Base URL: http://numbersapi.com/ (the API is HTTP-only; its HTTPS host 404s)
 
-const NUMBERS_BASE = "https://numbersapi.com";
+const NUMBERS_BASE = "http://numbersapi.com";
 const NUMBERS_TIMEOUT_MS = Number(process.env.NUMBERS_TIMEOUT_MS) || 10000;
 
 const VALID_TYPES = ["trivia", "math", "date", "year"] as const;

--- a/packages/mcp-server/src/restcountries-tool.test.ts
+++ b/packages/mcp-server/src/restcountries-tool.test.ts
@@ -38,6 +38,18 @@ describe("rest countries connector resilience (L2)", () => {
     await expect(countryByName({})).rejects.toThrow(/name is required/i);
   });
 
+  it("surfaces the upstream message when the API answers with a non-array body", async () => {
+    // Observed live 2026-06-11: HTTP 200 with an object body crashed every
+    // list operation as "countries.map is not a function".
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ message: "'fields' query not specified", status: 400 }),
+    })));
+    await expect(countryByName({ name: "Australia" })).rejects.toThrow(/REST Countries API error.*fields/i);
+    await expect(countryByCode({ code: "AU" })).rejects.toThrow(/REST Countries API error/i);
+  });
+
   it("normalizes a returned country", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => ({
       ok: true,

--- a/packages/mcp-server/src/restcountries-tool.ts
+++ b/packages/mcp-server/src/restcountries-tool.ts
@@ -45,6 +45,22 @@ async function rcFetch(path: string, fields?: string): Promise<unknown> {
   return response.json();
 }
 
+// --- Shape guard ---
+// The API contract is "array of countries", but upstream has started answering
+// some requests with a bare object (an error/notice body under HTTP 200). That
+// used to crash as "countries.map is not a function". Surface the upstream
+// message as a clean error instead, so the caller sees what actually happened.
+function toCountryArray(data: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(data)) return data as Array<Record<string, unknown>>;
+  if (data && typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    const message = typeof obj.message === "string" ? obj.message : null;
+    const status = obj.status !== undefined ? ` (status ${String(obj.status)})` : "";
+    throw new Error(`REST Countries API error${status}: ${message ?? "unexpected non-array response."}`);
+  }
+  throw new Error("REST Countries API returned an unexpected response shape.");
+}
+
 // --- Normalizer ---
 
 function normalizeCountry(c: Record<string, unknown>) {
@@ -93,7 +109,7 @@ export async function countryAll(args: Record<string, unknown>): Promise<unknown
 
   if (data && typeof data === "object" && "results" in data) return data;
 
-  const countries = data as Array<Record<string, unknown>>;
+  const countries = toCountryArray(data);
   return {
     count: countries.length,
     countries: countries.map(normalizeCountry),
@@ -108,7 +124,7 @@ export async function countryByName(args: Record<string, unknown>): Promise<unkn
 
   if (data && typeof data === "object" && "results" in data) return data;
 
-  const countries = data as Array<Record<string, unknown>>;
+  const countries = toCountryArray(data);
   return stampMeta({
     count: countries.length,
     countries: countries.map(normalizeCountry),
@@ -127,11 +143,16 @@ export async function countryByCode(args: Record<string, unknown>): Promise<unkn
 
   if (data && typeof data === "object" && "results" in data) return data;
 
-  // /alpha/{code} can return a single object or array
-  const arr = Array.isArray(data) ? data : [data];
+  // /alpha/{code} can return a single country object or an array; anything
+  // else (error/notice bodies) goes through the shape guard.
+  const arr = Array.isArray(data)
+    ? (data as Array<Record<string, unknown>>)
+    : data && typeof data === "object" && "name" in (data as Record<string, unknown>)
+      ? [data as Record<string, unknown>]
+      : toCountryArray(data);
   return {
     count: arr.length,
-    countries: (arr as Array<Record<string, unknown>>).map(normalizeCountry),
+    countries: arr.map(normalizeCountry),
   };
 }
 
@@ -144,7 +165,7 @@ export async function countryByRegion(args: Record<string, unknown>): Promise<un
 
   if (data && typeof data === "object" && "results" in data) return data;
 
-  const countries = data as Array<Record<string, unknown>>;
+  const countries = toCountryArray(data);
   return {
     region,
     count: countries.length,
@@ -160,7 +181,7 @@ export async function countryByCurrency(args: Record<string, unknown>): Promise<
 
   if (data && typeof data === "object" && "results" in data) return data;
 
-  const countries = data as Array<Record<string, unknown>>;
+  const countries = toCountryArray(data);
   return {
     currency,
     count: countries.length,
@@ -176,7 +197,7 @@ export async function countryByLanguage(args: Record<string, unknown>): Promise<
 
   if (data && typeof data === "object" && "results" in data) return data;
 
-  const countries = data as Array<Record<string, unknown>>;
+  const countries = toCountryArray(data);
   return {
     language,
     count: countries.length,

--- a/scripts/generate-app-catalog.mjs
+++ b/scripts/generate-app-catalog.mjs
@@ -762,6 +762,9 @@ function capBlurb(text) {
 
 // Brand domains for the favicon icon. Known brands show a real favicon (framed
 // consistently); unknown apps fall back to the tinted letter chip at render time.
+// The special value "local" marks a connector with no real brand site (pure
+// local compute). It is emitted as domain: null so the icon never asks a favicon
+// service for a bogus host, and it feeds the offline/online/hybrid classifier.
 const DOMAIN_OF = {
   github: "github.com", gitlab: "gitlab.com", vercel: "vercel.com", netlify: "netlify.com",
   render: "render.com", flyio: "fly.io", digitalocean: "digitalocean.com", circleci: "circleci.com",
@@ -958,6 +961,27 @@ function titleCase(slug) {
   return slug.split(/[-_]/).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
 }
 
+// ─── Network classification (offline / online / hybrid) ────────────────────────
+// Read straight from each connector's source file: a connector that calls
+// fetch() needs the internet ("online"). A connector with no network call is
+// pure local compute ("offline"). A connector that does not fetch but builds
+// URLs pointing at an external service (QR Server, Placehold, RoboHash, ...)
+// is "hybrid": the action itself works offline, but its output needs internet.
+const MCP_SRC = path.join(ROOT, "packages/mcp-server/src");
+
+function classifyNetwork(slug) {
+  let src = "";
+  try {
+    src = fs.readFileSync(path.join(MCP_SRC, `${slug}-tool.ts`), "utf8");
+  } catch {
+    return "online"; // unknown source: assume the conservative case
+  }
+  if (/\bfetch\s*\(/.test(src)) return "online";
+  const domain = DOMAIN_OF[slug];
+  if (domain && domain !== "local") return "hybrid";
+  return "offline";
+}
+
 function build() {
   const toolIndex = Object.values(JSON.parse(fs.readFileSync(TOOL_INDEX, "utf8")));
   const ladder = JSON.parse(fs.readFileSync(LADDER, "utf8"));
@@ -971,12 +995,14 @@ function build() {
       const category = CATEGORY_OF[slug] ?? "Other";
       if (category === "Other") uncategorized.push(slug);
       const grade = levelOf.get(slug) ?? null;
+      const domain = DOMAIN_OF[slug] && DOMAIN_OF[slug] !== "local" ? DOMAIN_OF[slug] : null;
       return {
         slug,
         name: NAME_OF[slug] ?? titleCase(slug),
         category,
         blurb: BLURB_OF[slug] ?? capBlurb(tools[0]?.description ?? `${NAME_OF[slug] ?? titleCase(slug)} tools.`),
-        domain: DOMAIN_OF[slug] ?? null,
+        domain,
+        network: classifyNetwork(slug),
         toolCount: tools.length,
         tools: tools.map((t) => ({ name: t.name, description: t.description })),
         level: grade?.level ?? null,

--- a/scripts/generate-connector-setup.mjs
+++ b/scripts/generate-connector-setup.mjs
@@ -1,0 +1,63 @@
+// Generates src/data/connector-setup.generated.json from the canonical
+// connector setup registry (packages/mcp-server/src/connector-setup.ts).
+// The frontend connect wizard reads this to show, per app, what credential is
+// needed, where to get it, and any extra setup note - without importing the
+// MCP package into browser code.
+//
+// Run:        node scripts/generate-connector-setup.mjs
+// Verify CI:  node scripts/generate-connector-setup.mjs --check
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const SOURCE = path.join(ROOT, "packages/mcp-server/src/connector-setup.ts");
+const OUT = path.join(ROOT, "src/data/connector-setup.generated.json");
+
+const FIELDS = ["displayName", "credential", "arg", "envVar", "setupUrl", "note"];
+
+function parse(source) {
+  const start = source.indexOf("export const CONNECTOR_SETUP");
+  if (start === -1) throw new Error("CONNECTOR_SETUP not found in connector-setup.ts");
+  const body = source.slice(start);
+
+  // One row looks like:  slug: { displayName: "...", credential: "...", ... },
+  // Keys may be quoted ("npm-registry"). Field values are one-line strings.
+  const rowRe = /^\s{2}(?:"([a-z0-9-]+)"|([a-z0-9-]+)):\s*\{([\s\S]*?)^\s{2}\},/gm;
+  const fieldRe = /(\w+):\s*"((?:[^"\\]|\\.)*)"/g;
+
+  const connectors = {};
+  for (const m of body.matchAll(rowRe)) {
+    const slug = m[1] ?? m[2];
+    const chunk = m[3];
+    const row = {};
+    for (const f of chunk.matchAll(fieldRe)) {
+      const [, key, raw] = f;
+      if (!FIELDS.includes(key)) continue;
+      row[key] = raw.replace(/\\"/g, '"');
+    }
+    if (Object.keys(row).length > 0) connectors[slug] = row;
+  }
+  return connectors;
+}
+
+const connectors = parse(fs.readFileSync(SOURCE, "utf8"));
+const json = JSON.stringify(
+  { generatedAt: "static", count: Object.keys(connectors).length, connectors },
+  null,
+  2,
+) + "\n";
+
+if (process.argv.includes("--check")) {
+  const current = fs.existsSync(OUT) ? fs.readFileSync(OUT, "utf8") : "";
+  if (current !== json) {
+    console.error("connector setup data is stale. Run: node scripts/generate-connector-setup.mjs");
+    process.exit(1);
+  }
+  console.log(`connector setup data up to date (${Object.keys(connectors).length} connectors).`);
+} else {
+  fs.writeFileSync(OUT, json);
+  console.log(`Wrote ${path.relative(ROOT, OUT)} (${Object.keys(connectors).length} connectors).`);
+}

--- a/src/components/apps/AppIcon.tsx
+++ b/src/components/apps/AppIcon.tsx
@@ -43,7 +43,11 @@ export function AppIcon({
   const [imgFailed, setImgFailed] = useState(false);
   const letter = (name.replace(/[^A-Za-z0-9]/g, "").charAt(0) || "?").toUpperCase();
   const tint = CATEGORY_TINT[category] ?? "#9ca3af";
-  const showImg = Boolean(domain) && !imgFailed;
+  // Only real, dotted hostnames get a favicon lookup. Anything else (null, the
+  // legacy "local" marker, bare words) falls straight back to the letter chip,
+  // because the favicon service answers unknown hosts with a generic placeholder
+  // instead of an error - which used to leave built-in apps with a junk icon.
+  const showImg = Boolean(domain && domain.includes(".")) && !imgFailed;
 
   return (
     <span

--- a/src/components/apps/AppsTable.test.tsx
+++ b/src/components/apps/AppsTable.test.tsx
@@ -5,9 +5,9 @@ import { AppsTable } from "./AppsTable";
 import type { AppEntry } from "@/lib/appCatalog";
 
 const APPS: AppEntry[] = [
-  { slug: "github", name: "GitHub", category: "Developer & infra", blurb: "Manage repos.", domain: null, toolCount: 1, tools: [{ name: "github_action", description: "Repos and issues." }], level: 2, hardened: true },
-  { slug: "jobsmith", name: "Jobsmith", category: "Productivity", blurb: "Create source-backed job applications.", domain: null, toolCount: 2, tools: [{ name: "jobsmith_check", description: "Check application quality." }], level: 5, hardened: true },
-  { slug: "openmeteo", name: "Open-Meteo", category: "Weather & science", blurb: "Forecasts.", domain: null, toolCount: 3, tools: [{ name: "weather_current", description: "Current weather." }], level: 5, hardened: true },
+  { slug: "github", name: "GitHub", category: "Developer & infra", blurb: "Manage repos.", domain: null, network: "online", toolCount: 1, tools: [{ name: "github_action", description: "Repos and issues." }], level: 2, hardened: true },
+  { slug: "jobsmith", name: "Jobsmith", category: "Productivity", blurb: "Create source-backed job applications.", domain: null, network: "offline", toolCount: 2, tools: [{ name: "jobsmith_check", description: "Check application quality." }], level: 5, hardened: true },
+  { slug: "openmeteo", name: "Open-Meteo", category: "Weather & science", blurb: "Forecasts.", domain: null, network: "online", toolCount: 3, tools: [{ name: "weather_current", description: "Current weather." }], level: 5, hardened: true },
 ];
 
 function renderTable(ui: React.ReactElement) {
@@ -44,6 +44,47 @@ describe("AppsTable", () => {
     fireEvent.change(search, { target: { value: "jo smi" } });
     expect(screen.getByText("Jobsmith")).toBeInTheDocument();
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+  });
+
+  it("filters by internet need via the offline / online / hybrid chips", () => {
+    renderTable(<AppsTable apps={APPS} mode="public" />);
+    expect(screen.getByText("Jobsmith")).toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Works offline" }));
+    expect(screen.getByText("Jobsmith")).toBeInTheDocument();
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Uses internet" }));
+    expect(screen.queryByText("Jobsmith")).not.toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+  });
+
+  it("shows the full blurb and the internet badge when a row is expanded", () => {
+    renderTable(<AppsTable apps={APPS} mode="public" />);
+    const row = screen.getByText("Jobsmith").closest("[role='button']");
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+    // The blurb now appears twice: the truncated cell and the untruncated
+    // expansion (the fix for descriptions being cut off with no way to read them).
+    expect(screen.getAllByText(APPS[1].blurb).length).toBeGreaterThanOrEqual(2);
+    // "Works offline" shows as both the filter chip (button) and the badge (span).
+    expect(screen.getAllByText("Works offline").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("Check application quality.")).toBeInTheDocument();
+  });
+
+  it("admin mode: the status pill becomes a button that fires onStatusClick", () => {
+    const onStatusClick = vi.fn();
+    renderTable(
+      <AppsTable
+        apps={[APPS[0]]}
+        mode="admin"
+        statusOf={() => ({ label: "Needs key", tone: "" })}
+        onStatusClick={onStatusClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Needs key" }));
+    expect(onStatusClick).toHaveBeenCalledWith(expect.objectContaining({ slug: "github" }));
   });
 
   it("admin mode shows checkboxes + bulk controls and fires toggle callbacks", () => {

--- a/src/components/apps/AppsTable.tsx
+++ b/src/components/apps/AppsTable.tsx
@@ -15,7 +15,15 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { ArrowDown, ArrowUp, ChevronRight, Search } from "lucide-react";
-import { actionLabel, APP_CATEGORIES, levelLabel, type AppEntry, type AppTool } from "@/lib/appCatalog";
+import {
+  actionLabel,
+  APP_CATEGORIES,
+  levelLabel,
+  NETWORK_META,
+  NETWORK_ORDER,
+  type AppEntry,
+  type AppTool,
+} from "@/lib/appCatalog";
 import { AppIcon } from "./AppIcon";
 import { useAppFilter, type AppSortKey } from "./useAppFilter";
 
@@ -32,6 +40,8 @@ interface AppsTableProps {
   onToggle?: (slug: string, next: boolean) => void;
   onToggleAll?: (next: boolean) => void;
   statusOf?: (app: AppEntry) => AppStatus | null;
+  /** admin: makes the status pill a button (used to open the connect wizard). */
+  onStatusClick?: (app: AppEntry) => void;
   busy?: boolean;
 }
 
@@ -54,8 +64,8 @@ function SortHeader({
   );
 }
 
-export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf, busy }: AppsTableProps) {
-  const { query, setQuery, category, setCategory, sortKey, sortDir, toggleSort, filtered } = useAppFilter(apps);
+export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf, onStatusClick, busy }: AppsTableProps) {
+  const { query, setQuery, category, setCategory, network, setNetwork, sortKey, sortDir, toggleSort, filtered } = useAppFilter(apps);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [showRaw, setShowRaw] = useState(false);
   const isAdmin = mode === "admin";
@@ -155,6 +165,21 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
         ))}
       </div>
 
+      {/* Network chips: does the app need internet? */}
+      <div className="mb-3 flex flex-wrap items-center gap-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-white/35">Internet</span>
+        <Chip label="Any" active={network === null} onClick={() => setNetwork(null)} />
+        {NETWORK_ORDER.map((n) => (
+          <Chip
+            key={n}
+            label={NETWORK_META[n].label}
+            title={NETWORK_META[n].description}
+            active={network === n}
+            onClick={() => setNetwork(network === n ? null : n)}
+          />
+        ))}
+      </div>
+
       {/* Header row */}
       <div className={`grid ${cols} items-center gap-3 border-b border-white/[0.08] px-3 py-2`}>
         {isAdmin && <span className="text-[10px] font-semibold uppercase tracking-wide text-white/35">On</span>}
@@ -207,7 +232,7 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
                   <span className="truncate font-medium text-white hover:text-[#9be4e6]">{app.name}</span>
                 </Link>
                 <span className="truncate text-white/45">{app.category}</span>
-                <span className="truncate text-white/50">{app.blurb}</span>
+                <span className="truncate text-white/50" title={app.blurb}>{app.blurb}</span>
                 <span className="flex items-center justify-end gap-1 tabular-nums text-white/40">
                   <ChevronRight className={`h-3 w-3 transition-transform ${open ? "rotate-90 text-[#61C1C4]" : "text-white/30"}`} />
                   {app.toolCount}
@@ -215,7 +240,20 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
                 <div className="flex justify-end">
                   {isAdmin ? (
                     status ? (
-                      <span className={`rounded border px-1.5 py-0.5 text-[10px] font-medium ${status.tone}`}>{status.label}</span>
+                      onStatusClick ? (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onStatusClick(app);
+                          }}
+                          className={`rounded border px-1.5 py-0.5 text-[10px] font-medium transition-opacity hover:opacity-80 ${status.tone}`}
+                        >
+                          {status.label}
+                        </button>
+                      ) : (
+                        <span className={`rounded border px-1.5 py-0.5 text-[10px] font-medium ${status.tone}`}>{status.label}</span>
+                      )
                     ) : (
                       <span className="text-[10px] text-white/30">{on ? "On" : "Off"}</span>
                     )
@@ -231,6 +269,17 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
               {open && (
                 <div className={`grid ${cols} gap-3 bg-white/[0.015] px-3 pb-2`}>
                   <div style={{ gridColumn: `${actionsColStart} / -1` }} className="min-w-0">
+                    {/* Full, untruncated description first, so nothing is lost to the
+                        single-line row above. The internet badge rides along. */}
+                    <div className="flex flex-wrap items-center gap-2 py-1.5">
+                      <span className="text-[11px] leading-snug text-white/70">{app.blurb}</span>
+                      <span
+                        title={NETWORK_META[app.network].description}
+                        className="rounded border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[10px] font-medium text-white/55"
+                      >
+                        {NETWORK_META[app.network].label}
+                      </span>
+                    </div>
                     {app.tools.map((t) => (
                       <div key={t.name} className="border-t border-white/[0.04] py-1.5 first:border-t-0">
                         <span className="block text-[10px] font-medium text-white/85">{actionLabel(t)}</span>
@@ -254,10 +303,11 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
   );
 }
 
-function Chip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+function Chip({ label, active, onClick, title }: { label: string; active: boolean; onClick: () => void; title?: string }) {
   return (
     <button
       type="button"
+      title={title}
       onClick={onClick}
       className={`rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors ${
         active

--- a/src/components/apps/ConnectAppModal.test.tsx
+++ b/src/components/apps/ConnectAppModal.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectAppModal } from "./ConnectAppModal";
+import type { AppEntry } from "@/lib/appCatalog";
+
+const APP: AppEntry = {
+  slug: "alphavantage",
+  name: "Alpha Vantage",
+  category: "Markets & crypto",
+  blurb: "Stocks and FX.",
+  domain: null,
+  network: "online",
+  toolCount: 1,
+  tools: [{ name: "stock_quote", description: "Get a stock quote." }],
+  level: 5,
+  hardened: true,
+};
+
+const CONNECTOR = { id: "alphavantage", auth_type: "api_key" as const, setup_url: null };
+
+function renderModal(overrides: Partial<Parameters<typeof ConnectAppModal>[0]> = {}) {
+  return render(
+    <ConnectAppModal
+      app={APP}
+      connector={CONNECTOR}
+      accessToken="session-token"
+      onClose={() => {}}
+      onSaved={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+describe("ConnectAppModal", () => {
+  beforeEach(() => {
+    localStorage.setItem("unclick_api_key", "uk_test_key");
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("explains the proof-first contract and uses the registry's credential label", () => {
+    renderModal();
+    expect(screen.getByText(/live-tested first and only stored/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/paste api key here/i)).toBeInTheDocument();
+    // Setup link comes from the generated CONNECTOR_SETUP registry.
+    expect(screen.getByRole("link", { name: /where do i get my api key/i })).toHaveAttribute(
+      "href",
+      "https://www.alphavantage.co/support/#api-key",
+    );
+  });
+
+  it("shows a proven green state only when the server reports ok: true", async () => {
+    const onSaved = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: true, message: "Credential verified in 120ms." }),
+        }),
+      ),
+    );
+    renderModal({ onSaved });
+    fireEvent.change(screen.getByPlaceholderText(/paste api key here/i), { target: { value: "demo-key" } });
+    fireEvent.click(screen.getByRole("button", { name: /test and connect/i }));
+    expect(await screen.findByText(/connected, live-tested/i)).toBeInTheDocument();
+    expect(onSaved).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/memory-admin?action=admin_connect_app",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("reports an honest unproven save when no live test exists (ok: null)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: null, message: "no probe" }),
+        }),
+      ),
+    );
+    renderModal();
+    fireEvent.change(screen.getByPlaceholderText(/paste api key here/i), { target: { value: "demo-key" } });
+    fireEvent.click(screen.getByRole("button", { name: /test and connect/i }));
+    expect(await screen.findByText(/saved \(not proven\)/i)).toBeInTheDocument();
+  });
+
+  it("surfaces a rejection and stores nothing when the platform refuses the key", async () => {
+    const onSaved = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ok: false, message: "Credential rejected by alphavantage (HTTP 401)." }),
+        }),
+      ),
+    );
+    renderModal({ onSaved });
+    fireEvent.change(screen.getByPlaceholderText(/paste api key here/i), { target: { value: "bad-key" } });
+    fireEvent.click(screen.getByRole("button", { name: /test and connect/i }));
+    expect(await screen.findByText(/credential rejected/i)).toBeInTheDocument();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("asks for the UnClick API key when it is not cached in this browser", async () => {
+    localStorage.clear();
+    renderModal();
+    fireEvent.change(screen.getByPlaceholderText(/paste api key here/i), { target: { value: "demo-key" } });
+    fireEvent.click(screen.getByRole("button", { name: /test and connect/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/not cached in this browser/i);
+  });
+
+  it("routes OAuth platforms to the login flow instead of a key field", () => {
+    renderModal({ connector: { id: "github", auth_type: "oauth2", setup_url: null } });
+    expect(screen.getByRole("link", { name: /continue to alpha vantage login/i })).toHaveAttribute(
+      "href",
+      "/connect/alphavantage",
+    );
+    expect(screen.queryByPlaceholderText(/paste/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/apps/ConnectAppModal.tsx
+++ b/src/components/apps/ConnectAppModal.tsx
@@ -1,0 +1,215 @@
+// Connect wizard for apps that show "Needs key" / "Needs login" on the admin
+// Apps page. Click the status pill -> this modal opens -> paste the key ->
+// Submit. The server (admin_connect_app) live-tests the credential against the
+// platform's test endpoint BEFORE storing it:
+//   - test passes  -> stored, green "Connected, live-tested"
+//   - test fails   -> NOT stored, the provider's rejection is shown
+//   - no test path -> stored, amber "Saved, not yet proven"
+// So a green tick is always a proven connection, never an assumption.
+
+import { useState } from "react";
+import { CheckCircle2, ExternalLink, KeyRound, Loader2, X, XCircle, AlertTriangle } from "lucide-react";
+import type { AppEntry } from "@/lib/appCatalog";
+import connectorSetupData from "@/data/connector-setup.generated.json";
+
+interface ConnectorSetupRow {
+  displayName?: string;
+  credential?: string;
+  arg?: string;
+  envVar?: string;
+  setupUrl?: string;
+  note?: string;
+}
+
+const CONNECTOR_SETUP: Record<string, ConnectorSetupRow> =
+  (connectorSetupData as { connectors: Record<string, ConnectorSetupRow> }).connectors;
+
+export interface ConnectableConnector {
+  id: string;
+  auth_type?: "oauth2" | "api_key" | "bot_token";
+  setup_url?: string | null;
+}
+
+interface ConnectAppModalProps {
+  app: AppEntry;
+  connector: ConnectableConnector;
+  accessToken: string;
+  onClose: () => void;
+  /** Called after a credential was stored, so the caller can refresh statuses. */
+  onSaved: () => void;
+}
+
+type Outcome =
+  | { kind: "connected"; message: string }
+  | { kind: "saved_unproven"; message: string }
+  | { kind: "rejected"; message: string };
+
+function readLocalApiKey(): string | null {
+  try {
+    return localStorage.getItem("unclick_api_key");
+  } catch {
+    return null;
+  }
+}
+
+export function ConnectAppModal({ app, connector, accessToken, onClose, onSaved }: ConnectAppModalProps) {
+  const setup = CONNECTOR_SETUP[app.slug];
+  const [credential, setCredential] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [outcome, setOutcome] = useState<Outcome | null>(null);
+
+  const credentialLabel = setup?.credential ?? "API key";
+  const setupUrl = setup?.setupUrl ?? connector.setup_url ?? null;
+  const isOAuth = connector.auth_type === "oauth2";
+
+  async function submit() {
+    const apiKey = readLocalApiKey();
+    if (!apiKey) {
+      setError("Your UnClick API key is not cached in this browser. Visit the You page (/admin/you) to claim it, then retry.");
+      return;
+    }
+    if (!credential.trim()) {
+      setError(`Paste your ${credentialLabel} first.`);
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setOutcome(null);
+    try {
+      const res = await fetch("/api/memory-admin?action=admin_connect_app", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ platform: app.slug, credential: credential.trim(), api_key: apiKey }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean | null;
+        message?: string;
+        error?: string;
+      };
+      if (!res.ok) {
+        setError(body.error ?? `Connect failed with ${res.status}.`);
+        return;
+      }
+      if (body.ok === true) {
+        setOutcome({ kind: "connected", message: body.message ?? "Credential verified." });
+        setCredential("");
+        onSaved();
+      } else if (body.ok === null) {
+        setOutcome({
+          kind: "saved_unproven",
+          message: "Key saved and encrypted. This app has no automatic live test yet, so it is marked as saved (not proven) until its first real use.",
+        });
+        setCredential("");
+        onSaved();
+      } else {
+        setOutcome({ kind: "rejected", message: body.message ?? "The platform rejected this credential. Nothing was stored." });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Connect failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-md rounded-xl border border-white/[0.08] bg-[#101418] p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="flex items-center gap-2 text-sm font-semibold text-white">
+            <KeyRound className="h-4 w-4 text-[#E2B93B]" />
+            Connect {app.name}
+          </h3>
+          <button onClick={onClose} className="rounded-md p-1 text-[#888] transition-colors hover:bg-white/[0.04] hover:text-white" aria-label="Close">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {isOAuth ? (
+          <div className="text-xs leading-5 text-white/60">
+            <p>{app.name} connects with a login instead of a pasted key.</p>
+            <a
+              href={`/connect/${app.slug}`}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#61C1C4] px-3 py-2 font-medium text-black hover:bg-[#61C1C4]/90"
+            >
+              Continue to {app.name} login
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        ) : (
+          <>
+            <p className="text-xs leading-5 text-white/60">
+              Paste your {app.name} {credentialLabel}. It is live-tested first and only stored (encrypted) when the platform accepts it.
+            </p>
+            {setup?.note && <p className="mt-2 text-[11px] leading-4 text-white/45">{setup.note}</p>}
+            {setupUrl && (
+              <a
+                href={setupUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex items-center gap-1 text-[11px] text-[#9be4e6] hover:underline"
+              >
+                Where do I get my {credentialLabel}?
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+
+            <input
+              type="password"
+              value={credential}
+              onChange={(e) => setCredential(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !busy) void submit();
+              }}
+              placeholder={`Paste ${credentialLabel} here`}
+              autoFocus
+              className="mt-3 w-full rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 text-sm text-white placeholder:text-[#444] focus:border-[#E2B93B]/40 focus:outline-none"
+            />
+
+            {error && (
+              <p role="alert" className="mt-2 text-[11px] text-red-400">{error}</p>
+            )}
+
+            {outcome && (
+              <div
+                role="status"
+                className={`mt-3 flex items-start gap-2 rounded-lg border px-3 py-2 text-[11px] leading-4 ${
+                  outcome.kind === "connected"
+                    ? "border-emerald-300/25 bg-emerald-300/10 text-emerald-100"
+                    : outcome.kind === "saved_unproven"
+                      ? "border-amber-300/25 bg-amber-300/10 text-amber-100"
+                      : "border-red-400/30 bg-red-400/10 text-red-200"
+                }`}
+              >
+                {outcome.kind === "connected" && <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+                {outcome.kind === "saved_unproven" && <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+                {outcome.kind === "rejected" && <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+                <span>
+                  {outcome.kind === "connected" && <strong>Connected, live-tested. </strong>}
+                  {outcome.message}
+                </span>
+              </div>
+            )}
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button onClick={onClose} className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] hover:text-white">
+                {outcome && outcome.kind !== "rejected" ? "Done" : "Cancel"}
+              </button>
+              <button
+                onClick={() => void submit()}
+                disabled={busy}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[#E2B93B] px-3 py-2 text-xs font-medium text-black hover:bg-[#E2B93B]/90 disabled:opacity-50"
+              >
+                {busy && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                {busy ? "Testing key..." : "Test and connect"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/apps/useAppFilter.ts
+++ b/src/components/apps/useAppFilter.ts
@@ -5,7 +5,7 @@
 // and descriptions, so "weather" finds Open-Meteo even by capability.
 
 import { useMemo, useState } from "react";
-import type { AppEntry } from "@/lib/appCatalog";
+import type { AppEntry, AppNetwork } from "@/lib/appCatalog";
 import { appMatchesSearch } from "@/lib/appSearch";
 
 export type AppSortKey = "name" | "category" | "toolCount" | "level";
@@ -14,6 +14,7 @@ export type SortDir = "asc" | "desc";
 export function useAppFilter(apps: AppEntry[]) {
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<string | null>(null);
+  const [network, setNetwork] = useState<AppNetwork | null>(null);
   const [sortKey, setSortKey] = useState<AppSortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -21,6 +22,7 @@ export function useAppFilter(apps: AppEntry[]) {
     let rows = apps;
 
     if (category) rows = rows.filter((a) => a.category === category);
+    if (network) rows = rows.filter((a) => a.network === network);
 
     rows = rows.filter((app) => appMatchesSearch(app, query));
 
@@ -33,7 +35,7 @@ export function useAppFilter(apps: AppEntry[]) {
       else if (sortKey === "level") cmp = (a.level ?? 0) - (b.level ?? 0);
       return cmp * dir;
     });
-  }, [apps, query, category, sortKey, sortDir]);
+  }, [apps, query, category, network, sortKey, sortDir]);
 
   function toggleSort(key: AppSortKey) {
     if (sortKey === key) {
@@ -50,6 +52,8 @@ export function useAppFilter(apps: AppEntry[]) {
     setQuery,
     category,
     setCategory,
+    network,
+    setNetwork,
     sortKey,
     sortDir,
     toggleSort,

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -30,7 +30,8 @@
       "name": "2-SAT Solver",
       "category": "Utilities",
       "blurb": "2-SAT boolean satisfiability solver using implication graph and SCC.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -46,7 +47,8 @@
       "name": "3D Convex Hull",
       "category": "Utilities",
       "blurb": "Compute the 3D convex hull of a point set returning triangular faces.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -62,7 +64,8 @@
       "name": "A* Pathfinding",
       "category": "Utilities",
       "blurb": "Find the shortest path on a 2D grid using the A* algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -79,6 +82,7 @@
       "category": "Travel, maps & local",
       "blurb": "Look up an Australian Business Number (ABN).",
       "domain": null,
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -99,6 +103,7 @@
       "category": "Security",
       "blurb": "Check if an IP address has been reported for abuse.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -122,7 +127,8 @@
       "name": "Ackermann Function",
       "category": "Utilities",
       "blurb": "Compute the Ackermann function A(m,n) with closed-form optimization.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -138,7 +144,8 @@
       "name": "Acronym Generator",
       "category": "Utilities",
       "blurb": "Generate an acronym from a phrase, skipping small words by default.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -154,7 +161,8 @@
       "name": "Activation Functions",
       "category": "Utilities",
       "blurb": "Compute activation functions (sigmoid, tanh, relu, etc.) and their derivatives.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -171,6 +179,7 @@
       "category": "Utilities",
       "blurb": "Get random advice or search advice by topic.",
       "domain": "api.adviceslip.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -195,6 +204,7 @@
       "category": "Utilities",
       "blurb": "Get random positive affirmations for daily motivation.",
       "domain": "affirmations.dev",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -211,6 +221,7 @@
       "category": "Games & esports",
       "blurb": "Browse Age of Empires II civilizations, units, and technologies.",
       "domain": "age-of-empires-2-api.herokuapp.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -242,7 +253,8 @@
       "name": "Aho-Corasick",
       "category": "Utilities",
       "blurb": "Multi-pattern string search using the Aho-Corasick automaton.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -259,6 +271,7 @@
       "category": "Productivity",
       "blurb": "Read and update records across your Airtable bases.",
       "domain": "airtable.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -275,6 +288,7 @@
       "category": "Books",
       "blurb": "Read Quran verses and surahs with English translation.",
       "domain": "alquran.cloud",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -295,6 +309,7 @@
       "category": "Developer & infra",
       "blurb": "Search an Algolia index for records matching a query.",
       "domain": "algolia.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -323,6 +338,7 @@
       "category": "Markets & crypto",
       "blurb": "Get a real-time stock quote from Alpha Vantage.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -359,6 +375,7 @@
       "category": "Shopping",
       "blurb": "Search for products on Amazon.",
       "domain": "amazon.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -387,6 +404,7 @@
       "category": "Travel, maps & local",
       "blurb": "Get Amber Electric sites for the authenticated user.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -411,6 +429,7 @@
       "category": "Games & esports",
       "blurb": "Search Nintendo Amiibo figures by name, series, or type.",
       "domain": "amiiboapi.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -434,7 +453,8 @@
       "name": "Angle Converter",
       "category": "Utilities",
       "blurb": "Convert between degrees, radians, gradians, and turns with trig values.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -451,6 +471,7 @@
       "category": "Games & esports",
       "blurb": "Animal Crossing: New Horizons villagers, fish, and bugs data.",
       "domain": "acnhapi.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -475,6 +496,7 @@
       "category": "Social",
       "blurb": "Get random anime quotes or search by anime title.",
       "domain": "animechan.io",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -495,6 +517,7 @@
       "category": "AI",
       "blurb": "Chat completions from Claude models.",
       "domain": "anthropic.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -514,7 +537,8 @@
       "name": "Area Calculator",
       "category": "Utilities",
       "blurb": "Area and perimeter of circles, rectangles, triangles, trapezoids, ellipses, and more.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -531,6 +555,7 @@
       "category": "News & reading",
       "blurb": "Search and explore artworks from the Art Institute of Chicago collection.",
       "domain": "artic.edu",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -551,6 +576,7 @@
       "category": "Books",
       "blurb": "Search scientific preprints on arXiv by keyword, title, or author.",
       "domain": "arxiv.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -567,6 +593,7 @@
       "category": "Productivity",
       "blurb": "List all Asana workspaces accessible by the authenticated user.",
       "domain": "asana.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -606,7 +633,8 @@
       "name": "Aspect Ratio Calculator",
       "category": "Developer & infra",
       "blurb": "Calculate the simplified aspect ratio for any width and height.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -623,6 +651,7 @@
       "category": "AI",
       "blurb": "Submit an audio or video file for transcription with AssemblyAI.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -658,7 +687,8 @@
       "name": "Atbash Cipher",
       "category": "Utilities",
       "blurb": "Apply the Atbash cipher (A=Z, B=Y) to text. Self-inverse.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -675,6 +705,7 @@
       "category": "Travel, maps & local",
       "blurb": "Track an Australia Post parcel by tracking number.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -698,7 +729,8 @@
       "name": "AVL Tree",
       "category": "Utilities",
       "blurb": "Self-balancing BST with O(log n) insert, search, and height guarantees.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -714,7 +746,8 @@
       "name": "Baby-step Giant-step",
       "category": "Utilities",
       "blurb": "Discrete logarithm solver using baby-step giant-step method.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -731,6 +764,7 @@
       "category": "Utilities",
       "blurb": "Generate meat-themed lorem ipsum placeholder text.",
       "domain": "baconipsum.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -747,6 +781,7 @@
       "category": "Games & esports",
       "blurb": "NBA player stats, team info, and game scores.",
       "domain": "balldontlie.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -771,6 +806,7 @@
       "category": "Events & tickets",
       "blurb": "Get an artist profile from Bandsintown.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -794,7 +830,8 @@
       "name": "Base Converter",
       "category": "Utilities",
       "blurb": "Convert numbers between any bases (binary, octal, decimal, hex, base 2-36).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -810,7 +847,8 @@
       "name": "Base64 Codec",
       "category": "Developer & infra",
       "blurb": "Encode and decode text to/from Base64.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -830,7 +868,8 @@
       "name": "Bellman-Ford",
       "category": "Utilities",
       "blurb": "Single-source shortest paths with negative edge weight support (Bellman-Ford).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -846,7 +885,8 @@
       "name": "Berlekamp-Massey",
       "category": "Utilities",
       "blurb": "Find the shortest linear recurrence for a sequence using Berlekamp-Massey.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -862,7 +902,8 @@
       "name": "Bezier Clip",
       "category": "Utilities",
       "blurb": "Extract a Bezier sub-curve for a parameter range using de Casteljau subdivision.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -878,7 +919,8 @@
       "name": "Bezier Curve",
       "category": "Utilities",
       "blurb": "Compute Bezier curves from control points with arc length and evaluation.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -894,7 +936,8 @@
       "name": "BFS Search",
       "category": "Utilities",
       "blurb": "Breadth-first search for shortest unweighted paths and reachability.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -911,6 +954,7 @@
       "category": "Security",
       "blurb": "BGP/ASN lookup: network details, IP prefixes, and routing data.",
       "domain": "bgpview.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -935,6 +979,7 @@
       "category": "Books",
       "blurb": "Look up Bible verses and passages, or get a random verse.",
       "domain": "bible-api.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -954,7 +999,8 @@
       "name": "Binomial Probability",
       "category": "Utilities",
       "blurb": "Binomial distribution probability, cumulative probabilities, mean, and variance.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -970,7 +1016,8 @@
       "name": "Bipartite Check",
       "category": "Utilities",
       "blurb": "Check if a graph is bipartite and return the vertex partition or odd cycle.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -986,7 +1033,8 @@
       "name": "Bit Count",
       "category": "Utilities",
       "blurb": "Count set bits, convert between decimal/binary/hex/octal, detect powers of two.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1003,6 +1051,7 @@
       "category": "Developer & infra",
       "blurb": "Browse Bitbucket repositories and pull requests.",
       "domain": "bitbucket.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1026,7 +1075,8 @@
       "name": "Bitmask Ops",
       "category": "Utilities",
       "blurb": "Bitmask operations: submasks, supersets, next permutation, and bit info.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1042,7 +1092,8 @@
       "name": "Bitwise Calculator",
       "category": "Developer & infra",
       "blurb": "Perform bitwise operations (AND, OR, XOR, NOT, shifts) on integers.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1058,7 +1109,8 @@
       "name": "Bloom Filter",
       "category": "Utilities",
       "blurb": "Probabilistic set membership testing with configurable false positive rate.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1075,6 +1127,7 @@
       "category": "Social",
       "blurb": "Post, read, search, and follow on Bluesky.",
       "domain": "bsky.app",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -1091,6 +1144,7 @@
       "category": "Games & esports",
       "blurb": "Search BoardGameGeek for board games by name.",
       "domain": null,
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -1122,7 +1176,8 @@
       "name": "Booth's Rotation",
       "category": "Utilities",
       "blurb": "Find the lexicographically smallest rotation of a string in O(n).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1139,6 +1194,7 @@
       "category": "Utilities",
       "blurb": "Get random activity suggestions when you need inspiration.",
       "domain": "bored-api.appbrewery.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1162,7 +1218,8 @@
       "name": "Braille Converter",
       "category": "Utilities",
       "blurb": "Convert text to Braille Unicode dots or decode Braille to text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1179,6 +1236,7 @@
       "category": "Social",
       "blurb": "Get random Breaking Bad quotes.",
       "domain": "breakingbadquotes.xyz",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -1195,6 +1253,7 @@
       "category": "Messaging & email",
       "blurb": "Read Brevo contacts, email campaigns, and account.",
       "domain": "brevo.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1218,7 +1277,8 @@
       "name": "Bucket Sort",
       "category": "Utilities",
       "blurb": "Distribution-based sort dividing elements into buckets then merging.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1235,6 +1295,7 @@
       "category": "Games & esports",
       "blurb": "Search for a Destiny 2 player by display name.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -1262,7 +1323,8 @@
       "name": "Burrows-Wheeler",
       "category": "Utilities",
       "blurb": "Burrows-Wheeler Transform for text compression preprocessing.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1279,6 +1341,7 @@
       "category": "AI",
       "blurb": "Run a C-Suite multi-perspective analysis on a business scenario.",
       "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1295,6 +1358,7 @@
       "category": "Productivity",
       "blurb": "Get the authenticated Cal.com user's profile.",
       "domain": "cal.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1319,6 +1383,7 @@
       "category": "Utilities",
       "blurb": "Calculate tip amount and total for a bill.",
       "domain": null,
+      "network": "offline",
       "toolCount": 5,
       "tools": [
         {
@@ -1351,6 +1416,7 @@
       "category": "Productivity",
       "blurb": "Get the authenticated Calendly user profile.",
       "domain": "calendly.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -1383,6 +1449,7 @@
       "category": "Weather & science",
       "blurb": "UK national grid carbon intensity - current, forecast, and generation mix.",
       "domain": "carbonintensity.org.uk",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1407,6 +1474,7 @@
       "category": "Weather & science",
       "blurb": "Estimate carbon emissions for a flight.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1430,7 +1498,8 @@
       "name": "Cartesian Tree",
       "category": "Utilities",
       "blurb": "Cartesian tree construction from an array for range minimum queries.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1446,7 +1515,8 @@
       "name": "Case Converter",
       "category": "Utilities",
       "blurb": "Convert between camelCase, PascalCase, snake_case, kebab-case, and CONSTANT_CASE.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1463,6 +1533,7 @@
       "category": "Images",
       "blurb": "Random cat images with optional text overlay and tags.",
       "domain": "cataas.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -1483,6 +1554,7 @@
       "category": "Utilities",
       "blurb": "Get random cat facts and browse cat breeds.",
       "domain": "catfact.ninja",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1506,7 +1578,8 @@
       "name": "Catalan Numbers",
       "category": "Utilities",
       "blurb": "Compute the nth Catalan number with combinatorial interpretations.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1522,7 +1595,8 @@
       "name": "Catmull-Rom Spline",
       "category": "Utilities",
       "blurb": "Evaluate Catmull-Rom splines through control points with configurable alpha.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1538,7 +1612,8 @@
       "name": "Centroid Decomposition",
       "category": "Utilities",
       "blurb": "Centroid decomposition of trees for efficient path queries.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1554,7 +1629,8 @@
       "name": "Character Codes",
       "category": "Utilities",
       "blurb": "Convert characters to Unicode code points in decimal, hex, or binary.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1570,7 +1646,8 @@
       "name": "Character Frequency",
       "category": "Developer & infra",
       "blurb": "Analyze character frequency and type breakdown for any text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1587,6 +1664,7 @@
       "category": "Games & esports",
       "blurb": "Compare game deals across Steam, GOG, and other stores.",
       "domain": "cheapshark.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -1607,6 +1685,7 @@
       "category": "Games & esports",
       "blurb": "Get a Chess.com player profile.",
       "domain": null,
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -1638,7 +1717,8 @@
       "name": "Chinese Remainder",
       "category": "Utilities",
       "blurb": "Solve simultaneous congruences using the generalised Chinese Remainder Theorem.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1654,7 +1734,8 @@
       "name": "Chinese Remainder Theorem",
       "category": "Utilities",
       "blurb": "Solve simultaneous congruences using the Chinese Remainder Theorem.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1670,7 +1751,8 @@
       "name": "Chromatic Number",
       "category": "Utilities",
       "blurb": "Exact chromatic number computation using inclusion-exclusion (up to 20 vertices).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1687,6 +1769,7 @@
       "category": "Utilities",
       "blurb": "Get random Chuck Norris jokes by category.",
       "domain": "api.chucknorris.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1710,7 +1793,8 @@
       "name": "CIDR Calculator",
       "category": "Developer & infra",
       "blurb": "Calculate subnet details from CIDR notation (network, broadcast, hosts).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1727,6 +1811,7 @@
       "category": "Security",
       "blurb": "CVE vulnerability lookup and recent CVE feed from CIRCL.",
       "domain": "cve.circl.lu",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -1747,6 +1832,7 @@
       "category": "Developer & infra",
       "blurb": "List CircleCI pipelines for a project or organization. Optionally filter by branch.",
       "domain": "circleci.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -1783,6 +1869,7 @@
       "category": "Travel, maps & local",
       "blurb": "Browse bike-sharing networks and station availability worldwide.",
       "domain": "citybik.es",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -1803,6 +1890,7 @@
       "category": "Productivity",
       "blurb": "Read and update ClickUp tasks, lists, and spaces.",
       "domain": "clickup.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -1819,6 +1907,7 @@
       "category": "Productivity",
       "blurb": "Track time and read Clockify projects and reports.",
       "domain": "clockify.me",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -1835,6 +1924,7 @@
       "category": "Developer & infra",
       "blurb": "List your Cloudinary media and check usage.",
       "domain": "cloudinary.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -1855,6 +1945,7 @@
       "category": "Weather & science",
       "blurb": "Filter cocktails by ingredient and get ingredient details.",
       "domain": "thecocktaildb.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -1875,6 +1966,7 @@
       "category": "Productivity",
       "blurb": "Read your Coda docs, tables, and rows.",
       "domain": "coda.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1899,6 +1991,7 @@
       "category": "AI",
       "blurb": "Chat with a Cohere Command model. Supports system preamble and conversation history.",
       "domain": "cohere.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -1934,7 +2027,8 @@
       "name": "Coin Change",
       "category": "Utilities",
       "blurb": "Minimum coins and combination count for a target amount using DP.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -1951,6 +2045,7 @@
       "category": "Markets & crypto",
       "blurb": "Real-time cryptocurrency market data, asset prices, and exchange rates.",
       "domain": "coincap.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -1975,6 +2070,7 @@
       "category": "Markets & crypto",
       "blurb": "Get cryptocurrency prices from CoinGecko.",
       "domain": "coingecko.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -2011,6 +2107,7 @@
       "category": "Markets & crypto",
       "blurb": "Cryptocurrency market overview, tickers, and coin details from Coinlore.",
       "domain": "coinlore.net",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -2035,6 +2132,7 @@
       "category": "Markets & crypto",
       "blurb": "Get latest cryptocurrency listings from CoinMarketCap.",
       "domain": "coinmarketcap.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -2067,6 +2165,7 @@
       "category": "Markets & crypto",
       "blurb": "Cryptocurrency market data, coin info, and live tickers.",
       "domain": "coinpaprika.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -2090,7 +2189,8 @@
       "name": "Collatz Sequence",
       "category": "Utilities",
       "blurb": "Compute the Collatz (3n+1) sequence for any positive integer.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2107,6 +2207,7 @@
       "category": "Utilities",
       "blurb": "Convert a color from one format into ALL other formats (HEX, RGB, HSL, HSV, CMYK) at once.",
       "domain": null,
+      "network": "offline",
       "toolCount": 5,
       "tools": [
         {
@@ -2138,7 +2239,8 @@
       "name": "Color Blender",
       "category": "Developer & infra",
       "blurb": "Blend two hex colors together and generate gradient palettes.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2154,7 +2256,8 @@
       "name": "Color Converter",
       "category": "Utilities",
       "blurb": "Convert hex colors to RGB and HSL values locally.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2171,6 +2274,7 @@
       "category": "Utilities",
       "blurb": "Find the closest named color for any hex code.",
       "domain": "color.pizza",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -2191,6 +2295,7 @@
       "category": "AI",
       "blurb": "Generate AI-powered 5-color palettes for design.",
       "domain": "colormind.io",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -2211,6 +2316,7 @@
       "category": "Images",
       "blurb": "Get random color palettes from colr.org.",
       "domain": "colr.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -2226,7 +2332,8 @@
       "name": "Combinations",
       "category": "Utilities",
       "blurb": "Calculate combinations C(n,r) for unordered selections.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2243,6 +2350,7 @@
       "category": "Quality (XPass)",
       "blurb": "Sanity-gate a worker before it claims it is done.",
       "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -2262,7 +2370,8 @@
       "name": "Complex Numbers",
       "category": "Utilities",
       "blurb": "Complex number arithmetic: add, subtract, multiply, divide, polar form.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2279,6 +2388,7 @@
       "category": "Quality (XPass)",
       "blurb": "Check a repo for compliance readiness and gaps.",
       "domain": null,
+      "network": "offline",
       "toolCount": 4,
       "tools": [
         {
@@ -2307,6 +2417,7 @@
       "category": "Productivity",
       "blurb": "Search and read Confluence pages and spaces.",
       "domain": "atlassian.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -2331,6 +2442,7 @@
       "category": "Content & CMS",
       "blurb": "List Contentful entries, optionally filtered by content_type or full-text query.",
       "domain": "contentful.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -2358,7 +2470,8 @@
       "name": "Continued Fractions",
       "category": "Utilities",
       "blurb": "Convert rational numbers to continued fraction representation with convergents.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2375,6 +2488,7 @@
       "category": "Messaging & email",
       "blurb": "List all subscribers in a ConvertKit account.",
       "domain": "convertkit.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -2410,7 +2524,8 @@
       "name": "Convex Hull",
       "category": "Utilities",
       "blurb": "Compute the convex hull of 2D points with area and perimeter.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2426,7 +2541,8 @@
       "name": "Convolution",
       "category": "Utilities",
       "blurb": "Compute discrete convolution of a signal with a kernel (full/same/valid).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2443,6 +2559,7 @@
       "category": "Quality (XPass)",
       "blurb": "Review AI-written copy for quality and clarity.",
       "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -2463,6 +2580,7 @@
       "category": "Utilities",
       "blurb": "Generate random corporate buzzword phrases.",
       "domain": "corporatebs-generator.sameerkumar.website",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -2478,7 +2596,8 @@
       "name": "Correlation",
       "category": "Utilities",
       "blurb": "Compute Pearson correlation, r-squared, covariance, and regression line.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2494,7 +2613,8 @@
       "name": "Cosine Similarity",
       "category": "Utilities",
       "blurb": "Calculate cosine similarity between two texts using word frequency vectors.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2510,7 +2630,8 @@
       "name": "Countdown Calculator",
       "category": "Utilities",
       "blurb": "Calculate days and weeks until or since any date.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2526,7 +2647,8 @@
       "name": "Counting Sort",
       "category": "Utilities",
       "blurb": "Integer sorting in O(n+k) time with frequency analysis.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2543,6 +2665,7 @@
       "category": "Images",
       "blurb": "Get country flag images by ISO code.",
       "domain": "flagcdn.com",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -2559,6 +2682,7 @@
       "category": "Travel, maps & local",
       "blurb": "Detect country from an IP address using country.is.",
       "domain": "country.is",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -2575,6 +2699,7 @@
       "category": "Developer & infra",
       "blurb": "Search and look up Rust crates on crates.io.",
       "domain": "crates.io",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -2594,7 +2719,8 @@
       "name": "CRC32 Checksum",
       "category": "Utilities",
       "blurb": "Calculate CRC32 checksums for data integrity verification.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2611,6 +2737,7 @@
       "category": "Productivity",
       "blurb": "Run a multi-advisor Crews council on a task.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -2634,7 +2761,8 @@
       "name": "Cron Explainer",
       "category": "Developer & infra",
       "blurb": "Explain cron expressions in human-readable terms.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2650,7 +2778,8 @@
       "name": "Cross Product",
       "category": "Utilities",
       "blurb": "Cross product of two 3D vectors with magnitude and parallelism check.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2667,6 +2796,7 @@
       "category": "Books",
       "blurb": "Academic paper metadata and DOI lookup from Crossref.",
       "domain": "crossref.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -2686,7 +2816,8 @@
       "name": "CSV Parser",
       "category": "Developer & infra",
       "blurb": "Parse CSV text into structured JSON with headers and row objects.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2703,6 +2834,7 @@
       "category": "Markets & crypto",
       "blurb": "Free currency exchange rates from fawazahmed0 currency API via jsDelivr CDN.",
       "domain": "cdn.jsdelivr.net",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -2723,6 +2855,7 @@
       "category": "Games & esports",
       "blurb": "Browse D&D 5e classes, spells, and monster stat blocks.",
       "domain": "dnd5eapi.co",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -2759,6 +2892,7 @@
       "category": "Utilities",
       "blurb": "Random dad jokes - search, browse, or get a random groaner.",
       "domain": "icanhazdadjoke.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -2782,7 +2916,8 @@
       "name": "Damerau-Levenshtein",
       "category": "Utilities",
       "blurb": "Calculate Damerau-Levenshtein distance (edits plus transpositions).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2799,6 +2934,7 @@
       "category": "Developer & infra",
       "blurb": "List Datadog monitors (alerts) with optional name or tag filters.",
       "domain": "datadoghq.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -2835,6 +2971,7 @@
       "category": "Utilities",
       "blurb": "Find words by meaning, rhyme, sound, or spelling pattern.",
       "domain": "datamuse.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -2855,6 +2992,7 @@
       "category": "Utilities",
       "blurb": "Get the current date and time, optionally in a specific timezone.",
       "domain": null,
+      "network": "offline",
       "toolCount": 7,
       "tools": [
         {
@@ -2895,6 +3033,7 @@
       "category": "Books",
       "blurb": "Computer science publication and author search from DBLP.",
       "domain": "dblp.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -2914,7 +3053,8 @@
       "name": "de Bruijn Sequence",
       "category": "Utilities",
       "blurb": "Generate de Bruijn sequences containing every k-ary substring of length n.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -2931,6 +3071,7 @@
       "category": "Utilities",
       "blurb": "Create, shuffle, and draw from virtual card decks.",
       "domain": "deckofcardsapi.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -2955,6 +3096,7 @@
       "category": "AI",
       "blurb": "Translate text into another language using DeepL's neural translation engine.",
       "domain": "deepl.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -2983,6 +3125,7 @@
       "category": "Music & video",
       "blurb": "Search Deezer for tracks, artists, or albums.",
       "domain": "deezer.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -3018,7 +3161,8 @@
       "name": "Derangement",
       "category": "Utilities",
       "blurb": "Count and enumerate derangements (permutations with no fixed points).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3034,7 +3178,8 @@
       "name": "Descriptive Stats",
       "category": "Utilities",
       "blurb": "Full descriptive statistics: mean, median, mode, std, skewness, kurtosis, IQR.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3050,7 +3195,8 @@
       "name": "DFS Search",
       "category": "Utilities",
       "blurb": "Depth-first search with path finding, reachability, and cycle detection.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3067,6 +3213,7 @@
       "category": "Utilities",
       "blurb": "Generate secure random passphrases from a word list.",
       "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3083,6 +3230,7 @@
       "category": "Utilities",
       "blurb": "Look up word definitions, phonetics, and examples.",
       "domain": "dictionaryapi.dev",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -3103,6 +3251,7 @@
       "category": "Social",
       "blurb": "Browse Digimon by name or evolution level.",
       "domain": "digimon-api.vercel.app",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -3126,7 +3275,8 @@
       "name": "Digit DP",
       "category": "Utilities",
       "blurb": "Count integers up to N with a given digit sum using digit DP.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3143,6 +3293,7 @@
       "category": "Developer & infra",
       "blurb": "List DigitalOcean droplets (signals when any are powered off).",
       "domain": "digitalocean.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -3170,7 +3321,8 @@
       "name": "Dijkstra Shortest Path",
       "category": "Utilities",
       "blurb": "Find the shortest path between two nodes in a weighted graph.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3186,7 +3338,8 @@
       "name": "Dinic Max Flow",
       "category": "Utilities",
       "blurb": "Maximum flow computation using Dinic's blocking flow algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3203,6 +3356,7 @@
       "category": "Music & video",
       "blurb": "Search for music releases on Discogs.",
       "domain": "discogs.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -3239,6 +3393,7 @@
       "category": "Messaging & email",
       "blurb": "Send a message to a Discord channel.",
       "domain": "discord.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -3279,6 +3434,7 @@
       "category": "Weather & science",
       "blurb": "Global and per-country COVID-19 statistics and vaccine data.",
       "domain": "disease.sh",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -3303,6 +3459,7 @@
       "category": "Social",
       "blurb": "Search and browse Disney characters.",
       "domain": "disneyapi.dev",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -3323,6 +3480,7 @@
       "category": "Developer & infra",
       "blurb": "Resolve DNS records (A, AAAA, MX, TXT, CNAME) via Google DNS-over-HTTPS.",
       "domain": "dns.google",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -3339,6 +3497,7 @@
       "category": "Images",
       "blurb": "Get random dog images and browse breeds.",
       "domain": "dog.ceo",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -3367,6 +3526,7 @@
       "category": "Utilities",
       "blurb": "Random dog facts and trivia.",
       "domain": "dogapi.dog",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -3383,6 +3543,7 @@
       "category": "Travel, maps & local",
       "blurb": "Search Australian property listings on Domain.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -3407,6 +3568,7 @@
       "category": "Developer & infra",
       "blurb": "Search registered domain names and browse TLDs.",
       "domain": "domainsdb.info",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -3426,7 +3588,8 @@
       "name": "Dot Product",
       "category": "Utilities",
       "blurb": "Dot product of two vectors with angle and orthogonality detection.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3443,6 +3606,7 @@
       "category": "Productivity",
       "blurb": "Browse, search, and read your Dropbox files.",
       "domain": "dropbox.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -3467,6 +3631,7 @@
       "category": "Images",
       "blurb": "Generate placeholder image URLs with custom size, colors, and text.",
       "domain": "dummyimage.com",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -3483,6 +3648,7 @@
       "category": "Developer & infra",
       "blurb": "Fake products, quotes, and users for testing and prototyping.",
       "domain": "dummyjson.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -3510,7 +3676,8 @@
       "name": "Duval / Lyndon",
       "category": "Utilities",
       "blurb": "Lyndon factorization of a string using Duval's O(n) algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3527,6 +3694,7 @@
       "category": "Shopping",
       "blurb": "Search eBay listings via the Browse API.",
       "domain": "ebay.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -3555,6 +3723,7 @@
       "category": "Weather & science",
       "blurb": "Get recent bird observations from eBird.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -3578,7 +3747,8 @@
       "name": "Edit Distance",
       "category": "Utilities",
       "blurb": "Full edit distance with backtrace of insert, delete, and replace operations.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3594,7 +3764,8 @@
       "name": "Edmonds-Karp",
       "category": "Utilities",
       "blurb": "Compute maximum flow and minimum cut via BFS-augmenting paths.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3610,7 +3781,8 @@
       "name": "Eertree",
       "category": "Utilities",
       "blurb": "Palindromic tree (eertree) for counting distinct palindromic substrings.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3627,6 +3799,7 @@
       "category": "AI",
       "blurb": "List all available voices in ElevenLabs.",
       "domain": "elevenlabs.io",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -3659,6 +3832,7 @@
       "category": "Messaging & email",
       "blurb": "Send an email via Gmail/IMAP.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -3694,7 +3868,8 @@
       "name": "Emoji Lookup",
       "category": "Utilities",
       "blurb": "Search emojis by name or keyword.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3711,6 +3886,7 @@
       "category": "Utilities",
       "blurb": "Browse emojis by category with HTML and Unicode codes.",
       "domain": "emojihub.yurace.pro",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -3730,7 +3906,8 @@
       "name": "Entropy Calculator",
       "category": "Utilities",
       "blurb": "Calculate Shannon entropy to measure text randomness and information density.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3746,7 +3923,8 @@
       "name": "Epoch Converter",
       "category": "Developer & infra",
       "blurb": "Convert Unix epoch timestamps to ISO 8601 and human-readable formats.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -3767,6 +3945,7 @@
       "category": "Games & esports",
       "blurb": "Get current NFL scores from ESPN.",
       "domain": null,
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -3807,6 +3986,7 @@
       "category": "Shopping",
       "blurb": "Search active Etsy listings by keyword.",
       "domain": "etsy.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -3838,7 +4018,8 @@
       "name": "Euler Path",
       "category": "Utilities",
       "blurb": "Check whether a graph has an Eulerian path or circuit via degree analysis.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3854,7 +4035,8 @@
       "name": "Euler Totient",
       "category": "Utilities",
       "blurb": "Compute Euler's totient phi(n) counting integers coprime to n.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3870,7 +4052,8 @@
       "name": "Euler Tour",
       "category": "Utilities",
       "blurb": "Euler tour of a tree with tin/tout timestamps, depths, and subtree sizes.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -3887,6 +4070,7 @@
       "category": "News & reading",
       "blurb": "Search millions of European cultural heritage objects from museums and archives.",
       "domain": "europeana.eu",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -3907,6 +4091,7 @@
       "category": "Events & tickets",
       "blurb": "Search for events on Eventbrite.",
       "domain": "eventbrite.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -3943,6 +4128,7 @@
       "category": "Utilities",
       "blurb": "Random insults for entertainment (multi-language).",
       "domain": "evilinsult.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -3959,6 +4145,7 @@
       "category": "Markets & crypto",
       "blurb": "Get latest currency exchange rates for a base currency. Works without API key using the free tier.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -3987,6 +4174,7 @@
       "category": "Markets & crypto",
       "blurb": "Open exchange rates from ExchangeRate-API (no key needed).",
       "domain": "open.er-api.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4003,6 +4191,7 @@
       "category": "Utilities",
       "blurb": "Get random excuses by category for fun or testing.",
       "domain": "excuser-three.vercel.app",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4018,7 +4207,8 @@
       "name": "Exponential Growth",
       "category": "Utilities",
       "blurb": "Exponential growth and decay with doubling time and half-life.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4034,7 +4224,8 @@
       "name": "Extended GCD",
       "category": "Utilities",
       "blurb": "Extended Euclidean algorithm returning GCD, Bezout coefficients, and modular inverse.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4051,6 +4242,7 @@
       "category": "Developer & infra",
       "blurb": "Fake e-commerce products and categories for testing and prototyping.",
       "domain": "fakestoreapi.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -4075,6 +4267,7 @@
       "category": "Developer & infra",
       "blurb": "Generate fake persons, companies, and text data for testing and prototyping.",
       "domain": "fakerapi.it",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -4099,6 +4292,7 @@
       "category": "Games & esports",
       "blurb": "Get Fantasy Premier League bootstrap data (players, teams, etc.).",
       "domain": null,
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -4139,6 +4333,7 @@
       "category": "News & reading",
       "blurb": "Perform a Feedly action: get_feedly_feeds, get_feedly_streams, search_feedly, get_feedly_categories, mark_as_read.",
       "domain": "feedly.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4154,7 +4349,8 @@
       "name": "Fenwick 2D",
       "category": "Utilities",
       "blurb": "2D Fenwick tree for point updates and rectangle sum queries.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4170,7 +4366,8 @@
       "name": "Fenwick Range",
       "category": "Utilities",
       "blurb": "Fenwick tree supporting both range update and range query operations.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4186,7 +4383,8 @@
       "name": "Fenwick Tree",
       "category": "Utilities",
       "blurb": "Fenwick tree (BIT) for efficient prefix sums and point updates.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4202,7 +4400,8 @@
       "name": "FFT (Fast Fourier Transform)",
       "category": "Utilities",
       "blurb": "Fast Fourier Transform (Cooley-Tukey radix-2) for frequency analysis.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4218,7 +4417,8 @@
       "name": "Fibonacci Generator",
       "category": "Utilities",
       "blurb": "Generate Fibonacci sequences and check if a number is Fibonacci.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4235,6 +4435,7 @@
       "category": "Quality (XPass)",
       "blurb": "Prove exact-copy work with a verified receipt.",
       "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -4255,6 +4456,7 @@
       "category": "Productivity",
       "blurb": "Get a Figma file's structure and metadata - pages, frames, and component count.",
       "domain": "figma.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -4295,6 +4497,7 @@
       "category": "Social",
       "blurb": "Browse Final Space characters and episodes.",
       "domain": "finalspaceapi.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -4315,6 +4518,7 @@
       "category": "Weather & science",
       "blurb": "NOAA FishWatch species data with sustainability and nutrition info.",
       "domain": "fishwatch.gov",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -4335,6 +4539,7 @@
       "category": "Quality (XPass)",
       "blurb": "Check a user journey end to end for gaps.",
       "domain": null,
+      "network": "offline",
       "toolCount": 7,
       "tools": [
         {
@@ -4374,7 +4579,8 @@
       "name": "Floyd-Warshall",
       "category": "Utilities",
       "blurb": "All-pairs shortest paths via Floyd-Warshall algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4391,6 +4597,7 @@
       "category": "Developer & infra",
       "blurb": "List all Fly.io apps in your organization.",
       "domain": "fly.io",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -4423,6 +4630,7 @@
       "category": "Weather & science",
       "blurb": "Random food images by category (pizza, burger, pasta, and more).",
       "domain": "foodish-api.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -4443,6 +4651,7 @@
       "category": "Travel, maps & local",
       "blurb": "Search for places on Foursquare.",
       "domain": "foursquare.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -4475,6 +4684,7 @@
       "category": "Markets & crypto",
       "blurb": "Currency exchange rates from ECB data - convert and historical.",
       "domain": "frankfurter.app",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -4503,6 +4713,7 @@
       "category": "Games & esports",
       "blurb": "Browse and search free-to-play games across platforms.",
       "domain": "freetogame.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -4522,7 +4733,8 @@
       "name": "Frequency Analysis",
       "category": "Utilities",
       "blurb": "Analyse character or bigram frequencies in text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4539,6 +4751,7 @@
       "category": "Weather & science",
       "blurb": "Look up fruit nutrition facts including calories, sugar, and protein.",
       "domain": "fruityvice.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -4559,6 +4772,7 @@
       "category": "Utilities",
       "blurb": "Translate text into Yoda, Pirate, Shakespeare, and more.",
       "domain": "funtranslations.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4574,7 +4788,8 @@
       "name": "Gabow SCC",
       "category": "Utilities",
       "blurb": "Strongly connected components via Gabow's path-based algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4590,7 +4805,8 @@
       "name": "Game of Life",
       "category": "Games & esports",
       "blurb": "Run Conway's Game of Life simulation locally with customizable grids.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4606,7 +4822,8 @@
       "name": "Gaussian Elimination",
       "category": "Utilities",
       "blurb": "Solve systems of linear equations via Gaussian elimination with partial pivoting.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4623,6 +4840,7 @@
       "category": "Weather & science",
       "blurb": "Global biodiversity species search and occurrence records from GBIF.",
       "domain": "gbif.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -4646,7 +4864,8 @@
       "name": "GCD/LCM Calculator",
       "category": "Utilities",
       "blurb": "Compute the greatest common divisor and least common multiple of integers.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4662,7 +4881,8 @@
       "name": "GCD/LCM Calculator",
       "category": "Developer & infra",
       "blurb": "Calculate greatest common divisor and least common multiple of integers.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4679,6 +4899,7 @@
       "category": "News & reading",
       "blurb": "Search world news and event trends.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -4707,6 +4928,7 @@
       "category": "Utilities",
       "blurb": "Predict gender from a first name with probability score.",
       "domain": "genderize.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4723,6 +4945,7 @@
       "category": "Music & video",
       "blurb": "Search Genius for songs and lyrics.",
       "domain": "genius.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -4751,6 +4974,7 @@
       "category": "Travel, maps & local",
       "blurb": "IP geolocation with country, city, and coordinates from GeoJS.",
       "domain": "geojs.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4766,7 +4990,8 @@
       "name": "Geometric Series",
       "category": "Utilities",
       "blurb": "Finite and infinite sums of geometric series.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4783,6 +5008,7 @@
       "category": "Quality (XPass)",
       "blurb": "Run GEOPass against a public URL.",
       "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -4803,6 +5029,7 @@
       "category": "Content & CMS",
       "blurb": "Read posts, pages, and tags from your Ghost site.",
       "domain": "ghost.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -4827,6 +5054,7 @@
       "category": "Images",
       "blurb": "Search trending and random GIFs on Giphy.",
       "domain": "giphy.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -4851,6 +5079,7 @@
       "category": "Developer & infra",
       "blurb": "Manage repos, issues, pull requests, and Actions.",
       "domain": "github.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4867,6 +5096,7 @@
       "category": "Utilities",
       "blurb": "Browse all GitHub emoji names and image URLs.",
       "domain": "github.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4883,6 +5113,7 @@
       "category": "Developer & infra",
       "blurb": "Manage GitLab repos, issues, and merge requests.",
       "domain": "gitlab.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -4898,7 +5129,8 @@
       "name": "Goertzel DFT",
       "category": "Utilities",
       "blurb": "Compute a single DFT frequency bin efficiently without a full FFT.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4914,7 +5146,8 @@
       "name": "Graph Analyze",
       "category": "Utilities",
       "blurb": "Analyze graph structure: nodes, edges, components, density, and degrees.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4930,7 +5163,8 @@
       "name": "Graph Coloring",
       "category": "Utilities",
       "blurb": "Greedy vertex coloring of an undirected graph with color groups.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4946,7 +5180,8 @@
       "name": "Graph Condensation",
       "category": "Utilities",
       "blurb": "SCC condensation of directed graphs into a DAG using Kosaraju's algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4962,7 +5197,8 @@
       "name": "Gray Code",
       "category": "Utilities",
       "blurb": "Convert between binary and Gray code or generate full n-bit Gray code sequences.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -4979,6 +5215,7 @@
       "category": "AI",
       "blurb": "Run a fast LLM inference with Groq. Supports Llama 3, Mixtral, Gemma, and other open models at high speed.",
       "domain": "groq.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -4999,6 +5236,7 @@
       "category": "News & reading",
       "blurb": "Search for articles on The Guardian.",
       "domain": "theguardian.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -5031,6 +5269,7 @@
       "category": "Money & payments",
       "blurb": "List all products in a Gumroad account.",
       "domain": "gumroad.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -5063,6 +5302,7 @@
       "category": "Books",
       "blurb": "Search and browse 70,000+ free ebooks from Project Gutenberg.",
       "domain": "gutendex.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -5082,7 +5322,8 @@
       "name": "Haar Wavelet",
       "category": "Utilities",
       "blurb": "Haar wavelet transform (forward and inverse) on power-of-2 length arrays.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5099,6 +5340,7 @@
       "category": "Social",
       "blurb": "Get the top stories from Hacker News.",
       "domain": "ycombinator.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -5138,7 +5380,8 @@
       "name": "Hamming Distance",
       "category": "Utilities",
       "blurb": "Calculate Hamming distance between equal-length strings.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5154,7 +5397,8 @@
       "name": "Harmonic Series",
       "category": "Utilities",
       "blurb": "Partial sums of the harmonic series with ln approximation.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5171,6 +5415,7 @@
       "category": "Social",
       "blurb": "Harry Potter characters, students, staff, and houses.",
       "domain": "hp-api.onrender.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -5198,7 +5443,8 @@
       "name": "Hash Generator",
       "category": "Developer & infra",
       "blurb": "Generate and compare cryptographic hashes (MD5, SHA-256, SHA-512).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -5219,6 +5465,7 @@
       "category": "Security",
       "blurb": "Check if an email account has been in a data breach.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -5242,7 +5489,8 @@
       "name": "Heap Sort",
       "category": "Utilities",
       "blurb": "In-place O(n log n) sorting using a binary heap with swap tracking.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5258,7 +5506,8 @@
       "name": "Heavy-Light Decomposition",
       "category": "Utilities",
       "blurb": "Heavy-light decomposition of trees for efficient path queries.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5275,6 +5524,7 @@
       "category": "AI",
       "blurb": "Generate avatar videos and list voices.",
       "domain": "heygen.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -5303,6 +5553,7 @@
       "category": "AI",
       "blurb": "Generate images and video from prompts.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -5330,7 +5581,8 @@
       "name": "Histogram",
       "category": "Utilities",
       "blurb": "Create a histogram from numeric data with configurable bins and ASCII chart.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5346,7 +5598,8 @@
       "name": "Hopcroft-Karp",
       "category": "Utilities",
       "blurb": "Maximum bipartite matching via Hopcroft-Karp in O(E * sqrt(V)).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5362,7 +5615,8 @@
       "name": "HTML Stripper",
       "category": "Developer & infra",
       "blurb": "Strip HTML tags and decode entities to plain text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5379,6 +5633,7 @@
       "category": "Images",
       "blurb": "Get a cat image for any HTTP status code from http.cat.",
       "domain": "http.cat",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -5395,6 +5650,7 @@
       "category": "Images",
       "blurb": "Dog images for HTTP status codes (like httpcat but with dogs).",
       "domain": "http.dog",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -5411,6 +5667,7 @@
       "category": "Developer & infra",
       "blurb": "HTTP request and response testing service for developers.",
       "domain": "httpbin.org",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -5443,6 +5700,7 @@
       "category": "Productivity",
       "blurb": "Read and update CRM contacts, companies, and deals.",
       "domain": "hubspot.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -5478,7 +5736,8 @@
       "name": "Huffman Coding",
       "category": "Utilities",
       "blurb": "Build Huffman codes and analyze compression ratio and entropy.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5494,7 +5753,8 @@
       "name": "Hungarian Assignment",
       "category": "Utilities",
       "blurb": "Optimally assign workers to tasks using the Hungarian algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5511,6 +5771,7 @@
       "category": "Security",
       "blurb": "Find email addresses for a domain using Hunter.io.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -5534,7 +5795,8 @@
       "name": "Hypothesis Test",
       "category": "Utilities",
       "blurb": "Run z-test, t-test, or chi-squared hypothesis tests with p-values.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5551,6 +5813,7 @@
       "category": "Social",
       "blurb": "Browse characters, houses, and books from Game of Thrones.",
       "domain": "anapioficeandfire.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -5575,6 +5838,7 @@
       "category": "Games & esports",
       "blurb": "Search the IGDB games database by name.",
       "domain": "igdb.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -5607,6 +5871,7 @@
       "category": "Quality (XPass)",
       "blurb": "Run IgniteOnly policy checks and receipts.",
       "domain": null,
+      "network": "offline",
       "toolCount": 3,
       "tools": [
         {
@@ -5631,6 +5896,7 @@
       "category": "Images",
       "blurb": "Browse the top 100 popular meme templates from Imgflip.",
       "domain": "imgflip.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5647,6 +5913,7 @@
       "category": "News & reading",
       "blurb": "Save and read articles in Instapaper.",
       "domain": "instapaper.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5662,7 +5929,8 @@
       "name": "Integer Partition",
       "category": "Utilities",
       "blurb": "Count integer partitions with optional part size and count constraints.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5679,6 +5947,7 @@
       "category": "Messaging & email",
       "blurb": "List recent Intercom conversations.",
       "domain": "intercom.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -5707,6 +5976,7 @@
       "category": "News & reading",
       "blurb": "Search the Internet Archive for books, movies, audio, and software.",
       "domain": "archive.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -5726,7 +5996,8 @@
       "name": "Interpolation",
       "category": "Utilities",
       "blurb": "Linear interpolation and extrapolation between two points.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5742,7 +6013,8 @@
       "name": "Interval Merge",
       "category": "Utilities",
       "blurb": "Merge overlapping intervals and report gaps and total coverage.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5759,6 +6031,7 @@
       "category": "Developer & infra",
       "blurb": "IP address geolocation, ISP, and timezone lookup via ipwho.is.",
       "domain": "ipwho.is",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5775,6 +6048,7 @@
       "category": "Travel, maps & local",
       "blurb": "Look up geolocation for an IP address.",
       "domain": null,
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -5795,6 +6069,7 @@
       "category": "Travel, maps & local",
       "blurb": "Search Australian trademarks via IP Australia.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -5818,7 +6093,8 @@
       "name": "IP Validator",
       "category": "Developer & infra",
       "blurb": "Validate and classify IP addresses as public, private, or loopback.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5835,6 +6111,7 @@
       "category": "Developer & infra",
       "blurb": "Get your public IP address (IPv4 or IPv6).",
       "domain": "ipify.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5851,6 +6128,7 @@
       "category": "Developer & infra",
       "blurb": "IP geolocation, ISP, and organization info for any IP address.",
       "domain": "ipinfo.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5867,6 +6145,7 @@
       "category": "Developer & infra",
       "blurb": "Check if a website or domain is currently up or down.",
       "domain": "isitup.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5883,6 +6162,7 @@
       "category": "Utilities",
       "blurb": "Check whether a number is even (the novelty API).",
       "domain": "isevenapi.xyz",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5899,6 +6179,7 @@
       "category": "Weather & science",
       "blurb": "Get upcoming ISS flyover times for any location on Earth.",
       "domain": "open-notify.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -5915,6 +6196,7 @@
       "category": "Weather & science",
       "blurb": "Track the ISS location and see who is in space right now.",
       "domain": "open-notify.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -5935,6 +6217,7 @@
       "category": "Weather & science",
       "blurb": "USDA taxonomic species search and full classification records.",
       "domain": "itis.gov",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -5954,7 +6237,8 @@
       "name": "Jaccard Similarity",
       "category": "Utilities",
       "blurb": "Calculate Jaccard similarity index between two texts.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -5971,6 +6255,7 @@
       "category": "Music & video",
       "blurb": "Search anime, manga, and characters from MyAnimeList.",
       "domain": "jikan.moe",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -6003,6 +6288,7 @@
       "category": "Productivity",
       "blurb": "Search, read, and create issues across your projects.",
       "domain": "atlassian.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -6035,6 +6321,7 @@
       "category": "Books",
       "blurb": "Search the Jisho.org Japanese-English dictionary for words and kanji.",
       "domain": "jisho.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -6051,6 +6338,7 @@
       "category": "Productivity",
       "blurb": "Check a CV or cover letter against JobSmith's quality rules.",
       "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -6071,6 +6359,7 @@
       "category": "Utilities",
       "blurb": "Get random jokes by category from JokeAPI.",
       "domain": "jokeapi.dev",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -6090,7 +6379,8 @@
       "name": "Josephus Problem",
       "category": "Utilities",
       "blurb": "Solve the Josephus problem - find the survivor in a circle elimination game.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6106,7 +6396,8 @@
       "name": "JSON Format",
       "category": "Developer & infra",
       "blurb": "Parse, pretty-print, and analyze JSON structure with element counts.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6122,7 +6413,8 @@
       "name": "JSON Formatter",
       "category": "Developer & infra",
       "blurb": "Prettify or minify JSON text with configurable indentation.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6139,6 +6431,7 @@
       "category": "Developer & infra",
       "blurb": "Fake REST API for testing - posts, comments, and users.",
       "domain": "jsonplaceholder.typicode.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -6166,7 +6459,8 @@
       "name": "JWT Decoder",
       "category": "Developer & infra",
       "blurb": "Decode JWT tokens to inspect header and payload claims (no signature verification).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6182,7 +6476,8 @@
       "name": "K-Means Clustering",
       "category": "Utilities",
       "blurb": "Partition data points into k clusters using the k-means algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6199,6 +6494,7 @@
       "category": "Utilities",
       "blurb": "Random Kanye West quotes.",
       "domain": "api.kanye.rest",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -6215,6 +6511,7 @@
       "category": "Developer & infra",
       "blurb": "Connect and manage your app logins and keys.",
       "domain": null,
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -6247,6 +6544,7 @@
       "category": "Messaging & email",
       "blurb": "List Klaviyo lists.",
       "domain": "klaviyo.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -6275,6 +6573,7 @@
       "category": "AI",
       "blurb": "Generate video clips from text or images.",
       "domain": null,
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -6294,7 +6593,8 @@
       "name": "KMP Automaton",
       "category": "Utilities",
       "blurb": "Build a full KMP DFA transition table for streaming pattern matching.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6310,7 +6610,8 @@
       "name": "KMP Search",
       "category": "Utilities",
       "blurb": "Single-pattern string search using Knuth-Morris-Pratt algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6326,7 +6627,8 @@
       "name": "Knapsack Solver",
       "category": "Utilities",
       "blurb": "Solve the 0-1 knapsack optimization problem for items with weight and value.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6342,7 +6644,8 @@
       "name": "Kosaraju SCC",
       "category": "Utilities",
       "blurb": "Find strongly connected components via Kosaraju's two-pass algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6359,6 +6662,7 @@
       "category": "Utilities",
       "blurb": "Grammar, spelling, and style checking for 30+ languages.",
       "domain": "languagetool.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -6379,6 +6683,7 @@
       "category": "Music & video",
       "blurb": "Get Last.fm artist info.",
       "domain": "last.fm",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -6418,7 +6723,8 @@
       "name": "LCS (Longest Common Subsequence)",
       "category": "Utilities",
       "blurb": "Find the longest common subsequence of two strings with similarity score.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6435,6 +6741,7 @@
       "category": "Quality (XPass)",
       "blurb": "Spot legal issues in text with guardrails.",
       "domain": null,
+      "network": "offline",
       "toolCount": 5,
       "tools": [
         {
@@ -6467,6 +6774,7 @@
       "category": "Games & esports",
       "blurb": "Search LEGO sets by name/theme (Rebrickable).",
       "domain": "lego.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -6506,7 +6814,8 @@
       "name": "Lehmer Code",
       "category": "Utilities",
       "blurb": "Convert between permutations and Lehmer codes for ranking and unranking.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6523,6 +6832,7 @@
       "category": "Money & payments",
       "blurb": "List all Lemon Squeezy stores on your account.",
       "domain": "lemonsqueezy.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -6559,6 +6869,7 @@
       "category": "Utilities",
       "blurb": "Open-source text translation, language detection, and supported language listing.",
       "domain": "libretranslate.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -6583,6 +6894,7 @@
       "category": "Games & esports",
       "blurb": "Get a Lichess user profile.",
       "domain": "lichess.org",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -6615,6 +6927,7 @@
       "category": "Messaging & email",
       "blurb": "Send a text message to a LINE user, group, or room.",
       "domain": "line.me",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -6650,7 +6963,8 @@
       "name": "Line Equation",
       "category": "Utilities",
       "blurb": "Line equation from two points in slope-intercept and standard form.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6666,7 +6980,8 @@
       "name": "Line Sorter",
       "category": "Utilities",
       "blurb": "Sort, deduplicate, and reverse lines of text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6683,6 +6998,7 @@
       "category": "Productivity",
       "blurb": "Interact with the Linear GraphQL API: list and search issues, create issues, get project details, and list teams.",
       "domain": "linear.app",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -6698,7 +7014,8 @@
       "name": "Linear Regression",
       "category": "Utilities",
       "blurb": "Fit a linear regression to x/y data and get slope, intercept, R-squared.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6714,7 +7031,8 @@
       "name": "Linear Solver",
       "category": "Utilities",
       "blurb": "Solve systems of linear equations Ax = b with partial pivoting.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6730,7 +7048,8 @@
       "name": "Link-Cut Tree",
       "category": "Utilities",
       "blurb": "Dynamic forest connectivity with link, cut, and path queries via splay trees.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6746,7 +7065,8 @@
       "name": "LIS Solver",
       "category": "Utilities",
       "blurb": "Find longest increasing subsequence in O(n log n) time.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6762,7 +7082,8 @@
       "name": "Logarithm Calculator",
       "category": "Utilities",
       "blurb": "Logarithm with any base, plus natural log, log10, and log2.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6779,6 +7100,7 @@
       "category": "Travel, maps & local",
       "blurb": "Country details and long weekends from Nager.Date.",
       "domain": "date.nager.at",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -6798,7 +7120,8 @@
       "name": "Longest Common Prefix",
       "category": "Utilities",
       "blurb": "Find the longest common prefix among an array of strings.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6815,6 +7138,7 @@
       "category": "Social",
       "blurb": "Browse Lord of the Rings books, characters, and movie quotes.",
       "domain": "the-one-api.dev",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -6838,7 +7162,8 @@
       "name": "Lorem Ipsum Generator",
       "category": "Utilities",
       "blurb": "Generate lorem ipsum placeholder text by paragraph count.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6855,6 +7180,7 @@
       "category": "Images",
       "blurb": "Random placeholder photos with custom dimensions and effects.",
       "domain": "picsum.photos",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -6878,7 +7204,8 @@
       "name": "Lowest Common Ancestor",
       "category": "Utilities",
       "blurb": "Lowest common ancestor with binary lifting and tree distance queries.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6894,7 +7221,8 @@
       "name": "LRU Cache Sim",
       "category": "Utilities",
       "blurb": "Simulate an LRU cache over access sequences and analyze hit/miss rates.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6910,7 +7238,8 @@
       "name": "Lucas' Theorem",
       "category": "Utilities",
       "blurb": "Compute large binomial coefficients mod prime using Lucas' theorem.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6926,7 +7255,8 @@
       "name": "Luhn Validator",
       "category": "Utilities",
       "blurb": "Validate or generate a Luhn check digit for credit cards and IMEI.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -6943,6 +7273,7 @@
       "category": "Music & video",
       "blurb": "Look up song lyrics by artist and title.",
       "domain": "lyrics.ovh",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -6959,6 +7290,7 @@
       "category": "Games & esports",
       "blurb": "Search Magic: The Gathering cards, sets, and types.",
       "domain": "magicthegathering.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -6983,6 +7315,7 @@
       "category": "Messaging & email",
       "blurb": "List all Mailchimp audiences (lists) in the account.",
       "domain": "mailchimp.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -7023,6 +7356,7 @@
       "category": "Shopping",
       "blurb": "Search makeup products by brand, type, category, or tags.",
       "domain": "makeup-api.herokuapp.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -7038,7 +7372,8 @@
       "name": "Manacher Palindrome",
       "category": "Utilities",
       "blurb": "Find longest palindromic substring in linear time.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7055,6 +7390,7 @@
       "category": "Travel, maps & local",
       "blurb": "Convert an address or place name to coordinates using Mapbox.",
       "domain": "mapbox.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -7086,7 +7422,8 @@
       "name": "Markdown Table",
       "category": "Utilities",
       "blurb": "Convert CSV or TSV text into a Markdown table.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7102,7 +7439,8 @@
       "name": "Markdown Tools",
       "category": "Developer & infra",
       "blurb": "Convert Markdown to HTML and analyze document structure.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -7122,7 +7460,8 @@
       "name": "Markov Chain",
       "category": "Utilities",
       "blurb": "Generate text using a Markov chain trained on input text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7139,6 +7478,7 @@
       "category": "Social",
       "blurb": "Post, read, and search on Mastodon.",
       "domain": "joinmastodon.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -7154,7 +7494,8 @@
       "name": "Matrix Calculator",
       "category": "Utilities",
       "blurb": "Perform matrix operations: add, multiply, transpose, determinant.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7170,7 +7511,8 @@
       "name": "Matrix Chain",
       "category": "Utilities",
       "blurb": "Find optimal parenthesization for matrix chain multiplication.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7186,7 +7528,8 @@
       "name": "Matrix Decomposition",
       "category": "Utilities",
       "blurb": "Matrix decomposition and analysis: LU, transpose, trace, rank.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7202,7 +7545,8 @@
       "name": "Matrix Exponentiation",
       "category": "Utilities",
       "blurb": "Matrix exponentiation via fast binary method with optional modular arithmetic.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7218,7 +7562,8 @@
       "name": "Matrix Inverse",
       "category": "Utilities",
       "blurb": "Compute the inverse and determinant of a square matrix.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7234,7 +7579,8 @@
       "name": "Matrix Rank",
       "category": "Utilities",
       "blurb": "Compute matrix rank using Gaussian elimination with partial pivoting.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7250,7 +7596,8 @@
       "name": "Max Independent Set",
       "category": "Utilities",
       "blurb": "Exact maximum independent set via bitmask enumeration (up to 20 vertices).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7267,6 +7614,7 @@
       "category": "Games & esports",
       "blurb": "Check Minecraft server status, player count, and MOTD.",
       "domain": "mcsrvstat.us",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -7283,6 +7631,7 @@
       "category": "Weather & science",
       "blurb": "Search for meals/recipes by name.",
       "domain": null,
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -7323,6 +7672,7 @@
       "category": "Images",
       "blurb": "Generate meme images from templates via memegen.link.",
       "domain": "memegen.link",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -7343,6 +7693,7 @@
       "category": "News & reading",
       "blurb": "Search the Met Museum collection and get artwork details.",
       "domain": "metmuseum.github.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -7366,7 +7717,8 @@
       "name": "Metaphone",
       "category": "Utilities",
       "blurb": "Encode words with the Metaphone phonetic algorithm and compare word sounds.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7382,7 +7734,8 @@
       "name": "Midpoint & Distance",
       "category": "Utilities",
       "blurb": "Midpoint, Euclidean distance, slope, and angle between two 2D points.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7398,7 +7751,8 @@
       "name": "Miller-Rabin",
       "category": "Utilities",
       "blurb": "Deterministic Miller-Rabin primality test with multiple witnesses.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7414,7 +7768,8 @@
       "name": "Min Cost Max Flow",
       "category": "Utilities",
       "blurb": "Minimum cost maximum flow using successive shortest paths.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7430,7 +7785,8 @@
       "name": "Min Spanning Tree",
       "category": "Utilities",
       "blurb": "Find the minimum spanning tree of a weighted graph (Kruskal's algorithm).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7446,7 +7802,8 @@
       "name": "Min Vertex Cover",
       "category": "Utilities",
       "blurb": "Exact minimum vertex cover via bitmask enumeration (up to 20 vertices).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7463,6 +7820,7 @@
       "category": "Productivity",
       "blurb": "List Miro boards and read what is on them.",
       "domain": "miro.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -7487,6 +7845,7 @@
       "category": "AI",
       "blurb": "Run a chat completion with a Mistral AI model (mistral-small, mistral-medium, mistral-large, etc.).",
       "domain": "mistral.ai",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -7511,6 +7870,7 @@
       "category": "Developer & infra",
       "blurb": "Track a custom event in Mixpanel.",
       "domain": "mixpanel.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -7542,7 +7902,8 @@
       "name": "Mo's Algorithm",
       "category": "Utilities",
       "blurb": "Offline range query processing with sqrt decomposition (sum and distinct count).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7558,7 +7919,8 @@
       "name": "Modular Arithmetic",
       "category": "Utilities",
       "blurb": "Modular exponentiation, modular inverse, and modular reduction.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7574,7 +7936,8 @@
       "name": "Moebius Function",
       "category": "Utilities",
       "blurb": "Compute Moebius function values and Mertens function using linear sieve.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7591,6 +7954,7 @@
       "category": "Productivity",
       "blurb": "List boards in a Monday.com account.",
       "domain": "monday.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -7627,6 +7991,7 @@
       "category": "Productivity",
       "blurb": "Manage contacts and reminders in Monica CRM.",
       "domain": "monicahq.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -7643,6 +8008,7 @@
       "category": "Games & esports",
       "blurb": "Browse Monster Hunter World monsters, weapons, and armor.",
       "domain": "mhw-db.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -7662,7 +8028,8 @@
       "name": "Monte Carlo",
       "category": "Utilities",
       "blurb": "Monte Carlo estimation of pi or definite integrals via random sampling.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7678,7 +8045,8 @@
       "name": "Morse Code",
       "category": "Utilities",
       "blurb": "Encode text to Morse code or decode Morse code to text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7695,6 +8063,7 @@
       "category": "Images",
       "blurb": "Generate unique deterministic avatar images from any string.",
       "domain": "multiavatar.com",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -7711,6 +8080,7 @@
       "category": "Music & video",
       "blurb": "Search for artists on MusicBrainz.",
       "domain": null,
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -7743,6 +8113,7 @@
       "category": "Utilities",
       "blurb": "Free text translation between 100+ languages via MyMemory.",
       "domain": "mymemory.translated.net",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -7758,7 +8129,8 @@
       "name": "N-gram Extractor",
       "category": "Utilities",
       "blurb": "Extract and count n-grams (word or character level) from text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7775,6 +8147,7 @@
       "category": "Utilities",
       "blurb": "Predict age, gender, and nationality from a first name.",
       "domain": "agify.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -7799,6 +8172,7 @@
       "category": "Weather & science",
       "blurb": "Get NASA Astronomy Picture of the Day.",
       "domain": "nasa.gov",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -7831,6 +8205,7 @@
       "category": "Utilities",
       "blurb": "Predict likely nationalities from a first name.",
       "domain": "nationalize.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -7846,7 +8221,8 @@
       "name": "NATO Phonetic Alphabet",
       "category": "Utilities",
       "blurb": "Convert text to NATO phonetic alphabet or decode NATO words.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7862,7 +8238,8 @@
       "name": "Necklace Count",
       "category": "Utilities",
       "blurb": "Count distinct necklaces and bracelets using Burnside's lemma.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -7879,6 +8256,7 @@
       "category": "Developer & infra",
       "blurb": "List all Neon Serverless Postgres projects in your account.",
       "domain": "neon.tech",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -7915,6 +8293,7 @@
       "category": "Developer & infra",
       "blurb": "List sites and deploys, and catch failed builds.",
       "domain": "netlify.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -7943,6 +8322,7 @@
       "category": "News & reading",
       "blurb": "Get top headlines from NewsAPI.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -7967,6 +8347,7 @@
       "category": "Utilities",
       "blurb": "Simplify, derive, integrate, and factor math expressions via Newton API.",
       "domain": "newton.now.sh",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -7983,6 +8364,7 @@
       "category": "Travel, maps & local",
       "blurb": "Decode vehicle VINs and search safety recalls from NHTSA.",
       "domain": "nhtsa.gov",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8003,6 +8385,7 @@
       "category": "News & reading",
       "blurb": "Search Nobel Prize winners, categories, and award history.",
       "domain": "nobelprize.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8023,6 +8406,7 @@
       "category": "Travel, maps & local",
       "blurb": "OpenStreetMap geocoding: convert addresses to coordinates and back.",
       "domain": "openstreetmap.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8042,7 +8426,8 @@
       "name": "Normal Distribution",
       "category": "Utilities",
       "blurb": "Normal (Gaussian) distribution PDF, CDF, survival, and percentile.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8059,6 +8444,7 @@
       "category": "Productivity",
       "blurb": "Read and write pages and databases in your workspace.",
       "domain": "notion.so",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8075,6 +8461,7 @@
       "category": "Developer & infra",
       "blurb": "Search and look up npm packages on the npm registry.",
       "domain": "npmjs.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8094,7 +8481,8 @@
       "name": "Nth Root",
       "category": "Utilities",
       "blurb": "Nth root of a number with verification and integer detection.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8110,7 +8498,8 @@
       "name": "NTT",
       "category": "Utilities",
       "blurb": "Polynomial multiplication using Number Theoretic Transform (mod 998244353).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8127,6 +8516,7 @@
       "category": "Quality (XPass)",
       "blurb": "Run NudgeOnly nudge policy and receipts.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8150,7 +8540,8 @@
       "name": "Number Base Converter",
       "category": "Developer & infra",
       "blurb": "Convert numbers between binary, octal, decimal, hex, and any base 2-36.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8167,6 +8558,7 @@
       "category": "Utilities",
       "blurb": "Get an interesting fact about a number.",
       "domain": null,
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8186,7 +8578,8 @@
       "name": "Numerical Differentiation",
       "category": "Utilities",
       "blurb": "Numerical differentiation using five-point stencil (1st through 4th order).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8202,7 +8595,8 @@
       "name": "Numerical Integration",
       "category": "Utilities",
       "blurb": "Numerical integration using Simpson, trapezoid, or midpoint rule.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8219,6 +8613,7 @@
       "category": "Security",
       "blurb": "Get details for a specific CVE by ID.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8242,7 +8637,8 @@
       "name": "ODE Solver",
       "category": "Utilities",
       "blurb": "Solve ordinary differential equations numerically via Euler or RK4.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8259,6 +8655,7 @@
       "category": "Weather & science",
       "blurb": "Search the Online Encyclopedia of Integer Sequences by sequence or keyword.",
       "domain": "oeis.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8275,6 +8672,7 @@
       "category": "Utilities",
       "blurb": "Random jokes by type (general, programming, knock-knock).",
       "domain": "official-joke-api.appspot.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8299,6 +8697,7 @@
       "category": "Music & video",
       "blurb": "Search movies/TV shows on OMDB.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8323,6 +8722,7 @@
       "category": "Travel, maps & local",
       "blurb": "Search and browse breweries worldwide.",
       "domain": "openbrewerydb.org",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -8351,6 +8751,7 @@
       "category": "Travel, maps & local",
       "blurb": "Find EV charging stations worldwide with connector and operator details.",
       "domain": "openchargemap.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8367,6 +8768,7 @@
       "category": "Travel, maps & local",
       "blurb": "Elevation lookup in meters for any coordinates on Earth.",
       "domain": "open-elevation.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8383,6 +8785,7 @@
       "category": "Markets & crypto",
       "blurb": "Get latest forex exchange rates from Open Exchange Rates.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -8411,6 +8814,7 @@
       "category": "Weather & science",
       "blurb": "Search for food products on Open Food Facts.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8435,6 +8839,7 @@
       "category": "Books",
       "blurb": "Search books on Open Library.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -8471,6 +8876,7 @@
       "category": "Utilities",
       "blurb": "Trivia questions by category, difficulty, and type from Open Trivia DB.",
       "domain": "opentdb.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8491,6 +8897,7 @@
       "category": "Weather & science",
       "blurb": "Get current weather for a location from Open-Meteo (no API key required).",
       "domain": "open-meteo.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8515,6 +8922,7 @@
       "category": "Weather & science",
       "blurb": "Current and forecast air quality index and pollutant levels.",
       "domain": "open-meteo.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8535,6 +8943,7 @@
       "category": "Weather & science",
       "blurb": "Climate normal projections (temperature and precipitation) from Open-Meteo.",
       "domain": "open-meteo.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8551,6 +8960,7 @@
       "category": "Weather & science",
       "blurb": "River discharge flood forecast from Open-Meteo.",
       "domain": "open-meteo.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8567,6 +8977,7 @@
       "category": "Weather & science",
       "blurb": "Historical daily weather data from 1940 to present via Open-Meteo archive.",
       "domain": "open-meteo.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8583,6 +8994,7 @@
       "category": "Weather & science",
       "blurb": "Ocean wave height, swell, and marine weather forecast.",
       "domain": "open-meteo.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8599,6 +9011,7 @@
       "category": "AI",
       "blurb": "Chat, embeddings, images, and transcription from OpenAI.",
       "domain": "openai.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -8631,6 +9044,7 @@
       "category": "Books",
       "blurb": "Open scholarly metadata: works, authors, and citation data from OpenAlex.",
       "domain": "openalex.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8655,6 +9069,7 @@
       "category": "Weather & science",
       "blurb": "Get air quality data for a location from OpenAQ.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8679,6 +9094,7 @@
       "category": "Games & esports",
       "blurb": "Dota 2 hero stats, win rates, and pro match results from OpenDota.",
       "domain": "opendota.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8703,6 +9119,7 @@
       "category": "Games & esports",
       "blurb": "Get Formula 1 sessions from OpenF1.",
       "domain": null,
+      "network": "online",
       "toolCount": 8,
       "tools": [
         {
@@ -8747,6 +9164,7 @@
       "category": "Weather & science",
       "blurb": "Search FDA drug labels, recalls, and adverse event reports.",
       "domain": "api.fda.gov",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -8771,6 +9189,7 @@
       "category": "Markets & crypto",
       "blurb": "Map financial instrument identifiers (ticker, ISIN, CUSIP) to FIGI codes.",
       "domain": "openfigi.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8791,6 +9210,7 @@
       "category": "Utilities",
       "blurb": "Validate IBANs and get BIC/bank information via OpenIBAN.",
       "domain": "openiban.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -8807,6 +9227,7 @@
       "category": "Travel, maps & local",
       "blurb": "Live aircraft tracking: positions, altitudes, and flight history worldwide.",
       "domain": "opensky-network.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8826,7 +9247,8 @@
       "name": "PageRank",
       "category": "Utilities",
       "blurb": "Compute PageRank scores for nodes in a directed link graph.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8843,6 +9265,7 @@
       "category": "Developer & infra",
       "blurb": "List PagerDuty incidents. Filter by status (triggered, acknowledged, resolved), service, or date range.",
       "domain": "pagerduty.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -8882,7 +9305,8 @@
       "name": "Palindrome Checker",
       "category": "Utilities",
       "blurb": "Check if text is a palindrome and find longest palindromic substring.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8899,6 +9323,7 @@
       "category": "Games & esports",
       "blurb": "Get esports matches from PandaScore.",
       "domain": null,
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -8930,7 +9355,8 @@
       "name": "Pascal's Triangle",
       "category": "Utilities",
       "blurb": "Generate rows of Pascal's triangle or fetch a specific row.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8946,7 +9372,8 @@
       "name": "Password Generator",
       "category": "Developer & infra",
       "blurb": "Generate cryptographically secure random passwords with configurable options.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8963,6 +9390,7 @@
       "category": "Money & payments",
       "blurb": "Create or retrieve a PayPal order.",
       "domain": "paypal.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -8982,7 +9410,8 @@
       "name": "Percentage Calculator",
       "category": "Developer & infra",
       "blurb": "Perform percentage calculations: of, change, increase, decrease.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -8998,7 +9427,8 @@
       "name": "Percentile",
       "category": "Utilities",
       "blurb": "Compute percentiles (p5-p99) and find the percentile rank of a value.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9014,7 +9444,8 @@
       "name": "Permutations",
       "category": "Utilities",
       "blurb": "Calculate permutations P(n,r) for ordered arrangements.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9031,6 +9462,7 @@
       "category": "AI",
       "blurb": "Run a search-augmented chat completion with Perplexity AI. Returns grounded answers with citations from the web.",
       "domain": "perplexity.ai",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -9046,7 +9478,8 @@
       "name": "Persistent Array",
       "category": "Utilities",
       "blurb": "Persistent array with version-controlled get/set operations.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9062,7 +9495,8 @@
       "name": "Phonetic Alphabet",
       "category": "Utilities",
       "blurb": "Spell out text using NATO or IPA phonetic alphabet.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9078,7 +9512,8 @@
       "name": "Pi Approximation",
       "category": "Utilities",
       "blurb": "Approximate pi using Leibniz, Nilakantha, and Wallis formulas.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9094,7 +9529,8 @@
       "name": "Pig Latin Translator",
       "category": "Utilities",
       "blurb": "Translate text to Pig Latin or decode Pig Latin back to English.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9111,6 +9547,7 @@
       "category": "AI",
       "blurb": "Generate short video clips with Pika.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -9135,6 +9572,7 @@
       "category": "Developer & infra",
       "blurb": "List all Pinecone vector indexes in the project.",
       "domain": "pinecone.io",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -9167,6 +9605,7 @@
       "category": "Social",
       "blurb": "List Pinterest boards for the authenticated user.",
       "domain": "pinterest.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -9203,6 +9642,7 @@
       "category": "Productivity",
       "blurb": "Read deals, contacts, and companies in your Pipedrive CRM.",
       "domain": "pipedrive.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -9231,6 +9671,7 @@
       "category": "Images",
       "blurb": "Bear placeholder image URLs at custom dimensions.",
       "domain": "placebear.com",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -9247,6 +9688,7 @@
       "category": "Images",
       "blurb": "Placeholder image URL builder with custom size, colors, and text.",
       "domain": "placehold.co",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -9263,6 +9705,7 @@
       "category": "Images",
       "blurb": "Generate placeholder image URLs with custom dimensions.",
       "domain": "placekitten.com",
+      "network": "hybrid",
       "toolCount": 2,
       "tools": [
         {
@@ -9283,6 +9726,7 @@
       "category": "Money & payments",
       "blurb": "Get accounts for a Plaid-linked item.",
       "domain": "plaid.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -9315,6 +9759,7 @@
       "category": "Music & video",
       "blurb": "Search for podcasts on Podcast Index.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -9351,6 +9796,7 @@
       "category": "Books",
       "blurb": "Search poems by author or title, or get random poems from PoetryDB.",
       "domain": "poetrydb.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -9374,7 +9820,8 @@
       "name": "Poisson Distribution",
       "category": "Utilities",
       "blurb": "Poisson distribution PMF and CDF for modeling rare events.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9391,6 +9838,7 @@
       "category": "Games & esports",
       "blurb": "Look up Pokemon stats, types, abilities, and generations.",
       "domain": "pokeapi.co",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -9423,6 +9871,7 @@
       "category": "Games & esports",
       "blurb": "Search Pokemon Trading Card Game cards and sets.",
       "domain": "pokemontcg.io",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -9442,7 +9891,8 @@
       "name": "Pollard's Rho",
       "category": "Utilities",
       "blurb": "Integer factorization using Pollard's rho with Miller-Rabin primality testing.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9458,7 +9908,8 @@
       "name": "Polygon Calculator",
       "category": "Utilities",
       "blurb": "Calculate area, perimeter, angles, apothem, and circumradius of regular polygons.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9474,7 +9925,8 @@
       "name": "Polynomial Ops",
       "category": "Utilities",
       "blurb": "Evaluate, differentiate, integrate, add, or multiply polynomials.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9491,6 +9943,7 @@
       "category": "Travel, maps & local",
       "blurb": "UK postcode lookup with lat/lon, region, and constituency data.",
       "domain": "postcodes.io",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -9511,6 +9964,7 @@
       "category": "Developer & infra",
       "blurb": "Read product analytics, insights, and feature flags.",
       "domain": "posthog.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -9539,6 +9993,7 @@
       "category": "Developer & infra",
       "blurb": "Interact with the Postman API: list and retrieve collections, list environments, and list monitors.",
       "domain": "postman.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -9555,6 +10010,7 @@
       "category": "Messaging & email",
       "blurb": "Send a transactional email via Postmark. Supports HTML and plain text.",
       "domain": "postmarkapp.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -9590,7 +10046,8 @@
       "name": "Power Iteration",
       "category": "Utilities",
       "blurb": "Find the dominant eigenvalue and eigenvector of a square matrix.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9606,7 +10063,8 @@
       "name": "Power Set",
       "category": "Utilities",
       "blurb": "Generate all subsets of a set using bitmask enumeration.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9622,7 +10080,8 @@
       "name": "Prefix Function",
       "category": "Utilities",
       "blurb": "Compute the KMP prefix/failure function with optional pattern matching.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9638,7 +10097,8 @@
       "name": "Pressure Converter",
       "category": "Developer & infra",
       "blurb": "Convert pressure between Pa, bar, atm, psi, torr, and more.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9654,7 +10114,8 @@
       "name": "Prime Checker",
       "category": "Utilities",
       "blurb": "Check primality, get prime factorization, and find adjacent primes.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9670,7 +10131,8 @@
       "name": "Prime Factorization",
       "category": "Utilities",
       "blurb": "Find the prime factorization of any integer up to one trillion.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9687,6 +10149,7 @@
       "category": "Books",
       "blurb": "Search and read free ebooks from Project Gutenberg.",
       "domain": "gutendex.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -9706,7 +10169,8 @@
       "name": "Proportion Solver",
       "category": "Utilities",
       "blurb": "Solve a proportion a/b = c/d given any three of the four values.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9723,6 +10187,7 @@
       "category": "Travel, maps & local",
       "blurb": "Live Melbourne train, tram, and bus departures and disruptions.",
       "domain": "ptv.vic.gov.au",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -9755,6 +10220,7 @@
       "category": "Weather & science",
       "blurb": "Search chemical compounds and molecular properties from PubChem.",
       "domain": "pubchem.ncbi.nlm.nih.gov",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -9775,6 +10241,7 @@
       "category": "Developer & infra",
       "blurb": "Search and browse the directory of free public APIs.",
       "domain": "api.publicapis.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -9799,6 +10266,7 @@
       "category": "Travel, maps & local",
       "blurb": "Get public holidays, long weekends, and country calendars.",
       "domain": "date.nager.at",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -9827,6 +10295,7 @@
       "category": "Weather & science",
       "blurb": "Browse and search BrewDog craft beer recipes.",
       "domain": "punkapi.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -9851,6 +10320,7 @@
       "category": "Quality (XPass)",
       "blurb": "Run PushOnly wake-and-push policy.",
       "domain": null,
+      "network": "offline",
       "toolCount": 3,
       "tools": [
         {
@@ -9875,6 +10345,7 @@
       "category": "Messaging & email",
       "blurb": "Send a push notification via Pushover.",
       "domain": "pushover.net",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -9907,6 +10378,7 @@
       "category": "Developer & infra",
       "blurb": "Look up Python packages and version metadata from PyPI.",
       "domain": "pypi.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -9927,6 +10399,7 @@
       "category": "Quality (XPass)",
       "blurb": "Run quality-control checklists and copy audits.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -9951,6 +10424,7 @@
       "category": "Developer & infra",
       "blurb": "Generate QR code image URLs for any text or URL.",
       "domain": "goqr.me",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -9966,7 +10440,8 @@
       "name": "Quadratic Solver",
       "category": "Utilities",
       "blurb": "Solve quadratic equations with real or complex roots, discriminant, and vertex.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -9983,6 +10458,7 @@
       "category": "Money & payments",
       "blurb": "Query QuickBooks Online customers.",
       "domain": "quickbooks.intuit.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -10011,6 +10487,7 @@
       "category": "Utilities",
       "blurb": "Browse and search inspirational quotes by author or tag.",
       "domain": "quotable.io",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -10042,7 +10519,8 @@
       "name": "Rabin-Karp Search",
       "category": "Utilities",
       "blurb": "Find all pattern occurrences in text using Rabin-Karp rolling hash.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10059,6 +10537,7 @@
       "category": "Music & video",
       "blurb": "Search for radio stations via Radio Browser.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -10094,7 +10573,8 @@
       "name": "Radix Sort",
       "category": "Utilities",
       "blurb": "Non-comparative integer sort using digit-by-digit bucketing.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10110,7 +10590,8 @@
       "name": "Rail Fence Cipher",
       "category": "Utilities",
       "blurb": "Encrypt or decrypt text using the rail fence zigzag cipher.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10127,6 +10608,7 @@
       "category": "News & reading",
       "blurb": "Save and organise bookmarks in Raindrop.",
       "domain": "raindrop.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -10143,6 +10625,7 @@
       "category": "Utilities",
       "blurb": "Generate a random UUID.",
       "domain": null,
+      "network": "offline",
       "toolCount": 8,
       "tools": [
         {
@@ -10187,6 +10670,7 @@
       "category": "Images",
       "blurb": "Random duck images from random-d.uk.",
       "domain": "random-d.uk",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -10207,6 +10691,7 @@
       "category": "Images",
       "blurb": "Random fox images for fun or as placeholders.",
       "domain": "randomfox.ca",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -10222,7 +10707,8 @@
       "name": "Random Name Generator",
       "category": "Utilities",
       "blurb": "Generate random placeholder names with optional email addresses.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10239,6 +10725,7 @@
       "category": "Developer & infra",
       "blurb": "Generate realistic random user profiles with photos and addresses.",
       "domain": "randomuser.me",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -10254,7 +10741,8 @@
       "name": "Ratio Simplifier",
       "category": "Utilities",
       "blurb": "Simplify ratios to lowest terms with decimal and percentage forms.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10271,6 +10759,7 @@
       "category": "Games & esports",
       "blurb": "Search for video games on RAWG.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -10307,6 +10796,7 @@
       "category": "Security",
       "blurb": "Domain and IP registration data via the RDAP protocol (WHOIS replacement).",
       "domain": "rdap.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -10326,7 +10816,8 @@
       "name": "Readability Analyzer",
       "category": "Utilities",
       "blurb": "Analyze text readability with Flesch-Kincaid grade and reading ease scores.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10342,7 +10833,8 @@
       "name": "Readability Score",
       "category": "Utilities",
       "blurb": "Calculate Flesch-Kincaid readability scores and reading level for text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10359,6 +10851,7 @@
       "category": "News & reading",
       "blurb": "Read your Readwise highlights and documents.",
       "domain": "readwise.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -10374,7 +10867,8 @@
       "name": "Red-Black Tree",
       "category": "Utilities",
       "blurb": "Red-black tree simulation with insert, inorder traversal, and validity check.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10391,6 +10885,7 @@
       "category": "Social",
       "blurb": "Read public posts from a Reddit subreddit. OAuth is optional for public reads.",
       "domain": "reddit.com",
+      "network": "online",
       "toolCount": 8,
       "tools": [
         {
@@ -10434,7 +10929,8 @@
       "name": "Regex Tester",
       "category": "Developer & infra",
       "blurb": "Test regex patterns against text and get match positions.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10451,6 +10947,7 @@
       "category": "Developer & infra",
       "blurb": "List all Render services (web services, static sites, cron jobs, etc.).",
       "domain": "render.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -10487,6 +10984,7 @@
       "category": "AI",
       "blurb": "List public models available on Replicate.",
       "domain": "replicate.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -10523,6 +11021,7 @@
       "category": "Developer & infra",
       "blurb": "Realistic fake REST API for frontend testing with users and resources.",
       "domain": "reqres.in",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -10547,6 +11046,7 @@
       "category": "Messaging & email",
       "blurb": "Send an email using Resend.",
       "domain": "resend.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -10570,7 +11070,8 @@
       "name": "Reservoir Sampling",
       "category": "Utilities",
       "blurb": "Select k random items from a list with equal probability (reservoir sampling).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10587,6 +11088,7 @@
       "category": "Travel, maps & local",
       "blurb": "Get all countries from REST Countries.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -10623,6 +11125,7 @@
       "category": "Social",
       "blurb": "Search Rick and Morty characters, episodes, and locations.",
       "domain": "rickandmortyapi.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -10655,6 +11158,7 @@
       "category": "Games & esports",
       "blurb": "Get a League of Legends summoner by name.",
       "domain": "riotgames.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -10687,6 +11191,7 @@
       "category": "Security",
       "blurb": "Network information and ASN peering data from RIPE NCC.",
       "domain": "stat.ripe.net",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -10706,7 +11211,8 @@
       "name": "RLE Numeric",
       "category": "Utilities",
       "blurb": "Run-length encode or decode numeric arrays for compression analysis.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10722,7 +11228,8 @@
       "name": "RMQ Sparse Table",
       "category": "Utilities",
       "blurb": "Build a sparse table for O(1) range minimum/maximum queries.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10739,6 +11246,7 @@
       "category": "Images",
       "blurb": "Generate unique robot, monster, or cat avatars from any text.",
       "domain": "robohash.org",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -10754,7 +11262,8 @@
       "name": "Roman Numerals",
       "category": "Utilities",
       "blurb": "Convert between Roman numerals and decimal numbers (1-3999).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10770,7 +11279,8 @@
       "name": "Root Finder",
       "category": "Utilities",
       "blurb": "Find roots of expressions using Newton's method or bisection.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10786,7 +11296,8 @@
       "name": "ROT13 Cipher",
       "category": "Utilities",
       "blurb": "Apply ROT13 or ROT-N Caesar cipher to text.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10802,7 +11313,8 @@
       "name": "Run-Length Encoding",
       "category": "Utilities",
       "blurb": "Run-length encode and decode strings for compression analysis.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10818,7 +11330,8 @@
       "name": "Run-Length Encoding",
       "category": "Utilities",
       "blurb": "Run-length encode or decode text (e.g. aaabbb to 3a3b).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10834,7 +11347,8 @@
       "name": "Running Stats",
       "category": "Utilities",
       "blurb": "Compute sliding-window running mean, std, min, and max over numeric data.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10851,6 +11365,7 @@
       "category": "AI",
       "blurb": "Generate video with Runway models.",
       "domain": "runwayml.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -10874,7 +11389,8 @@
       "name": "Scientific Notation",
       "category": "Utilities",
       "blurb": "Convert numbers to scientific and engineering notation.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -10891,6 +11407,7 @@
       "category": "Events & tickets",
       "blurb": "Search for events on SeatGeek.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -10927,6 +11444,7 @@
       "category": "Quality (XPass)",
       "blurb": "Start a scope-gated SecurityPass scan against a registered pack or target URL.",
       "domain": null,
+      "network": "offline",
       "toolCount": 7,
       "tools": [
         {
@@ -10967,6 +11485,7 @@
       "category": "Developer & infra",
       "blurb": "Track a custom event in Segment. Use for recording user actions like 'Signed Up', 'Item Purchased', etc.",
       "domain": "segment.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -10998,7 +11517,8 @@
       "name": "Segment Intersection",
       "category": "Utilities",
       "blurb": "Find pairwise intersections among 2D line segments.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11014,7 +11534,8 @@
       "name": "Segment Tree",
       "category": "Utilities",
       "blurb": "Segment tree for range queries (sum/min/max) with point updates.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11030,7 +11551,8 @@
       "name": "Semver Tools",
       "category": "Developer & infra",
       "blurb": "Parse and compare semantic version strings.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -11051,6 +11573,7 @@
       "category": "Messaging & email",
       "blurb": "Send a transactional email via SendGrid.",
       "domain": "sendgrid.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -11087,6 +11610,7 @@
       "category": "Travel, maps & local",
       "blurb": "Get a shipping quote from Sendle.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -11111,6 +11635,7 @@
       "category": "Developer & infra",
       "blurb": "Interact with the Sentry REST API: list projects and issues, get issue details and events, and resolve issues.",
       "domain": "sentry.io",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -11127,6 +11652,7 @@
       "category": "Quality (XPass)",
       "blurb": "Check a page for search-visibility issues.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -11154,7 +11680,8 @@
       "name": "Set Operations",
       "category": "Utilities",
       "blurb": "Perform set operations: union, intersection, difference, subset checks.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11171,6 +11698,7 @@
       "category": "Music & video",
       "blurb": "Search for an artist on Setlist.fm.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -11198,7 +11726,8 @@
       "name": "Shell Sort",
       "category": "Utilities",
       "blurb": "Shell sort with gap sequence tracking, comparison and swap counts.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11215,6 +11744,7 @@
       "category": "Images",
       "blurb": "Random Shiba Inu, cat, or bird images.",
       "domain": "shibe.online",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -11231,6 +11761,7 @@
       "category": "Security",
       "blurb": "Search Shodan for internet-connected devices.",
       "domain": "shodan.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -11255,6 +11786,7 @@
       "category": "Shopping",
       "blurb": "Get products from a Shopify store.",
       "domain": "shopify.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -11295,6 +11827,7 @@
       "category": "Productivity",
       "blurb": "Search stories, projects, and epics in Shortcut.",
       "domain": "shortcut.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -11322,7 +11855,8 @@
       "name": "Shunting-Yard",
       "category": "Utilities",
       "blurb": "Convert infix math expressions to postfix (RPN) and evaluate using the shunting-yard algorithm.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11338,7 +11872,8 @@
       "name": "Sieve of Eratosthenes",
       "category": "Utilities",
       "blurb": "Generate all prime numbers up to N using the Sieve of Eratosthenes.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11354,7 +11889,8 @@
       "name": "Simplex LP",
       "category": "Utilities",
       "blurb": "Solve linear programming problems (maximize subject to constraints) via simplex.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11370,7 +11906,8 @@
       "name": "Skip List",
       "category": "Utilities",
       "blurb": "Probabilistic sorted data structure with O(log n) search.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11387,6 +11924,7 @@
       "category": "Messaging & email",
       "blurb": "Send and read messages across your channels.",
       "domain": "slack.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -11403,6 +11941,7 @@
       "category": "Games & esports",
       "blurb": "Get the current NFL state from Sleeper.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -11439,6 +11978,7 @@
       "category": "Quality (XPass)",
       "blurb": "Catch AI-code slop and quality issues.",
       "domain": null,
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -11454,7 +11994,8 @@
       "name": "Slug Generator",
       "category": "Developer & infra",
       "blurb": "Convert text into URL-safe slugs with configurable separators.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11471,6 +12012,7 @@
       "category": "Weather & science",
       "blurb": "Browse planets, moons, asteroids, and comets in the solar system.",
       "domain": "le-systeme-solaire.net",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -11490,7 +12032,8 @@
       "name": "SOS DP",
       "category": "Utilities",
       "blurb": "Sum over Subsets (SOS) dynamic programming and zeta transform on bitmasks.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11506,7 +12049,8 @@
       "name": "Soundex",
       "category": "Utilities",
       "blurb": "Encode words with the Soundex phonetic algorithm and compare name similarity.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11523,6 +12067,7 @@
       "category": "News & reading",
       "blurb": "Latest spaceflight news articles, blog posts, and reports.",
       "domain": "spaceflightnewsapi.net",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -11547,6 +12092,7 @@
       "category": "Weather & science",
       "blurb": "SpaceX launches, rockets, and mission data.",
       "domain": "spacex.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -11570,7 +12116,8 @@
       "name": "Sparse Table",
       "category": "Utilities",
       "blurb": "Build a sparse table for O(1) range minimum or maximum queries.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11587,6 +12134,7 @@
       "category": "Games & esports",
       "blurb": "Search for games on Speedrun.com by name. No API key required.",
       "domain": null,
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -11618,7 +12166,8 @@
       "name": "Spline Interpolation",
       "category": "Utilities",
       "blurb": "Natural cubic spline interpolation through data points with evaluation.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11635,6 +12184,7 @@
       "category": "Money & payments",
       "blurb": "Perform a Splitwise action: get_groups, get_expenses, get_balances, create_expense, get_friends.",
       "domain": "splitwise.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -11651,6 +12201,7 @@
       "category": "Music & video",
       "blurb": "Search Spotify for tracks, albums, artists, or playlists.",
       "domain": "spotify.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -11691,6 +12242,7 @@
       "category": "Money & payments",
       "blurb": "List or create Square payments.",
       "domain": "squareup.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -11719,6 +12271,7 @@
       "category": "AI",
       "blurb": "Generate images from a text prompt using Stability AI.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -11747,6 +12300,7 @@
       "category": "Developer & infra",
       "blurb": "Search Stack Overflow and Stack Exchange Q&A by keyword or question ID.",
       "domain": "stackoverflow.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -11767,6 +12321,7 @@
       "category": "Social",
       "blurb": "Search Star Trek characters, species, and starships.",
       "domain": "stapi.co",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -11791,6 +12346,7 @@
       "category": "Games & esports",
       "blurb": "Look up Star Wars characters, planets, and starships.",
       "domain": "swapi.dev",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -11826,7 +12382,8 @@
       "name": "Statistics Calculator",
       "category": "Developer & infra",
       "blurb": "Calculate mean, median, mode, standard deviation for a set of numbers.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11843,6 +12400,7 @@
       "category": "Games & esports",
       "blurb": "Get Steam player profile summaries for one or more Steam IDs.",
       "domain": "steampowered.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -11874,7 +12432,8 @@
       "name": "Stern-Brocot Tree",
       "category": "Utilities",
       "blurb": "Best rational approximation via the Stern-Brocot tree and continued fractions.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11890,7 +12449,8 @@
       "name": "Stirling Numbers",
       "category": "Utilities",
       "blurb": "Compute Stirling numbers of the first or second kind via dynamic programming.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11906,7 +12466,8 @@
       "name": "String Case Converter",
       "category": "Developer & infra",
       "blurb": "Convert text between camelCase, snake_case, kebab-case, PascalCase, and more.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11922,7 +12483,8 @@
       "name": "String Distance",
       "category": "Developer & infra",
       "blurb": "Calculate Levenshtein edit distance and similarity between two strings.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -11939,6 +12501,7 @@
       "category": "Money & payments",
       "blurb": "Look up customers, charges, invoices, and subscriptions.",
       "domain": "stripe.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -11975,6 +12538,7 @@
       "category": "Social",
       "blurb": "Browse Studio Ghibli films and characters.",
       "domain": "ghibliapi.vercel.app",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -11994,7 +12558,8 @@
       "name": "Suffix Array",
       "category": "Utilities",
       "blurb": "Build a suffix array for a string with optional LCP array.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12010,7 +12575,8 @@
       "name": "Suffix Automaton",
       "category": "Utilities",
       "blurb": "Suffix automaton construction with distinct substring counting.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12026,7 +12592,8 @@
       "name": "Suffix Tree",
       "category": "Utilities",
       "blurb": "Suffix tree construction via Ukkonen's algorithm with substring analysis.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12043,6 +12610,7 @@
       "category": "Weather & science",
       "blurb": "Sunrise and sunset times for any GPS coordinates.",
       "domain": "sunrise-sunset.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -12059,6 +12627,7 @@
       "category": "Games & esports",
       "blurb": "Get a Clash of Clans player by tag.",
       "domain": null,
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -12099,6 +12668,7 @@
       "category": "Utilities",
       "blurb": "Look up comic book superhero and villain stats and bios.",
       "domain": "akabab.github.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -12123,6 +12693,7 @@
       "category": "Travel, maps & local",
       "blurb": "Get TAB race meetings for a date.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -12147,6 +12718,7 @@
       "category": "Utilities",
       "blurb": "Generate random taco recipes with layers and seasonings.",
       "domain": "taco-randomizer.herokuapp.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -12162,7 +12734,8 @@
       "name": "Tarjan SCC",
       "category": "Utilities",
       "blurb": "Find all strongly connected components in a directed graph (Tarjan's algorithm).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12179,6 +12752,7 @@
       "category": "Utilities",
       "blurb": "Draw tarot cards and look up card meanings.",
       "domain": "tarotapi.dev",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -12202,7 +12776,8 @@
       "name": "Taylor Series",
       "category": "Utilities",
       "blurb": "Taylor series approximation for exp, sin, cos, ln(1+x), and atan.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12219,6 +12794,7 @@
       "category": "Messaging & email",
       "blurb": "Send a Telegram message.",
       "domain": "telegram.org",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -12254,7 +12830,8 @@
       "name": "Temperature Converter",
       "category": "Utilities",
       "blurb": "Convert temperature between Celsius, Fahrenheit, Kelvin, and Rankine.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12270,7 +12847,8 @@
       "name": "Ternary Search",
       "category": "Utilities",
       "blurb": "Ternary search on sorted arrays or unimodal extremum finding.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12287,6 +12865,7 @@
       "category": "Quality (XPass)",
       "blurb": "List TestPass packs available to the caller, including system packs and the caller's custom packs.",
       "domain": null,
+      "network": "online",
       "toolCount": 10,
       "tools": [
         {
@@ -12339,6 +12918,7 @@
       "category": "Utilities",
       "blurb": "Analyse text (word count, sentences, readability).",
       "domain": null,
+      "network": "offline",
       "toolCount": 7,
       "tools": [
         {
@@ -12378,7 +12958,8 @@
       "name": "Text Diff",
       "category": "Developer & infra",
       "blurb": "Compare two texts line by line and show added/removed lines.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12394,7 +12975,8 @@
       "name": "Text Reverser",
       "category": "Utilities",
       "blurb": "Reverse text by characters, words, lines, or sentences.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12410,7 +12992,8 @@
       "name": "Text Wrapper",
       "category": "Utilities",
       "blurb": "Hard-wrap text to a specified column width for display or formatting.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12426,7 +13009,8 @@
       "name": "TF-IDF",
       "category": "Utilities",
       "blurb": "Calculate TF-IDF scores to rank documents by relevance to a query.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12443,6 +13027,7 @@
       "category": "Images",
       "blurb": "Random cat images and breed information from The Cat API.",
       "domain": "thecatapi.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -12463,6 +13048,7 @@
       "category": "Images",
       "blurb": "Detailed color information and scheme generation for any hex color.",
       "domain": "thecolorapi.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -12483,6 +13069,7 @@
       "category": "Images",
       "blurb": "Random dog images and breed information from The Dog API.",
       "domain": "thedogapi.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -12503,6 +13090,7 @@
       "category": "Travel, maps & local",
       "blurb": "Get Australian lottery results from The Lott.",
       "domain": null,
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -12523,6 +13111,7 @@
       "category": "Weather & science",
       "blurb": "Search cocktail recipes, ingredients, and categories.",
       "domain": "thecocktaildb.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -12559,6 +13148,7 @@
       "category": "Games & esports",
       "blurb": "Search teams, players, leagues, and upcoming events across all sports.",
       "domain": "thesportsdb.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -12587,6 +13177,7 @@
       "category": "Events & tickets",
       "blurb": "Search for events on Ticketmaster.",
       "domain": "ticketmaster.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -12619,6 +13210,7 @@
       "category": "Social",
       "blurb": "Get the authenticated TikTok user profile (follower count, video count, etc.).",
       "domain": "tiktok.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -12643,6 +13235,7 @@
       "category": "Utilities",
       "blurb": "Current time and timezone lookup via timeapi.io.",
       "domain": "timeapi.io",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -12662,7 +13255,8 @@
       "name": "Timezone Reference",
       "category": "Utilities",
       "blurb": "Look up timezone abbreviations, UTC offsets, and full names.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12679,6 +13273,7 @@
       "category": "Music & video",
       "blurb": "Search for movies on TMDB.",
       "domain": "themoviedb.org",
+      "network": "online",
       "toolCount": 8,
       "tools": [
         {
@@ -12723,6 +13318,7 @@
       "category": "Productivity",
       "blurb": "List, create, and complete your Todoist tasks.",
       "domain": "todoist.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -12751,6 +13347,7 @@
       "category": "AI",
       "blurb": "Run a chat completion with any Together AI model. Supports Llama, Mistral, Qwen, and 100+ open-source models.",
       "domain": null,
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -12779,6 +13376,7 @@
       "category": "Productivity",
       "blurb": "Get Toggl time entries.",
       "domain": "toggl.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -12807,6 +13405,7 @@
       "category": "Travel, maps & local",
       "blurb": "Find the nearest public toilets to a location (Australia).",
       "domain": null,
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -12826,7 +13425,8 @@
       "name": "Token Counter",
       "category": "Utilities",
       "blurb": "Estimate token counts for text across different LLM tokenizers.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12843,6 +13443,7 @@
       "category": "Weather & science",
       "blurb": "Get realtime weather from Tomorrow.io.",
       "domain": "tomorrow.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -12866,7 +13467,8 @@
       "name": "Topo Order Count",
       "category": "Utilities",
       "blurb": "Count distinct topological orderings of a directed acyclic graph.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12882,7 +13484,8 @@
       "name": "Topological Sort",
       "category": "Utilities",
       "blurb": "Topological sort of a directed graph with cycle detection.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12898,7 +13501,8 @@
       "name": "Treap",
       "category": "Utilities",
       "blurb": "Randomized BST combining tree and heap properties.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12915,6 +13519,7 @@
       "category": "Productivity",
       "blurb": "Manage Trello boards, lists, and cards.",
       "domain": "trello.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -12930,7 +13535,8 @@
       "name": "Triangle Solver",
       "category": "Utilities",
       "blurb": "Solve triangles from three side lengths: angles, area, inradius, circumradius.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12946,7 +13552,8 @@
       "name": "Trie",
       "category": "Utilities",
       "blurb": "Prefix tree for word search, prefix counting, and autocomplete.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -12963,6 +13570,7 @@
       "category": "Utilities",
       "blurb": "Get trivia questions from Open Trivia DB.",
       "domain": null,
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -12983,6 +13591,7 @@
       "category": "News & reading",
       "blurb": "Search the National Library of Australia's Trove.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13006,7 +13615,8 @@
       "name": "TSP Solver",
       "category": "Utilities",
       "blurb": "Find a short tour visiting all cities (traveling salesman, nearest-neighbor heuristic).",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13023,6 +13633,7 @@
       "category": "Developer & infra",
       "blurb": "List all databases in a Turso organization.",
       "domain": "turso.tech",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -13055,6 +13666,7 @@
       "category": "Music & video",
       "blurb": "Search TV shows, get details, and browse schedules.",
       "domain": "tvmaze.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13079,6 +13691,7 @@
       "category": "Messaging & email",
       "blurb": "Send an SMS via Twilio.",
       "domain": "twilio.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -13119,6 +13732,7 @@
       "category": "Social",
       "blurb": "Search for live streams on Twitch.",
       "domain": "twitch.tv",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -13159,6 +13773,7 @@
       "category": "Productivity",
       "blurb": "List your Typeform forms.",
       "domain": "typeform.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13183,6 +13798,7 @@
       "category": "Images",
       "blurb": "Generate text-based avatar images from initials.",
       "domain": "ui-avatars.com",
+      "network": "hybrid",
       "toolCount": 1,
       "tools": [
         {
@@ -13199,6 +13815,7 @@
       "category": "Security",
       "blurb": "UK police forces and street-level crime data from data.police.uk.",
       "domain": "data.police.uk",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13218,7 +13835,8 @@
       "name": "Union-Find",
       "category": "Utilities",
       "blurb": "Merge elements and query connectivity using union-find with path compression.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13235,6 +13853,7 @@
       "category": "Utilities",
       "blurb": "Convert between length units.",
       "domain": null,
+      "network": "offline",
       "toolCount": 7,
       "tools": [
         {
@@ -13275,6 +13894,7 @@
       "category": "Images",
       "blurb": "Search and fetch free Unsplash photos.",
       "domain": "unsplash.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13299,6 +13919,7 @@
       "category": "Weather & science",
       "blurb": "Search for beers on Untappd.",
       "domain": null,
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -13331,6 +13952,7 @@
       "category": "Shopping",
       "blurb": "Look up products by UPC/EAN barcode or search by name.",
       "domain": "upcitemdb.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13351,6 +13973,7 @@
       "category": "Developer & infra",
       "blurb": "Get the value of a key from an Upstash Redis database.",
       "domain": "upstash.com",
+      "network": "online",
       "toolCount": 7,
       "tools": [
         {
@@ -13391,6 +14014,7 @@
       "category": "Developer & infra",
       "blurb": "Check your monitors and get alerted when one is down.",
       "domain": "uptimerobot.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13411,6 +14035,7 @@
       "category": "Utilities",
       "blurb": "Look up slang definitions or browse trending words.",
       "domain": "urbandictionary.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13430,7 +14055,8 @@
       "name": "URL Encoder",
       "category": "Developer & infra",
       "blurb": "URL percent-encode and decode text for query strings.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 2,
       "tools": [
         {
@@ -13451,6 +14077,7 @@
       "category": "Security",
       "blurb": "Check URLs against the URLhaus malware database.",
       "domain": "urlhaus.abuse.ch",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13471,6 +14098,7 @@
       "category": "Security",
       "blurb": "Submit a URL for scanning on urlscan.io.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13495,6 +14123,7 @@
       "category": "Utilities",
       "blurb": "Random interesting but useless facts.",
       "domain": "uselessfacts.jsph.pl",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13515,6 +14144,7 @@
       "category": "Weather & science",
       "blurb": "Get recent earthquakes from USGS.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13538,7 +14168,8 @@
       "name": "UUID Generator",
       "category": "Developer & infra",
       "blurb": "Generate cryptographically random UUID v4 strings.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13555,6 +14186,7 @@
       "category": "Quality (XPass)",
       "blurb": "Check a page's UI and UX for usability issues.",
       "domain": null,
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -13590,7 +14222,8 @@
       "name": "Variance Calculator",
       "category": "Utilities",
       "blurb": "Population/sample variance, standard deviation, median, range, and CV.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13607,6 +14240,7 @@
       "category": "Markets & crypto",
       "blurb": "EU VAT rates and member state data from VATcomply.",
       "domain": "vatcomply.com",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13627,6 +14261,7 @@
       "category": "Developer & infra",
       "blurb": "Perform a vault action: vault_init, vault_store, vault_retrieve, vault_list, vault_delete, vault_rotate, vault_audit.",
       "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13643,6 +14278,7 @@
       "category": "Developer & infra",
       "blurb": "List Vercel deployments for a project.",
       "domain": "vercel.com",
+      "network": "online",
       "toolCount": 8,
       "tools": [
         {
@@ -13686,7 +14322,8 @@
       "name": "Vigenere Cipher",
       "category": "Utilities",
       "blurb": "Encrypt or decrypt text using the Vigenere polyalphabetic cipher.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13703,6 +14340,7 @@
       "category": "Security",
       "blurb": "Submit a URL for scanning on VirusTotal.",
       "domain": "virustotal.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -13730,7 +14368,8 @@
       "name": "Wavelength Converter",
       "category": "Utilities",
       "blurb": "Convert between wavelength and frequency with energy and EM spectrum band.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13746,7 +14385,8 @@
       "name": "Wavelet Tree",
       "category": "Utilities",
       "blurb": "Wavelet tree for range kth-smallest queries on integer arrays.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13763,6 +14403,7 @@
       "category": "News & reading",
       "blurb": "Check if a URL has been archived by the Wayback Machine.",
       "domain": "web.archive.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -13779,6 +14420,7 @@
       "category": "Content & CMS",
       "blurb": "List Webflow sites for the account.",
       "domain": "webflow.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -13806,7 +14448,8 @@
       "name": "Weighted Mean",
       "category": "Utilities",
       "blurb": "Weighted, arithmetic, geometric, and harmonic means of a value set.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -13823,6 +14466,7 @@
       "category": "Weather & science",
       "blurb": "Browse exercises, muscle groups, and workout categories.",
       "domain": "wger.de",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13847,6 +14491,7 @@
       "category": "Messaging & email",
       "blurb": "Send a text message via WhatsApp Business Cloud API.",
       "domain": "whatsapp.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -13879,6 +14524,7 @@
       "category": "Weather & science",
       "blurb": "Track the International Space Station position in real time.",
       "domain": "wheretheiss.at",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13899,6 +14545,7 @@
       "category": "News & reading",
       "blurb": "Structured knowledge base: search and retrieve entity data from Wikidata.",
       "domain": "wikidata.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -13919,6 +14566,7 @@
       "category": "News & reading",
       "blurb": "Search Wikipedia and read article summaries.",
       "domain": "wikipedia.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13943,6 +14591,7 @@
       "category": "Books",
       "blurb": "Look up word definitions in Wiktionary (multi-language).",
       "domain": "wiktionary.org",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -13959,6 +14608,7 @@
       "category": "Weather & science",
       "blurb": "Get weather forecast from WillyWeather for an Australian location.",
       "domain": null,
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -13983,6 +14633,7 @@
       "category": "Money & payments",
       "blurb": "Get exchange rates from Wise.",
       "domain": "wise.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -14011,6 +14662,7 @@
       "category": "Shopping",
       "blurb": "List or get WooCommerce products.",
       "domain": "woocommerce.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -14034,7 +14686,8 @@
       "name": "Word Counter",
       "category": "Utilities",
       "blurb": "Count words, characters, sentences, and estimate reading time.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -14050,7 +14703,8 @@
       "name": "Word Frequency",
       "category": "Utilities",
       "blurb": "Analyse word frequencies in text with counts and top-word ranking.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -14067,6 +14721,7 @@
       "category": "Content & CMS",
       "blurb": "Read posts and pages from your WordPress site.",
       "domain": "wordpress.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -14091,6 +14746,7 @@
       "category": "Weather & science",
       "blurb": "Country profiles and economic indicators from the World Bank.",
       "domain": "worldbank.org",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {
@@ -14111,6 +14767,7 @@
       "category": "Weather & science",
       "blurb": "Current time by timezone or IP address with UTC offset.",
       "domain": "worldtimeapi.org",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -14135,6 +14792,7 @@
       "category": "News & reading",
       "blurb": "Search universities worldwide by name or country.",
       "domain": "universities.hipolabs.com",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -14151,6 +14809,7 @@
       "category": "Money & payments",
       "blurb": "Get invoices from Xero.",
       "domain": "xero.com",
+      "network": "online",
       "toolCount": 8,
       "tools": [
         {
@@ -14195,6 +14854,7 @@
       "category": "Social",
       "blurb": "Read xkcd comics - latest, by number, or random.",
       "domain": "xkcd.com",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -14218,7 +14878,8 @@
       "name": "XOR Basis",
       "category": "Utilities",
       "blurb": "Compute a linear basis over GF(2) (XOR basis) for a set of integers.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -14235,6 +14896,7 @@
       "category": "Quality (XPass)",
       "blurb": "Return one XPass conductor verdict for a target PR/change at a specific commit SHA.",
       "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -14251,6 +14913,7 @@
       "category": "Travel, maps & local",
       "blurb": "Search for businesses on Yelp.",
       "domain": "yelp.com",
+      "network": "online",
       "toolCount": 5,
       "tools": [
         {
@@ -14283,6 +14946,7 @@
       "category": "Utilities",
       "blurb": "Random yes/no answers with animated GIFs for fun decisions.",
       "domain": "yesno.wtf",
+      "network": "online",
       "toolCount": 1,
       "tools": [
         {
@@ -14299,6 +14963,7 @@
       "category": "Social",
       "blurb": "Search YouTube for videos, channels, or playlists.",
       "domain": "youtube.com",
+      "network": "online",
       "toolCount": 6,
       "tools": [
         {
@@ -14334,7 +14999,8 @@
       "name": "Z-Algorithm",
       "category": "Utilities",
       "blurb": "Z-array computation and linear-time pattern matching.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -14350,7 +15016,8 @@
       "name": "Z-Function",
       "category": "Utilities",
       "blurb": "Z-function string algorithm for pattern matching and prefix analysis.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -14366,7 +15033,8 @@
       "name": "Z-Score Calculator",
       "category": "Utilities",
       "blurb": "Calculate z-scores, cumulative probabilities, and percentiles.",
-      "domain": "local",
+      "domain": null,
+      "network": "offline",
       "toolCount": 1,
       "tools": [
         {
@@ -14383,6 +15051,7 @@
       "category": "Utilities",
       "blurb": "Inspirational and motivational quotes of the day.",
       "domain": "zenquotes.io",
+      "network": "online",
       "toolCount": 3,
       "tools": [
         {
@@ -14407,6 +15076,7 @@
       "category": "Messaging & email",
       "blurb": "Search, read, and reply to support tickets.",
       "domain": "zendesk.com",
+      "network": "online",
       "toolCount": 4,
       "tools": [
         {
@@ -14435,6 +15105,7 @@
       "category": "Developer & infra",
       "blurb": "Look up zip and postal codes for city, state, and country.",
       "domain": "zippopotam.us",
+      "network": "online",
       "toolCount": 2,
       "tools": [
         {

--- a/src/data/app-test-results.json
+++ b/src/data/app-test-results.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-06-09T04:56:04.429Z",
+  "updatedAt": "2026-06-11T05:45:00.000Z",
   "results": {
     "abn": {
       "status": "attention",
@@ -12,8 +12,8 @@
     },
     "abuseipdb": {
       "status": "attention",
-      "note": "IP reputation API; needs ABUSEIPDB_API_KEY.",
-      "testedAt": "2026-06-07T09:41:21.082Z",
+      "note": "IP reputation API; needs ABUSEIPDB_API_KEY. Not-connected card re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "abuseipdb_check_ip"
       ],
@@ -21,8 +21,8 @@
     },
     "adviceslip": {
       "status": "pass",
-      "note": "advice_random() returned a random advice slip with id and advice text. Free API.",
-      "testedAt": "2026-06-07T12:45:00.000Z",
+      "note": "advice_random() returned a random advice slip with id and advice text. Free API. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "advice_random"
       ]
@@ -59,8 +59,8 @@
     },
     "alphavantage": {
       "status": "attention",
-      "note": "not_connected; needs free API key from alphavantage.co. Set ALPHAVANTAGE_API_KEY.",
-      "testedAt": "2026-06-07T09:39:36.511Z",
+      "note": "not_connected; needs free API key from alphavantage.co. Set ALPHAVANTAGE_API_KEY. Not-connected card re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "stock_quote"
       ],
@@ -85,12 +85,11 @@
       "comment": ""
     },
     "animechan": {
-      "status": "pass",
-      "note": "animechan_random and animechan_search return anime quotes. Free, no key needed.",
-      "testedAt": "2026-06-08T09:00:00.000Z",
+      "status": "fail",
+      "note": "animechan_random: HTTP 404 HTML page; API moved to api.animechan.io/v1. Fix shipped; retest after deploy.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "animechan_random",
-        "animechan_search"
+        "animechan_random"
       ]
     },
     "amiibo": {
@@ -109,9 +108,9 @@
       "comment": ""
     },
     "aoe2": {
-      "status": "pass",
-      "note": "aoe2_civilizations() returned all AoE2 civilizations with bonuses. Free public API.",
-      "testedAt": "2026-06-07T12:50:00.000Z",
+      "status": "fail",
+      "note": "aoe2_civilizations returns Heroku 'No such app' 404; age-of-empires-2-api.herokuapp.com is gone. No drop-in replacement API known.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "aoe2_civilizations"
       ]
@@ -228,9 +227,9 @@
       "comment": ""
     },
     "bored": {
-      "status": "pass",
-      "note": "bored_random() returned activity suggestion with type and participants. Free public API.",
-      "testedAt": "2026-06-07T12:50:00.000Z",
+      "status": "fail",
+      "note": "bored_random: HTTP 404 'Cannot GET /api/activity'; bored-api.appbrewery.com moved to /random and /filter. Path fix shipped; retest after deploy.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "bored_random"
       ]
@@ -253,9 +252,9 @@
       "comment": ""
     },
     "breakingbad": {
-      "status": "pass",
-      "note": "breaking_bad_quote returns random Breaking Bad quotes. Free, no key needed.",
-      "testedAt": "2026-06-08T08:30:00.000Z",
+      "status": "attention",
+      "note": "breaking_bad_quote returns upstream rate-limit persistently from the shared deployment IP. Works but throttled; needs spacing between calls.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "breaking_bad_quote"
       ]
@@ -278,9 +277,10 @@
     },
     "calculator": {
       "status": "pass",
-      "note": "calc_tip returned correct tip calculation (bill=50, 15% tip = 7.50, total 57.50)",
-      "testedAt": "2026-06-07T03:01:02.000Z",
+      "note": "calc_tip returned correct tip calculation (bill=50, 15% tip = 7.50, total 57.50). Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
+        "calc_bmi",
         "calc_tip"
       ],
       "comment": ""
@@ -331,11 +331,11 @@
     },
     "catfacts": {
       "status": "pass",
-      "note": "New connector: Cat Facts API. Free public API, no key needed. Random facts and cat breed data. 3 tools, all tests passing.",
-      "testedAt": "2026-06-07T12:25:00.000Z",
+      "note": "New connector: Cat Facts API. Free public API, no key needed. Random facts and cat breed data. 3 tools, all tests passing. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "cat_fact",
-        "cat_breeds"
+        "cat_breeds",
+        "cat_fact"
       ],
       "comment": ""
     },
@@ -360,11 +360,11 @@
     },
     "chucknorris": {
       "status": "pass",
-      "note": "New connector: Chuck Norris API. Free public API, no key needed. Random jokes, search, categories. 3 tools, all tests passing.",
-      "testedAt": "2026-06-07T12:25:00.000Z",
+      "note": "New connector: Chuck Norris API. Free public API, no key needed. Random jokes, search, categories. 3 tools, all tests passing. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "chuck_random",
-        "chuck_categories"
+        "chuck_categories",
+        "chuck_random"
       ],
       "comment": ""
     },
@@ -530,8 +530,8 @@
     },
     "corporatebs": {
       "status": "pass",
-      "note": "corporate_bs_phrase returned a buzzword phrase; free, no key needed.",
-      "testedAt": "2026-06-08T03:57:15.086Z",
+      "note": "corporate_bs_phrase returned a buzzword phrase; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "corporate_bs_phrase"
       ]
@@ -629,12 +629,12 @@
     },
     "digimon": {
       "status": "pass",
-      "note": "digimon_all, digimon_by_name, digimon_by_level return Digimon data. Free, no key needed.",
-      "testedAt": "2026-06-08T08:30:00.000Z",
+      "note": "digimon_all, digimon_by_name, digimon_by_level return Digimon data. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "digimon_all",
-        "digimon_by_name",
-        "digimon_by_level"
+        "digimon_by_level",
+        "digimon_by_name"
       ]
     },
     "discogs": {
@@ -687,8 +687,8 @@
     },
     "dogfacts": {
       "status": "pass",
-      "note": "dog_fact_random returned a random dog fact. Free, no key needed.",
-      "testedAt": "2026-06-08T06:30:00.000Z",
+      "note": "dog_fact_random returned a random dog fact. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "dog_fact_random"
       ]
@@ -808,9 +808,9 @@
       "comment": ""
     },
     "evilinsult": {
-      "status": "pass",
-      "note": "evil_insult_random returned a random insult from evilinsult.com; free, no key needed.",
-      "testedAt": "2026-06-08T04:01:53.563Z",
+      "status": "fail",
+      "note": "evil_insult_random: HTTP 403 Cloudflare challenge page; evilinsult.com blocks server-side callers.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "evil_insult_random"
       ]
@@ -834,8 +834,8 @@
     },
     "excuser": {
       "status": "pass",
-      "note": "excuser_random returned a random excuse. Free, no key needed.",
-      "testedAt": "2026-06-08T06:30:00.000Z",
+      "note": "excuser_random returned a random excuse. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "excuser_random"
       ]
@@ -873,8 +873,8 @@
     },
     "finalspace": {
       "status": "pass",
-      "note": "final_space_characters returned Final Space character list. Free, no key needed.",
-      "testedAt": "2026-06-08T06:45:00.000Z",
+      "note": "final_space_characters returned Final Space character list. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "final_space_characters"
       ]
@@ -924,8 +924,8 @@
     },
     "frankfurter": {
       "status": "pass",
-      "note": "frankfurter_latest returned EUR exchange rates from ECB data; free, no key needed.",
-      "testedAt": "2026-06-08T03:51:41.572Z",
+      "note": "frankfurter_latest returned EUR exchange rates from ECB data; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "frankfurter_latest"
       ]
@@ -1042,8 +1042,8 @@
     },
     "hackernews": {
       "status": "pass",
-      "note": "hn_top_stories returned 3 stories with titles, URLs, scores, and comment counts from Firebase API",
-      "testedAt": "2026-06-07T03:49:32.000Z",
+      "note": "hn_top_stories returned 3 stories with titles, URLs, scores, and comment counts from Firebase API. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "hn_top_stories"
       ],
@@ -1202,8 +1202,8 @@
     },
     "iseven": {
       "status": "pass",
-      "note": "is_even checks if a number is even via isevenapi.xyz. Free, no key needed.",
-      "testedAt": "2026-06-08T08:00:00.000Z",
+      "note": "is_even checks if a number is even via isevenapi.xyz. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "is_even"
       ]
@@ -1254,8 +1254,8 @@
     },
     "kanye": {
       "status": "pass",
-      "note": "kanye_quote returned a Kanye West quote from api.kanye.rest; free, no key needed.",
-      "testedAt": "2026-06-08T03:51:41.572Z",
+      "note": "kanye_quote returned a Kanye West quote from api.kanye.rest; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "kanye_quote"
       ]
@@ -1358,8 +1358,8 @@
     },
     "lyrics": {
       "status": "pass",
-      "note": "lyrics_get fetches song lyrics from lyrics.ovh by artist and title. Free, no key needed.",
-      "testedAt": "2026-06-08T10:00:00.000Z",
+      "note": "lyrics_get fetches song lyrics from lyrics.ovh by artist and title. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "lyrics_get"
       ]
@@ -1373,8 +1373,8 @@
     },
     "makeup": {
       "status": "pass",
-      "note": "makeup_search returned product results from Makeup API. Free, no key needed.",
-      "testedAt": "2026-06-08T06:00:00.000Z",
+      "note": "makeup_search returned product results from Makeup API. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "makeup_search"
       ]
@@ -1569,8 +1569,8 @@
     },
     "numbers": {
       "status": "fail",
-      "note": "numbersapi.com returning HTTP 404. Service appears down. No code fix possible.",
-      "testedAt": "2026-06-07T09:37:28.711Z",
+      "note": "Confirmed still failing 2026-06-11: number_fact gets HTTP 404 from numbersapi.com over HTTPS. Switched base to HTTP (the API is HTTP-only); retest after deploy.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "number_fact"
       ],
@@ -1667,8 +1667,8 @@
     },
     "openmeteo": {
       "status": "pass",
-      "note": "weather_current returned Melbourne weather (16.7C, partly cloudy) - no auth needed",
-      "testedAt": "2026-06-07T04:25:00.000Z",
+      "note": "weather_current returned Melbourne weather (16.7C, partly cloudy) - no auth needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "weather_current"
       ],
@@ -1796,8 +1796,8 @@
     },
     "pokeapi": {
       "status": "pass",
-      "note": "New connector: PokeAPI. Free public API, no key needed. Get Pokemon by name/id, search, types, abilities, generations. 5 tools, all tests passing.",
-      "testedAt": "2026-06-07T09:55:00.000Z",
+      "note": "New connector: PokeAPI. Free public API, no key needed. Get Pokemon by name/id, search, types, abilities, generations. 5 tools, all tests passing. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "poke_get_pokemon",
         "poke_search_pokemon"
@@ -1872,9 +1872,9 @@
       ]
     },
     "punkapi": {
-      "status": "pass",
-      "note": "punkapi_random_beer returned a BrewDog craft beer recipe. Free, no key needed.",
-      "testedAt": "2026-06-08T06:15:00.000Z",
+      "status": "fail",
+      "note": "punkapi_random_beer: fetch failed; punkapi.com no longer resolves (Punk API shut down). Community mirror punkapi.online unverified.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "punkapi_random_beer"
       ]
@@ -1911,9 +1911,9 @@
       "comment": ""
     },
     "quotable": {
-      "status": "pass",
-      "note": "quote_random() returned a random quote with content, author, and tags. Free public API.",
-      "testedAt": "2026-06-07T12:45:00.000Z",
+      "status": "fail",
+      "note": "quote_random: 'Quotable network error: fetch failed'; api.quotable.io unreachable (known cert/hosting issues).",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "quote_random"
       ]
@@ -1947,8 +1947,8 @@
     },
     "randomfox": {
       "status": "pass",
-      "note": "random_fox_image returned a fox image URL from randomfox.ca; free, no key needed.",
-      "testedAt": "2026-06-08T03:57:15.086Z",
+      "note": "random_fox_image returned a fox image URL from randomfox.ca; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "random_fox_image"
       ]
@@ -2023,11 +2023,14 @@
       "comment": ""
     },
     "restcountries": {
-      "status": "pass",
-      "note": "country_by_name returned Australia with full metadata (population, currencies, timezones) - no auth needed",
-      "testedAt": "2026-06-07T04:45:00.000Z",
+      "status": "fail",
+      "note": "All endpoints broken live: country_by_name/by_region/all throw 'countries.map is not a function' (upstream now returns a non-array object). Defensive fix shipped; retest after deploy.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "country_by_name"
+        "country_by_name",
+        "country_by_code",
+        "country_by_region",
+        "country_all"
       ],
       "comment": ""
     },
@@ -2144,9 +2147,9 @@
       "comment": ""
     },
     "shibe": {
-      "status": "pass",
-      "note": "shibe_random_image returned random Shiba Inu image URLs. Free, no key needed.",
-      "testedAt": "2026-06-08T06:15:00.000Z",
+      "status": "fail",
+      "note": "shibe_random_image: fetch failed; shibe.online unreachable.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "shibe_random_image"
       ]
@@ -2199,12 +2202,11 @@
       ]
     },
     "spacex": {
-      "status": "pass",
-      "note": "spacex_latest_launch, spacex_launches, spacex_rockets fetch SpaceX data from api.spacexdata.com. Free, no key needed.",
-      "testedAt": "2026-06-08T11:00:00.000Z",
+      "status": "fail",
+      "note": "spacex_latest_launch and spacex_rockets time out (10s) on repeated calls; api.spacexdata.com (archived r/SpaceX API) is unresponsive.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "spacex_latest_launch",
-        "spacex_launches",
         "spacex_rockets"
       ]
     },
@@ -2316,9 +2318,9 @@
       "comment": ""
     },
     "tacofancy": {
-      "status": "pass",
-      "note": "random_taco generates random taco recipes from Taco Fancy API. Free, no key needed.",
-      "testedAt": "2026-06-08T08:30:00.000Z",
+      "status": "fail",
+      "note": "random_taco returns Heroku 'No such app' 404; taco-randomizer.herokuapp.com is gone.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "random_taco"
       ]
@@ -2357,9 +2359,9 @@
       "comment": ""
     },
     "thelott": {
-      "status": "fail",
-      "note": "POST endpoint at data.api.thelott.com returning \"Game or draw not found\". Product filter names may need adjustment.",
-      "testedAt": "2026-06-07T09:37:28.711Z",
+      "status": "pass",
+      "note": "Recovered: lott_jackpots and lott_results(game=Powerball) both returned valid live draw data on 2026-06-11 recheck.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "lott_results",
         "lott_jackpots"
@@ -2566,8 +2568,8 @@
     },
     "urbandictionary": {
       "status": "pass",
-      "note": "urban_define and urban_random look up slang definitions from urbandictionary.com. Free, no key needed.",
-      "testedAt": "2026-06-08T10:00:00.000Z",
+      "note": "urban_define and urban_random look up slang definitions from urbandictionary.com. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "urban_define",
         "urban_random"
@@ -2575,16 +2577,16 @@
     },
     "uselessfacts": {
       "status": "pass",
-      "note": "useless_fact_random returned a random fact from uselessfacts.jsph.pl; free, no key needed.",
-      "testedAt": "2026-06-08T03:57:15.086Z",
+      "note": "useless_fact_random returned a random fact from uselessfacts.jsph.pl; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "useless_fact_random"
       ]
     },
     "usgs": {
       "status": "pass",
-      "note": "usgs_recent_earthquakes returned 3 M5+ quakes from past day near Timor Leste - no auth needed",
-      "testedAt": "2026-06-07T05:05:00.000Z",
+      "note": "usgs_recent_earthquakes returned 3 M5+ quakes from past day near Timor Leste - no auth needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "usgs_recent_earthquakes"
       ],
@@ -2715,11 +2717,11 @@
     },
     "xkcd": {
       "status": "pass",
-      "note": "New connector: xkcd. Free public API, no key needed. Latest, by number, or random comics. 3 tools, all tests passing.",
-      "testedAt": "2026-06-07T12:25:00.000Z",
+      "note": "New connector: xkcd. Free public API, no key needed. Latest, by number, or random comics. 3 tools, all tests passing. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "xkcd_latest",
-        "xkcd_comic"
+        "xkcd_comic",
+        "xkcd_latest"
       ],
       "comment": ""
     },
@@ -2741,8 +2743,8 @@
     },
     "yesno": {
       "status": "pass",
-      "note": "yesno_random returned yes/no answer with GIF from yesno.wtf; free, no key needed.",
-      "testedAt": "2026-06-08T04:01:53.563Z",
+      "note": "yesno_random returned yes/no answer with GIF from yesno.wtf; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "yesno_random"
       ]
@@ -2763,16 +2765,16 @@
     },
     "zenquotes": {
       "status": "pass",
-      "note": "zen_quote_random returned an inspirational quote from zenquotes.io; free, no key needed.",
-      "testedAt": "2026-06-08T03:51:41.572Z",
+      "note": "zen_quote_random returned an inspirational quote from zenquotes.io; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "zen_quote_random"
       ]
     },
     "zippopotamus": {
       "status": "pass",
-      "note": "zip_lookup returned Beverly Hills for 90210 from zippopotam.us; free, no key needed.",
-      "testedAt": "2026-06-08T04:01:53.563Z",
+      "note": "zip_lookup returned Beverly Hills for 90210 from zippopotam.us; free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "zip_lookup"
       ]
@@ -2848,21 +2850,19 @@
     },
     "foodish": {
       "status": "pass",
-      "note": "foodish_random and foodish_by_category return food images from foodish-api.com. Free, no key needed.",
-      "testedAt": "2026-06-08T12:30:00.000Z",
+      "note": "foodish_random and foodish_by_category return food images from foodish-api.com. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "foodish_random",
-        "foodish_by_category"
+        "foodish_by_category",
+        "foodish_random"
       ]
     },
     "acnhapi": {
-      "status": "pass",
-      "note": "acnh_villagers, acnh_fish, acnh_bugs return Animal Crossing data from acnhapi.com. Free, no key needed.",
-      "testedAt": "2026-06-08T12:30:00.000Z",
+      "status": "fail",
+      "note": "acnh_villagers: fetch failed; acnhapi.com is dead (successor Nookipedia API needs a key).",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "acnh_villagers",
-        "acnh_fish",
-        "acnh_bugs"
+        "acnh_villagers"
       ]
     },
     "httpcat": {
@@ -2894,21 +2894,21 @@
     },
     "wheretheiss": {
       "status": "pass",
-      "note": "iss_position and iss_pass_times return ISS tracking data from wheretheiss.at. Free, no key needed.",
-      "testedAt": "2026-06-08T13:00:00.000Z",
+      "note": "iss_position and iss_pass_times return ISS tracking data from wheretheiss.at. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "iss_position",
-        "iss_pass_times"
+        "iss_pass_times",
+        "iss_position"
       ]
     },
     "coinlore": {
       "status": "pass",
-      "note": "coinlore_global, coinlore_tickers, coinlore_coin return crypto data from coinlore.net. Free, no key needed.",
-      "testedAt": "2026-06-08T13:00:00.000Z",
+      "note": "coinlore_global, coinlore_tickers, coinlore_coin return crypto data from coinlore.net. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
+        "coinlore_coin",
         "coinlore_global",
-        "coinlore_tickers",
-        "coinlore_coin"
+        "coinlore_tickers"
       ]
     },
     "openmeteo-airquality": {
@@ -3230,11 +3230,11 @@
     },
     "crates": {
       "status": "pass",
-      "note": "crates_search returns Rust crate listings from crates.io. Free, no key needed.",
-      "testedAt": "2026-06-08T16:00:00.000Z",
+      "note": "crates_search returns Rust crate listings from crates.io. Free, no key needed. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
-        "crates_search",
-        "crates_get"
+        "crates_get",
+        "crates_search"
       ]
     },
     "npm-registry": {
@@ -3325,9 +3325,9 @@
       ]
     },
     "isup": {
-      "status": "pass",
-      "note": "isup_check reports whether a domain is up or down via isitup.org. Free, no key needed.",
-      "testedAt": "2026-06-08T17:30:00.000Z",
+      "status": "fail",
+      "note": "isup_check returns 'isitup.org 404' for every domain (google.com included): isitup.org requires a User-Agent header. Fix shipped; retest after deploy.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "isup_check"
       ]
@@ -5085,8 +5085,8 @@
     },
     "twosat": {
       "status": "pass",
-      "note": "two_sat solves 2-SAT via implication graph and Kosaraju SCC. Local computation, all tests pass.",
-      "testedAt": "2026-06-09T02:43:00.000Z",
+      "note": "two_sat solves 2-SAT via implication graph and Kosaraju SCC. Local computation, all tests pass. Re-verified live 2026-06-11.",
+      "testedAt": "2026-06-11T05:45:00.000Z",
       "toolsTested": [
         "two_sat"
       ]
@@ -5532,5 +5532,5 @@
       ]
     }
   },
-  "note": "Maintained by the AppTesting loop. Each entry is the result of physically calling a representative action on that app MCP tools. The comment field is for admin notes and is preserved across loop runs. Apps not listed here are treated as untested. Statuses: pass | fail | attention | untested."
+  "note": "Includes a manual false-positive audit (44 apps physically re-called on 2026-06-11): 13 recorded passes were actually broken and are now fail; thelott recovered to pass."
 }

--- a/src/data/connector-setup.generated.json
+++ b/src/data/connector-setup.generated.json
@@ -1,0 +1,1197 @@
+{
+  "generatedAt": "static",
+  "count": 166,
+  "connectors": {
+    "stripe": {
+      "displayName": "Stripe",
+      "credential": "secret key",
+      "arg": "secret_key",
+      "envVar": "STRIPE_SECRET_KEY",
+      "setupUrl": "https://dashboard.stripe.com/apikeys",
+      "note": "The Stripe secret key starts with sk_live_ or sk_test_."
+    },
+    "etsy": {
+      "displayName": "Etsy",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "ETSY_API_KEY",
+      "setupUrl": "https://www.etsy.com/developers/your-apps"
+    },
+    "paypal": {
+      "displayName": "PayPal",
+      "credential": "client id",
+      "arg": "client_id",
+      "envVar": "PAYPAL_CLIENT_ID",
+      "setupUrl": "https://developer.paypal.com/dashboard/applications",
+      "note": "Also pass client_secret (or set PAYPAL_CLIENT_SECRET)."
+    },
+    "square": {
+      "displayName": "Square",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "SQUARE_ACCESS_TOKEN",
+      "setupUrl": "https://developer.squareup.com/apps"
+    },
+    "shopify": {
+      "displayName": "Shopify",
+      "credential": "Admin API access token",
+      "arg": "access_token",
+      "envVar": "SHOPIFY_ACCESS_TOKEN",
+      "setupUrl": "https://admin.shopify.com/",
+      "note": "Also pass store (your-shop or your-shop.myshopify.com)."
+    },
+    "woocommerce": {
+      "displayName": "WooCommerce",
+      "credential": "consumer key",
+      "arg": "consumer_key",
+      "envVar": "WOOCOMMERCE_CONSUMER_KEY",
+      "setupUrl": "https://woocommerce.com/document/woocommerce-rest-api/",
+      "note": "Also pass consumer_secret (WooCommerce > Settings > Advanced > REST API)."
+    },
+    "gumroad": {
+      "displayName": "Gumroad",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "GUMROAD_ACCESS_TOKEN",
+      "setupUrl": "https://app.gumroad.com/settings/advanced"
+    },
+    "lemonsqueezy": {
+      "displayName": "Lemon Squeezy",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "LEMONSQUEEZY_API_KEY",
+      "setupUrl": "https://app.lemonsqueezy.com/settings/api"
+    },
+    "quickbooks": {
+      "displayName": "QuickBooks",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "QUICKBOOKS_ACCESS_TOKEN",
+      "setupUrl": "https://developer.intuit.com/app/developer/dashboard"
+    },
+    "xero": {
+      "displayName": "Xero",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "XERO_ACCESS_TOKEN",
+      "setupUrl": "https://developer.xero.com/app/manage",
+      "note": "Also pass tenant_id for the Xero organisation."
+    },
+    "plaid": {
+      "displayName": "Plaid",
+      "credential": "client id",
+      "arg": "client_id",
+      "envVar": "PLAID_CLIENT_ID",
+      "setupUrl": "https://dashboard.plaid.com/team/keys",
+      "note": "Also pass secret, and access_token for item endpoints."
+    },
+    "wise": {
+      "displayName": "Wise",
+      "credential": "API token",
+      "envVar": "WISE_API_TOKEN",
+      "setupUrl": "https://wise.com/settings/"
+    },
+    "openai": {
+      "displayName": "OpenAI",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "OPENAI_API_KEY",
+      "setupUrl": "https://platform.openai.com/api-keys"
+    },
+    "anthropic": {
+      "displayName": "Anthropic",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "ANTHROPIC_API_KEY",
+      "setupUrl": "https://console.anthropic.com/settings/keys"
+    },
+    "cohere": {
+      "displayName": "Cohere",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "COHERE_API_KEY",
+      "setupUrl": "https://dashboard.cohere.com/api-keys"
+    },
+    "mistral": {
+      "displayName": "Mistral",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "MISTRAL_API_KEY",
+      "setupUrl": "https://console.mistral.ai/api-keys/"
+    },
+    "groq": {
+      "displayName": "Groq",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "GROQ_API_KEY",
+      "setupUrl": "https://console.groq.com/keys"
+    },
+    "perplexity": {
+      "displayName": "Perplexity",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "PERPLEXITY_API_KEY",
+      "setupUrl": "https://www.perplexity.ai/settings/api"
+    },
+    "openrouter": {
+      "displayName": "OpenRouter",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "OPENROUTER_API_KEY",
+      "setupUrl": "https://openrouter.ai/keys"
+    },
+    "togetherai": {
+      "displayName": "Together AI",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "TOGETHERAI_API_KEY",
+      "setupUrl": "https://api.together.ai/settings/api-keys"
+    },
+    "replicate": {
+      "displayName": "Replicate",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "REPLICATE_API_TOKEN",
+      "setupUrl": "https://replicate.com/account/api-tokens"
+    },
+    "elevenlabs": {
+      "displayName": "ElevenLabs",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "ELEVENLABS_API_KEY",
+      "setupUrl": "https://elevenlabs.io/app/settings/api-keys"
+    },
+    "stability": {
+      "displayName": "Stability AI",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "STABILITY_API_KEY",
+      "setupUrl": "https://platform.stability.ai/account/keys"
+    },
+    "pinecone": {
+      "displayName": "Pinecone",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "PINECONE_API_KEY",
+      "setupUrl": "https://app.pinecone.io/"
+    },
+    "assemblyai": {
+      "displayName": "AssemblyAI",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "ASSEMBLYAI_API_KEY",
+      "setupUrl": "https://www.assemblyai.com/app/account"
+    },
+    "heygen": {
+      "displayName": "HeyGen",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "HEYGEN_API_KEY",
+      "setupUrl": "https://app.heygen.com/settings/api"
+    },
+    "higgsfield": {
+      "displayName": "Higgsfield",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "HIGGSFIELD_API_KEY",
+      "setupUrl": "https://higgsfield.ai/"
+    },
+    "kling": {
+      "displayName": "Kling",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "KLING_API_KEY",
+      "setupUrl": "https://klingai.com/"
+    },
+    "pika": {
+      "displayName": "Pika",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "PIKA_API_KEY",
+      "setupUrl": "https://pika.art/"
+    },
+    "runway": {
+      "displayName": "Runway",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "RUNWAY_API_KEY",
+      "setupUrl": "https://dev.runwayml.com/"
+    },
+    "notion": {
+      "displayName": "Notion",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "NOTION_API_KEY",
+      "setupUrl": "https://www.notion.so/my-integrations",
+      "note": "Use an Internal Integration Secret and share the pages with it."
+    },
+    "airtable": {
+      "displayName": "Airtable",
+      "credential": "personal access token",
+      "arg": "access_token",
+      "envVar": "AIRTABLE_API_KEY",
+      "setupUrl": "https://airtable.com/create/tokens"
+    },
+    "asana": {
+      "displayName": "Asana",
+      "credential": "personal access token",
+      "arg": "api_key",
+      "envVar": "ASANA_API_KEY",
+      "setupUrl": "https://app.asana.com/0/my-apps"
+    },
+    "clickup": {
+      "displayName": "ClickUp",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "CLICKUP_API_KEY",
+      "setupUrl": "https://app.clickup.com/settings/apps"
+    },
+    "monday": {
+      "displayName": "monday.com",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "MONDAY_API_KEY",
+      "setupUrl": "https://monday.com/developers/v2"
+    },
+    "linear": {
+      "displayName": "Linear",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "LINEAR_API_KEY",
+      "setupUrl": "https://linear.app/settings/api"
+    },
+    "trello": {
+      "displayName": "Trello",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "TRELLO_API_KEY",
+      "setupUrl": "https://trello.com/power-ups/admin",
+      "note": "Also pass token (the per-user authorization token)."
+    },
+    "clockify": {
+      "displayName": "Clockify",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "CLOCKIFY_API_KEY",
+      "setupUrl": "https://app.clockify.me/user/settings"
+    },
+    "toggl": {
+      "displayName": "Toggl Track",
+      "credential": "API token",
+      "arg": "api_key",
+      "envVar": "TOGGL_API_KEY",
+      "setupUrl": "https://track.toggl.com/profile"
+    },
+    "calendly": {
+      "displayName": "Calendly",
+      "credential": "personal access token",
+      "arg": "api_key",
+      "envVar": "CALENDLY_API_KEY",
+      "setupUrl": "https://calendly.com/integrations/api_webhooks"
+    },
+    "raindrop": {
+      "displayName": "Raindrop.io",
+      "credential": "test token",
+      "arg": "token",
+      "envVar": "RAINDROP_TOKEN",
+      "setupUrl": "https://app.raindrop.io/settings/integrations"
+    },
+    "readwise": {
+      "displayName": "Readwise",
+      "credential": "access token",
+      "arg": "token",
+      "envVar": "READWISE_TOKEN",
+      "setupUrl": "https://readwise.io/access_token"
+    },
+    "instapaper": {
+      "displayName": "Instapaper",
+      "credential": "consumer key",
+      "arg": "consumer_key",
+      "envVar": "INSTAPAPER_CONSUMER_KEY",
+      "setupUrl": "https://www.instapaper.com/main/request_oauth_consumer_token",
+      "note": "Also pass consumer_secret, username, and password (xAuth)."
+    },
+    "feedly": {
+      "displayName": "Feedly",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "FEEDLY_ACCESS_TOKEN",
+      "setupUrl": "https://developer.feedly.com/"
+    },
+    "monica": {
+      "displayName": "Monica",
+      "credential": "API token",
+      "arg": "api_key",
+      "envVar": "MONICA_API_KEY",
+      "setupUrl": "https://app.monicahq.com/settings/api"
+    },
+    "postman": {
+      "displayName": "Postman",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "POSTMAN_API_KEY",
+      "setupUrl": "https://go.postman.co/settings/me/api-keys"
+    },
+    "slack": {
+      "displayName": "Slack",
+      "credential": "bot token",
+      "arg": "bot_token",
+      "envVar": "SLACK_BOT_TOKEN",
+      "setupUrl": "https://api.slack.com/apps",
+      "note": "The bot token starts with xoxb-."
+    },
+    "discord": {
+      "displayName": "Discord",
+      "credential": "bot token",
+      "arg": "bot_token",
+      "envVar": "DISCORD_BOT_TOKEN",
+      "setupUrl": "https://discord.com/developers/applications"
+    },
+    "telegram": {
+      "displayName": "Telegram",
+      "credential": "bot token",
+      "arg": "bot_token",
+      "envVar": "TELEGRAM_BOT_TOKEN",
+      "setupUrl": "https://core.telegram.org/bots#botfather",
+      "note": "Create the bot and get its token from @BotFather."
+    },
+    "line": {
+      "displayName": "LINE",
+      "credential": "channel access token",
+      "arg": "channel_access_token",
+      "envVar": "LINE_CHANNEL_ACCESS_TOKEN",
+      "setupUrl": "https://developers.line.biz/console/"
+    },
+    "whatsapp": {
+      "displayName": "WhatsApp",
+      "credential": "bearer token",
+      "arg": "bearer_token",
+      "envVar": "WHATSAPP_TOKEN",
+      "setupUrl": "https://developers.facebook.com/apps"
+    },
+    "twilio": {
+      "displayName": "Twilio",
+      "credential": "account SID",
+      "arg": "account_sid",
+      "envVar": "TWILIO_ACCOUNT_SID",
+      "setupUrl": "https://console.twilio.com/",
+      "note": "Also pass auth_token (or set TWILIO_AUTH_TOKEN)."
+    },
+    "sendgrid": {
+      "displayName": "SendGrid",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "SENDGRID_API_KEY",
+      "setupUrl": "https://app.sendgrid.com/settings/api_keys"
+    },
+    "mailchimp": {
+      "displayName": "Mailchimp",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "MAILCHIMP_API_KEY",
+      "setupUrl": "https://admin.mailchimp.com/account/api/"
+    },
+    "postmark": {
+      "displayName": "Postmark",
+      "credential": "server API token",
+      "arg": "api_key",
+      "envVar": "POSTMARK_API_KEY",
+      "setupUrl": "https://account.postmarkapp.com/servers"
+    },
+    "resend": {
+      "displayName": "Resend",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "RESEND_API_KEY",
+      "setupUrl": "https://resend.com/api-keys"
+    },
+    "convertkit": {
+      "displayName": "Kit (ConvertKit)",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "CONVERTKIT_API_KEY",
+      "setupUrl": "https://app.convertkit.com/account_settings/advanced_settings"
+    },
+    "pushover": {
+      "displayName": "Pushover",
+      "credential": "application token",
+      "arg": "app_token",
+      "envVar": "PUSHOVER_APP_TOKEN",
+      "setupUrl": "https://pushover.net/apps/build",
+      "note": "Also pass user (your Pushover user key)."
+    },
+    "reddit": {
+      "displayName": "Reddit",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "REDDIT_ACCESS_TOKEN",
+      "setupUrl": "https://www.reddit.com/prefs/apps"
+    },
+    "mastodon": {
+      "displayName": "Mastodon",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "MASTODON_ACCESS_TOKEN",
+      "setupUrl": "https://docs.joinmastodon.org/client/token/",
+      "note": "Create the token under Preferences > Development on your instance."
+    },
+    "pinterest": {
+      "displayName": "Pinterest",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "PINTEREST_ACCESS_TOKEN",
+      "setupUrl": "https://developers.pinterest.com/apps/"
+    },
+    "tiktok": {
+      "displayName": "TikTok",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "TIKTOK_ACCESS_TOKEN",
+      "setupUrl": "https://developers.tiktok.com/"
+    },
+    "youtube": {
+      "displayName": "YouTube",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "YOUTUBE_API_KEY",
+      "setupUrl": "https://console.cloud.google.com/apis/credentials"
+    },
+    "spotify": {
+      "displayName": "Spotify",
+      "credential": "access token",
+      "arg": "bearer_token",
+      "envVar": "SPOTIFY_ACCESS_TOKEN",
+      "setupUrl": "https://developer.spotify.com/dashboard"
+    },
+    "genius": {
+      "displayName": "Genius",
+      "credential": "access token",
+      "envVar": "GENIUS_ACCESS_TOKEN",
+      "setupUrl": "https://genius.com/api-clients"
+    },
+    "lastfm": {
+      "displayName": "Last.fm",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "LASTFM_API_KEY",
+      "setupUrl": "https://www.last.fm/api/account/create"
+    },
+    "discogs": {
+      "displayName": "Discogs",
+      "credential": "personal access token",
+      "arg": "token",
+      "envVar": "DISCOGS_TOKEN",
+      "setupUrl": "https://www.discogs.com/settings/developers"
+    },
+    "untappd": {
+      "displayName": "Untappd",
+      "credential": "client id",
+      "arg": "client_id",
+      "envVar": "UNTAPPD_CLIENT_ID",
+      "setupUrl": "https://untappd.com/api/",
+      "note": "Also pass client_secret (or set UNTAPPD_CLIENT_SECRET)."
+    },
+    "github": {
+      "displayName": "GitHub",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "GITHUB_TOKEN",
+      "setupUrl": "https://github.com/settings/tokens"
+    },
+    "gitlab": {
+      "displayName": "GitLab",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "GITLAB_TOKEN",
+      "setupUrl": "https://gitlab.com/-/user_settings/personal_access_tokens"
+    },
+    "vercel": {
+      "displayName": "Vercel",
+      "credential": "access token",
+      "arg": "api_key",
+      "envVar": "VERCEL_TOKEN",
+      "setupUrl": "https://vercel.com/account/tokens"
+    },
+    "render": {
+      "displayName": "Render",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "RENDER_API_KEY",
+      "setupUrl": "https://dashboard.render.com/u/settings/api-keys"
+    },
+    "flyio": {
+      "displayName": "Fly.io",
+      "credential": "API token",
+      "arg": "api_key",
+      "envVar": "FLY_API_KEY",
+      "setupUrl": "https://fly.io/user/personal_access_tokens"
+    },
+    "neon": {
+      "displayName": "Neon",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "NEON_API_KEY",
+      "setupUrl": "https://console.neon.tech/app/settings/api-keys"
+    },
+    "turso": {
+      "displayName": "Turso",
+      "credential": "API token",
+      "arg": "api_key",
+      "envVar": "TURSO_API_KEY",
+      "setupUrl": "https://app.turso.tech/"
+    },
+    "circleci": {
+      "displayName": "CircleCI",
+      "credential": "API token",
+      "arg": "api_key",
+      "envVar": "CIRCLECI_TOKEN",
+      "setupUrl": "https://app.circleci.com/settings/user/tokens"
+    },
+    "datadog": {
+      "displayName": "Datadog",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "DATADOG_API_KEY",
+      "setupUrl": "https://app.datadoghq.com/organization-settings/api-keys",
+      "note": "Some endpoints also need an application key (app_key)."
+    },
+    "sentry": {
+      "displayName": "Sentry",
+      "credential": "auth token",
+      "arg": "auth_token",
+      "envVar": "SENTRY_AUTH_TOKEN",
+      "setupUrl": "https://sentry.io/settings/account/api/auth-tokens/"
+    },
+    "pagerduty": {
+      "displayName": "PagerDuty",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "PAGERDUTY_API_KEY",
+      "setupUrl": "https://support.pagerduty.com/docs/api-access-keys"
+    },
+    "segment": {
+      "displayName": "Segment",
+      "credential": "write key",
+      "arg": "write_key",
+      "envVar": "SEGMENT_WRITE_KEY",
+      "setupUrl": "https://app.segment.com/",
+      "note": "Management API calls use api_token instead of write_key."
+    },
+    "mixpanel": {
+      "displayName": "Mixpanel",
+      "credential": "service account username",
+      "arg": "service_account_username",
+      "envVar": "MIXPANEL_SERVICE_ACCOUNT_USERNAME",
+      "setupUrl": "https://mixpanel.com/settings/project",
+      "note": "Also pass service_account_secret."
+    },
+    "foursquare": {
+      "displayName": "Foursquare",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "FOURSQUARE_API_KEY",
+      "setupUrl": "https://foursquare.com/developers/home"
+    },
+    "mapbox": {
+      "displayName": "Mapbox",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "MAPBOX_ACCESS_TOKEN",
+      "setupUrl": "https://account.mapbox.com/access-tokens/"
+    },
+    "yelp": {
+      "displayName": "Yelp",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "YELP_API_KEY",
+      "setupUrl": "https://www.yelp.com/developers/v3/manage_app"
+    },
+    "tmdb": {
+      "displayName": "TMDB",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "TMDB_API_KEY",
+      "setupUrl": "https://www.themoviedb.org/settings/api"
+    },
+    "omdb": {
+      "displayName": "OMDb",
+      "credential": "API key",
+      "envVar": "OMDB_API_KEY",
+      "setupUrl": "https://www.omdbapi.com/apikey.aspx"
+    },
+    "rawg": {
+      "displayName": "RAWG",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "RAWG_API_KEY",
+      "setupUrl": "https://rawg.io/apidocs"
+    },
+    "igdb": {
+      "displayName": "IGDB",
+      "credential": "client id",
+      "arg": "client_id",
+      "envVar": "IGDB_CLIENT_ID",
+      "setupUrl": "https://api-docs.igdb.com/#account-creation",
+      "note": "Also pass client_secret (Twitch developer credentials)."
+    },
+    "ticketmaster": {
+      "displayName": "Ticketmaster",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "TICKETMASTER_API_KEY",
+      "setupUrl": "https://developer.ticketmaster.com/"
+    },
+    "seatgeek": {
+      "displayName": "SeatGeek",
+      "credential": "client id",
+      "arg": "client_id",
+      "envVar": "SEATGEEK_CLIENT_ID",
+      "setupUrl": "https://seatgeek.com/account/develop"
+    },
+    "eventbrite": {
+      "displayName": "Eventbrite",
+      "credential": "private token",
+      "arg": "token",
+      "envVar": "EVENTBRITE_TOKEN",
+      "setupUrl": "https://www.eventbrite.com/platform/api-keys"
+    },
+    "newsapi": {
+      "displayName": "NewsAPI",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "NEWS_API_KEY",
+      "setupUrl": "https://newsapi.org/account"
+    },
+    "guardian": {
+      "displayName": "The Guardian",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "GUARDIAN_API_KEY",
+      "setupUrl": "https://open-platform.theguardian.com/access/"
+    },
+    "podcastindex": {
+      "displayName": "Podcast Index",
+      "credential": "API key",
+      "envVar": "PODCASTINDEX_API_KEY",
+      "setupUrl": "https://api.podcastindex.org/",
+      "note": "Also set PODCASTINDEX_API_SECRET."
+    },
+    "nasa": {
+      "displayName": "NASA",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "NASA_API_KEY",
+      "setupUrl": "https://api.nasa.gov/",
+      "note": "Defaults to the shared DEMO_KEY if none is provided."
+    },
+    "coinmarketcap": {
+      "displayName": "CoinMarketCap",
+      "credential": "API key",
+      "envVar": "COINMARKETCAP_API_KEY",
+      "setupUrl": "https://pro.coinmarketcap.com/account"
+    },
+    "exchangerate": {
+      "displayName": "ExchangeRate-API",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "EXCHANGERATE_API_KEY",
+      "setupUrl": "https://app.exchangerate-api.com/dashboard"
+    },
+    "deepl": {
+      "displayName": "DeepL",
+      "credential": "auth key",
+      "arg": "auth_key",
+      "envVar": "DEEPL_AUTH_KEY",
+      "setupUrl": "https://www.deepl.com/your-account/keys"
+    },
+    "riot": {
+      "displayName": "Riot Games",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "RIOT_API_KEY",
+      "setupUrl": "https://developer.riotgames.com/"
+    },
+    "bungie": {
+      "displayName": "Bungie",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "BUNGIE_API_KEY",
+      "setupUrl": "https://www.bungie.net/en/Application"
+    },
+    "twitch": {
+      "displayName": "Twitch",
+      "credential": "client id",
+      "arg": "client_id",
+      "envVar": "TWITCH_CLIENT_ID",
+      "setupUrl": "https://dev.twitch.tv/console/apps",
+      "note": "Also pass client_secret (or set TWITCH_CLIENT_SECRET)."
+    },
+    "shodan": {
+      "displayName": "Shodan",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "SHODAN_API_KEY",
+      "setupUrl": "https://account.shodan.io/"
+    },
+    "virustotal": {
+      "displayName": "VirusTotal",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "VIRUSTOTAL_API_KEY",
+      "setupUrl": "https://www.virustotal.com/gui/my-apikey"
+    },
+    "urlscan": {
+      "displayName": "urlscan.io",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "URLSCAN_API_KEY",
+      "setupUrl": "https://urlscan.io/user/profile/"
+    },
+    "abuseipdb": {
+      "displayName": "AbuseIPDB",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "ABUSEIPDB_API_KEY",
+      "setupUrl": "https://www.abuseipdb.com/account/api"
+    },
+    "hunter": {
+      "displayName": "Hunter",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "HUNTER_API_KEY",
+      "setupUrl": "https://hunter.io/api-keys"
+    },
+    "haveibeenpwned": {
+      "displayName": "Have I Been Pwned",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "HIBP_API_KEY",
+      "setupUrl": "https://haveibeenpwned.com/API/Key"
+    },
+    "splitwise": {
+      "displayName": "Splitwise",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "SPLITWISE_API_KEY",
+      "setupUrl": "https://secure.splitwise.com/apps"
+    },
+    "ebird": {
+      "displayName": "eBird",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "EBIRD_API_KEY",
+      "setupUrl": "https://ebird.org/api/keygen"
+    },
+    "figma": {
+      "displayName": "Figma",
+      "credential": "personal access token",
+      "arg": "personal_access_token",
+      "envVar": "FIGMA_ACCESS_TOKEN",
+      "setupUrl": "https://www.figma.com/developers/api#access-tokens"
+    },
+    "trove": {
+      "displayName": "Trove",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "TROVE_API_KEY",
+      "setupUrl": "https://trove.nla.gov.au/about/create-something/using-api"
+    },
+    "domain": {
+      "displayName": "Domain",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "DOMAIN_API_KEY",
+      "setupUrl": "https://developer.domain.com.au/"
+    },
+    "amber": {
+      "displayName": "Amber Electric",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "AMBER_API_KEY",
+      "setupUrl": "https://app.amber.com.au/developers"
+    },
+    "sendle": {
+      "displayName": "Sendle",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "SENDLE_API_KEY",
+      "setupUrl": "https://www.sendle.com/",
+      "note": "Also pass sendle_id (or set SENDLE_ID)."
+    },
+    "ebay": {
+      "displayName": "eBay",
+      "credential": "client id",
+      "arg": "client_id",
+      "envVar": "EBAY_CLIENT_ID",
+      "setupUrl": "https://developer.ebay.com/my/keys",
+      "note": "Also pass client_secret (or set EBAY_CLIENT_SECRET)."
+    },
+    "algolia": {
+      "displayName": "Algolia",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "ALGOLIA_API_KEY",
+      "setupUrl": "https://dashboard.algolia.com/account/api-keys/all",
+      "note": "Also pass app_id (the Algolia application id)."
+    },
+    "bandsintown": {
+      "displayName": "Bandsintown",
+      "credential": "app id",
+      "arg": "app_id",
+      "envVar": "BANDSINTOWN_APP_ID",
+      "setupUrl": "https://www.artists.bandsintown.com/bandsintown-api"
+    },
+    "alphavantage": {
+      "displayName": "Alpha Vantage",
+      "credential": "API key",
+      "envVar": "ALPHAVANTAGE_API_KEY",
+      "setupUrl": "https://www.alphavantage.co/support/#api-key"
+    },
+    "coingecko": {
+      "displayName": "CoinGecko",
+      "credential": "API key",
+      "envVar": "COINGECKO_API_KEY",
+      "setupUrl": "https://www.coingecko.com/en/developers/dashboard",
+      "note": "Public endpoints work without a key; a key raises rate limits."
+    },
+    "openexchangerates": {
+      "displayName": "Open Exchange Rates",
+      "credential": "app id",
+      "envVar": "OPENEXCHANGERATES_APP_ID",
+      "setupUrl": "https://openexchangerates.org/account/app-ids"
+    },
+    "tomorrowio": {
+      "displayName": "Tomorrow.io",
+      "credential": "API key",
+      "envVar": "TOMORROWIO_API_KEY",
+      "setupUrl": "https://app.tomorrow.io/development/keys"
+    },
+    "willyweather": {
+      "displayName": "WillyWeather",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "WILLYWEATHER_KEY",
+      "setupUrl": "https://www.willyweather.com.au/info/api.html"
+    },
+    "amazon": {
+      "displayName": "Amazon Product Advertising",
+      "credential": "access key",
+      "arg": "access_key",
+      "envVar": "AMAZON_ACCESS_KEY",
+      "setupUrl": "https://webservices.amazon.com/paapi5/documentation/register-for-pa-api.html",
+      "note": "Also pass secret_key (or set AMAZON_SECRET_KEY)."
+    },
+    "carboninterface": {
+      "displayName": "Carbon Interface",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "CARBONINTERFACE_API_KEY",
+      "setupUrl": "https://www.carboninterface.com/account/api_tokens"
+    },
+    "openaq": {
+      "displayName": "OpenAQ",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "OPENAQ_API_KEY",
+      "setupUrl": "https://explore.openaq.org/register"
+    },
+    "bgg": {
+      "displayName": "BoardGameGeek",
+      "credential": "API token",
+      "envVar": "BGG_API_TOKEN",
+      "setupUrl": "https://boardgamegeek.com/wiki/page/BGG_XML_API2"
+    },
+    "tab": {
+      "displayName": "TAB Australia",
+      "credential": "API base URL",
+      "envVar": "TAB_API_BASE",
+      "setupUrl": "https://www.studio.tab.com.au/docs"
+    },
+    "steam": {
+      "displayName": "Steam",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "STEAM_API_KEY",
+      "setupUrl": "https://steamcommunity.com/dev/apikey"
+    },
+    "setlistfm": {
+      "displayName": "setlist.fm",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "SETLISTFM_API_KEY",
+      "setupUrl": "https://www.setlist.fm/settings/api"
+    },
+    "esports": {
+      "displayName": "PandaScore",
+      "credential": "API token",
+      "arg": "api_key",
+      "envVar": "PANDASCORE_TOKEN",
+      "setupUrl": "https://app.pandascore.co/dashboard/main"
+    },
+    "nvd": {
+      "displayName": "NVD (NIST)",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "NVD_API_KEY",
+      "setupUrl": "https://nvd.nist.gov/developers/request-an-api-key",
+      "note": "Optional; a key raises the NVD rate limit."
+    },
+    "upstash": {
+      "displayName": "Upstash",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "UPSTASH_API_KEY",
+      "setupUrl": "https://console.upstash.com/account/api"
+    },
+    "australiapost": {
+      "displayName": "Australia Post",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "AUSPOST_API_KEY",
+      "setupUrl": "https://developers.auspost.com.au/"
+    },
+    "ipaustralia": {
+      "displayName": "IP Australia",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "IPAUSTRALIA_API_KEY",
+      "setupUrl": "https://www.ipaustralia.gov.au/tools-and-research/professional-resources/data-and-apis"
+    },
+    "lego": {
+      "displayName": "LEGO (Rebrickable)",
+      "credential": "API key",
+      "arg": "rebrickable_api_key",
+      "envVar": "REBRICKABLE_API_KEY",
+      "setupUrl": "https://rebrickable.com/api/"
+    },
+    "brickset": {
+      "displayName": "Brickset",
+      "credential": "API key",
+      "arg": "brickset_api_key",
+      "envVar": "BRICKSET_API_KEY",
+      "setupUrl": "https://brickset.com/tools/webservices/requestkey"
+    },
+    "coc": {
+      "displayName": "Clash of Clans",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "COC_API_KEY",
+      "setupUrl": "https://developer.clashofclans.com/"
+    },
+    "cr": {
+      "displayName": "Clash Royale",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "CR_API_KEY",
+      "setupUrl": "https://developer.clashroyale.com/"
+    },
+    "bs": {
+      "displayName": "Brawl Stars",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "BS_API_KEY",
+      "setupUrl": "https://developer.brawlstars.com/"
+    },
+    "hubspot": {
+      "displayName": "HubSpot",
+      "credential": "Private App access token",
+      "arg": "access_token",
+      "envVar": "HUBSPOT_ACCESS_TOKEN",
+      "setupUrl": "https://app.hubspot.com/settings/integrations/private-apps",
+      "note": "Create a Private App and copy its access token; grant the crm.objects.* scopes you need."
+    },
+    "jira": {
+      "displayName": "Jira",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "JIRA_API_TOKEN",
+      "setupUrl": "https://id.atlassian.com/manage-profile/security/api-tokens",
+      "note": "Also pass site (e.g. mycompany) and email, or set JIRA_SITE and JIRA_EMAIL. Auth is your email + the API token."
+    },
+    "posthog": {
+      "displayName": "PostHog",
+      "credential": "Personal API key",
+      "arg": "api_key",
+      "envVar": "POSTHOG_API_KEY",
+      "setupUrl": "https://app.posthog.com/settings/user-api-keys",
+      "note": "Also pass project_id (or set POSTHOG_PROJECT_ID). Default host is US Cloud; pass host for EU or self-hosted."
+    },
+    "netlify": {
+      "displayName": "Netlify",
+      "credential": "personal access token",
+      "arg": "access_token",
+      "envVar": "NETLIFY_ACCESS_TOKEN",
+      "setupUrl": "https://app.netlify.com/user/applications#personal-access-tokens"
+    },
+    "zendesk": {
+      "displayName": "Zendesk",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "ZENDESK_API_TOKEN",
+      "setupUrl": "https://support.zendesk.com/hc/en-us/articles/4408889192858",
+      "note": "Also pass subdomain and email, or set ZENDESK_SUBDOMAIN and ZENDESK_EMAIL. Auth is email/token + the API token."
+    },
+    "intercom": {
+      "displayName": "Intercom",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "INTERCOM_ACCESS_TOKEN",
+      "setupUrl": "https://developers.intercom.com/building-apps/docs/authentication-types"
+    },
+    "typeform": {
+      "displayName": "Typeform",
+      "credential": "personal access token",
+      "arg": "access_token",
+      "envVar": "TYPEFORM_ACCESS_TOKEN",
+      "setupUrl": "https://admin.typeform.com/account#/section/tokens"
+    },
+    "calcom": {
+      "displayName": "Cal.com",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "CALCOM_API_KEY",
+      "setupUrl": "https://app.cal.com/settings/developer/api-keys"
+    },
+    "contentful": {
+      "displayName": "Contentful",
+      "credential": "Content Delivery API token",
+      "arg": "access_token",
+      "envVar": "CONTENTFUL_ACCESS_TOKEN",
+      "setupUrl": "https://app.contentful.com/",
+      "note": "Also pass space_id (or set CONTENTFUL_SPACE_ID). environment defaults to master."
+    },
+    "webflow": {
+      "displayName": "Webflow",
+      "credential": "API token",
+      "arg": "access_token",
+      "envVar": "WEBFLOW_ACCESS_TOKEN",
+      "setupUrl": "https://developers.webflow.com/data/reference/authentication"
+    },
+    "digitalocean": {
+      "displayName": "DigitalOcean",
+      "credential": "personal access token",
+      "arg": "access_token",
+      "envVar": "DIGITALOCEAN_ACCESS_TOKEN",
+      "setupUrl": "https://cloud.digitalocean.com/account/api/tokens"
+    },
+    "klaviyo": {
+      "displayName": "Klaviyo",
+      "credential": "private API key",
+      "arg": "api_key",
+      "envVar": "KLAVIYO_API_KEY",
+      "setupUrl": "https://www.klaviyo.com/settings/account/api-keys",
+      "note": "Use a private API key (starts with pk_)."
+    },
+    "todoist": {
+      "displayName": "Todoist",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "TODOIST_API_TOKEN",
+      "setupUrl": "https://app.todoist.com/app/settings/integrations/developer"
+    },
+    "pipedrive": {
+      "displayName": "Pipedrive",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "PIPEDRIVE_API_TOKEN",
+      "setupUrl": "https://app.pipedrive.com/settings/api"
+    },
+    "confluence": {
+      "displayName": "Confluence",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "CONFLUENCE_API_TOKEN",
+      "setupUrl": "https://id.atlassian.com/manage-profile/security/api-tokens",
+      "note": "Also pass site and email (or set CONFLUENCE_SITE / CONFLUENCE_EMAIL, or reuse JIRA_SITE / JIRA_EMAIL)."
+    },
+    "unsplash": {
+      "displayName": "Unsplash",
+      "credential": "Access Key",
+      "arg": "access_key",
+      "envVar": "UNSPLASH_ACCESS_KEY",
+      "setupUrl": "https://unsplash.com/oauth/applications"
+    },
+    "giphy": {
+      "displayName": "Giphy",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "GIPHY_API_KEY",
+      "setupUrl": "https://developers.giphy.com/dashboard/"
+    },
+    "miro": {
+      "displayName": "Miro",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "MIRO_ACCESS_TOKEN",
+      "setupUrl": "https://developers.miro.com/"
+    },
+    "shortcut": {
+      "displayName": "Shortcut",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "SHORTCUT_API_TOKEN",
+      "setupUrl": "https://app.shortcut.com/settings/account/api-tokens"
+    },
+    "coda": {
+      "displayName": "Coda",
+      "credential": "API token",
+      "arg": "api_token",
+      "envVar": "CODA_API_TOKEN",
+      "setupUrl": "https://coda.io/account"
+    },
+    "brevo": {
+      "displayName": "Brevo",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "BREVO_API_KEY",
+      "setupUrl": "https://app.brevo.com/settings/keys/api"
+    },
+    "uptimerobot": {
+      "displayName": "UptimeRobot",
+      "credential": "API key",
+      "arg": "api_key",
+      "envVar": "UPTIMEROBOT_API_KEY",
+      "setupUrl": "https://uptimerobot.com/dashboard#mySettings",
+      "note": "A Main or Read-Only API key both work for reads."
+    },
+    "dropbox": {
+      "displayName": "Dropbox",
+      "credential": "access token",
+      "arg": "access_token",
+      "envVar": "DROPBOX_ACCESS_TOKEN",
+      "setupUrl": "https://www.dropbox.com/developers/apps"
+    },
+    "bitbucket": {
+      "displayName": "Bitbucket",
+      "credential": "App password",
+      "arg": "app_password",
+      "envVar": "BITBUCKET_APP_PASSWORD",
+      "setupUrl": "https://bitbucket.org/account/settings/app-passwords/",
+      "note": "Also pass username (or set BITBUCKET_USERNAME) and a workspace id on repo calls."
+    },
+    "cloudinary": {
+      "displayName": "Cloudinary",
+      "credential": "API key + secret",
+      "arg": "api_key",
+      "envVar": "CLOUDINARY_API_KEY",
+      "setupUrl": "https://console.cloudinary.com/settings/api-keys",
+      "note": "Also pass api_secret and cloud_name (or set CLOUDINARY_API_SECRET / CLOUDINARY_CLOUD_NAME)."
+    },
+    "wordpress": {
+      "displayName": "WordPress",
+      "credential": "Application Password",
+      "arg": "app_password",
+      "envVar": "WORDPRESS_APP_PASSWORD",
+      "setupUrl": "https://wordpress.org/documentation/article/application-passwords/",
+      "note": "Also pass site_url and username (or set WORDPRESS_SITE_URL / WORDPRESS_USERNAME)."
+    },
+    "ghost": {
+      "displayName": "Ghost",
+      "credential": "Content API key",
+      "arg": "content_key",
+      "envVar": "GHOST_CONTENT_KEY",
+      "setupUrl": "https://ghost.org/docs/content-api/",
+      "note": "Also pass site_url (or set GHOST_SITE_URL). Create a Content API key under Settings > Integrations."
+    }
+  }
+}

--- a/src/lib/appCatalog.test.ts
+++ b/src/lib/appCatalog.test.ts
@@ -17,7 +17,18 @@ describe("app catalog integrity", () => {
       expect(app.category, `category for ${app.slug}`).toBeTruthy();
       expect(app.blurb, `blurb for ${app.slug}`).toBeTruthy();
       expect(app.toolCount, `toolCount for ${app.slug}`).toBe(app.tools.length);
+      expect(["offline", "online", "hybrid"], `network for ${app.slug}`).toContain(app.network);
     }
+  });
+
+  it("never ships the internal 'local' marker as a domain (it breaks the icon)", () => {
+    const bad = APP_CATALOG.filter((a) => a.domain === "local").map((a) => a.slug);
+    expect(bad, `apps with domain "local": ${bad.join(", ")}`).toEqual([]);
+  });
+
+  it("keeps the offline bucket honest: offline apps have no brand domain", () => {
+    const suspicious = APP_CATALOG.filter((a) => a.network === "offline" && a.domain).map((a) => a.slug);
+    expect(suspicious, `offline apps with a domain: ${suspicious.join(", ")}`).toEqual([]);
   });
 
   it("classifies every app into a real, user-facing category (none fall to Other)", () => {

--- a/src/lib/appCatalog.ts
+++ b/src/lib/appCatalog.ts
@@ -11,12 +11,16 @@ export interface AppTool {
   label?: string;
 }
 
+/** Whether an app needs the internet: derived from its connector source at generation time. */
+export type AppNetwork = "offline" | "online" | "hybrid";
+
 export interface AppEntry {
   slug: string;
   name: string;
   category: string;
   blurb: string;
   domain: string | null;
+  network: AppNetwork;
   toolCount: number;
   tools: AppTool[];
   level: number | null;
@@ -46,6 +50,15 @@ export const LEVEL_LABEL: Record<number, string> = {
 export function levelLabel(level: number | null): string {
   return level ? LEVEL_LABEL[level] ?? "" : "";
 }
+
+// Simple-English copy for the offline/online/hybrid filter and badges.
+export const NETWORK_META: Record<AppNetwork, { label: string; description: string }> = {
+  offline: { label: "Works offline", description: "Runs entirely on the server with no internet calls." },
+  online: { label: "Uses internet", description: "Calls an external service, so it needs internet access." },
+  hybrid: { label: "Hybrid", description: "Works without internet, but its output (like an image URL) needs internet to use." },
+};
+
+export const NETWORK_ORDER: AppNetwork[] = ["offline", "online", "hybrid"];
 
 // Tokens that read better fully upper-cased in an auto-generated Action label.
 const ACRONYMS = new Set([

--- a/src/pages/AppDetail.tsx
+++ b/src/pages/AppDetail.tsx
@@ -1,11 +1,12 @@
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, KeyRound, Sparkles } from "lucide-react";
+import { AlertTriangle, ArrowLeft, KeyRound, Sparkles } from "lucide-react";
 import PageShell from "../components/PageShell";
 import FadeIn from "../components/FadeIn";
 import { useCanonical } from "../hooks/use-canonical";
 import { useMetaTags } from "../hooks/useMetaTags";
 import { presets } from "../lib/design-system";
-import { actionLabel, getApp, levelLabel } from "@/lib/appCatalog";
+import { actionLabel, getApp, levelLabel, NETWORK_META } from "@/lib/appCatalog";
+import { getAppTestResult } from "@/lib/appTestResults";
 import { AppIcon } from "@/components/apps/AppIcon";
 import { APP_DETAIL_EXTRAS } from "@/components/apps/appDetailExtras";
 
@@ -38,6 +39,9 @@ const AppDetail = () => {
 
   const Extra = APP_DETAIL_EXTRAS[app.slug];
   const quality = levelLabel(app.level);
+  // Failing apps are hidden from the store list, but deep links still resolve.
+  // Be upfront here instead of pretending the app works.
+  const testResult = getAppTestResult(app.slug);
 
   return (
     <PageShell eyebrow={app.category} title={app.name} lede={app.blurb} halo={false}>
@@ -54,6 +58,12 @@ const AppDetail = () => {
                 <h2 className="text-xl font-semibold text-white">{app.name}</h2>
                 <p className="text-xs text-white/45">
                   {app.category} · {app.toolCount} actions
+                  <span
+                    title={NETWORK_META[app.network].description}
+                    className="ml-2 inline-flex items-center rounded border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[10px] font-medium text-white/55"
+                  >
+                    {NETWORK_META[app.network].label}
+                  </span>
                   {quality === "Smart" && (
                     <span className="ml-2 inline-flex items-center gap-1 rounded border border-[#61C1C4]/25 bg-[#61C1C4]/10 px-1.5 py-0.5 text-[10px] font-medium text-[#9be4e6]">
                       <Sparkles className="h-3 w-3" /> Smart
@@ -62,6 +72,16 @@ const AppDetail = () => {
                 </p>
               </div>
             </div>
+
+            {testResult.status === "fail" && (
+              <div className="mt-6 flex items-start gap-2 rounded-xl border border-red-400/25 bg-red-400/[0.07] p-4 text-xs leading-5 text-red-100">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-300" />
+                <span>
+                  {app.name} is currently not working: its last live test failed, so it is hidden from the
+                  Apps store until a retest passes. Your AI will not rely on it in the meantime.
+                </span>
+              </div>
+            )}
 
             {/* How your AI uses it - super simple English */}
             <div className="mt-6 rounded-2xl border border-[#61C1C4]/20 bg-[#61C1C4]/[0.05] p-5">

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -3,8 +3,16 @@ import FadeIn from "../components/FadeIn";
 import { useCanonical } from "../hooks/use-canonical";
 import { useMetaTags } from "../hooks/useMetaTags";
 import { presets } from "../lib/design-system";
-import { APP_CATALOG, APP_COUNT, TOOL_COUNT } from "@/lib/appCatalog";
+import { APP_CATALOG } from "@/lib/appCatalog";
+import { getAppTestResult } from "@/lib/appTestResults";
 import { AppsTable } from "@/components/apps/AppsTable";
+
+// Apps with a verified live failure (AppTesting status "fail") are kept out of
+// the public store until they pass a retest. Needs-key apps stay listed; every
+// excluded app remains visible with its failure note in admin AppTesting.
+const LIVE_APPS = APP_CATALOG.filter((a) => getAppTestResult(a.slug).status !== "fail");
+const LIVE_APP_COUNT = LIVE_APPS.length;
+const LIVE_TOOL_COUNT = LIVE_APPS.reduce((n, a) => n + a.toolCount, 0);
 
 // Super-simple-English induction so anyone gets what this page is in one read.
 function HowItWorks() {
@@ -33,7 +41,7 @@ const Apps = () => {
   useCanonical("/apps");
   useMetaTags({
     title: "Apps. Every action your AI can reach.",
-    description: `Browse ${APP_COUNT} apps and ${TOOL_COUNT} actions your AI can use. It picks the right one for you, or you can ask for one by name.`,
+    description: `Browse ${LIVE_APP_COUNT} apps and ${LIVE_TOOL_COUNT} actions your AI can use. It picks the right one for you, or you can ask for one by name.`,
     ogTitle: "Apps. Every action your AI can reach.",
     ogDescription: "An app store for AI agents. Built-in apps work straight away; connect the rest once.",
     ogUrl: "https://unclick.world/apps",
@@ -44,14 +52,14 @@ const Apps = () => {
       eyebrow="Apps"
       title="Every action your AI can reach."
       accent="One install."
-      lede={`${APP_COUNT} apps · ${TOOL_COUNT} actions. Your AI picks the right one, or you can ask for one by name.`}
+      lede={`${LIVE_APP_COUNT} apps · ${LIVE_TOOL_COUNT} actions. Your AI picks the right one, or you can ask for one by name.`}
       cta={{ label: "Get started", href: "/#install" }}
     >
       <section className={presets.section}>
         <FadeIn>
           <HowItWorks />
           <div className="mx-auto max-w-6xl">
-            <AppsTable apps={APP_CATALOG} mode="public" />
+            <AppsTable apps={LIVE_APPS} mode="public" />
           </div>
         </FadeIn>
       </section>

--- a/src/pages/admin/AdminAppTesting.tsx
+++ b/src/pages/admin/AdminAppTesting.tsx
@@ -118,6 +118,10 @@ export default function AdminAppTesting() {
           manual check rather than fired automatically. The Comments column holds admin notes and is
           preserved across runs.
         </p>
+        <p className="mt-1">
+          Apps with an <span className="text-red-300">Issue</span> status are hidden from the public Apps
+          store until a retest passes; this page is their system of record while they are out.
+        </p>
       </div>
 
       {/* Progress + status counts */}
@@ -167,7 +171,14 @@ export default function AdminAppTesting() {
           <div className="divide-y divide-white/[0.04]">
             {filtered.map(({ app, result }) => (
               <div key={app.slug} className={`grid ${COLS} items-start gap-3 px-3 py-2 text-xs`}>
-                <div><StatusBadge status={result.status} /></div>
+                <div className="flex flex-col items-start gap-1">
+                  <StatusBadge status={result.status} />
+                  {result.status === "fail" && (
+                    <span className="rounded border border-white/10 bg-white/[0.04] px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-white/40">
+                      Hidden from store
+                    </span>
+                  )}
+                </div>
                 <Link to={`/apps/${app.slug}`} className="truncate font-medium text-white hover:text-[#9be4e6]">
                   {app.name}
                 </Link>

--- a/src/pages/admin/AdminTools.test.tsx
+++ b/src/pages/admin/AdminTools.test.tsx
@@ -68,6 +68,11 @@ describe("AdminTools (Apps library)", () => {
     expect(screen.getByRole("link", { name: /Passport/i })).toHaveAttribute("href", "/admin/keychain");
   });
 
+  // The network filter chips and the connect wizard are covered by the cheap
+  // fixture-based tests in src/components/apps/ (AppsTable.test.tsx and
+  // ConnectAppModal.test.tsx); rendering the full catalog again here for each
+  // assertion is what stalls jsdom.
+
   // Note: the toggle->admin_set_app_state persistence path is covered by the
   // enforcement unit tests (tool-gating.test.ts) and the API handler; a full
   // render-and-click integration test over the real ~200-app catalog is too slow

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { KeyRound, PenSquare, Sparkles, Wrench } from "lucide-react";
 import { useSession } from "@/lib/auth";
-import { APP_CATALOG, APP_COUNT, TOOL_COUNT } from "@/lib/appCatalog";
+import { APP_CATALOG, APP_COUNT, TOOL_COUNT, type AppEntry } from "@/lib/appCatalog";
 import { AppsTable, type AppStatus } from "@/components/apps/AppsTable";
+import { ConnectAppModal } from "@/components/apps/ConnectAppModal";
 import { AdminAppsIntro } from "./AdminEcosystemPages";
 
 // A connector row as returned by /api/memory-admin?action=admin_tools. Used here
-// only to derive each app's connection status (connected / needs key / built-in).
+// only to derive each app's connection status (connected / needs key / built-in)
+// and to feed the connect wizard.
 interface Connector {
   id: string;
   auth_type?: "oauth2" | "api_key" | "bot_token";
+  setup_url?: string | null;
   credential: { is_valid: boolean; last_tested_at: string | null } | null;
 }
 
@@ -20,24 +23,27 @@ export default function AdminToolsPage() {
   const [disabled, setDisabled] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [connectTarget, setConnectTarget] = useState<AppEntry | null>(null);
+
+  const refreshStatus = useCallback(async () => {
+    if (!session) return;
+    try {
+      const res = await fetch("/api/memory-admin?action=admin_tools", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+      });
+      if (res.ok) {
+        const body = await res.json();
+        setConnectors(body.connectors ?? []);
+        setDisabled(new Set((body.disabled_apps as string[] | undefined) ?? []));
+      }
+    } catch {
+      // status is best-effort; the catalog still renders without it.
+    }
+  }, [session]);
 
   useEffect(() => {
-    if (!session) return;
-    (async () => {
-      try {
-        const res = await fetch("/api/memory-admin?action=admin_tools", {
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
-        if (res.ok) {
-          const body = await res.json();
-          setConnectors(body.connectors ?? []);
-          setDisabled(new Set((body.disabled_apps as string[] | undefined) ?? []));
-        }
-      } catch {
-        // status is best-effort; the catalog still renders without it.
-      }
-    })();
-  }, [session]);
+    void refreshStatus();
+  }, [refreshStatus]);
 
   const connectorBySlug = useMemo(() => {
     const map = new Map<string, Connector>();
@@ -96,10 +102,26 @@ export default function AdminToolsPage() {
   function statusOf(app: { slug: string }): AppStatus | null {
     const c = connectorBySlug.get(app.slug);
     if (!c) return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
-    if (c.credential?.is_valid) return { label: "Connected", tone: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100" };
+    // "Connected" (green) is reserved for credentials that passed a real live
+    // test. A stored key that was never probed shows as "Key saved" so the
+    // green tick is proof, not an assumption.
+    if (c.credential?.is_valid && c.credential.last_tested_at) {
+      return { label: "Connected", tone: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100" };
+    }
+    if (c.credential?.is_valid) {
+      return { label: "Key saved", tone: "border-sky-300/25 bg-sky-300/10 text-sky-100" };
+    }
     if (c.auth_type === "oauth2") return { label: "Needs login", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     if (c.auth_type) return { label: "Needs key", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
+  }
+
+  // Clicking the status pill opens the connect wizard for any connector-backed
+  // app (also lets you replace or re-prove an existing key). Built-in apps have
+  // nothing to connect.
+  function handleStatusClick(app: AppEntry) {
+    if (!connectorBySlug.has(app.slug)) return;
+    setConnectTarget(app);
   }
 
   if (!session) {
@@ -138,8 +160,19 @@ export default function AdminToolsPage() {
         onToggle={handleToggle}
         onToggleAll={handleToggleAll}
         statusOf={statusOf}
+        onStatusClick={handleStatusClick}
         busy={saving}
       />
+
+      {connectTarget && session && connectorBySlug.get(connectTarget.slug) && (
+        <ConnectAppModal
+          app={connectTarget}
+          connector={connectorBySlug.get(connectTarget.slug)!}
+          accessToken={session.access_token}
+          onClose={() => setConnectTarget(null)}
+          onSaved={() => void refreshStatus()}
+        />
+      )}
 
       {/* Slim footer: where keys and related libraries live */}
       <div className="mt-8 grid gap-3 sm:grid-cols-3">


### PR DESCRIPTION
One pass over the Apps surface (admin Apps, public store, AppTesting) covering the 8-point goal: fix the junk icons, validate the testing data against live reality, add offline/online/hybrid filtering, stop blurbs being cut off, give Needs-key apps a proof-first connect wizard, fix what was fixable, and exclude what is broken from the store while keeping it on the AppTesting record.

## 1. Icons (the ">" placeholders)

Root cause: `DOMAIN_OF` marks built-in connectors with the pseudo-domain `"local"`, and `AppIcon` asked DuckDuckGo for `local.ico`. DDG answers unknown hosts with a generic placeholder under HTTP 200, so the letter-chip fallback never fired. The generator now emits `domain: null` for `"local"`, and `AppIcon` only fetches favicons for dotted hostnames. A catalog integrity test now guards against `"local"` ever shipping as a domain.

Note: open PR #1433 adds real domain mappings for 87 apps in the same `DOMAIN_OF` map. No row conflicts (this PR adds none), but whichever merges second must re-run `node scripts/generate-app-catalog.mjs`.

## 2 + 3 + 7. AppTesting truth audit (no false positives)

44 apps were physically re-called through the live MCP server, biased toward fragile hobby APIs. Results:

- **13 recorded passes were actually broken** and are now `fail`: restcountries (`countries.map is not a function` on every endpoint), spacex (timeouts, archived API), isup (404 for every domain), aoe2 + tacofancy (Heroku apps gone), punkapi (domain dead), quotable (unreachable), bored (endpoint path moved), animechan (API host moved), acnhapi (dead), shibe (unreachable), evilinsult (Cloudflare-blocked), and numbers re-confirmed down.
- **thelott recovered**: recorded fail, but `lott_jackpots` and `lott_results` both returned valid live draw data; flipped to pass.
- **breakingbad**: persistent upstream rate limit from the shared egress IP; reclassified `attention`.
- 30 passes re-verified live with fresh timestamps; alphavantage/abuseipdb attention statuses confirmed (clean not-connected cards).

New counts: 483 pass / 175 attention / 13 fail. The failing 13 are hidden from the public store (counts adjust), keep an honest warning on their detail pages, and stay fully recorded in admin AppTesting with a "Hidden from store" marker.

Connector fixes shipped for the fixable ones, pending a deploy retest: isup (missing required User-Agent), bored (`/random` + `/filter` paths), animechan (`api.animechan.io`), numbers (API is HTTP-only), restcountries (shape-guard non-array bodies and surface the upstream message).

## 4. Offline / online / hybrid filter

The catalog generator now derives a `network` field per app by scanning each connector source for `fetch(`: 375 online, 285 offline (pure local compute), 11 hybrid (URL builders like QR Server that work offline but produce internet-dependent output). Filter chips appear on both the public store and admin Apps; the badge also shows on detail pages and expanded rows.

## 5. Truncated descriptions

Expanding a row now shows the full untruncated blurb (plus the internet badge) above the actions list, and the single-line cell has a hover tooltip.

## 6. Needs-key connect wizard, proof-first

Clicking a status pill on the admin Apps page opens a connect wizard that shows what the app needs (credential label, where to get it, setup notes, generated from `CONNECTOR_SETUP`). Submitting calls the new `admin_connect_app` action, which **live-tests the credential against the platform's test endpoint before storing**:

- test passes: stored (keychain-compatible encryption into `platform_credentials`), green "Connected, live-tested"
- test fails: nothing stored, the provider's rejection is shown
- no test endpoint: stored but reported amber "saved, not proven"

The Apps page green "Connected" pill now requires a real test stamp; an untested stored key shows "Key saved". OAuth apps route to the existing `/connect/<slug>` login flow.

## 8. Things found beyond the brief

- **Stored credentials are not auto-injected into most tool calls.** `requireCredential` reads only inline args and env vars; vault-bridge covers only a small connector subset; `keychainGetCredential` has no callers at dispatch time. A proven key is stored and visible, but most hosted connectors still need deployment env vars until a credential-injection lane lands in MCP dispatch. Recorded in memory and worth a dedicated chip in the Connectors lane.
- Two parallel credential stores exist (`user_credentials` via Connect/Passport, `platform_credentials` via keychain). The web UI previously had no path that writes the store the Apps page reads, so keys added via the UI never turned the page green. The wizard closes that gap.
- The AppTesting loop's recorded passes for hobby APIs drift quickly; the loop's 14-day stale window is too slow for these. Suggest a tighter recheck cadence for apps on hobby/Heroku-class hosting.
- `numbers` had no colocated test (L2 requires one); left as-is to stay in scope but flagged.

## Proof

- Root suite: 207 files / 1684 tests pass
- MCP package suite: pass, including tool-index / depth-ladder / standalone `--check` gates
- `npm run build` + prerender: pass; MCP `tsc --noEmit`: clean
- Generators in order and `--check` green: tool-index, app-catalog, connector-setup (new), brainmap
- New tests: AppsTable network filter + full-blurb expansion + status-pill button, ConnectAppModal proof-first flow (connected / unproven / rejected / no-key / OAuth), catalog integrity (network field, no `"local"` domains, honest offline bucket), restcountries shape guard, bored new paths

https://claude.ai/code/session_01EQVkhDpnjAMk1RSMPD3nrr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQVkhDpnjAMk1RSMPD3nrr)_