### PR TITLE
chore: update server.json description to canonical one-liner

### DIFF
--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.malamutemayhem/unclick",
   "title": "UnClick",
-  "description": "AI agent tool marketplace. 178+ tools for social, e-commerce, accounting, and messaging.",
+    "description": "UnClick is the universal remote for AI: one MCP install that gives any compatible agent 450+ callable endpoints across 60+ integrations, plus persistent cross-session memory.",
   "version": "0.3.110",
   "repository": {
     "url": "https://github.com/malamutemayhem/unclick.git",


### PR DESCRIPTION
## Summary
Updates the server.json description to the canonical UnClick one-liner so directories that pull from the MCP registry (PulseMCP etc.) show the correct, current description.

## Changes
- packages/mcp-server/server.json: description updated to canonical line (450+ endpoints, 60+ integrations, persistent cross-session memory)
## Owner and lift status
- Owner: malamutemayhem
- - Non-overlap: yes
- - Status: ready
## Deletions
None