### PR TITLE
fix(memory): write-gate value-change supersede, valid_from recency, fused retrieval on by default

### DIFF
--- a/docs/memory-hardening/eval-scorecard-2026-06-11.md
+++ b/docs/memory-hardening/eval-scorecard-2026-06-11.md
@@ -1,0 +1,18 @@
+# Memory Eval Scorecard (2026-06-11 night pass)
+
+Deterministic lane-10 harness (`runMemoryHardeningEval`, LocalBackend, local hash embeddings). Full hardened flag set: scopes, write gate, reconcile, hard forget, provenance.
+
+| Configuration | recall@5 | latest_value | forget_compliance | duplicate_rate | scorecard |
+| --- | --- | --- | --- | --- | --- |
+| Frozen lane-10 baseline (2026-06-04) | 1.0 | 1.0 | 1.0 | 0.667 | 0.667 |
+| Tonight, fusion OFF | 1.0 | 1.0 | 1.0 | 0.0 | 0.833 |
+| Tonight, fusion ON | 1.0 | 1.0 | 1.0 | 0.0 | 0.833 |
+
+Notes:
+
+- Before tonight's fixes, `latest-value` FAILED in both configurations under the full flag set: the write gate's cool-down treated a changed value ("channel is beta" vs "channel is alpha", similarity 0.76) as a NOOP and silently dropped the newer fact. Fixed by the value-change supersede rule in `write-gate.ts` (small token swap on the same subject now routes to UPDATE/supersession; paraphrase rewrites still NOOP).
+- With the gate off, fusion ranked the older value first because recency used `created_at` (seconds apart) instead of the declared `valid_from` (days apart). Fixed in `orderByEffectiveScore`.
+- `scope-bleed` fails in every configuration including the frozen baseline: the fixture writes "private" as a plain category without scope context, so it measures an aspirational contract. Real scope enforcement is covered by `scopes.test.ts`. Fixing the fixture is a follow-up chip.
+- Flip decision: fused retrieval meets the master-plan gate (at or above baseline on every metric), so `MEMORY_FUSED_RETRIEVAL_ENABLED` now defaults ON with `0`/`false` as the kill switch.
+
+Reproduce: set the flag matrix and call `runMemoryHardeningEval(new LocalBackend())` (see `src/memory/__tests__/eval-harness.test.ts`).

--- a/packages/mcp-server/src/memory/__tests__/business-context-search.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/business-context-search.test.ts
@@ -97,12 +97,12 @@ async function makeSupabaseBackend(rowsByTable: Record<string, unknown[]>): Prom
 // ─── 1. retrieval-fusion helper (pure) ───────────────────────────────────────
 
 describe("lane-01 retrieval-fusion helper", () => {
-  test("isFusedRetrievalEnabled reads the flag, default off", async () => {
+  test("isFusedRetrievalEnabled defaults on; 0/false is the kill switch", async () => {
     const { isFusedRetrievalEnabled } = await import("../retrieval-fusion.js");
     const snap = snapshot([FLAG]);
     try {
       delete process.env[FLAG];
-      assert.equal(isFusedRetrievalEnabled(), false);
+      assert.equal(isFusedRetrievalEnabled(), true);
       process.env[FLAG] = "true";
       assert.equal(isFusedRetrievalEnabled(), true);
       process.env[FLAG] = "1";
@@ -181,7 +181,7 @@ describe("Supabase backend: business_context in keyword search", () => {
     const snap = snapshot([FLAG, ...EMBED_KEYS]);
     try {
       for (const key of EMBED_KEYS) delete process.env[key];
-      delete process.env[FLAG];
+      process.env[FLAG] = "0"; // kill switch
       const backend = await makeSupabaseBackend(rows);
       const results = await backend.searchMemory("timezone", 5);
       assert.deepEqual(results, []);
@@ -210,7 +210,7 @@ describe("Local backend: business_context in search", () => {
         "flag on should surface the standing rule"
       );
 
-      delete process.env[FLAG];
+      process.env[FLAG] = "0"; // kill switch
       const off = (await backend.searchMemory("timezone", 5)) as Array<{ source: string }>;
       assert.ok(
         !off.some((row) => row.source === "business_context"),

--- a/packages/mcp-server/src/memory/__tests__/fused-retrieval.test.ts
+++ b/packages/mcp-server/src/memory/__tests__/fused-retrieval.test.ts
@@ -202,7 +202,7 @@ describe("Supabase searchMemory: keyword + vector fusion", () => {
     const snap = snapshot([FLAG, ...EMBED_KEYS]);
     try {
       for (const key of EMBED_KEYS) delete process.env[key];
-      delete process.env[FLAG];
+      process.env[FLAG] = "0"; // kill switch
       process.env.MEMORY_OPEN_SOURCE_EMBEDDINGS_ENABLED = "true";
       const backend = await makeBackend();
       const results = await backend.searchMemory(QUERY, 10);

--- a/packages/mcp-server/src/memory/local.ts
+++ b/packages/mcp-server/src/memory/local.ts
@@ -511,6 +511,7 @@ export class LocalBackend implements MemoryBackend {
           category: fact.category,
           confidence: fact.confidence,
           created_at: fact.created_at,
+          valid_from: fact.valid_from ?? null,
           score,
         };
       });

--- a/packages/mcp-server/src/memory/retrieval-fusion.ts
+++ b/packages/mcp-server/src/memory/retrieval-fusion.ts
@@ -29,12 +29,15 @@ import { scoreLocalMemoryContent, tokenizeLocalMemoryQuery } from "./supabase.js
 import type { MemorySearchResultRow, MemorySearchSource } from "./types.js";
 
 /**
- * Lane-01 flag gate. Treats "1" or "true" (any case) as enabled, mirroring the
- * existing embeddings flag idiom (see embeddings.ts). Default off.
+ * Lane-01 flag gate. Default ON since 2026-06-11: the eval harness scored the
+ * fused configuration at or above the frozen lane-10 baseline on every metric
+ * (latest-value fixed by the write-gate value-change supersede and the
+ * valid_from-aware recency in orderByEffectiveScore). Setting the env var to
+ * "0" or "false" is the kill switch that restores keyword-first short-circuit.
  */
 export function isFusedRetrievalEnabled(): boolean {
-  const raw = process.env.MEMORY_FUSED_RETRIEVAL_ENABLED ?? "";
-  return raw === "1" || raw.toLowerCase() === "true";
+  const raw = (process.env.MEMORY_FUSED_RETRIEVAL_ENABLED ?? "").trim().toLowerCase();
+  return raw !== "0" && raw !== "false";
 }
 
 /**
@@ -220,6 +223,12 @@ export interface EffectiveScoreRow {
   source: string;
   final_score: number;
   created_at?: string | null;
+  /**
+   * Declared validity start. When present it outranks created_at as the
+   * recency signal: two writes seconds apart can describe values that became
+   * true days apart, and "latest value" queries care about the latter.
+   */
+  valid_from?: string | null;
   effective_score?: number;
   scope_weight?: number;
 }
@@ -249,14 +258,15 @@ export function orderByEffectiveScore<T extends EffectiveScoreRow>(
     .map((row) => {
       const base = finiteOr(row.effective_score, finiteOr(row.final_score, 0));
       const weight = finiteOr(row.scope_weight, scopeWeightForSource(row.source));
-      const effective = base * weight * recencyWeight(row.created_at, asOf);
+      const effective = base * weight * recencyWeight(row.valid_from ?? row.created_at, asOf);
       return { ...row, effective_score: effective } as T;
     })
     .sort((a, b) => {
       const sa = finiteOr(a.effective_score, 0);
       const sb = finiteOr(b.effective_score, 0);
       const diff = sb - sa;
-      return diff !== 0 ? diff : (b.created_at ?? "").localeCompare(a.created_at ?? "");
+      if (diff !== 0) return diff;
+      return (b.valid_from ?? b.created_at ?? "").localeCompare(a.valid_from ?? a.created_at ?? "");
     })
     .slice(0, maxResults);
 }

--- a/packages/mcp-server/src/memory/supabase.ts
+++ b/packages/mcp-server/src/memory/supabase.ts
@@ -1106,6 +1106,7 @@ export class SupabaseBackend implements MemoryBackend {
           category: r.category,
           confidence: r.confidence,
           created_at: r.created_at,
+          valid_from: r.valid_from ?? null,
           score: s,
         };
       });

--- a/packages/mcp-server/src/memory/write-gate.ts
+++ b/packages/mcp-server/src/memory/write-gate.ts
@@ -264,6 +264,26 @@ export function scoreMemoryWriteSimilarity(left: string, right: string): number 
   return Math.max(phraseContainment, overlap * 0.7 + jaccard * 0.3);
 }
 
+/**
+ * Same-subject value change: the candidate swaps a small slot of the existing
+ * fact's tokens (e.g. "channel is alpha" -> "channel is beta"). This must
+ * supersede, never NOOP: a cool-down or semantic-duplicate NOOP here silently
+ * loses the newer value, which is the exact data-loss class the gate exists
+ * to prevent. A large token swap is a rewrite, not a value change, and still
+ * falls through to the duplicate heuristics.
+ */
+function isValueChange(candidate: FactInput, existing: MemoryWriteGateCandidate, similarity: number): boolean {
+  if (similarity >= 1 || similarity < WRITE_GATE_UPDATE_SIMILARITY) return false;
+  if (candidate.category !== existing.category) return false;
+  const candidateTokens = new Set(tokenizeMemoryWriteGateText(candidate.fact));
+  const existingTokens = new Set(tokenizeMemoryWriteGateText(existing.fact));
+  if (existingTokens.size < 3 || candidateTokens.size < 3) return false;
+  const replaced = [...existingTokens].filter((token) => !candidateTokens.has(token));
+  const added = [...candidateTokens].filter((token) => !existingTokens.has(token));
+  if (replaced.length === 0 || added.length === 0) return false;
+  return replaced.length / existingTokens.size <= 0.34;
+}
+
 function isExpansion(candidate: FactInput, existing: MemoryWriteGateCandidate, similarity: number): boolean {
   if (similarity < WRITE_GATE_UPDATE_SIMILARITY) return false;
   if (candidate.category !== existing.category) return false;
@@ -390,6 +410,17 @@ export function selectAdmissionDecision(
     return decision({
       action: "UPDATE",
       reason: "compatible_expansion",
+      candidate,
+      matched: best.candidate,
+      similarity: best.similarity,
+      admittedToFactStore: true,
+    });
+  }
+
+  if (best && isValueChange(candidate, best.candidate, best.similarity)) {
+    return decision({
+      action: "UPDATE",
+      reason: "value_change_supersede",
       candidate,
       matched: best.candidate,
       similarity: best.similarity,


### PR DESCRIPTION
## Memory night pass 3: two real bugs fixed, fused retrieval goes live

The eval harness comparison (fusion off vs on, full hardened flag set) surfaced two genuine bugs; fixing them clears the master-plan gate for flipping fused retrieval on by default. Scorecard: `docs/memory-hardening/eval-scorecard-2026-06-11.md`.

### Bug 1: write gate silently lost changed values (data loss)

A same-subject value change inside the 5-minute cool-down window ("channel is **alpha**" then "channel is **beta**", similarity 0.76) was NOOPed — the newer value was dropped forever. This is the inverse of the Mem0 junk problem the gate was built to prevent. New `value_change_supersede` rule: a small token swap on the same subject routes to UPDATE (supersession, history preserved); paraphrase rewrites (large swaps) still NOOP.

### Bug 2: fusion ranked stale values above current ones

`orderByEffectiveScore` used `created_at` for recency, so two facts written seconds apart ranked by insertion order even when their declared `valid_from` differed by days. Recency weighting and tiebreak now prefer `valid_from`; the keyword lanes in both backends carry it through.

### Fused retrieval default ON

With both fixes, the eval gate is met: fused config scores at or above the frozen lane-10 baseline on every metric (scorecard 0.833 vs 0.667 frozen; latest-value PASS in all configurations, with and without the write gate). `MEMORY_FUSED_RETRIEVAL_ENABLED=0` is the kill switch. This closes lane 1 and retires the research's "do not ship hybrid while the vector half is dead" blocker.

### Proof

- 228 memory tests / 60 suites passing (legacy keyword-first tests now pin the kill switch explicitly)
- `tsc --noEmit` clean, `boardroom:check` clean
- Before/after eval runs recorded in the scorecard doc

https://claude.ai/code/session_01TkhH2ara8UF11mEa33CMyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkhH2ara8UF11mEa33CMyB)_