### PR TITLE
fix: ops follow-ups - TestPass Vercel wait, blocking lint, XPass Gate Phase 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
           cache: "npm"
       - run: npm ci --no-audit --no-fund
       - name: Lint
+        # Blocking since 2026-06-11: the 9 standing errors were fixed, so a
+        # red lint step now means a new regression, not old debt. Warnings
+        # do not fail eslint, only errors do.
         run: npm run lint
-        continue-on-error: true
       - name: Build
         run: npm run build
       - name: Brainmap stale guard

--- a/.github/workflows/testpass-pr-check.yml
+++ b/.github/workflows/testpass-pr-check.yml
@@ -55,8 +55,11 @@ jobs:
         uses: actions/github-script@v9
         env:
           VERCEL_STATUS_CONTEXT: Vercel
-          VERCEL_WAIT_SECONDS: "600"
-          VERCEL_WAIT_INTERVAL_SECONDS: "10"
+          # 2026-06-11: Vercel preview queues twice exceeded the old 600s
+          # window on PR #1464, failing TestPass for timing alone and
+          # needing manual reruns. 1800s covers observed queue delays.
+          VERCEL_WAIT_SECONDS: "1800"
+          VERCEL_WAIT_INTERVAL_SECONDS: "15"
         with:
           script: |
             const { pathToFileURL } = require('node:url');

--- a/AUTOPILOT.md
+++ b/AUTOPILOT.md
@@ -109,6 +109,15 @@ Enforcement path:
 - Phase 2: enforce completed Passes only. A missing incomplete Pass is a recorded skip, not a blocker.
 - Phase 3: enforce all relevant completed Passes before merge for Autopilot, admin UI, public pages, tools/connectors, and security-sensitive surfaces.
 
+**Current phase: Phase 2 (operator-approved 2026-06-11).** For passes with a
+stable runner (TestPass, UXPass, FlowPass, SecurityPass, CopyPass,
+FidelityPass, SEOPass, GEOPass, LegalPass, CompliancePass, CommonSensePass,
+SlopPass), a BLOCKER receipt on the current head SHA stops the merge unless
+the operator explicitly overrides. Passes without a runner (UIPass) or
+boundary-only passes (WakePass, RotatePass) remain recorded skips, never
+silent passes. Use `xpass_aggregated_verdict` with `available_checks` to
+compute the gate.
+
 This project should bias toward fixing real user-visible confusion over inventing new dashboards. When in doubt, dogfood the current product, write down the friction, and ship the smallest improvement that removes it.
 
 ## Autonomy Tiers

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -15475,8 +15475,8 @@
   "source_manifest": [
     {
       "source": "AUTOPILOT.md",
-      "hash": "18863a2e935a",
-      "bytes": 18077
+      "hash": "969ddb05e2d3",
+      "bytes": 18609
     },
     {
       "source": "FLEET_SYNC.md",
@@ -15560,8 +15560,8 @@
     },
     {
       "source": ".github/workflows/ci.yml",
-      "hash": "5fe8ef28e93c",
-      "bytes": 1882
+      "hash": "ee6e7f0dd609",
+      "bytes": 2047
     },
     {
       "source": ".github/workflows/brainmap-auto-update.yml",
@@ -16595,8 +16595,8 @@
     },
     {
       "source": ".github/workflows/testpass-pr-check.yml",
-      "hash": "bca601f0a1c2",
-      "bytes": 20251
+      "hash": "ab425e8d32b7",
+      "bytes": 20467
     },
     {
       "source": ".github/workflows/testpass-scheduled-smoke.yml",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -13,7 +13,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 
 | Source | Hash | Bytes |
 | --- | --- | --- |
-| AUTOPILOT.md | 18863a2e935a | 18077 |
+| AUTOPILOT.md | 969ddb05e2d3 | 18609 |
 | FLEET_SYNC.md | 0768614dd1ed | 14732 |
 | docs/unclick-context-boot-packet.md | d02028751751 | 11234 |
 | docs/agent-observability.md | bffd9f890c75 | 4629 |
@@ -30,7 +30,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminSkills.tsx | a3cf298f1eda | 4203 |
 | src/lib/skillLibrary.ts | 3a15b942a827 | 12515 |
 | src/lib/skillLibrarySeeds.ts | 51ca658707f8 | 652 |
-| .github/workflows/ci.yml | 5fe8ef28e93c | 1882 |
+| .github/workflows/ci.yml | ee6e7f0dd609 | 2047 |
 | .github/workflows/brainmap-auto-update.yml | 4771ebdbdba3 | 1211 |
 | .github/workflows/continuous-improvement-watch.yml | d121a434a464 | 2358 |
 | package.json | 0946c1ef23c5 | 7326 |
@@ -237,7 +237,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | .github/workflows/scheduled-build-self-test.yml | 1362b535ff33 | 1024 |
 | .github/workflows/secret-scan.yml | 437fe35aa550 | 1158 |
 | .github/workflows/seed-vault.yml | 003a9bd13283 | 1246 |
-| .github/workflows/testpass-pr-check.yml | bca601f0a1c2 | 20251 |
+| .github/workflows/testpass-pr-check.yml | ab425e8d32b7 | 20467 |
 | .github/workflows/testpass-scheduled-smoke.yml | 46f9a65b1dbb | 1673 |
 | .github/workflows/tier2-auto-merge-queue-check.yml | 5abfca8c42dc | 830 |
 | .github/workflows/tier2-rollback.yml | 1468c05586fb | 1495 |

--- a/packages/mcp-server/src/colorconvert-tool.ts
+++ b/packages/mcp-server/src/colorconvert-tool.ts
@@ -13,7 +13,7 @@ function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
   if (max === min) return [0, 0, Math.round(l * 100)];
   const d = max - min;
   const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-  let h = 0;
+  let h: number;
   if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
   else if (max === g) h = ((b - r) / d + 2) / 6;
   else h = ((r - g) / d + 4) / 6;

--- a/packages/mcp-server/src/convexhull3d-tool.ts
+++ b/packages/mcp-server/src/convexhull3d-tool.ts
@@ -56,7 +56,7 @@ export async function convexHull3D(args: Record<string, unknown>) {
 
   // Find initial tetrahedron
   // Pick 4 non-coplanar points
-  let i0 = 0;
+  const i0 = 0;
   let i1 = -1;
   for (let i = 1; i < pts.length; i++) {
     if (norm(sub(pts[i], pts[i0])) > 1e-10) {

--- a/packages/mcp-server/src/dijkstra-tool.ts
+++ b/packages/mcp-server/src/dijkstra-tool.ts
@@ -75,7 +75,7 @@ export async function dijkstraPath(args: Record<string, unknown>) {
   const distance = dist.get(target)!;
   const reachable = distance !== Infinity;
 
-  let path: string[] = [];
+  const path: string[] = [];
   if (reachable) {
     let node: string | null = target;
     while (node !== null) {

--- a/packages/mcp-server/src/fenwick2d-tool.ts
+++ b/packages/mcp-server/src/fenwick2d-tool.ts
@@ -92,7 +92,7 @@ export async function fenwick2D(args: Record<string, unknown>) {
       }
       results.push(rectSum(r1, c1, r2, c2));
     } else {
-      throw new Error(`Unknown operation type: ${(op as any).type}`);
+      throw new Error(`Unknown operation type: ${(op as { type?: unknown }).type}`);
     }
   }
 

--- a/packages/mcp-server/src/goertzel-tool.ts
+++ b/packages/mcp-server/src/goertzel-tool.ts
@@ -32,12 +32,11 @@ export async function goertzel(args: Record<string, unknown>) {
   const omega = (2 * Math.PI * bin) / N;
   const coeff = 2 * Math.cos(omega);
 
-  let s0 = 0;
   let s1 = 0;
   let s2 = 0;
 
   for (let i = 0; i < N; i++) {
-    s0 = samples[i] + coeff * s1 - s2;
+    const s0 = samples[i] + coeff * s1 - s2;
     s2 = s1;
     s1 = s0;
   }

--- a/packages/mcp-server/src/lca-tool.ts
+++ b/packages/mcp-server/src/lca-tool.ts
@@ -66,7 +66,7 @@ export async function lowestCommonAncestor(args: Record<string, unknown>) {
     let a = u;
     let b = v;
     if (depth[a] < depth[b]) [a, b] = [b, a];
-    let diff = depth[a] - depth[b];
+    const diff = depth[a] - depth[b];
     for (let k = 0; k < LOG; k++) {
       if ((diff >> k) & 1) a = up[k][a];
     }

--- a/packages/mcp-server/src/poweriter-tool.ts
+++ b/packages/mcp-server/src/poweriter-tool.ts
@@ -53,7 +53,6 @@ export async function powerIteration(args: Record<string, unknown>) {
     const newV = w.map(x => x / norm);
 
     if (Math.abs(newEigenvalue - eigenvalue) < tolerance) {
-      eigenvalue = newEigenvalue;
       v = newV;
       break;
     }

--- a/packages/mcp-server/src/rootfind-tool.ts
+++ b/packages/mcp-server/src/rootfind-tool.ts
@@ -75,12 +75,12 @@ export async function rootFind(args: Record<string, unknown>) {
     if (a >= b) throw new Error("a must be less than b.");
 
     let fa = evaluate(a);
-    let fb = evaluate(b);
+    const fb = evaluate(b);
     if (fa * fb > 0) throw new Error("f(a) and f(b) must have opposite signs.");
 
     let converged = false;
     let mid = (a + b) / 2;
-    let iter = 0;
+    let iter: number;
 
     for (iter = 0; iter < maxIter; iter++) {
       mid = (a + b) / 2;
@@ -91,7 +91,6 @@ export async function rootFind(args: Record<string, unknown>) {
       }
       if (fa * fmid < 0) {
         b = mid;
-        fb = fmid;
       } else {
         a = mid;
         fa = fmid;


### PR DESCRIPTION
## What

Operator-approved follow-ups from the 2026-06-11 Autopilot ops audit ("green light to everyone you recommend through to live"), low-hanging fruit first.

### 1. TestPass PR check: survive Vercel preview queues
The wait-for-Vercel window goes from 600s to 1800s (15s poll). Vercel preview queues exceeded 600s twice on PR #1464, failing TestPass purely on timing and requiring manual `rerun_failed_jobs` after each Ready event. 1800s covers the observed ~20 minute queue delays.

### 2. Lint debt cleared and lint made blocking
Fixed all 9 standing eslint errors: 3 `prefer-const` autofixes (convexhull3d, dijkstra, lca), 4 dead stores removed (goertzel `s0` init, poweriter pre-break `eigenvalue` store, rootfind `iter` init and dead `fb = fmid`, colorconvert `h` init), 1 `any` cast typed in fenwick2d. All are behavior-identical: the 8 touched connector tools keep their colocated tests green (42 passed). With the error count at zero, the CI `Lint` step drops `continue-on-error` so a red lint step now means a new regression, not old debt. Warnings still do not fail eslint.

### 3. XPass Gate Phase 2 declared
`AUTOPILOT.md` now states Phase 2 is active (operator-approved): a BLOCKER receipt on the current head from a pass with a stable runner stops a merge unless the operator overrides; runnerless (UIPass) and boundary passes (WakePass, RotatePass) remain recorded skips.

### 4. Brainmap regenerated
Workflow hashes changed (ci.yml, testpass-pr-check.yml), so the generated inventory is refreshed.

## Verification

- `npx eslint . --quiet` exits 0 (was 9 errors)
- `cd packages/mcp-server && npx vitest run` on all 8 touched tool tests: 42 passed
- `packages/mcp-server` `npm run build` exit 0
- `npm run brainmap:check` and `npm run boardroom:check` clean

## Not in this PR (needs operator or another seat)

- XGate shadow mode: code is wired and off by default; going live is one dashboard action - add `UNCLICK_XGATE_ENFORCE=1` (production + preview) on the `unclick-agent-native-endpoints` Vercel project. No Vercel write credentials exist on this seat.
- Merge queue adoption (repo settings), sampling-capable seat (Boardroom todo a17af7b8).

https://claude.ai/code/session_01L2mGMVXnLaU8HpMm7FXkyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2mGMVXnLaU8HpMm7FXkyQ)_