### PR TITLE
Workspace team layer kickoff: plan + Simple Laws docs, Jobs due dates + quick-add

### DIFF
--- a/api/lib/todo-due.test.ts
+++ b/api/lib/todo-due.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { parseDueAtInput } from "./todo-due.js";
+
+describe("parseDueAtInput", () => {
+  it("treats undefined as no change", () => {
+    expect(parseDueAtInput(undefined)).toEqual({ ok: true, value: undefined });
+  });
+
+  it("treats null and empty string as clear", () => {
+    expect(parseDueAtInput(null)).toEqual({ ok: true, value: null });
+    expect(parseDueAtInput("")).toEqual({ ok: true, value: null });
+    expect(parseDueAtInput("   ")).toEqual({ ok: true, value: null });
+  });
+
+  it("normalizes a date-only string to end of that day UTC", () => {
+    const result = parseDueAtInput("2026-06-15");
+    expect(result).toEqual({ ok: true, value: "2026-06-15T23:59:59.999Z" });
+  });
+
+  it("keeps a full ISO timestamp, normalized to UTC", () => {
+    const result = parseDueAtInput("2026-06-15T09:00:00+10:00");
+    expect(result).toEqual({ ok: true, value: "2026-06-14T23:00:00.000Z" });
+  });
+
+  it("rejects non-string non-null values", () => {
+    const result = parseDueAtInput(12345);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects unparseable strings", () => {
+    const result = parseDueAtInput("next tuesday-ish");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("valid date");
+  });
+
+  it("rejects years outside the sane window", () => {
+    expect(parseDueAtInput("1999-12-31").ok).toBe(false);
+    expect(parseDueAtInput("2101-01-01").ok).toBe(false);
+  });
+});

--- a/api/lib/todo-due.ts
+++ b/api/lib/todo-due.ts
@@ -1,0 +1,43 @@
+/**
+ * Due-date input parsing for the Boardroom todo substrate.
+ *
+ * Callers send due_at in three shapes:
+ *   - undefined: field untouched (create: no due date; update: no change)
+ *   - null or "": clear the due date
+ *   - string: any Date-parseable value. Date-only strings ("2026-06-15")
+ *     mean "due by the end of that day", so they normalize to 23:59:59 UTC
+ *     instead of midnight (which would mark the job overdue all day).
+ *
+ * Returns a normalized ISO timestamp (or null to clear, or undefined for
+ * "no change") ready for the due_at column.
+ */
+export type DueAtParse =
+  | { ok: true; value: string | null | undefined }
+  | { ok: false; error: string };
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const MIN_DUE_YEAR = 2000;
+const MAX_DUE_YEAR = 2100;
+
+export function parseDueAtInput(raw: unknown): DueAtParse {
+  if (raw === undefined) return { ok: true, value: undefined };
+  if (raw === null) return { ok: true, value: null };
+  if (typeof raw !== "string") {
+    return { ok: false, error: "due_at must be an ISO date string, an empty string, or null" };
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") return { ok: true, value: null };
+  const candidate = DATE_ONLY.test(trimmed) ? `${trimmed}T23:59:59.999Z` : trimmed;
+  const parsed = new Date(candidate);
+  if (Number.isNaN(parsed.getTime())) {
+    return {
+      ok: false,
+      error: "due_at must be a valid date, e.g. 2026-06-15 or 2026-06-15T09:00:00+10:00",
+    };
+  }
+  const year = parsed.getUTCFullYear();
+  if (year < MIN_DUE_YEAR || year > MAX_DUE_YEAR) {
+    return { ok: false, error: `due_at year must be between ${MIN_DUE_YEAR} and ${MAX_DUE_YEAR}` };
+  }
+  return { ok: true, value: parsed.toISOString() };
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -113,6 +113,7 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { encrypt as keychainEncrypt, hashKeyFull as keychainHashKeyFull } from "../packages/mcp-server/src/keychain-crypto.js";
 import { testCredential as keychainTestCredential } from "../packages/mcp-server/src/keychain-tool.js";
 import { evaluateFishbowlCompletionPolicy } from "./lib/fishbowl-completion-policy.js";
+import { parseDueAtInput } from "./lib/todo-due.js";
 import { inferFishbowlJobPipeline } from "./lib/fishbowl-job-pipeline.js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import { buildRecallFactSections, isRecallVisibleFact } from "./lib/memory-recall-sections.js";
@@ -10810,6 +10811,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             assignee = a;
           }
 
+          const dueRes = parseDueAtInput(body.due_at);
+          if (!dueRes.ok) return res.status(400).json({ error: dueRes.error });
+
           const { data, error } = await supabase
             .from("mc_fishbowl_todos")
             .insert({
@@ -10820,6 +10824,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               status: "open",
               created_by_agent_id: agentId,
               assigned_to_agent_id: assignee,
+              due_at: dueRes.value ?? null,
             })
             .select("*")
             .single();
@@ -10937,6 +10942,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             const a = String(body.assigned_to_agent_id ?? "").trim();
             if (a.length > 128) return res.status(400).json({ error: "assigned_to_agent_id must be at most 128 characters" });
             update.assigned_to_agent_id = a.length === 0 ? null : a;
+          }
+          if (body.due_at !== undefined) {
+            const dueRes = parseDueAtInput(body.due_at);
+            if (!dueRes.ok) return res.status(400).json({ error: dueRes.error });
+            if (dueRes.value !== undefined) update.due_at = dueRes.value;
           }
 
           if (update.status === "done" && beforeTodo) {

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16207,8 +16207,8 @@
     },
     {
       "source": "src/pages/admin/AdminJobs.tsx",
-      "hash": "e891d0a7df9e",
-      "bytes": 65839
+      "hash": "5d4ff9ca88ab",
+      "bytes": 75369
     },
     {
       "source": "src/pages/admin/AdminJobsmith.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -101,7 +101,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/crews/CrewsSettings.tsx | 9a2037783312 | 889 |
 | src/pages/admin/crews/CrewsCatalog.tsx | 53d4116c6739 | 5945 |
 | src/pages/admin/AdminDashboard.tsx | e38f909e6d5b | 7090 |
-| src/pages/admin/AdminJobs.tsx | e891d0a7df9e | 65839 |
+| src/pages/admin/AdminJobs.tsx | 5d4ff9ca88ab | 75369 |
 | src/pages/admin/AdminJobsmith.tsx | fd2aad657f06 | 54734 |
 | src/pages/admin/AdminKeychain.tsx | b8e0f75ecee7 | 78511 |
 | src/pages/admin/AdminMemory.tsx | 25b2ecae9ca8 | 10814 |

--- a/docs/prd/workspace-team-layer-plan.md
+++ b/docs/prd/workspace-team-layer-plan.md
@@ -1,0 +1,158 @@
+# Workspace Team Layer: the staged build plan and scope contract
+
+Status: operator-approved build direction, 2026-06-12. This is the buildable companion to `docs/prd/workspace-team-layer-brief.md` (the strategy capsule) and `docs/workspace-simple-laws.md` (the UX gate).
+Decisions below were made by the operator in the planning thread on 2026-06-12. Do not relitigate them in build PRs; flag new evidence in the Boardroom instead.
+
+## The one-paragraph version
+
+UnClick enters the workspace category as the verification-and-attribution layer over a bring-your-own-AI stack. We build the daily-use 80/20 natively on the existing substrate (jobs with proof, Boardroom, memory, seats, Circle) and we aggregate calendar, email, and incumbent task tools instead of owning them. Two moats, working together: proof that work is real, and screens a brand-new person can use with zero documentation.
+
+## Locked decisions (operator, 2026-06-12)
+
+- **Inbox is its own surface**, separate from Signals, and serves both humans (admin UI) and agents (MCP). Signals stays UnClick's own alert bus and is never an aggregator.
+- **Stage 0 approved:** Google and Microsoft OAuth join the Connections flow. Security lane rules apply (operator approval given for the lane; credential code still follows the hardening plan).
+- **Today strip lands on the existing Dashboard**, which also gets a tidy-up.
+- **Chat (Human to Human) is planned.** Hard rule: no AI subscription bots in Chat, ever (tried before, failed). AI joins only as API seats, summoned by @-mention or by tapping the seat in the members rail, governed from Agents > Seats > API with SpendGate in the loop. Default OFF per seat.
+- **One owner per job.** The independent verifier is the second person. No multiple assignees.
+- **Simplicity is a moat.** The Simple Laws gate every workspace screen.
+- Build order: Circle first (unblocks attribution and Chat), native Jobs chips and Calendar in parallel, then Inbox, then Jobs Bridge, then Chat.
+
+## Stages
+
+| Stage | What ships | Notes |
+|---|---|---|
+| 0 | Google + Microsoft OAuth in Connections; calendar and mail read connectors | Embed permissive libraries only (rrule.js wrapped, ICAL.js, tsdav, ImapFlow). Never AGPL. Existing IMAP/SMTP email tool stays as the long-tail fallback |
+| 1 | Circle + You Profile (name + thumbnail) | Per `docs/prd/connections-circle.md`, already greenlit |
+| 2a | Native Jobs 80/20 chips | Due dates (first chip, shipped with this plan), My Jobs / Today view, quick-add (shipped with this plan), checklists, project grouping, recurring later |
+| 2b | Calendar read layer at /admin/calendar | Merged Day/Week view across all connected accounts, duplicate collapse, source badges, timezone and location aware. Read first; write-back waits |
+| 3 | Inbox at /admin/inbox | Merged mail triage: read, Assign (human or AI seat), Make a Job, Archive. Reply deep-links back to the provider; UnClick never sends mail |
+| 4 | Four-way Jobs matrix finish + Jobs Bridge | Circle "can assign me jobs" toggle; face + seat attribution on every assignment; live read layer over Asana, ClickUp, monday, Todoist, Trello, Linear, Jira, Notion, Shortcut via existing connectors with promote-to-verified-Job |
+| 5 | Chat | Channels, DMs, threads, search, @mentions. Nothing else. Requires Circle |
+| each | Today strip grows one tile per stage on the Dashboard | The first tile ships with the Dashboard tidy-up |
+
+Dogfood gate between every stage: the internal team runs a full week with zero fallback for that surface's core loop, with XPass receipts on the build, before the next stage starts or any public claim is made.
+
+## Admin tree (target state)
+
+```text
+Dashboard                      Today strip (calendar / inbox / jobs due) + tidy-up
+
+HUMAN
+├── You                        Profile (name + thumbnail) NEW, Keys, AI Style
+├── Memory                     unchanged
+├── Orchestrator               unchanged
+├── Connections                Apps (+ Google, Microsoft OAuth) / Circle NEW / Health NEW
+├── Calendar                   NEW merged read view, Day / Week
+├── Inbox                      NEW merged mail triage, humans in UI + agents via MCP
+├── Chat                       NEW human-to-human; API seats only via @-mention
+├── Jobs (Human)               + due dates, quick-add, attribution, Bridge tasks
+├── Signals                    unchanged: UnClick's own alerts only
+├── Settings / Billing         unchanged
+
+AGENTS                         unchanged, except Seats > API gains the
+                               per-seat "Can join Chat when @-mentioned" toggle
+
+ADMIN (internal)               unchanged
+```
+
+## Naming (rename-safe rule applies)
+
+New display names live only in `src/config/product-names.ts`; internal identifiers stay neutral.
+
+| Display name | Internal identifiers | Notes |
+|---|---|---|
+| Calendar | `calendar_events`, `/api/calendar-*` | Plain English wins |
+| Inbox | `mail_threads`, `/api/mail-*` | "Signals" stays reserved for UnClick's own bus |
+| Chat | `chat_channels`, `chat_messages`, `/api/chat-*` | Rooms, Boardroom, Crews, Circle, Seats, Members all stay reserved |
+
+## Feature scope matrix (the contract)
+
+Status keys: SHIPPED (exists today), BUILD (in the staged plan), IDEA (approved idea pass, slots when its stage lands), LATER (agreed but explicitly after dogfood), OUT (deliberately refused; needs operator decision to revisit).
+
+### Tasks core
+| Feature | Status |
+|---|---|
+| Tasks with a named owner | SHIPPED |
+| Due dates + reminders | BUILD (2a; due dates shipped with this plan, Signals reminders to follow) |
+| My Jobs / Today view | BUILD (2a) |
+| Quick add | BUILD (2a; shipped with this plan) |
+| Subtasks / checklists | BUILD (2a) |
+| Recurring jobs | BUILD (2a, later chip; reuse the wrapped recurrence library from Calendar work) |
+| Projects / grouping for the human lane | BUILD (2a) |
+| Sections, priorities, comments, proof states, approvals-as-gates | SHIPPED |
+| @mentions in job comments | BUILD (with Chat stage) |
+| File attachments on jobs | BUILD (minimal) |
+| Task dependencies | LATER (parked; revisit only if dogfood screams) |
+| Multiple assignees | OUT (one owner + independent verifier) |
+| Start dates, custom fields, template galleries, time tracking, goals/OKRs, workload view, milestones | OUT |
+
+### Views
+| Feature | Status |
+|---|---|
+| List view, agent kanban | SHIPPED |
+| Board toggle for human lane | BUILD (2a) |
+| Jobs with due dates appear on Calendar | BUILD (2b) |
+| Timeline/Gantt, spreadsheet view, mind maps, whiteboards, custom dashboards | OUT |
+
+### Chat and communication
+| Feature | Status |
+|---|---|
+| Channels, DMs, threads, @mentions, search | BUILD (5) |
+| Emoji reactions | BUILD (5; it is how humans say "seen") |
+| File sharing in chat (minimal) | BUILD (5) |
+| Human presence | LATER (Yjs, only if pulled) |
+| Huddles, video calls, screen share, clips, canvas, external guest access | OUT |
+
+### Calendar and scheduling
+| Feature | Status |
+|---|---|
+| Merged Day/Week view, duplicate collapse, timezones and locations | BUILD (2b) |
+| Event reminders via Signals | BUILD (2b) |
+| Accept/decline invites, create/reschedule, find-a-time | LATER (write-back wave, after the read layer proves) |
+| Booking pages, auto meeting links | OUT until pulled |
+
+### Email and inbox
+| Feature | Status |
+|---|---|
+| Unified inbox, triage (Assign / Make a Job / Archive), email becomes a job | BUILD (3) |
+| Email-in capture address | IDEA (rides 3) |
+| Snooze | LATER |
+| Sending or replying inside UnClick | OUT (deep-link back; the provider keeps deliverability) |
+| Hosting email or CalDAV | OUT permanently |
+
+### Docs and knowledge
+| Feature | Status |
+|---|---|
+| Notes, files, library | SHIPPED (Memory) |
+| Forms / intake that create jobs | LATER (research phase two) |
+| AI meeting notes that become jobs | IDEA (aggregate via existing transcription connector; no video product) |
+| Full docs/wiki editor, databases | OUT |
+
+### Automation, AI, reporting
+| Feature | Status |
+|---|---|
+| Agents as teammates, automations-as-agents, audit ledger | SHIPPED |
+| Morning Brief (Today strip card) | IDEA (top pick) |
+| Status that writes itself (from receipts) | IDEA (top pick) |
+| Ask the workspace (cross-surface plain-English answers) | IDEA (top pick, next wave) |
+| Agent timesheet (what my AI did this week and cost) | IDEA (next wave) |
+| Switch-from-Asana coexistence wizard | IDEA (rides 4) |
+| Bundled AI assistant | OUT (bring-your-own-AI is the moat) |
+| Dashboards, charts, time reports | OUT |
+
+### People, capture, platform
+| Feature | Status |
+|---|---|
+| Profiles with faces | BUILD (1) |
+| Sharing permissions (both-sides opt-in) | BUILD (1, Circle) |
+| Live import bridge from incumbent task tools | BUILD (4) |
+| Workspaces / org container | OUT (the word "Members" stays reserved for it) |
+| Mobile apps, offline | OUT for now (web core loop first) |
+
+## Constraints carried from the brief (non-negotiable)
+
+- Truth-locked claims only; public surfaces stay pricing-neutral in beta; no competitor comparisons until the lane works in-house.
+- Naming registry and the rename rule bind every new feature.
+- No em dashes in code or content. Plain-English UI voice (see Simple Laws).
+- Security lanes (credentials, auth, billing, DNS, migrations) follow FLEET_SYNC approval rules.
+- Build with the fleet, verify with XPass, file human-needed steps as Jobs (Human). The build process dogfoods the product.

--- a/docs/workspace-simple-laws.md
+++ b/docs/workspace-simple-laws.md
@@ -1,0 +1,32 @@
+# Workspace Simple Laws
+
+Status: operator-approved direction, 2026-06-12. Binding on every workspace surface (Jobs, Calendar, Inbox, Chat, Circle, Dashboard Today strip).
+Companion: `docs/prd/workspace-team-layer-plan.md` (the staged build plan and scope contract).
+
+## Why this document exists
+
+The operator's words: the goal is to be "super simple to use, easy english". He tried ClickUp once, was extremely confused, and did not enjoy it. Review mining across Asana, monday, and ClickUp shows the same top complaints everywhere: too many features, notification spam, steep learning curve. Bloat is how incumbents raise prices per tier, which means they cannot simplify without breaking their pricing ladder. UnClick can start simple and stay simple. Simplicity is a moat, alongside verified work.
+
+So this is not a style guide. It is a release gate. A workspace screen that breaks these laws does not ship.
+
+## The laws
+
+1. **One obvious view per surface.** Jobs opens to Today. Calendar opens to Day. Inbox opens to the queue. No view-picker carousel.
+2. **Easy English everywhere.** Banned words in workspace UI copy: sprint, portfolio, workload, capacity, custom field, automation builder, orchestration. Preferred words: job, today, done, proof, who, when.
+3. **Every toggle gets one sentence of consequence.** The Circle pattern ("Alex will be able to read your memory. You can stop this any time.") is the template for all surfaces.
+4. **Zero setup before value.** No templates to pick, no workspace wizard, no column configuration. Defaults work; the first screen is already useful.
+5. **Power hides behind "More".** Progressive disclosure: filters, bulk actions, and advanced options exist but the default screen never shows them.
+6. **The zero-doc test.** A brand-new person must complete the core loop (capture, assign, done) with no tour, no tooltip trail, no docs. If a screen needs a tour, the screen failed and goes back.
+7. **Three actions max on any row.** Example: an Inbox thread offers Assign, Make a Job, Archive. Nothing else on the row.
+
+## Enforcement (machinery that already exists)
+
+- **CopyPass simplicity pack:** every new workspace screen's copy runs through CopyPass with the banned-word list and a plain-reading-level target. Fail blocks the ship, like any other receipt.
+- **UXPass zero-doc journey pack:** the core loop of each surface is a UXPass journey run by a fresh-context agent with zero instructions. If the agent cannot complete it from the screen alone, a new human cannot either.
+- **Dogfood gate:** each build stage needs a full week of the internal team running the surface with no fallback tool, plus a zero-doc pass, before any public claim.
+
+No new XPass product is created for this. Simplicity packs ride on CopyPass and UXPass.
+
+## Scope discipline reminder
+
+The feature boundary lives in the plan document's feature matrix. The deliberately-refused list (Gantt, time tracking, whiteboards, custom fields, dashboards, bundled AI assistant, hosted email) is part of the product, not a gap. When real use pulls a refused feature, the pull gets recorded and decided by the operator; it does not slide in through a side door.

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -864,6 +864,11 @@ export const VISIBLE_TOOLS = [
         description: { type: "string", description: "Optional longer description (max 4000 chars)" },
         priority: { type: "string", enum: ["low", "normal", "high", "urgent"], default: "normal" },
         assigned_to_agent_id: { type: "string", description: "Optional agent_id of the agent who should own this todo" },
+        due_at: {
+          type: "string",
+          description:
+            "Optional due date in ISO format. A date-only value like 2026-06-15 means due by the end of that day.",
+        },
       },
       required: ["agent_id", "title"],
     },
@@ -938,7 +943,7 @@ export const VISIBLE_TOOLS = [
     name: "update_todo",
     title: "Update a Boardroom todo",
     description:
-      "Update a todo's title, description, priority, status, or assignee. Use when scope changes, ownership shifts, or you move it between kanban columns ('open', 'in_progress', 'done', 'dropped'). agent_id required for attribution.",
+      "Update a todo's title, description, priority, status, assignee, or due date. Use when scope changes, ownership shifts, or you move it between kanban columns ('open', 'in_progress', 'done', 'dropped'). agent_id required for attribution.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
@@ -950,6 +955,11 @@ export const VISIBLE_TOOLS = [
         status: { type: "string", enum: ["open", "in_progress", "done", "dropped"] },
         priority: { type: "string", enum: ["low", "normal", "high", "urgent"] },
         assigned_to_agent_id: { type: "string", description: "Pass empty string to unassign" },
+        due_at: {
+          type: "string",
+          description:
+            "Optional due date in ISO format. A date-only value like 2026-06-15 means due by the end of that day. Pass empty string to clear.",
+        },
       },
       required: ["agent_id", "todo_id"],
     },

--- a/scripts/boardroom-naming-baseline.json
+++ b/scripts/boardroom-naming-baseline.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Boardroom naming ratchet baseline. Per-file count of legacy 'fishbowl'/'popcorn' occurrences (path + content, case-insensitive substring). CI fails when any count grows (new legacy references are banned) or when it shrinks without this file being regenerated. Regenerate with: npm run boardroom:baseline. Policy: docs/fishbowl-compat-map.md.",
-  "total_legacy_occurrences": 1607,
-  "file_count": 179,
+  "total_legacy_occurrences": 1612,
+  "file_count": 180,
   "files": {
     ".claude/agents/heartbeat.md": 3,
     ".github/architecture-qc-checklist.md": 4,
@@ -160,7 +160,7 @@
     "src/pages/admin/AdminControlTower.tsx": 3,
     "src/pages/admin/AdminEcosystemPages.test.tsx": 1,
     "src/pages/admin/AdminJobs.test.tsx": 6,
-    "src/pages/admin/AdminJobs.tsx": 3,
+    "src/pages/admin/AdminJobs.tsx": 5,
     "src/pages/admin/Boardroom.tsx": 3,
     "src/pages/admin/boardroom/Comments.tsx": 2,
     "src/pages/admin/boardroom/Ideas.tsx": 5,
@@ -179,6 +179,7 @@
     "supabase/migrations/20260520050000_expressroom_manual_builds.sql": 1,
     "supabase/migrations/20260601000000_eval_routing_and_job_proof_columns.sql": 2,
     "supabase/migrations/20260602080000_seat_identity_and_posted_at.sql": 4,
+    "supabase/migrations/20260612143000_todos_due_at.sql": 3,
     "tests/crews-eval/seed.json": 1,
     "tests/rotatepass/fixtures/system-credentials.metadata.json": 1,
     "vercel.json": 1

--- a/src/pages/admin/AdminJobs.test.tsx
+++ b/src/pages/admin/AdminJobs.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdminJobs, {
   JOBS_REFRESH_INTERVAL_MS,
   displayCopyFor,
+  dueBadge,
   matchesJobSearch,
   simplifyJobTitle,
   statusLabel,
@@ -375,5 +376,28 @@ describe("AdminJobs copy and search helpers (characterization)", () => {
     expect(statusLabel("needs_proof")).toBe("needs proof");
     expect(statusLabel("in_progress")).toBe("active");
     expect(statusLabel("open")).toBe("open");
+  });
+
+  it("dueBadge speaks plain English: overdue, due today, due tomorrow", () => {
+    const now = new Date(2026, 5, 12, 9, 0, 0);
+    const withDue = (dueAt: string) => ({ ...baseTodo, due_at: dueAt }) as Parameters<typeof dueBadge>[0];
+    expect(dueBadge(withDue(new Date(2026, 5, 11, 23, 59).toISOString()), now)?.label).toBe("overdue");
+    expect(dueBadge(withDue(new Date(2026, 5, 12, 23, 59).toISOString()), now)?.label).toBe("due today");
+    expect(dueBadge(withDue(new Date(2026, 5, 13, 23, 59).toISOString()), now)?.label).toBe("due tomorrow");
+    expect(dueBadge(withDue(new Date(2026, 5, 20, 23, 59).toISOString()), now)?.label).toMatch(/^due /);
+  });
+
+  it("dueBadge stays quiet when there is nothing to chase", () => {
+    expect(dueBadge(baseTodo)).toBeNull();
+    const doneTodo = {
+      ...baseTodo,
+      status: "done",
+      effective_status: "done",
+      completed_at: "2026-06-10T02:00:00Z",
+      due_at: "2026-06-01T00:00:00Z",
+    } as Parameters<typeof dueBadge>[0];
+    expect(dueBadge(doneTodo)).toBeNull();
+    const badDate = { ...baseTodo, due_at: "not-a-date" } as Parameters<typeof dueBadge>[0];
+    expect(dueBadge(badDate)).toBeNull();
   });
 });

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -51,6 +51,7 @@ interface JobTodo {
   created_by_agent_id: string;
   assigned_to_agent_id: string | null;
   source_idea_id?: string | null;
+  due_at?: string | null;
   created_at: string;
   completed_at: string | null;
   updated_at: string;
@@ -285,6 +286,52 @@ export function statusLabel(status: DisplayStatus): string {
   if (status === "needs_proof") return "needs proof";
   if (status === "in_progress") return "active";
   return status.replace("_", " ");
+}
+
+/** Whole-day difference between the due date and today, in local time. */
+function dueDayDiff(dueAt: string, now = new Date()): number | null {
+  const due = new Date(dueAt);
+  if (Number.isNaN(due.getTime())) return null;
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  return Math.round((startOfDay(due) - startOfDay(now)) / 86_400_000);
+}
+
+/**
+ * Plain-English due chip for a job row. Red is reserved for overdue (genuine
+ * urgency), amber for due today, neutral for everything later. Finished and
+ * dropped jobs show no chip: their due date no longer needs attention.
+ */
+export function dueBadge(
+  todo: JobTodo,
+  now = new Date(),
+): { label: string; className: string } | null {
+  if (!todo.due_at) return null;
+  const displayStatus = displayStatusFor(todo);
+  if (displayStatus === "done" || displayStatus === "dropped") return null;
+  const diff = dueDayDiff(todo.due_at, now);
+  if (diff == null) return null;
+  if (diff < 0) return { label: "overdue", className: "border-red-300/30 bg-red-500/10 text-red-200" };
+  if (diff === 0) return { label: "due today", className: "border-[#E2B93B]/35 bg-[#E2B93B]/12 text-[#E8C766]" };
+  if (diff === 1) return { label: "due tomorrow", className: "border-white/12 bg-white/[0.04] text-white/55" };
+  const label = `due ${new Date(todo.due_at).toLocaleDateString(undefined, { day: "numeric", month: "short" })}`;
+  return { label, className: "border-white/[0.08] bg-white/[0.03] text-white/45" };
+}
+
+/** "2026-06-15T13:59:59.999Z" -> "2026-06-15" in local time, for date inputs. */
+function isoToDateInput(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** "2026-06-15" from a date input -> local end-of-day ISO, so the job stays due all day. */
+function dateInputToIso(value: string): string | null {
+  if (!value) return null;
+  const [y, m, d] = value.split("-").map(Number);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d, 23, 59, 59, 999).toISOString();
 }
 
 function syncSignalFor(todo: JobTodo): JobGithubSyncSignal {
@@ -688,6 +735,7 @@ function JobRow({
   onDragEnd,
   onDrop,
   searchQuery,
+  onDueChange,
 }: {
   todo: JobTodo;
   queueRank: number;
@@ -700,11 +748,32 @@ function JobRow({
   onDragEnd: () => void;
   onDrop: (id: string) => void;
   searchQuery: string;
+  onDueChange: (id: string, dueAt: string | null) => void;
 }) {
   const attention = needsAttention(todo);
   const description = todo.description?.trim();
   const [showDetails, setShowDetails] = useState(false);
   const [showComments, setShowComments] = useState(false);
+  const [dueSaving, setDueSaving] = useState(false);
+
+  // Setting a due date is a normal update on the todo substrate; the admin
+  // profile (human-*) carries attribution like any other write.
+  const saveDue = async (nextIso: string | null) => {
+    if (!humanAgentId || dueSaving) return;
+    setDueSaving(true);
+    try {
+      const res = await fetch("/api/memory-admin?action=fishbowl_update_todo", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ agent_id: humanAgentId, todo_id: todo.id, due_at: nextIso ?? "" }),
+      });
+      if (res.ok) onDueChange(todo.id, nextIso);
+    } catch {
+      // Leave the previous value in place; the next poll re-syncs the row.
+    } finally {
+      setDueSaving(false);
+    }
+  };
   const rawOwner = todo.assigned_to_agent_id?.trim() || "unassigned";
   const alert = attention ? attentionCopy(todo) : null;
   const emoji = ownerEmoji(todo);
@@ -781,8 +850,20 @@ function JobRow({
           >
             {highlightSearchText(displayCopy.title, searchQuery)}
           </p>
-          <p className="truncate text-[10px] leading-4 text-white/35">
-            {highlightSearchText(displayCopy.summary, searchQuery)}
+          <p className="flex items-center gap-1 text-[10px] leading-4 text-white/35">
+            {(() => {
+              const due = dueBadge(todo);
+              return due ? (
+                <span
+                  className={`shrink-0 rounded-[4px] border px-[3px] py-px text-[9px] font-semibold uppercase ${due.className}`}
+                  title={todo.due_at ? new Date(todo.due_at).toLocaleString() : undefined}
+                  data-testid="job-due-badge"
+                >
+                  {due.label}
+                </span>
+              ) : null;
+            })()}
+            <span className="min-w-0 truncate">{highlightSearchText(displayCopy.summary, searchQuery)}</span>
           </p>
         </div>
 
@@ -841,10 +922,40 @@ function JobRow({
 
       {expanded && (
         <div className="mx-3 mb-2 space-y-2 rounded-md border border-white/[0.06] bg-white/[0.03] p-2.5">
-          <div className="grid gap-3 text-xs text-white/50 sm:grid-cols-5">
+          <div className="grid gap-3 text-xs text-white/50 sm:grid-cols-6">
             <div>
               <span className="block text-[10px] uppercase tracking-wide text-white/30">Created</span>
               <span>{relativeTime(todo.created_at)}</span>
+            </div>
+            <div>
+              <span className="block text-[10px] uppercase tracking-wide text-white/30">Due</span>
+              {humanAgentId ? (
+                <span className="mt-0.5 flex items-center gap-1">
+                  <input
+                    type="date"
+                    value={isoToDateInput(todo.due_at)}
+                    disabled={dueSaving}
+                    onChange={(event) => void saveDue(dateInputToIso(event.target.value))}
+                    className="rounded-[4px] border border-white/[0.08] bg-white/[0.03] px-1 py-0.5 text-[11px] text-white/60 outline-none [color-scheme:dark] focus:border-[#61C1C4]/35 disabled:opacity-50"
+                    aria-label="Due date"
+                    data-testid="job-due-input"
+                  />
+                  {todo.due_at && (
+                    <button
+                      type="button"
+                      disabled={dueSaving}
+                      onClick={() => void saveDue(null)}
+                      className="rounded-[4px] p-0.5 text-white/35 hover:bg-white/[0.06] hover:text-white/65 disabled:opacity-50"
+                      aria-label="Clear due date"
+                      title="Clear due date"
+                    >
+                      <X className="h-3 w-3" aria-hidden="true" />
+                    </button>
+                  )}
+                </span>
+              ) : (
+                <span>{todo.due_at ? new Date(todo.due_at).toLocaleDateString() : "None"}</span>
+              )}
             </div>
             <div>
               <span className="block text-[10px] uppercase tracking-wide text-white/30">Worker</span>
@@ -956,6 +1067,7 @@ function JobSection({
   showMoreLoading,
   loading,
   searchQuery,
+  onDueChange,
 }: {
   sectionKey: JobSectionKey;
   jobs: JobTodo[];
@@ -965,6 +1077,7 @@ function JobSection({
   humanAgentId: string | null;
   pollSeq: number;
   onMoveJob: (sectionKey: JobSectionKey, sourceId: string, targetId: string) => void;
+  onDueChange: (id: string, dueAt: string | null) => void;
   sectionExpanded?: boolean;
   visibleCount?: number;
   totalCount?: number;
@@ -1081,6 +1194,7 @@ function JobSection({
                 setDraggedId(null);
               }}
               searchQuery={searchQuery}
+              onDueChange={onDueChange}
             />
           ))}
           {canShowMore && (
@@ -1221,6 +1335,10 @@ export default function AdminJobs() {
   const [manualOrder, setManualOrder] = useState<ManualOrder>(() => loadManualOrder());
   const [sectionPrefs, setSectionPrefs] = useState<SectionPreferences>(() => loadSectionPreferences());
   const [searchQuery, setSearchQuery] = useState("");
+  const [quickTitle, setQuickTitle] = useState("");
+  const [quickDue, setQuickDue] = useState("");
+  const [quickAddBusy, setQuickAddBusy] = useState(false);
+  const [quickAddError, setQuickAddError] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const laneFilter = parseLaneFilter(searchParams.get("lane"));
   const setLaneFilter = useCallback(
@@ -1238,6 +1356,13 @@ export default function AdminJobs() {
     [setSearchParams],
   );
   const jobsReadAgentId = humanAgentId ?? (token ? ADMIN_JOBS_READ_AGENT_ID : null);
+
+  // Optimistic due-date sync so an edited row reflects the change immediately;
+  // the next poll confirms it from the server.
+  const handleDueChange = useCallback((id: string, dueAt: string | null) => {
+    setTodos((prev) => prev.map((todo) => (todo.id === id ? { ...todo, due_at: dueAt } : todo)));
+    setCompletedHistory((prev) => prev.map((todo) => (todo.id === id ? { ...todo, due_at: dueAt } : todo)));
+  }, []);
 
   useEffect(() => {
     if (!token) {
@@ -1571,6 +1696,73 @@ export default function AdminJobs() {
         </div>
       )}
 
+      {humanAgentId && (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            const title = quickTitle.trim();
+            if (!title || quickAddBusy) return;
+            setQuickAddBusy(true);
+            setQuickAddError(null);
+            void (async () => {
+              try {
+                const res = await fetch("/api/memory-admin?action=fishbowl_create_todo", {
+                  method: "POST",
+                  headers: { ...authHeader, "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    agent_id: humanAgentId,
+                    title,
+                    // Adding from the Human lane files the job to yourself;
+                    // anywhere else it lands unassigned for the agent queue.
+                    ...(laneFilter === "human" ? { assigned_to_agent_id: humanAgentId } : {}),
+                    ...(quickDue ? { due_at: dateInputToIso(quickDue) } : {}),
+                  }),
+                });
+                const body = (await res.json().catch(() => ({}))) as { todo?: JobTodo; error?: string };
+                if (!res.ok) throw new Error(body.error ?? "Could not add the job");
+                if (body.todo) setTodos((prev) => [body.todo as JobTodo, ...prev]);
+                setQuickTitle("");
+                setQuickDue("");
+              } catch (e) {
+                setQuickAddError(e instanceof Error ? e.message : "Could not add the job");
+              } finally {
+                setQuickAddBusy(false);
+              }
+            })();
+          }}
+          className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2"
+        >
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              type="text"
+              value={quickTitle}
+              onChange={(event) => setQuickTitle(event.target.value)}
+              placeholder={laneFilter === "human" ? "Add a job for you, press Enter" : "Add a job, press Enter"}
+              maxLength={200}
+              className="min-w-0 flex-1 rounded-md border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-sm text-white/80 outline-none transition-colors placeholder:text-white/25 focus:border-[#61C1C4]/35"
+              aria-label="New job title"
+              data-testid="job-quick-add-input"
+            />
+            <input
+              type="date"
+              value={quickDue}
+              onChange={(event) => setQuickDue(event.target.value)}
+              className="rounded-md border border-white/[0.06] bg-white/[0.03] px-2 py-2 text-sm text-white/60 outline-none [color-scheme:dark] focus:border-[#61C1C4]/35"
+              aria-label="Due date (optional)"
+              title="Due date (optional)"
+            />
+            <button
+              type="submit"
+              disabled={!quickTitle.trim() || quickAddBusy}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md border border-[#61C1C4]/30 bg-[#61C1C4]/10 px-4 py-2 text-sm font-medium text-[#8EE8EB] transition-colors hover:bg-[#61C1C4]/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {quickAddBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Add"}
+            </button>
+          </div>
+          {quickAddError && <p className="mt-2 text-xs text-red-300">{quickAddError}</p>}
+        </form>
+      )}
+
       <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2">
         <div className="mb-2 flex items-center gap-1.5" role="tablist" aria-label="Job lane">
           {([
@@ -1641,6 +1833,7 @@ export default function AdminJobs() {
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
           onMoveJob={moveJob}
+          onDueChange={handleDueChange}
           sectionExpanded={sectionPrefs.expanded.active}
           visibleCount={sectionPrefs.visible.active}
           onToggleSection={() => toggleSection("active")}
@@ -1657,6 +1850,7 @@ export default function AdminJobs() {
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
           onMoveJob={moveJob}
+          onDueChange={handleDueChange}
           sectionExpanded={sectionPrefs.expanded.next}
           visibleCount={sectionPrefs.visible.next}
           onToggleSection={() => toggleSection("next")}
@@ -1673,6 +1867,7 @@ export default function AdminJobs() {
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
           onMoveJob={moveJob}
+          onDueChange={handleDueChange}
           sectionExpanded={sectionPrefs.expanded.inline}
           visibleCount={sectionPrefs.visible.inline}
           onToggleSection={() => toggleSection("inline")}
@@ -1689,6 +1884,7 @@ export default function AdminJobs() {
           humanAgentId={humanAgentId}
           pollSeq={pollSeq}
           onMoveJob={moveJob}
+          onDueChange={handleDueChange}
           sectionExpanded={sectionPrefs.expanded.done}
           visibleCount={sectionPrefs.visible.done}
           totalCount={completedSectionTotal}

--- a/supabase/migrations/20260612143000_todos_due_at.sql
+++ b/supabase/migrations/20260612143000_todos_due_at.sql
@@ -1,0 +1,14 @@
+-- Jobs due dates (workspace team layer, Stage 2a chip 1).
+-- Adds an optional due_at timestamp to the todo substrate so both job lanes
+-- can answer "what is due today". Additive and reversible: nullable column,
+-- nothing existing reads it, dropping the column restores the prior shape.
+--
+-- Idempotent: guarded with IF NOT EXISTS so re-applying is a safe no-op.
+
+ALTER TABLE mc_fishbowl_todos
+  ADD COLUMN IF NOT EXISTS due_at timestamptz;
+
+-- Partial index for "due soon" reads; skips the many rows with no due date.
+CREATE INDEX IF NOT EXISTS idx_mc_fishbowl_todos_tenant_due
+  ON mc_fishbowl_todos(api_key_hash, due_at)
+  WHERE due_at IS NOT NULL;


### PR DESCRIPTION
## What this is

The operator-approved kickoff of the workspace team layer (planning thread, 2026-06-12). Two pieces, both tidy and reversible:

### 1. The scope contract (docs)
- `docs/prd/workspace-team-layer-plan.md`: locked decisions (Inbox serves agents AND humans, separate from Signals; Chat rules with **no AI subscription bots**, API seats only via @-mention; one owner per job), the staged build order (Circle -> Jobs chips + Calendar -> Inbox -> Bridge -> Chat), target admin tree, rename-safe naming, and the full feature matrix (SHIPPED / BUILD / IDEA / LATER / OUT).
- `docs/workspace-simple-laws.md`: "super simple, easy English" as an enforceable release gate (CopyPass banned-word pack, UXPass zero-doc journey, dogfood week), not a vibe.

### 2. First Stage 2a chip: due dates + quick-add on the Jobs substrate
The substrate had no due date at all (confirmed by grep before building). Now:
- **Migration (additive, idempotent, reversible):** nullable `due_at` on `mc_fishbowl_todos` + partial index. Nothing existing reads it; dropping the column restores the prior shape.
- **API:** `create`/`update` todo accept `due_at`. Date-only values ("2026-06-15") mean end of that day; empty string clears. Validation isolated in `api/lib/todo-due.ts` with tests.
- **MCP:** `create_todo` / `update_todo` schemas expose `due_at`, so agents set due dates the same way humans do.
- **Jobs board:** plain-English due chips (overdue / due today / due tomorrow / due 15 Jun; red reserved for overdue per the board palette), a due-date editor in the expanded row, and a one-line quick-add bar (Enter to add, optional date, files to yourself from the Human lane).

### Naming baseline bump (deliberate)
The migration and admin fetch calls touch the live `fishbowl_*` contract (table + action names), which `docs/fishbowl-compat-map.md` keeps as the internal delivery address. `npm run boardroom:baseline` regenerated; no user-facing Fishbowl wording anywhere.

## Proof
- `npx vitest run api/lib/todo-due.test.ts src/pages/admin/AdminJobs.test.tsx`: 21 passed (includes new dueBadge tests)
- `npx vitest run api`: 108 files, 1079 tests passed
- `npm run test --workspace=@unclick/mcp-server`: green (fail 0); tool-index and depth ladder still up to date
- `npx tsc --noEmit`: clean
- `npx eslint` on touched files: 0 errors (8 pre-existing warnings, none introduced)
- `npm run boardroom:check`: clean after the deliberate baseline bump

## Reversibility
- Docs are pure additions.
- The column is nullable and unread by existing code paths; revert = drop column + revert commits.
- UI changes are additive (new chip, new cell, new bar); no existing behavior altered.

https://claude.ai/code/session_013Cq1MKgywXKeMRLkduTB9T

---
_Generated by [Claude Code](https://claude.ai/code/session_013Cq1MKgywXKeMRLkduTB9T)_