### PR TITLE
Connections clarity r1: crash-safe Passport API, retry UI, IA spec

### DIFF
--- a/api/backstagepass.test.ts
+++ b/api/backstagepass.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./backstagepass";
+
+interface CapturedResponse {
+  headers: Record<string, string>;
+  statusCode: number;
+  body: unknown;
+  ended: boolean;
+  setHeader(name: string, value: string): CapturedResponse;
+  status(code: number): CapturedResponse;
+  json(body: unknown): unknown;
+  end(): CapturedResponse;
+}
+
+function createResponse(): CapturedResponse {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: null,
+    ended: false,
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return body;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
+}
+
+describe("backstagepass API crash safety", () => {
+  const originalUrl = process.env.SUPABASE_URL;
+  const originalKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    if (originalUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = originalUrl;
+    if (originalKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = originalKey;
+  });
+
+  it("returns a readable JSON error instead of crashing when an upstream fetch throws", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("socket hang up");
+    }));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = createResponse();
+    await handler(
+      {
+        method: "GET",
+        query: { action: "list" },
+        headers: { authorization: "Bearer some-supabase-jwt" },
+      } as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "Temporary error loading your connections. Please retry." });
+  });
+
+  it("does not leak the internal exception message to the client", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("connect ECONNREFUSED 10.0.0.1:443 super-internal-detail");
+    }));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = createResponse();
+    await handler(
+      {
+        method: "GET",
+        query: { action: "list" },
+        headers: { authorization: "Bearer some-supabase-jwt" },
+      } as never,
+      res as never,
+    );
+
+    expect(JSON.stringify(res.body)).not.toContain("ECONNREFUSED");
+    expect(JSON.stringify(res.body)).not.toContain("super-internal-detail");
+  });
+
+  it("still answers OPTIONS preflight without touching upstream services", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const res = createResponse();
+    await handler({ method: "OPTIONS", headers: {} } as never, res as never);
+
+    expect(res.statusCode).toBe(204);
+    expect(res.ended).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -462,6 +462,18 @@ async function fetchConnectorMap(
 // ─── Handler ───────────────────────────────────────────────────────
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    return await handleBackstagePass(req, res);
+  } catch (err) {
+    // Crash safety: without this, an upstream throw (Supabase hiccup, network
+    // timeout) becomes a naked non-JSON 500 and the admin page can only show
+    // "List failed with 500". Always hand the UI a readable error instead.
+    console.error("backstagepass: unhandled error:", err instanceof Error ? err.message : String(err));
+    return res.status(500).json({ error: "Temporary error loading your connections. Please retry." });
+  }
+}
+
+async function handleBackstagePass(req: VercelRequest, res: VercelResponse) {
   res.setHeader("Access-Control-Allow-Origin",  "https://unclick.world");
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -15925,8 +15925,8 @@
     },
     {
       "source": "src/pages/admin/AdminKeychain.tsx",
-      "hash": "d743c17f4412",
-      "bytes": 78086
+      "hash": "b8e0f75ecee7",
+      "bytes": 78511
     },
     {
       "source": "src/pages/admin/AdminMemory.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -103,7 +103,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminDashboard.tsx | e38f909e6d5b | 7090 |
 | src/pages/admin/AdminJobs.tsx | e891d0a7df9e | 65839 |
 | src/pages/admin/AdminJobsmith.tsx | fd2aad657f06 | 54734 |
-| src/pages/admin/AdminKeychain.tsx | d743c17f4412 | 78086 |
+| src/pages/admin/AdminKeychain.tsx | b8e0f75ecee7 | 78511 |
 | src/pages/admin/AdminMemory.tsx | 25b2ecae9ca8 | 10814 |
 | src/pages/admin/AdminModeration.tsx | 27cae956bcfd | 883 |
 | src/pages/admin/AdminOrchestratorLog.tsx | af0abb526002 | 12944 |

--- a/docs/connections-ia.md
+++ b/docs/connections-ia.md
@@ -1,0 +1,74 @@
+# Connections IA: one list, many lenses
+
+**Status:** operator-approved direction (Chris, 2026-06-11)
+**Owns:** the information architecture for Apps, Passport, and Websites in the admin. Workers building on these surfaces follow this doc; if reality drifts, fix the source then update this doc.
+
+## The operator's decision (the anchor)
+
+> "The trend I am seeing is Apps covers most bases. Let's just make use of that page holistically to have a consistent side menu filtering, and the same filtering in the top section."
+
+Everything below serves that line. The Apps page is THE list. Other views are filters (lenses) of that one list, never separate lists that drift apart.
+
+## The model, one line each
+
+| Surface | What it is | One-liner for users |
+|---|---|---|
+| **Connections** | The umbrella: everything UnClick plugs into (outbound) | "What your AI is allowed to reach" |
+| **Apps** | The catalog page, used holistically. Every other view is a saved filter of this list | "What your AI can do" |
+| **Passport** | The credentials wallet view: OAuth grants, API keys, health, rotation, audit | "What your AI can sign into" |
+| **Websites** | Sites UnClick can act on through the Chrome extension | "Where your AI can act on the web" |
+
+The earlier confusion came from "Connected" feeling like a separate place. It is not. Connected is a state an app is in, shown and managed on the Apps list itself; Passport is the deep wallet view behind it.
+
+## Vocabulary (one set of words, everywhere)
+
+**Setup kinds** (what an app needs before first use):
+
+- **Built-in**: works immediately, no setup. No button.
+- **Sign-in app**: connects through a login popup (OAuth). Status button: **Connect**. This is the github/spotify/gmail style; the industry term is OAuth, the user-facing term is sign-in.
+- **Key app**: needs an API key pasted once. Status button: **Add key**.
+
+**States** (where a connectable app is right now):
+
+- **Connected**: credential saved and live-tested.
+- **Not connected**: no credential yet.
+- **Needs attention**: had a credential but the last health check failed or it expired.
+
+Sign-in platforms live today (`api/oauth-init.ts` ALLOWED_PLATFORMS): github, xero, reddit, shopify. Gmail, Spotify, and others need a provider added there plus OAuth app registration; until then they present as key apps.
+
+## Lenses (the filtering rule)
+
+Side menu entries and top filter chips are the SAME filter state with two controls. Selecting "Connected" in the side menu lights the same filter as clicking a "Connected" chip. One source of truth for filter state; no view-only forks.
+
+Planned lenses on the Apps list:
+
+- All (default)
+- Connected (default lens when arriving from the Connections section)
+- Not connected
+- Popular
+- Sign-in apps / Key apps / Built-in (setup kind)
+- Existing category chips (AI, Books, Content, ...) and internet chips (Works offline, Uses internet, Hybrid) stay as they are
+
+## Bridges (how the surfaces hand off)
+
+1. Status column buttons on app rows open the connect wizard (`ConnectAppModal`). On success the wizard says where the credential now lives ("Saved to Passport, live-tested") and the row flips to Connected.
+2. Passport rows link back to their app page, so the wallet is never a dead end.
+3. The Passport page keeps the audit, rotation, reveal, and health features; it does not grow a second catalog.
+
+## Naming rules
+
+- **Connections** is the section umbrella. **Passport** is the wallet page inside it. **Apps** and **Websites** keep their names.
+- Internal names stay in internal contracts only: route `/admin/keychain`, API `/api/backstagepass`. Same approach as the Boardroom rename precedent: rename the user surface, keep the plumbing stable.
+- Words retired from visible copy: BackstagePass, Keychain, Vault, Credentials. Enforced by `src/__tests__/passport-public-name-lock.test.ts`.
+
+## Build order and lane ownership
+
+1. **Shipped with this doc:** crash safety in `api/backstagepass.ts` (no more naked 500s; the page now gets a readable error) and a Retry button on the Passport list error banner.
+2. **Apps page lenses:** Connected / Not connected / Popular / setup-kind filters with the side-menu-equals-top-chips rule, and a status button on every connectable row. Unowned at the time of writing; claim it as one chip in the Boardroom.
+3. **Sidebar grouping:** Apps, Passport, and Websites grouped under a Connections section. `AdminShell.tsx` is ring-fenced by the open AdminShell polish lane; coordinate there before touching.
+4. **Websites surface:** lands when the Chrome extension exposes its site-permission list.
+5. **Sign-in expansion:** add Google and Spotify providers to `api/oauth-init.ts` and the OAuth callback when prioritized.
+
+## Known issues
+
+- The Advanced system inventory section on the Passport page rendered with overlapping rows (operator screenshot, 2026-06-11, Brave). Not reproducible from static code review; the row markup is a plain CSS grid. Needs a browser devtools look (computed styles on `.divide-y` children) before any fix. Tracked as a Boardroom todo; UXPass before/after screenshot proof required for the fix.

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -348,7 +348,7 @@ export default function AdminKeychain() {
       const res = await fetch("/api/backstagepass?action=list", { headers: authHeader });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? `List failed with ${res.status}`);
+        throw new Error(body.error ?? `Temporary error loading your connections (HTTP ${res.status}). Please retry.`);
       }
       const body = await res.json();
       setCredentials(body.data ?? []);
@@ -821,8 +821,16 @@ export default function AdminKeychain() {
 
       {/* List */}
       {error && (
-        <div className="mb-4 rounded-xl border border-red-500/20 bg-red-500/5 px-4 py-3 text-xs text-red-400">
-          {error}
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-red-500/20 bg-red-500/5 px-4 py-3 text-xs text-red-400">
+          <span>{error}</span>
+          <button
+            type="button"
+            onClick={() => void fetchList()}
+            disabled={loading}
+            className="shrink-0 rounded-lg border border-red-500/30 px-3 py-1.5 font-medium text-red-300 hover:bg-red-500/10 disabled:opacity-50"
+          >
+            Retry
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
# Connections clarity, round 1: crash-safe Passport API + retry + the IA spec

Operator-reported: `/admin/keychain` showed a raw **"List failed with 500"** and the system around Apps/Connections "is getting confusing, needs to be very clear".

## Fixes

1. **Crash safety in `api/backstagepass.ts`** (root cause of the raw 500): the handler had no top-level error handling, so any upstream throw (Supabase hiccup, network timeout) became a naked non-JSON 500 the page could only render as "List failed with 500". Uncaught errors now return a readable JSON error, with the internal exception detail kept server-side only. No changes to storage, encryption, or auth logic.
2. **Retry button** on the Passport list error banner + a friendlier fallback message for non-JSON failures.
3. **`docs/connections-ia.md`** - the operator-approved IA spec (Chris, 2026-06-11):
   - Apps is THE list; every other view is a lens of it. Side menu filters and top filter chips share one filter state.
   - Connections = umbrella section; Passport = wallet view (OAuth, keys, health); Websites = Chrome extension surface.
   - One vocabulary: setup kinds **Built-in / Sign-in app (Connect) / Key app (Add key)**; states **Connected / Not connected / Needs attention**.
   - Build order with lane ownership (AdminShell grouping deliberately deferred to its ring-fenced lane).

## Proof

- `npx vitest run api/backstagepass.test.ts src/__tests__/passport-public-name-lock.test.ts`: 4/4 pass (3 new crash-safety tests incl. no-internal-detail-leak; name lock intact)
- `npm run brainmap:check` clean, `test:brainmap` 7/7, Boardroom naming ratchet clean (none new)
- No em dashes in new content

## Known issue deliberately NOT fixed here

The overlapping rows in Advanced system inventory (operator screenshot): the row markup is a plain CSS grid and the overlap is not reproducible statically. Needs a browser devtools look; tracked in the IA spec's known issues with UXPass screenshot proof required.

https://claude.ai/code/session_01Tghhgm4hdLkf6Xggr4WHQp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tghhgm4hdLkf6Xggr4WHQp)_