### PR TITLE
fix(install): issue public signup keys server-side

### DIFF
--- a/api/install-ticket.ts
+++ b/api/install-ticket.ts
@@ -8,6 +8,8 @@
  *
  * Routes:
  *   POST /api/install-ticket
+ *     body: { action: "signup", email: "you@example.com" }
+ *       -> { api_key, prefix }
  *     body: { action: "issue",  api_key: "uc_..." }
  *       -> { ticket, expires_at }
  *     body: { action: "redeem", ticket: "unclick-ember-falcon-2847" }
@@ -74,6 +76,22 @@ function isValidTicketShape(ticket: unknown): ticket is string {
 
 function isValidApiKeyShape(key: unknown): key is string {
   return typeof key === "string" && /^uc_[a-f0-9]{16,}$/.test(key);
+}
+
+function isValidEmail(email: unknown): email is string {
+  return (
+    typeof email === "string" &&
+    email.length <= 320 &&
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  );
+}
+
+function generateApiKey(): string {
+  return `uc_${crypto.randomBytes(16).toString("hex")}`;
+}
+
+function sha256hex(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
 }
 
 // ─── Install guide (served over GET) ──────────────────────────────────────
@@ -339,11 +357,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       // Verify the API key is real and active.
+      const apiKeyHash = sha256hex(apiKey);
       const { data: keyRow, error: keyErr } = await supabase
         .from("api_keys")
-        .select("api_key, status")
-        .eq("api_key", apiKey)
-        .eq("status", "active")
+        .select("key_hash, is_active")
+        .eq("key_hash", apiKeyHash)
+        .eq("is_active", true)
         .maybeSingle();
       if (keyErr) throw keyErr;
       if (!keyRow) {
@@ -372,6 +391,38 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       return res.status(200).json({ ticket, expires_at: expiresAt });
+    }
+
+    if (action === "signup") {
+      const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+      if (!isValidEmail(email)) {
+        return res.status(400).json({ error: "Enter a valid email address." });
+      }
+      if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+        return res.status(500).json({ error: "Signup service unavailable" });
+      }
+
+      for (let attempt = 0; attempt < 5; attempt++) {
+        const rawKey = generateApiKey();
+        const { error: insertErr } = await supabase.from("api_keys").insert({
+          key_hash:    sha256hex(rawKey),
+          key_prefix:  rawKey.slice(0, 8),
+          label:       "public-signup",
+          tier:        "free",
+          is_active:   true,
+          usage_count: 0,
+        });
+
+        if (!insertErr) {
+          return res.status(200).json({
+            api_key: rawKey,
+            prefix:  rawKey.slice(0, 8),
+          });
+        }
+        if ((insertErr as { code?: string }).code !== "23505") throw insertErr;
+      }
+
+      return res.status(500).json({ error: "Could not allocate API key, try again" });
     }
 
     if (action === "redeem") {

--- a/src/components/ApiKeySignup.tsx
+++ b/src/components/ApiKeySignup.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { SITE_STATS } from "@/config/site-stats";
 import { motion, AnimatePresence } from "framer-motion";
-import { supabase } from "@/lib/supabase";
 
 const STORAGE_KEY = "unclick_api_key";
 const EMAIL_KEY = "unclick_user_email";
@@ -14,9 +13,23 @@ function isValidEmail(email: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
-function generateApiKey() {
-  const uuid = crypto.randomUUID().replace(/-/g, "");
-  return `uc_${uuid}`;
+interface SignupResponse {
+  api_key?: string;
+  prefix?: string;
+  error?: string;
+}
+
+async function requestApiKey(email: string): Promise<string> {
+  const response = await fetch("/api/install-ticket", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "signup", email }),
+  });
+  const data = (await response.json().catch(() => ({}))) as SignupResponse;
+  if (!response.ok || !data.api_key) {
+    throw new Error(data.error ?? `Signup failed with HTTP ${response.status}`);
+  }
+  return data.api_key;
 }
 
 const ApiKeySignup = ({ onKeyReady }: ApiKeySignupProps) => {
@@ -48,49 +61,12 @@ const ApiKeySignup = ({ onKeyReady }: ApiKeySignupProps) => {
     setLoading(true);
     setError("");
 
-    // Guard against preview deploys that forgot to set Supabase env vars.
-    const hasSupabaseConfig =
-      !!import.meta.env.VITE_SUPABASE_URL && !!import.meta.env.VITE_SUPABASE_ANON_KEY;
-    if (!hasSupabaseConfig) {
-      setLoading(false);
-      setError(
-        "Signup is not configured on this deployment. Email hello@unclick.world for a key.",
-      );
-      return;
-    }
-
     try {
-      // Check if email already has a key
-      const { data: existing, error: selectError } = await supabase
-        .from("api_keys")
-        .select("api_key")
-        .eq("email", trimmed.toLowerCase())
-        .eq("status", "active")
-        .maybeSingle();
-
-      if (selectError) throw selectError;
-
-      if (existing?.api_key) {
-        const key = existing.api_key as string;
-        localStorage.setItem(STORAGE_KEY, key);
-        localStorage.setItem(EMAIL_KEY, trimmed.toLowerCase());
-        setIsReturning(true);
-        setApiKey(key);
-        onKeyReady(key);
-        return;
-      }
-
-      // Generate a new key and insert
-      const newKey = generateApiKey();
-
-      const { error: insertError } = await supabase
-        .from("api_keys")
-        .insert({ email: trimmed.toLowerCase(), api_key: newKey });
-
-      if (insertError) throw insertError;
+      const normalizedEmail = trimmed.toLowerCase();
+      const newKey = await requestApiKey(normalizedEmail);
 
       localStorage.setItem(STORAGE_KEY, newKey);
-      localStorage.setItem(EMAIL_KEY, trimmed.toLowerCase());
+      localStorage.setItem(EMAIL_KEY, normalizedEmail);
       setIsReturning(false);
       setApiKey(newKey);
       onKeyReady(newKey);


### PR DESCRIPTION
## Summary

Fixes the `unclick.world/#install` "Get your free API key" failure shown on the public install page.

Root cause: the signup component still used the old browser-side Supabase flow, reading/writing plaintext `api_keys.api_key` + `status` via the anon key. The live schema is now hash-backed (`key_hash`, `key_prefix`, `is_active`) and service-role only, so the browser request fails behind the generic "Something went wrong" message.

## Changes

- `ApiKeySignup` now calls `/api/install-ticket` with `action: "signup"` instead of touching Supabase directly.
- `api/install-ticket` now mints modern `uc_...` keys server-side and inserts only `key_hash`, `key_prefix`, `label`, `tier`, `is_active`, and `usage_count`.
- Existing install-ticket `issue` action now validates a raw `uc_...` key by hashing it and looking up `api_keys.key_hash` + `is_active`, fixing the same schema drift for ticket generation.

## Verification

- Confirmed the current live `/api/install-ticket` `issue` action returns HTTP 500 for a known-good key, matching the stale-column root cause.
- `node --check api/install-ticket.ts` passes.
- `git diff --check` passes, with Windows line-ending warnings only.

Full repo `tsc --noEmit` was not run because this fresh checkout has no `node_modules`; `npm exec tsc` only returned the npm shim telling us TypeScript is not installed locally.

## Risk

Low-medium. This is public signup/key issuance, so it is user-facing and auth-adjacent, but the change moves key creation back behind the server/service-role path and stores only hashes in `api_keys`. The raw key is returned once to the browser and saved in localStorage, matching the current quick-install UX.