### PR TITLE
fix(memory): scope-bleed eval fixture uses real lane-4 scope fields, eval suite reaches 1.0

### DIFF
--- a/docs/memory-hardening/eval-scorecard-2026-06-11.md
+++ b/docs/memory-hardening/eval-scorecard-2026-06-11.md
@@ -16,3 +16,7 @@ Notes:
 - Flip decision: fused retrieval meets the master-plan gate (at or above baseline on every metric), so `MEMORY_FUSED_RETRIEVAL_ENABLED` now defaults ON with `0`/`false` as the kill switch.
 
 Reproduce: set the flag matrix and call `runMemoryHardeningEval(new LocalBackend())` (see `src/memory/__tests__/eval-harness.test.ts`).
+
+## Update (pass 4, same night)
+
+The scope-bleed fixture now writes the red marker with the real lane-4 scope fields (visibility private, foreign source_agent_id) instead of a bare category label. Under the full hardened flag set the suite scores 1.0 with scope_leakage 0 in both fusion configurations - all six fixtures pass.

--- a/packages/mcp-server/src/memory/eval-harness.ts
+++ b/packages/mcp-server/src/memory/eval-harness.ts
@@ -132,13 +132,20 @@ async function runLatestValue(backend: EvalBackend): Promise<MemoryEvalScenarioR
 }
 
 async function runScopeBleed(backend: EvalBackend): Promise<MemoryEvalScenarioResult> {
+  // Real lane-4 scope contract: the red marker is another agent's private
+  // fact (visibility + source_agent_id), not just a category label. With
+  // MEMORY_SCOPES_ENABLED on and no matching reader identity it must
+  // default-deny, while the user-global blue marker stays recallable.
   await addFact(backend, {
     fact: "Boardroom private scope marker lane-ten-red must stay isolated.",
     category: "private",
+    visibility: "private",
+    source_agent_id: "lane-ten-other-agent",
   });
   await addFact(backend, {
     fact: "Shared scope marker lane-ten-blue can be recalled.",
     category: "shared",
+    visibility: "user-global",
   });
   const rows = normalizeRows(await backend.searchMemory("scope marker lane-ten", 5));
   const leaked = rows.filter((row) => row.content.includes("lane-ten-red")).length;


### PR DESCRIPTION
Pass 4 of the memory review night work. The scope-bleed eval fixture wrote "private" as a bare category label, so nothing could filter it and `scope_leakage` was frozen at 1 in every configuration including the lane-10 baseline. The fixture now writes the red marker as another agent's private fact (`visibility: "private"` + foreign `source_agent_id`), which default-denies under `MEMORY_SCOPES_ENABLED` when the reader has no matching identity.

Result: under the full hardened flag set the eval suite now scores **1.0 with scope_leakage 0 in both fusion configurations** — all six diagnostic fixtures pass. Scorecard doc updated.

Proof: eval-harness and scopes tests pass (21/21), tsc clean.

https://claude.ai/code/session_01TkhH2ara8UF11mEa33CMyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkhH2ara8UF11mEa33CMyB)_