### PR TITLE
chore: update mcp-server package description to canonical one-liner

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,7 +2,7 @@
   "name": "@unclick/mcp-server",
   "version": "0.3.110",
   "mcpName": "io.github.malamutemayhem/unclick",
-  "description": "MCP server for the UnClick tool marketplace - lets AI agents discover and use every UnClick tool",
+    "description": "UnClick is the universal remote for AI: one MCP install that gives any compatible agent 450+ callable endpoints across 60+ integrations, plus persistent cross-session memory.",
   "type": "module",
   "bin": {
     "unclick-mcp": "./dist/index.js"


### PR DESCRIPTION
## Summary
Updates the mcp-server package.json description to the canonical UnClick one-liner. Directories that render the package description (Stork.AI, etc.) will show the correct, current copy.

## Changes
- packages/mcp-server/package.json: description updated to canonical line
## Owner and lift status
- Owner: malamutemayhem
- - Non-overlap: yes
- - Status: ready
## Deletions
None