### PR TITLE
Apps holistic: one list + lenses (rail + chips, one state), action buttons, Passport dissolve plan

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -15840,8 +15840,8 @@
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",
-      "hash": "e837ee6a6e33",
-      "bytes": 7846
+      "hash": "be784ae91b3f",
+      "bytes": 9616
     },
     {
       "source": "src/pages/admin/AdminAuditLog.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -86,7 +86,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAgents.tsx | 6df58623daf6 | 49162 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 5ba37cf2abff | 11567 |
-| src/pages/admin/AdminTools.tsx | e837ee6a6e33 | 7846 |
+| src/pages/admin/AdminTools.tsx | be784ae91b3f | 9616 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
 | src/pages/admin/AdminEcosystemPages.tsx | a43f559b89c3 | 13821 |

--- a/docs/prd/connections-apps-holistic.md
+++ b/docs/prd/connections-apps-holistic.md
@@ -1,0 +1,40 @@
+# Connections: Apps as THE list (holistic plan)
+
+Status: operator-directed build, 2026-06-12 ("Apps covers most bases, let's just make use of that page wholistically... consistent side menu filtering, but a same filtering in the top section"; Passport dissolve approved: "could all that be managed in the dropdown of each app?" -> yes -> "ok build")
+Companions: `docs/connections-ia.md` (PR #1476, the umbrella tree; this doc supersedes its "Passport keeps its name" line), `docs/prd/connections-circle.md` (Circle + sidebar), `docs/connectors/connections-hardening-plan.md`.
+
+## Principles (the operator's simple logic, made law)
+
+1. **One list, many lenses.** There is exactly one Apps list. Every view (Connected, Popular, Key apps...) is a filter of that list, never a fork or a second page.
+2. **One filter state, two controls.** The left rail and the top chips render from the same lens definition array and read/write the same state. Selecting anywhere updates everywhere. State lives in the URL (`?lens=...`) so views are linkable and survive refresh.
+3. **Buttons say the action, pills say the truth.** Status pills report proven state (green Connected only after a real test). The action button says what clicking does: Connect (sign-in apps), Add key (key apps), Manage (already connected). Built-in apps need nothing and show no button.
+4. **Three setup kinds, plain names.** Sign-in apps (OAuth popup: click, approve, done), Key apps (paste a key once), Built-in (work immediately). Derived from connector `auth_type`: oauth2 -> sign-in; api_key / bot_token -> key; no connector -> built-in.
+5. **Truth-locked lenses.** "Popular" is a curated starter set until real usage data exists (the code says so in a comment); "Connected" means a working credential is on file (the pill still distinguishes proven vs saved-untested).
+
+## The lens taxonomy (one source array drives rail + chips)
+
+| Group | Lens | Definition |
+|---|---|---|
+| Library | All | everything |
+| Library | Popular | curated set, catalog-membership-checked |
+| Status | Connected | connector credential `is_valid` |
+| Status | Not connected | connector exists, no working credential |
+| Setup | Sign-in apps | `auth_type === "oauth2"` |
+| Setup | Key apps | `auth_type` is api_key or bot_token |
+| Setup | Built-in | no connector row |
+
+Lenses compose with the existing search/category/sort (lens narrows first, table filters refine). One lens at a time, App Store style: simple beats clever.
+
+## Phases
+
+**P1 (this PR): lenses + buttons.** `appLenses.ts` (pure, tested) + `AppLensBar` (one component, rail and chips variants) + URL state in AdminTools + `actionOf` button column in AppsTable (additive optional prop; public mode untouched).
+
+**P2: the credential drawer (Passport absorb).** Each connector-backed app row's expansion gains a Credentials section: rows (label, status, last tested), relabel, delete, reveal behind the proof-of-possession prompt, multiple credentials per app. Reuses the existing backstagepass API actions unchanged. Coordinate with PR #1476 (it hardened that API's error handling); land #1476 first.
+
+**P3: retire Passport.** When P2 reaches parity: remove the sidebar entry, `/admin/keychain` redirects to `/admin/apps?lens=connected`, system-credential rows surface under a System lens (most map to existing tiles: Vercel and Supabase are already catalog apps), true infra oddballs move to the internal admin section, global credential audit folds into the existing internal Audit Log page. The Passport label retires at zero contract cost (rename rule: it was only ever a UI label).
+
+**P4: Websites surface** (extension lane: browser-login sites, "local session (this browser)", mandate state) joins the Connections group, which then ships in the sidebar with Circle (already-claimed chip dfa23691).
+
+## Out of scope here
+
+Public /apps page behavior (shares AppsTable; all P1 admin additions are optional props), the sidebar grouping (Circle PR 1), any backstagepass API change, OAuth provider expansion (todo 047a1928: Google, Spotify).

--- a/src/components/apps/AppLensBar.tsx
+++ b/src/components/apps/AppLensBar.tsx
@@ -1,0 +1,73 @@
+/**
+ * One filter state, two controls: the same LENSES array renders as a vertical
+ * rail (desktop) and horizontal chips (always visible, scrollable). Both call
+ * the same onSelect; neither owns the state (the page's URL does).
+ */
+
+import { LENSES, type AppLens } from "./appLenses";
+
+interface AppLensBarProps {
+  lens: AppLens;
+  counts: Record<AppLens, number>;
+  onSelect: (lens: AppLens) => void;
+  variant: "rail" | "chips";
+}
+
+export function AppLensBar({ lens, counts, onSelect, variant }: AppLensBarProps) {
+  if (variant === "chips") {
+    return (
+      <div className="flex items-center gap-1.5 overflow-x-auto pb-1" role="tablist" aria-label="App lenses">
+        {LENSES.map(({ id, label }) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={lens === id}
+            onClick={() => onSelect(id)}
+            className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              lens === id
+                ? "bg-[#61C1C4]/15 text-[#9FE0E2]"
+                : "bg-white/[0.03] text-white/45 hover:bg-white/[0.06] hover:text-white/75"
+            }`}
+          >
+            {label}
+            <span className={`ml-1.5 tabular-nums ${lens === id ? "text-[#9FE0E2]/60" : "text-white/25"}`}>
+              {counts[id]}
+            </span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  const groups = [...new Set(LENSES.map((l) => l.group))];
+  return (
+    <nav className="flex flex-col gap-4" aria-label="App lenses">
+      {groups.map((group) => (
+        <div key={group}>
+          <div className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-white/30">{group}</div>
+          <div className="flex flex-col gap-0.5">
+            {LENSES.filter((l) => l.group === group).map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                aria-current={lens === id}
+                onClick={() => onSelect(id)}
+                className={`flex items-center justify-between rounded-lg px-2 py-1.5 text-left text-xs font-medium transition-colors ${
+                  lens === id
+                    ? "bg-[#61C1C4]/12 text-[#9FE0E2]"
+                    : "text-white/50 hover:bg-white/[0.04] hover:text-white/80"
+                }`}
+              >
+                <span>{label}</span>
+                <span className={`tabular-nums text-[10px] ${lens === id ? "text-[#9FE0E2]/60" : "text-white/25"}`}>
+                  {counts[id]}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/apps/AppsTable.tsx
+++ b/src/components/apps/AppsTable.tsx
@@ -40,6 +40,8 @@ interface AppsTableProps {
   onToggle?: (slug: string, next: boolean) => void;
   onToggleAll?: (next: boolean) => void;
   statusOf?: (app: AppEntry) => AppStatus | null;
+  /** Admin mode: explicit action button next to the status pill. Buttons say the action (Connect / Add key / Manage); pills say the truth. null = nothing to do. */
+  actionOf?: (app: AppEntry) => { label: string; onClick: () => void } | null;
   /** admin: makes the status pill a button (used to open the connect wizard). */
   onStatusClick?: (app: AppEntry) => void;
   busy?: boolean;
@@ -64,7 +66,7 @@ function SortHeader({
   );
 }
 
-export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf, onStatusClick, busy }: AppsTableProps) {
+export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf, onStatusClick, actionOf, busy }: AppsTableProps) {
   const { query, setQuery, category, setCategory, network, setNetwork, sortKey, sortDir, toggleSort, filtered } = useAppFilter(apps);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [showRaw, setShowRaw] = useState(false);
@@ -237,7 +239,27 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
                   <ChevronRight className={`h-3 w-3 transition-transform ${open ? "rotate-90 text-[#61C1C4]" : "text-white/30"}`} />
                   {app.toolCount}
                 </span>
-                <div className="flex justify-end">
+                <div className="flex items-center justify-end gap-1.5">
+                  {isAdmin && actionOf && (() => {
+                    const action = actionOf(app);
+                    if (!action) return null;
+                    return (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          action.onClick();
+                        }}
+                        className={`rounded-md px-2 py-0.5 text-[10px] font-semibold transition-colors ${
+                          action.label === "Manage"
+                            ? "bg-white/[0.05] text-white/55 hover:bg-white/[0.09] hover:text-white/80"
+                            : "bg-[#61C1C4]/15 text-[#9FE0E2] hover:bg-[#61C1C4]/25"
+                        }`}
+                      >
+                        {action.label}
+                      </button>
+                    );
+                  })()}
                   {isAdmin ? (
                     status ? (
                       onStatusClick ? (

--- a/src/components/apps/appLenses.test.ts
+++ b/src/components/apps/appLenses.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  LENSES, POPULAR_SLUGS, setupKindOf, isConnected, actionLabelFor,
+  matchesLens, applyLens, lensCounts, parseAppLens, type LensConnector,
+} from "./appLenses";
+import type { AppEntry } from "@/lib/appCatalog";
+
+const app = (slug: string): AppEntry => ({
+  slug, name: slug, category: "test", blurb: "", domain: null, network: "online",
+  toolCount: 1, tools: [], level: 1, hardened: false,
+} as unknown as AppEntry);
+
+const oauthNoCred: LensConnector = { auth_type: "oauth2", credential: null };
+const keySaved: LensConnector = { auth_type: "api_key", credential: { is_valid: true, last_tested_at: null } };
+const keyTested: LensConnector = { auth_type: "api_key", credential: { is_valid: true, last_tested_at: "2026-06-12" } };
+const botNoCred: LensConnector = { auth_type: "bot_token", credential: null };
+
+describe("appLenses", () => {
+  it("classifies setup kinds from auth_type", () => {
+    expect(setupKindOf(oauthNoCred)).toBe("signin");
+    expect(setupKindOf(keySaved)).toBe("key");
+    expect(setupKindOf(botNoCred)).toBe("key");
+    expect(setupKindOf(undefined)).toBe("builtin");
+  });
+
+  it("connected means a working credential, tested or not", () => {
+    expect(isConnected(keySaved)).toBe(true);
+    expect(isConnected(keyTested)).toBe(true);
+    expect(isConnected(oauthNoCred)).toBe(false);
+    expect(isConnected(undefined)).toBe(false);
+  });
+
+  it("buttons say the action: Connect / Add key / Manage / nothing", () => {
+    expect(actionLabelFor(oauthNoCred)).toBe("Connect");
+    expect(actionLabelFor(botNoCred)).toBe("Add key");
+    expect(actionLabelFor(keyTested)).toBe("Manage");
+    expect(actionLabelFor(undefined)).toBe(null);
+  });
+
+  it("matchesLens covers every lens honestly", () => {
+    const a = app("github");
+    expect(matchesLens(a, "all", undefined)).toBe(true);
+    expect(matchesLens(a, "popular", undefined)).toBe(true);
+    expect(matchesLens(app("obscure-thing"), "popular", undefined)).toBe(false);
+    expect(matchesLens(a, "connected", keyTested)).toBe(true);
+    expect(matchesLens(a, "connected", undefined)).toBe(false);
+    expect(matchesLens(a, "not-connected", oauthNoCred)).toBe(true);
+    // built-in apps are not "not connected": there is nothing to connect
+    expect(matchesLens(a, "not-connected", undefined)).toBe(false);
+    expect(matchesLens(a, "signin", oauthNoCred)).toBe(true);
+    expect(matchesLens(a, "key", botNoCred)).toBe(true);
+    expect(matchesLens(a, "builtin", undefined)).toBe(true);
+  });
+
+  it("applyLens filters one list and never forks it", () => {
+    const apps = [app("github"), app("builtin-calc"), app("xero")];
+    const connectors = new Map<string, LensConnector>([
+      ["github", oauthNoCred],
+      ["xero", keyTested],
+    ]);
+    expect(applyLens(apps, "all", connectors)).toHaveLength(3);
+    expect(applyLens(apps, "connected", connectors).map((a) => a.slug)).toEqual(["xero"]);
+    expect(applyLens(apps, "signin", connectors).map((a) => a.slug)).toEqual(["github"]);
+    expect(applyLens(apps, "builtin", connectors).map((a) => a.slug)).toEqual(["builtin-calc"]);
+  });
+
+  it("lensCounts agrees with applyLens for every lens", () => {
+    const apps = [app("github"), app("builtin-calc"), app("xero"), app("slack")];
+    const connectors = new Map<string, LensConnector>([
+      ["github", oauthNoCred],
+      ["xero", keyTested],
+      ["slack", botNoCred],
+    ]);
+    const counts = lensCounts(apps, connectors);
+    for (const { id } of LENSES) {
+      expect(counts[id], `count for ${id}`).toBe(applyLens(apps, id, connectors).length);
+    }
+  });
+
+  it("parseAppLens is safe on junk", () => {
+    expect(parseAppLens("connected")).toBe("connected");
+    expect(parseAppLens("banana")).toBe("all");
+    expect(parseAppLens(null)).toBe("all");
+  });
+
+  it("popular slugs are lowercase slug-shaped", () => {
+    for (const slug of POPULAR_SLUGS) expect(slug).toMatch(/^[a-z0-9-]+$/);
+  });
+});

--- a/src/components/apps/appLenses.ts
+++ b/src/components/apps/appLenses.ts
@@ -1,0 +1,95 @@
+/**
+ * App lenses: the one-list-many-lenses brain for the admin Apps page.
+ *
+ * Operator's rule (docs/prd/connections-apps-holistic.md): there is exactly
+ * one Apps list; every view is a filter of it, selected through ONE state
+ * shared by the side rail and the top chips. These are the pure parts so the
+ * taxonomy is testable without a DOM.
+ */
+
+import type { AppEntry } from "@/lib/appCatalog";
+
+export type AppLens = "all" | "popular" | "connected" | "not-connected" | "signin" | "key" | "builtin";
+
+export type SetupKind = "signin" | "key" | "builtin";
+
+/** Minimal connector shape the lenses need; matches the admin_tools API rows. */
+export interface LensConnector {
+  auth_type?: "oauth2" | "api_key" | "bot_token";
+  credential: { is_valid: boolean; last_tested_at: string | null } | null;
+}
+
+/** One source array drives the rail, the chips, and the URL contract. */
+export const LENSES: ReadonlyArray<{ id: AppLens; label: string; group: "Library" | "Status" | "Setup" }> = [
+  { id: "all", label: "All", group: "Library" },
+  { id: "popular", label: "Popular", group: "Library" },
+  { id: "connected", label: "Connected", group: "Status" },
+  { id: "not-connected", label: "Not connected", group: "Status" },
+  { id: "signin", label: "Sign-in apps", group: "Setup" },
+  { id: "key", label: "Key apps", group: "Setup" },
+  { id: "builtin", label: "Built-in", group: "Setup" },
+];
+
+/**
+ * Curated starter set, not usage data (we do not have per-app usage analytics
+ * yet; when we do, this becomes a computed list). Checked against catalog
+ * membership at runtime so a stale slug degrades to nothing, never an error.
+ */
+export const POPULAR_SLUGS: ReadonlySet<string> = new Set([
+  "github", "openai", "anthropic", "slack", "notion", "stripe", "discord",
+  "spotify", "vercel", "supabase", "telegram", "reddit", "shopify", "linear",
+  "email", "weather",
+]);
+
+export function setupKindOf(connector: LensConnector | undefined): SetupKind {
+  if (!connector?.auth_type) return "builtin";
+  return connector.auth_type === "oauth2" ? "signin" : "key";
+}
+
+/** Connected = a working credential is on file. The status pill still distinguishes proven (tested) from saved. */
+export function isConnected(connector: LensConnector | undefined): boolean {
+  return Boolean(connector?.credential?.is_valid);
+}
+
+/**
+ * The action button label: buttons say the action, pills say the truth.
+ * null = nothing to do (built-in apps).
+ */
+export function actionLabelFor(connector: LensConnector | undefined): "Connect" | "Add key" | "Manage" | null {
+  const kind = setupKindOf(connector);
+  if (kind === "builtin") return null;
+  if (isConnected(connector)) return "Manage";
+  return kind === "signin" ? "Connect" : "Add key";
+}
+
+export function matchesLens(app: AppEntry, lens: AppLens, connector: LensConnector | undefined): boolean {
+  switch (lens) {
+    case "all": return true;
+    case "popular": return POPULAR_SLUGS.has(app.slug);
+    case "connected": return isConnected(connector);
+    case "not-connected": return Boolean(connector) && !isConnected(connector);
+    case "signin": return setupKindOf(connector) === "signin";
+    case "key": return setupKindOf(connector) === "key";
+    case "builtin": return setupKindOf(connector) === "builtin";
+  }
+}
+
+export function applyLens(apps: AppEntry[], lens: AppLens, connectorBySlug: Map<string, LensConnector>): AppEntry[] {
+  if (lens === "all") return apps;
+  return apps.filter((app) => matchesLens(app, lens, connectorBySlug.get(app.slug)));
+}
+
+export function lensCounts(apps: AppEntry[], connectorBySlug: Map<string, LensConnector>): Record<AppLens, number> {
+  const counts = Object.fromEntries(LENSES.map((l) => [l.id, 0])) as Record<AppLens, number>;
+  for (const app of apps) {
+    const connector = connectorBySlug.get(app.slug);
+    for (const { id } of LENSES) {
+      if (matchesLens(app, id, connector)) counts[id] += 1;
+    }
+  }
+  return counts;
+}
+
+export function parseAppLens(value: string | null | undefined): AppLens {
+  return (LENSES.some((l) => l.id === value) ? value : "all") as AppLens;
+}

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { KeyRound, PenSquare, Sparkles, Wrench } from "lucide-react";
 import { useSession } from "@/lib/auth";
 import { APP_CATALOG, APP_COUNT, TOOL_COUNT, type AppEntry } from "@/lib/appCatalog";
 import { AppsTable, type AppStatus } from "@/components/apps/AppsTable";
 import { ConnectAppModal } from "@/components/apps/ConnectAppModal";
+import { AppLensBar } from "@/components/apps/AppLensBar";
+import { applyLens, lensCounts, actionLabelFor, parseAppLens, type AppLens } from "@/components/apps/appLenses";
 import { AdminAppsIntro } from "./AdminEcosystemPages";
 
 // A connector row as returned by /api/memory-admin?action=admin_tools. Used here
@@ -24,6 +26,24 @@ export default function AdminToolsPage() {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [connectTarget, setConnectTarget] = useState<AppEntry | null>(null);
+  // One filter state, two controls: the rail and the chips both read/write
+  // this URL param, so views are linkable and survive refresh.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const lens = parseAppLens(searchParams.get("lens"));
+  const selectLens = useCallback(
+    (next: AppLens) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          if (next === "all") params.delete("lens");
+          else params.set("lens", next);
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const refreshStatus = useCallback(async () => {
     if (!session) return;
@@ -124,6 +144,16 @@ export default function AdminToolsPage() {
     setConnectTarget(app);
   }
 
+  // Buttons say the action (Connect / Add key / Manage); pills say the truth.
+  function actionOf(app: AppEntry) {
+    const label = actionLabelFor(connectorBySlug.get(app.slug));
+    if (!label) return null;
+    return { label, onClick: () => setConnectTarget(app) };
+  }
+
+  const counts = useMemo(() => lensCounts(APP_CATALOG, connectorBySlug), [connectorBySlug]);
+  const lensedApps = useMemo(() => applyLens(APP_CATALOG, lens, connectorBySlug), [lens, connectorBySlug]);
+
   if (!session) {
     return <p className="text-sm text-white/50">Sign in to manage Apps.</p>;
   }
@@ -153,16 +183,27 @@ export default function AdminToolsPage() {
         </div>
       )}
 
-      <AppsTable
-        apps={APP_CATALOG}
-        mode="admin"
-        enabled={enabled}
-        onToggle={handleToggle}
-        onToggleAll={handleToggleAll}
-        statusOf={statusOf}
-        onStatusClick={handleStatusClick}
-        busy={saving}
-      />
+      <div className="xl:grid xl:grid-cols-[180px_1fr] xl:gap-6">
+        <aside className="hidden xl:block">
+          <AppLensBar variant="rail" lens={lens} counts={counts} onSelect={selectLens} />
+        </aside>
+        <div className="min-w-0">
+          <div className="mb-3">
+            <AppLensBar variant="chips" lens={lens} counts={counts} onSelect={selectLens} />
+          </div>
+          <AppsTable
+            apps={lensedApps}
+            mode="admin"
+            enabled={enabled}
+            onToggle={handleToggle}
+            onToggleAll={handleToggleAll}
+            statusOf={statusOf}
+            onStatusClick={handleStatusClick}
+            actionOf={actionOf}
+            busy={saving}
+          />
+        </div>
+      </div>
 
       {connectTarget && session && connectorBySlug.get(connectTarget.slug) && (
         <ConnectAppModal


### PR DESCRIPTION
## What this is

Operator-directed (2026-06-12): "Apps covers most bases, let's just make use of that page wholistically to have a consistent side menu filtering, but a same filtering in the top section" — plus the Passport-dissolve decision ("could all that be managed in the dropdown of each app?" -> yes -> "ok build"). This is Phase 1 of `docs/prd/connections-apps-holistic.md`.

## What ships

1. **Lens taxonomy** (`src/components/apps/appLenses.ts` + 8 tests): one source array drives everything. Library (All / Popular), Status (Connected / Not connected), Setup (Sign-in apps / Key apps / Built-in, derived from connector `auth_type`). Popular is a curated starter set, catalog-membership-checked, explicitly commented as not-usage-data until we have usage data.
2. **One filter state, two controls** (`AppLensBar.tsx`): the same LENSES array renders as a vertical rail (xl screens) and horizontal chips (always), both reading/writing the same URL-backed state (`/admin/apps?lens=connected` is linkable and survives refresh).
3. **Action buttons** (AppsTable additive `actionOf` prop + AdminTools wiring): buttons say the action — **Connect** (sign-in apps), **Add key** (key apps), **Manage** (connected) — opening the existing ConnectAppModal. Pills keep saying the truth (green Connected only after a real test). Built-in apps show no button. Public /apps page untouched (optional prop, admin mode only).
4. **The thorough plan** (`docs/prd/connections-apps-holistic.md`): principles (one list many lenses; buttons say the action, pills say the truth; truth-locked lenses), the P1-P4 phasing (P2 credential drawer absorbs Passport's reveal/rotate/delete; P3 retires the Passport page with `/admin/keychain` redirect; P4 Websites surface), and explicit supersede of the "Passport keeps its name" line in #1476's IA doc.

## Verification

- Full root vitest: **1739/1739 (214 files)**.
- appLenses: 8/8 including a lensCounts-agrees-with-applyLens invariant.
- Naming ratchet clean; brainmap regenerated and `--check` green (the gate that bit the previous PR); tsc error lines mention none of the touched files.
- Visual check: Vercel preview -> /admin/apps (rail at wide widths, chips on top, lens counts, action buttons). No browser on this seat.

## Coordination

- Claims Boardroom chip `7f9118de` (Apps page lenses). No overlap with #1476 (api/backstagepass.ts and AdminKeychain.tsx untouched here) or #1459. P2 should land after #1476.

https://claude.ai/code/session_018crBViHBRmWbVc6V3q7VDv

---
_Generated by [Claude Code](https://claude.ai/code/session_018crBViHBRmWbVc6V3q7VDv)_