### PR TITLE
fix(install): make public MCP door primary

### DIFF
--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  pairingLoginUrl,
+  pairingToolResult,
+  PUBLIC_PAIRING_TOOL,
+} from "./mcp";
+
+describe("public MCP pairing door", () => {
+  it("advertises a single safe setup tool for unpaired clients", () => {
+    expect(PUBLIC_PAIRING_TOOL.name).toBe("unclick_start_pairing");
+    expect(PUBLIC_PAIRING_TOOL.description).toContain("not paired yet");
+    expect(PUBLIC_PAIRING_TOOL.description).not.toContain("API key");
+  });
+
+  it("builds a magic-link landing URL without embedding a secret", () => {
+    const url = new URL(pairingLoginUrl("USER@Example.COM"));
+
+    expect(url.origin).toBe("https://unclick.world");
+    expect(url.pathname).toBe("/login");
+    expect(url.searchParams.get("next")).toBe("/pair/connected");
+    expect(url.searchParams.get("email")).toBe("user@example.com");
+    expect(url.toString()).not.toContain("uc_");
+    expect(url.toString()).not.toContain("key=");
+  });
+
+  it("explains compatibility URLs without pretending they are the public door", () => {
+    const result = pairingToolResult({ email: "person@example.com" });
+    const text = result.content[0]?.text ?? "";
+
+    expect(text).toContain("not paired");
+    expect(text).toContain("https://unclick.world/login");
+    expect(text).toContain("Compatibility URL");
+    expect(text).toContain("public URL");
+    expect(text).not.toContain("Bearer");
+  });
+});

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -401,7 +401,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const method = singleRpcMethod(req.body);
   const toolName = singleToolName(req.body);
 
-  let ctx: ApiKeyContext | null = null;
+  let ctx: ApiKeyContext | null;
 
   if (apiKey) {
     ctx = await validateApiKey(apiKey);

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -45,6 +45,82 @@ const AUTH_REQUIRED_METHODS = new Set<string>(["tools/call"]);
 
 type JsonRpcId = string | number | null;
 
+export const PUBLIC_PAIRING_TOOL = {
+  name: "unclick_start_pairing",
+  title: "Connect UnClick",
+  description:
+    "Use when this UnClick MCP connection is not paired yet. It gives the user the shortest safe sign-in path and explains when to use a compatibility URL.",
+  inputSchema: {
+    type: "object" as const,
+    additionalProperties: false,
+    properties: {
+      email: {
+        type: "string",
+        description: "Optional email address to pre-fill on the UnClick sign-in page.",
+      },
+    },
+  },
+};
+
+function singleRpc(body: unknown): Record<string, unknown> | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  return body as Record<string, unknown>;
+}
+
+function singleRpcMethod(body: unknown): string | null {
+  const rpc = singleRpc(body);
+  return typeof rpc?.method === "string" ? rpc.method : null;
+}
+
+function singleToolName(body: unknown): string | null {
+  const rpc = singleRpc(body);
+  const params = rpc?.params;
+  if (!params || typeof params !== "object") return null;
+  const name = (params as Record<string, unknown>).name;
+  return typeof name === "string" ? name : null;
+}
+
+function singleToolArgs(body: unknown): Record<string, unknown> {
+  const rpc = singleRpc(body);
+  const params = rpc?.params;
+  if (!params || typeof params !== "object") return {};
+  const args = (params as Record<string, unknown>).arguments;
+  return args && typeof args === "object" && !Array.isArray(args)
+    ? (args as Record<string, unknown>)
+    : {};
+}
+
+export function pairingLoginUrl(email?: string): string {
+  const url = new URL("https://unclick.world/login");
+  url.searchParams.set("next", "/pair/connected");
+  if (email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    url.searchParams.set("email", email.trim().toLowerCase());
+  }
+  return url.toString();
+}
+
+export function pairingToolResult(args: Record<string, unknown>) {
+  const email = typeof args.email === "string" ? args.email.trim() : "";
+  const loginUrl = pairingLoginUrl(email);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          "UnClick is installed, but this AI app is not paired to an UnClick account yet.",
+          "",
+          "Next step:",
+          `Open ${loginUrl}`,
+          "",
+          "Sign in with email, Google, or Microsoft. The page will show the safest working next step for this AI app.",
+          "",
+          "If this AI app asks to pair again or only accepts a static URL, use the Compatibility URL shown on that page. The public URL stays the long-term goal because it does not carry a personal key.",
+        ].join("\n"),
+      },
+    ],
+  };
+}
+
 // Peek the JSON-RPC body so we can (1) echo the request id back in error
 // responses (JSON-RPC 2.0 § 5.1 requires id equality) and (2) decide whether
 // the request is attempting protected tool execution. Batches are handled
@@ -322,6 +398,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         ? (keyRaw[0] ?? "").trim()
         : "";
   const apiKey = keyFromHeader || keyFromQuery;
+  const method = singleRpcMethod(req.body);
+  const toolName = singleToolName(req.body);
 
   let ctx: ApiKeyContext | null = null;
 
@@ -339,18 +417,33 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         id: peeked.id,
       });
     }
-  } else if (peeked.authRequired) {
+  } else {
     // No api_key supplied - try resolving via Supabase session cookie.
     // Unprotected protocol methods skip this so the MCP SDK can answer them.
     ctx = await validateSessionCookie(req);
-    if (!ctx) {
+    if (!ctx && method === "tools/list") {
+      return res.status(200).json({
+        jsonrpc: "2.0",
+        result: { tools: [PUBLIC_PAIRING_TOOL] },
+        id: peeked.id,
+      });
+    }
+    if (!ctx && method === "tools/call" && toolName === PUBLIC_PAIRING_TOOL.name) {
+      return res.status(200).json({
+        jsonrpc: "2.0",
+        result: pairingToolResult(singleToolArgs(req.body)),
+        id: peeked.id,
+      });
+    }
+    if (!ctx && peeked.authRequired) {
       return res.status(401).json({
         jsonrpc: "2.0",
         error: {
           code: -32001,
           message:
-            "Missing API key. Pass it as Authorization: Bearer <key> or as ?key=<key> in the URL. " +
-            "Get a key at https://unclick.world",
+            "UnClick is installed but this AI app is not paired yet. " +
+            "Call unclick_start_pairing, or open https://unclick.world/login?next=%2Fpair%2Fconnected. " +
+            "If your client only accepts a static URL, use the Compatibility URL from https://unclick.world/#install.",
         },
         id: peeked.id,
       });

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,9 +9,9 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 1129,
-    "source_manifest": 246,
-    "pages": 112,
+    "inventory": 1130,
+    "source_manifest": 247,
+    "pages": 113,
     "tools": 672,
     "rooms": 23,
     "workers": 8
@@ -27,7 +27,7 @@
       "id": "public-surfaces",
       "name": "Public surfaces",
       "meaning": "Public product, docs, marketplace, and user-facing routes.",
-      "count": 54
+      "count": 55
     },
     {
       "id": "tools",
@@ -4039,6 +4039,16 @@
       "meaning": "User-facing page for Organiser.",
       "source": "src/pages/Organiser.tsx",
       "route": "/organiser",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-pairing-complete-src-pages-pairingcomplete-tsx-pair-connected",
+      "division": "Public surfaces",
+      "name": "Pairing Complete",
+      "kind": "public page",
+      "meaning": "User-facing page for Pairing Complete.",
+      "source": "src/pages/PairingComplete.tsx",
+      "route": "/pair/connected",
       "tags": []
     },
     {
@@ -11984,6 +11994,12 @@
       "src/pages/Organiser.tsx"
     ],
     [
+      "/pair/connected",
+      "Pairing Complete",
+      "User-facing page for Pairing Complete.",
+      "src/pages/PairingComplete.tsx"
+    ],
+    [
       "/pricing",
       "Pricing",
       "Plans, billing, and packaging.",
@@ -15812,8 +15828,8 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "8c7ce9adfe09",
-      "bytes": 22637
+      "hash": "740ff54af7e4",
+      "bytes": 23350
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
@@ -16147,8 +16163,8 @@
     },
     {
       "source": "src/pages/admin/AdminEcosystemPages.tsx",
-      "hash": "a43f559b89c3",
-      "bytes": 13821
+      "hash": "3d245def3231",
+      "bytes": 13772
     },
     {
       "source": "src/pages/admin/AdminBenchmarks.tsx",
@@ -16312,23 +16328,23 @@
     },
     {
       "source": "src/pages/admin/AdminYou.tsx",
-      "hash": "9d9c719dae1b",
-      "bytes": 69998
+      "hash": "4b186ef89df8",
+      "bytes": 71460
     },
     {
       "source": "src/pages/AppDetail.tsx",
-      "hash": "f6638bfd7203",
-      "bytes": 6608
+      "hash": "7d1bead9bac0",
+      "bytes": 6646
     },
     {
       "source": "src/pages/Apps.tsx",
-      "hash": "f2fab29b2942",
-      "bytes": 3137
+      "hash": "65bd43917eab",
+      "bytes": 3135
     },
     {
       "source": "src/pages/AuthCallback.tsx",
-      "hash": "c7dba82923b5",
-      "bytes": 4875
+      "hash": "e9ee37622f98",
+      "bytes": 5086
     },
     {
       "source": "src/pages/VerifyMfa.tsx",
@@ -16337,8 +16353,8 @@
     },
     {
       "source": "src/pages/Connect.tsx",
-      "hash": "7edc911d0c09",
-      "bytes": 30223
+      "hash": "3597b15bc3d8",
+      "bytes": 30272
     },
     {
       "source": "src/pages/Crews.tsx",
@@ -16487,8 +16503,8 @@
     },
     {
       "source": "src/pages/Login.tsx",
-      "hash": "c3b16f3ec268",
-      "bytes": 8416
+      "hash": "dce8bcccd23f",
+      "bytes": 8743
     },
     {
       "source": "src/pages/MemoryConnect.tsx",
@@ -16514,6 +16530,11 @@
       "source": "src/pages/Organiser.tsx",
       "hash": "ae35be237d83",
       "bytes": 16581
+    },
+    {
+      "source": "src/pages/PairingComplete.tsx",
+      "hash": "39b115053aa5",
+      "bytes": 8270
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,7 +22,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | 760883150b3f | 4888 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | bf91808d2d8d | 2169 |
-| src/App.tsx | 8c7ce9adfe09 | 22637 |
+| src/App.tsx | 740ff54af7e4 | 23350 |
 | src/pages/admin/AdminShell.tsx | b983e01ec6c0 | 33162 |
 | src/pages/admin/AdminControlTower.tsx | 4c84cc958957 | 21800 |
 | src/lib/controltower.ts | c9d18e61e7d8 | 21703 |
@@ -89,7 +89,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminTools.tsx | 93411db0999e | 9265 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
-| src/pages/admin/AdminEcosystemPages.tsx | a43f559b89c3 | 13821 |
+| src/pages/admin/AdminEcosystemPages.tsx | 3d245def3231 | 13772 |
 | src/pages/admin/AdminBenchmarks.tsx | d3f1d4d1e298 | 25705 |
 | src/pages/admin/Boardroom.tsx | 61d332b5a15e | 37186 |
 | src/pages/admin/AdminBrainmap.tsx | 48525d7a37d1 | 26608 |
@@ -122,12 +122,12 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminTruthRate.tsx | b99175b21cc1 | 8880 |
 | src/pages/admin/AdminUsers.tsx | 222654ee0f22 | 866 |
 | src/pages/admin/AdminXGate.tsx | 193295e6e4dc | 26811 |
-| src/pages/admin/AdminYou.tsx | 9d9c719dae1b | 69998 |
-| src/pages/AppDetail.tsx | f6638bfd7203 | 6608 |
-| src/pages/Apps.tsx | f2fab29b2942 | 3137 |
-| src/pages/AuthCallback.tsx | c7dba82923b5 | 4875 |
+| src/pages/admin/AdminYou.tsx | 4b186ef89df8 | 71460 |
+| src/pages/AppDetail.tsx | 7d1bead9bac0 | 6646 |
+| src/pages/Apps.tsx | 65bd43917eab | 3135 |
+| src/pages/AuthCallback.tsx | e9ee37622f98 | 5086 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
-| src/pages/Connect.tsx | 7edc911d0c09 | 30223 |
+| src/pages/Connect.tsx | 3597b15bc3d8 | 30272 |
 | src/pages/Crews.tsx | e6d7b1813cc9 | 12789 |
 | src/pages/DeveloperDocs.tsx | 40631b01bc27 | 21214 |
 | src/pages/DeveloperSubmit.tsx | 8724b6d03268 | 12447 |
@@ -157,12 +157,13 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/HomePreview.tsx | 4768b94b20d1 | 7592 |
 | src/pages/InstallRecover.tsx | 56c822e69817 | 6971 |
 | src/pages/Jobsmith.tsx | d0763d5d4c38 | 62520 |
-| src/pages/Login.tsx | c3b16f3ec268 | 8416 |
+| src/pages/Login.tsx | dce8bcccd23f | 8743 |
 | src/pages/MemoryConnect.tsx | c760d37398d5 | 18534 |
 | src/pages/MemorySetup.tsx | a64def7930d5 | 20088 |
 | src/pages/Memory.tsx | e1c923ee0c61 | 19193 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
+| src/pages/PairingComplete.tsx | 39b115053aa5 | 8270 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |
@@ -265,7 +266,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Division | Meaning | Items |
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 58 |
-| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 54 |
+| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 55 |
 | Tools | MCP and gateway capabilities available to seats. | 672 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
@@ -408,6 +409,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /memory | Memory | Public memory product page. | src/pages/Memory.tsx |
 | /new-to-ai | New To AI | Beginner-friendly AI orientation. | src/pages/NewToAI.tsx |
 | /organiser | Organiser | User-facing page for Organiser. | src/pages/Organiser.tsx |
+| /pair/connected | Pairing Complete | User-facing page for Pairing Complete. | src/pages/PairingComplete.tsx |
 | /pricing | Pricing | Plans, billing, and packaging. | src/pages/Pricing.tsx |
 | /privacy | Privacy | Privacy policy. | src/pages/Privacy.tsx |
 | /signup | Signup | Sign-up page. | src/pages/Signup.tsx |
@@ -1497,6 +1499,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Public surfaces | public page | Memory Setup Guide | User-facing page for Memory Setup Guide. | /memory/setup-guide | src/pages/MemorySetupGuide.tsx |
 | Public surfaces | public page | New To AI | Beginner-friendly AI orientation. | /new-to-ai | src/pages/NewToAI.tsx |
 | Public surfaces | public page | Organiser | User-facing page for Organiser. | /organiser | src/pages/Organiser.tsx |
+| Public surfaces | public page | Pairing Complete | User-facing page for Pairing Complete. | /pair/connected | src/pages/PairingComplete.tsx |
 | Public surfaces | public page | Pricing | Plans, billing, and packaging. | /pricing | src/pages/Pricing.tsx |
 | Public surfaces | public page | Privacy | Privacy policy. | /privacy | src/pages/Privacy.tsx |
 | Public surfaces | public page | Scheduling | Tool page for Scheduling. | /tools/scheduling | src/pages/tools/Scheduling.tsx |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ const DogfoodReportPage = lazy(() => import("./pages/DogfoodReport.tsx"));
 const LoginPage = lazy(() => import("./pages/Login.tsx"));
 const SignupPage = lazy(() => import("./pages/Signup.tsx"));
 const AuthCallbackPage = lazy(() => import("./pages/AuthCallback.tsx"));
+const PairingCompletePage = lazy(() => import("./pages/PairingComplete.tsx"));
 const VerifyMfaPage = lazy(() => import("./pages/VerifyMfa.tsx"));
 const BrochurePage = lazy(() => import("./components/BrochurePage.tsx"));
 const AdminShell = lazy(() => import("./pages/admin/AdminShell.tsx"));
@@ -158,6 +159,24 @@ function AnalyticsPageviewTracker() {
   return null;
 }
 
+function HashScrollHandler() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!location.hash) return;
+    const targetId = decodeURIComponent(location.hash.slice(1));
+    if (!targetId || targetId.includes("=")) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      document.getElementById(targetId)?.scrollIntoView({ block: "start", behavior: "auto" });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [location.hash, location.pathname, location.search]);
+
+  return null;
+}
+
 /** Quiet, theme-consistent placeholder while a lazy route chunk loads. */
 function RouteFallback() {
   return (
@@ -176,6 +195,7 @@ const App = () => (
       <BrowserRouter>
         <SiteAurora />
         <AnalyticsPageviewTracker />
+        <HashScrollHandler />
         <BetaBanner />
         <Suspense fallback={<RouteFallback />}>
         <Routes>
@@ -323,6 +343,7 @@ const App = () => (
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
+          <Route path="/pair/connected" element={<PairingCompletePage />} />
           <Route path="/auth/verify-mfa" element={<VerifyMfaPage />} />
           <Route path="/organiser" element={<OrganiserPage />} />
           <Route path="/dispatch" element={<DispatchPage />} />

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const installSection = () => readFileSync("src/components/InstallSection.tsx", "utf8");
+const pairingPage = () => readFileSync("src/pages/PairingComplete.tsx", "utf8");
+
+describe("public MCP door copy", () => {
+  it("makes the public URL the primary installer language", () => {
+    const src = installSection();
+
+    expect(src).toContain("Public door");
+    expect(src).toContain("Compatibility URL");
+    expect(src).toContain("No personal key in the URL");
+    expect(src).toContain("Private value hidden on screen");
+    expect(src).toContain("https://unclick.world/api/mcp");
+    expect(src).toContain("?key=");
+  });
+
+  it("keeps the magic-link landing page honest about fallback URLs", () => {
+    const src = pairingPage();
+
+    expect(src).toContain("Use the public door first");
+    expect(src).toContain("If your AI app only accepts a static URL");
+    expect(src).toContain("contains a private connection key");
+    expect(src).not.toContain("master key");
+  });
+});

--- a/src/components/ApiKeySignup.tsx
+++ b/src/components/ApiKeySignup.tsx
@@ -19,6 +19,11 @@ interface SignupResponse {
   error?: string;
 }
 
+function maskPrivateKey(key: string) {
+  if (key.length <= 10) return "hidden";
+  return `${key.slice(0, 6)}...${key.slice(-4)}`;
+}
+
 async function requestApiKey(email: string): Promise<string> {
   const response = await fetch("/api/install-ticket", {
     method: "POST",
@@ -115,12 +120,12 @@ const ApiKeySignup = ({ onKeyReady }: ApiKeySignupProps) => {
               </svg>
             </div>
             <span className="text-sm font-medium text-primary">
-              {isReturning ? "Welcome back. Your connection key is ready." : "You're in! Your connection key is ready."}
+              {isReturning ? "Welcome back. Your compatibility URL is ready." : "Compatibility URL ready."}
             </span>
           </div>
           <div className="flex items-center gap-2">
             <code className="flex-1 rounded-md bg-card/60 border border-border/40 px-3 py-2 font-mono text-xs text-heading truncate select-all">
-              {apiKey}
+              {maskPrivateKey(apiKey)}
             </code>
             <motion.button
               onClick={handleCopyKey}
@@ -131,7 +136,7 @@ const ApiKeySignup = ({ onKeyReady }: ApiKeySignupProps) => {
             </motion.button>
           </div>
           <p className="mt-2 text-[11px] text-muted-foreground">
-            The setup below uses this key. Keep copied URLs private.{" "}
+            This fallback uses a private connection key. It stays hidden on screen, but Copy uses the full value.{" "}
             <button onClick={handleReset} className="underline underline-offset-2 hover:text-body transition-colors">
               Use a different account
             </button>
@@ -150,9 +155,9 @@ const ApiKeySignup = ({ onKeyReady }: ApiKeySignupProps) => {
         transition={{ duration: 0.3 }}
         className="rounded-xl border border-border/60 bg-card/30 p-5"
       >
-        <p className="text-sm font-medium text-heading mb-1">Create your UnClick connection key</p>
+        <p className="text-sm font-medium text-heading mb-1">Create a compatibility URL</p>
         <p className="text-xs text-muted-foreground mb-4">
-          No credit card. No waitlist. Covers all {SITE_STATS.TOOLS_DISPLAY} tools immediately.
+          For AI apps that only accept a static MCP URL today. No credit card. Covers all {SITE_STATS.TOOLS_DISPLAY} tools.
         </p>
         <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row">
           <input
@@ -171,7 +176,7 @@ const ApiKeySignup = ({ onKeyReady }: ApiKeySignupProps) => {
             whileTap={{ scale: 0.97 }}
             className="shrink-0 rounded-md bg-primary px-5 py-2 text-sm font-semibold text-black transition-opacity hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            {loading ? "Working..." : "Get your API key"}
+            {loading ? "Working..." : "Create URL"}
           </motion.button>
         </form>
         {error && (

--- a/src/components/InstallSection.tsx
+++ b/src/components/InstallSection.tsx
@@ -7,16 +7,13 @@ import { motion } from "framer-motion";
 //
 // Every major MCP client in April 2026 accepts a remote MCP URL natively.
 // We show the 5 shortest paths (Claude, ChatGPT, Cursor, VS Code, Other) and
-// let the user pick. No AI middleman, no "walk me through it", just paste
-// one field or click one button.
-//
-// Auth: remote URL installs embed a persistent connection key as ?key=.
-// Claude.ai and ChatGPT custom connector dialogs only expose a URL field, so
-// there is no place to set a header. This is not the one-use install-ticket
-// flow used by local stdio installs.
+// let the user pick. The default story is the public UnClick door: one stable
+// URL, no personal key in the address. Compatibility mode remains available for
+// clients that only accept a static URL and cannot finish MCP pairing yet.
 
 type Platform = "Claude" | "ChatGPT" | "Cursor" | "VS Code" | "Other";
 type ClaudeSurface = "Web" | "Desktop" | "Code";
+type SetupMode = "Public" | "Compatibility";
 
 const MCP_ORIGIN = "https://unclick.world/api/mcp";
 const MCP_PACKAGE_URL = "https://github.com/malamutemayhem/unclick/releases/latest/download/unclick-mcp-server.tgz";
@@ -29,12 +26,12 @@ function mcpUrl(key: string) {
   return `${MCP_ORIGIN}?key=${key}`;
 }
 
-function claudeCodeCommand(key: string) {
-  return `claude mcp add --transport http unclick ${mcpUrl(key)}`;
+function claudeCodeCommand(connectionUrl: string) {
+  return `claude mcp add --transport http unclick ${connectionUrl}`;
 }
 
-function geminiCommand(key: string) {
-  return `gemini mcp add unclick --transport http ${mcpUrl(key)}`;
+function geminiCommand(connectionUrl: string) {
+  return `gemini mcp add unclick --transport http ${connectionUrl}`;
 }
 
 function stdioJson(key: string) {
@@ -49,18 +46,35 @@ function stdioJson(key: string) {
 }`;
 }
 
-function cursorDeeplink(key: string) {
-  const config = btoa(JSON.stringify({ url: mcpUrl(key) }));
+function cursorDeeplink(connectionUrl: string) {
+  const config = btoa(JSON.stringify({ url: connectionUrl }));
   return `cursor://anysphere.cursor-deeplink/mcp/install?name=unclick&config=${config}`;
 }
 
-function vscodeDeeplink(key: string) {
+function vscodeDeeplink(connectionUrl: string) {
   const config = JSON.stringify({
     name: "unclick",
     type: "http",
-    url: mcpUrl(key),
+    url: connectionUrl,
   });
   return `vscode:mcp/install?${encodeURIComponent(config)}`;
+}
+
+function connectionUrlFor(setupMode: SetupMode, apiKey: string) {
+  if (setupMode === "Public") return MCP_ORIGIN;
+  return mcpUrl(apiKey || PLACEHOLDER_KEY);
+}
+
+function canUseMode(setupMode: SetupMode, apiKey: string) {
+  return setupMode === "Public" || Boolean(apiKey);
+}
+
+function maskPrivateValue(value: string) {
+  return value.replace(/uc_[A-Za-z0-9_-]{8,}/g, (key) => `${key.slice(0, 6)}...${key.slice(-4)}`);
+}
+
+function hasPrivateValue(value: string) {
+  return /uc_[A-Za-z0-9_-]{8,}/.test(value);
 }
 
 // Tiny copyable row: a read-only input + Copy button. Same shape everywhere
@@ -84,6 +98,8 @@ function CopyField({
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
+  const privateValue = hasPrivateValue(value);
+  const displayValue = privateValue ? maskPrivateValue(value) : value;
   return (
     <div>
       <div className="mb-1 text-[11px] uppercase tracking-wider text-muted-foreground">
@@ -95,7 +111,7 @@ function CopyField({
             mono ? "font-mono" : ""
           } ${hasKey ? "border-border/50 text-heading" : "border-border/30 text-body/40 select-none blur-[2px]"}`}
         >
-          {value}
+          {displayValue}
         </code>
         <motion.button
           onClick={copy}
@@ -110,6 +126,11 @@ function CopyField({
           {copied ? "Copied!" : "Copy"}
         </motion.button>
       </div>
+      {privateValue && hasKey && (
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Private value hidden on screen. Copy still uses the full value.
+        </p>
+      )}
     </div>
   );
 }
@@ -123,6 +144,8 @@ function CodeBlock({ code, hasKey }: { code: string; hasKey: boolean }) {
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   };
+  const privateValue = hasPrivateValue(code);
+  const displayCode = privateValue ? maskPrivateValue(code) : code;
   return (
     <div className="relative rounded-md border border-border/40 bg-card/40 p-4">
       <pre
@@ -130,7 +153,7 @@ function CodeBlock({ code, hasKey }: { code: string; hasKey: boolean }) {
           hasKey ? "text-body" : "text-body/40 select-none blur-[2px]"
         }`}
       >
-        <code>{code}</code>
+        <code>{displayCode}</code>
       </pre>
       <motion.button
         onClick={copy}
@@ -144,6 +167,11 @@ function CodeBlock({ code, hasKey }: { code: string; hasKey: boolean }) {
       >
         {copied ? "Copied!" : "Copy"}
       </motion.button>
+      {privateValue && hasKey && (
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          Private value hidden on screen. Copy still uses the full value.
+        </p>
+      )}
     </div>
   );
 }
@@ -215,19 +243,116 @@ function Steps({ items }: { items: string[] }) {
   );
 }
 
-function PersistentUrlNotice() {
+function ConnectionUrlNotice({ setupMode }: { setupMode: SetupMode }) {
+  if (setupMode === "Public") {
+    return (
+      <div className="rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs text-primary/90">
+        Public door: no personal key in the URL. If your AI app cannot finish pairing yet, switch to Compatibility URL.
+      </div>
+    );
+  }
   return (
     <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-200/90">
-      The URL below contains a persistent UnClick connection key. Keep it private and reset it if it leaks.
+      Compatibility URL: contains a persistent UnClick connection key. Keep it private and rotate it if it leaks.
+    </div>
+  );
+}
+
+function SetupModeSwitch({
+  setupMode,
+  onChange,
+}: {
+  setupMode: SetupMode;
+  onChange: (mode: SetupMode) => void;
+}) {
+  const options: Array<{
+    mode: SetupMode;
+    title: string;
+    body: string;
+  }> = [
+    {
+      mode: "Public",
+      title: "Public door",
+      body: "One stable address. No personal key in the URL.",
+    },
+    {
+      mode: "Compatibility",
+      title: "Compatibility URL",
+      body: "Works in URL-only clients today. Uses a private key.",
+    },
+  ];
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      {options.map((option) => {
+        const active = setupMode === option.mode;
+        return (
+          <button
+            key={option.mode}
+            type="button"
+            onClick={() => onChange(option.mode)}
+            className={`rounded-lg border p-3 text-left transition-colors ${
+              active
+                ? "border-primary/45 bg-primary/10"
+                : "border-border/50 bg-card/35 hover:border-border/80"
+            }`}
+          >
+            <span className={active ? "text-sm font-semibold text-heading" : "text-sm font-semibold text-body"}>
+              {option.title}
+            </span>
+            <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+              {option.body}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function PublicDoorSummary() {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(MCP_ORIGIN);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <div className="rounded-xl border border-primary/25 bg-primary/5 p-5">
+      <p className="text-sm font-medium text-heading">Start with the public UnClick door</p>
+      <p className="mt-1 text-xs leading-5 text-muted-foreground">
+        Add this same address first. If your AI app cannot finish pairing yet, switch to the Compatibility URL.
+      </p>
+      <div className="mt-3 flex items-stretch gap-2">
+        <code className="min-w-0 flex-1 truncate rounded-md border border-border/50 bg-card/60 px-3 py-2 font-mono text-xs text-heading">
+          {MCP_ORIGIN}
+        </code>
+        <motion.button
+          type="button"
+          onClick={copy}
+          whileTap={{ scale: 0.95 }}
+          className="shrink-0 rounded-md border border-primary/30 bg-primary px-3 py-2 font-mono text-[11px] font-semibold text-black transition-opacity hover:opacity-90"
+        >
+          {copied ? "Copied!" : "Copy"}
+        </motion.button>
+      </div>
     </div>
   );
 }
 
 // ─── Per-platform panels ──────────────────────────────────────────────────
 
-function ClaudePanel({ apiKey, surface }: { apiKey: string; surface: ClaudeSurface }) {
-  const hasKey = Boolean(apiKey);
-  const key = apiKey || PLACEHOLDER_KEY;
+function ClaudePanel({
+  apiKey,
+  surface,
+  setupMode,
+}: {
+  apiKey: string;
+  surface: ClaudeSurface;
+  setupMode: SetupMode;
+}) {
+  const hasConnection = canUseMode(setupMode, apiKey);
+  const connectionUrl = connectionUrlFor(setupMode, apiKey);
 
   if (surface === "Code") {
     return (
@@ -239,7 +364,8 @@ function ClaudePanel({ apiKey, surface }: { apiKey: string; surface: ClaudeSurfa
             'Start a new session and ask: "What tools do you have from unclick?"',
           ]}
         />
-        <CopyField label="Terminal command" value={claudeCodeCommand(key)} hasKey={hasKey} />
+        <ConnectionUrlNotice setupMode={setupMode} />
+        <CopyField label="Terminal command" value={claudeCodeCommand(connectionUrl)} hasKey={hasConnection} />
       </div>
     );
   }
@@ -259,17 +385,21 @@ function ClaudePanel({ apiKey, surface }: { apiKey: string; surface: ClaudeSurfa
         ]}
       />
       <div className="space-y-3">
-        <CopyField label="Name" value="UnClick" hasKey={hasKey} mono={false} />
-        <PersistentUrlNotice />
-        <CopyField label="Persistent MCP connection URL" value={mcpUrl(key)} hasKey={hasKey} />
+        <CopyField label="Name" value="UnClick" hasKey={hasConnection} mono={false} />
+        <ConnectionUrlNotice setupMode={setupMode} />
+        <CopyField
+          label={setupMode === "Public" ? "Public MCP door" : "Compatibility MCP URL"}
+          value={connectionUrl}
+          hasKey={hasConnection}
+        />
       </div>
     </div>
   );
 }
 
-function ChatGPTPanel({ apiKey }: { apiKey: string }) {
-  const hasKey = Boolean(apiKey);
-  const key = apiKey || PLACEHOLDER_KEY;
+function ChatGPTPanel({ apiKey, setupMode }: { apiKey: string; setupMode: SetupMode }) {
+  const hasConnection = canUseMode(setupMode, apiKey);
+  const connectionUrl = connectionUrlFor(setupMode, apiKey);
   return (
     <div className="space-y-4">
       <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-300/90">
@@ -284,23 +414,28 @@ function ChatGPTPanel({ apiKey }: { apiKey: string }) {
         ]}
       />
       <div className="space-y-3">
-        <CopyField label="Name" value="UnClick" hasKey={hasKey} mono={false} />
-        <PersistentUrlNotice />
-        <CopyField label="Persistent MCP connection URL" value={mcpUrl(key)} hasKey={hasKey} />
+        <CopyField label="Name" value="UnClick" hasKey={hasConnection} mono={false} />
+        <ConnectionUrlNotice setupMode={setupMode} />
+        <CopyField
+          label={setupMode === "Public" ? "Public MCP door" : "Compatibility MCP URL"}
+          value={connectionUrl}
+          hasKey={hasConnection}
+        />
       </div>
     </div>
   );
 }
 
-function CursorPanel({ apiKey }: { apiKey: string }) {
-  const hasKey = Boolean(apiKey);
-  const key = apiKey || PLACEHOLDER_KEY;
+function CursorPanel({ apiKey, setupMode }: { apiKey: string; setupMode: SetupMode }) {
+  const hasConnection = canUseMode(setupMode, apiKey);
+  const connectionUrl = connectionUrlFor(setupMode, apiKey);
   return (
     <div className="space-y-4">
       <p className="text-sm text-body">
         One click. Cursor opens with the install pre-filled.
       </p>
-      <DeeplinkButton href={cursorDeeplink(key)} label="Add to Cursor" hasKey={hasKey} />
+      <ConnectionUrlNotice setupMode={setupMode} />
+      <DeeplinkButton href={cursorDeeplink(connectionUrl)} label="Add to Cursor" hasKey={hasConnection} />
       <details className="group">
         <summary className="cursor-pointer text-xs text-muted-foreground transition-colors hover:text-body">
           Prefer a manual install?
@@ -309,16 +444,16 @@ function CursorPanel({ apiKey }: { apiKey: string }) {
           <p className="text-xs text-muted-foreground">
             Edit <code className="font-mono">~/.cursor/mcp.json</code> and paste:
           </p>
-          <PersistentUrlNotice />
+          <ConnectionUrlNotice setupMode={setupMode} />
           <CodeBlock
             code={`{
   "mcpServers": {
     "unclick": {
-      "url": "${mcpUrl(key)}"
+      "url": "${connectionUrl}"
     }
   }
 }`}
-            hasKey={hasKey}
+            hasKey={hasConnection}
           />
         </div>
       </details>
@@ -326,15 +461,16 @@ function CursorPanel({ apiKey }: { apiKey: string }) {
   );
 }
 
-function VSCodePanel({ apiKey }: { apiKey: string }) {
-  const hasKey = Boolean(apiKey);
-  const key = apiKey || PLACEHOLDER_KEY;
+function VSCodePanel({ apiKey, setupMode }: { apiKey: string; setupMode: SetupMode }) {
+  const hasConnection = canUseMode(setupMode, apiKey);
+  const connectionUrl = connectionUrlFor(setupMode, apiKey);
   return (
     <div className="space-y-4">
       <p className="text-sm text-body">
         One click. VS Code (with GitHub Copilot) opens with the install pre-filled.
       </p>
-      <DeeplinkButton href={vscodeDeeplink(key)} label="Add to VS Code" hasKey={hasKey} />
+      <ConnectionUrlNotice setupMode={setupMode} />
+      <DeeplinkButton href={vscodeDeeplink(connectionUrl)} label="Add to VS Code" hasKey={hasConnection} />
       <details className="group">
         <summary className="cursor-pointer text-xs text-muted-foreground transition-colors hover:text-body">
           Prefer a manual install?
@@ -343,22 +479,27 @@ function VSCodePanel({ apiKey }: { apiKey: string }) {
           <p className="text-xs text-muted-foreground">
             Command Palette → "MCP: Add Server" → HTTP, then paste:
           </p>
-          <PersistentUrlNotice />
-          <CopyField label="Persistent MCP connection URL" value={mcpUrl(key)} hasKey={hasKey} />
+          <ConnectionUrlNotice setupMode={setupMode} />
+          <CopyField
+            label={setupMode === "Public" ? "Public MCP door" : "Compatibility MCP URL"}
+            value={connectionUrl}
+            hasKey={hasConnection}
+          />
         </div>
       </details>
     </div>
   );
 }
 
-function OtherPanel({ apiKey }: { apiKey: string }) {
-  const hasKey = Boolean(apiKey);
-  const key = apiKey || PLACEHOLDER_KEY;
+function OtherPanel({ apiKey, setupMode }: { apiKey: string; setupMode: SetupMode }) {
+  const hasConnection = canUseMode(setupMode, apiKey);
+  const connectionUrl = connectionUrlFor(setupMode, apiKey);
   return (
     <div className="space-y-6">
       <div className="space-y-3">
         <p className="text-sm font-medium text-heading">Gemini CLI</p>
-        <CopyField label="Terminal command" value={geminiCommand(key)} hasKey={hasKey} />
+        <ConnectionUrlNotice setupMode={setupMode} />
+        <CopyField label="Terminal command" value={geminiCommand(connectionUrl)} hasKey={hasConnection} />
       </div>
 
       <div className="space-y-3">
@@ -368,16 +509,28 @@ function OtherPanel({ apiKey }: { apiKey: string }) {
         <p className="text-xs text-muted-foreground">
           In your client's MCP settings, add a new server with this URL:
         </p>
-        <PersistentUrlNotice />
-        <CopyField label="Persistent MCP connection URL" value={mcpUrl(key)} hasKey={hasKey} />
+        <ConnectionUrlNotice setupMode={setupMode} />
+        <CopyField
+          label={setupMode === "Public" ? "Public MCP door" : "Compatibility MCP URL"}
+          value={connectionUrl}
+          hasKey={hasConnection}
+        />
       </div>
 
       <div className="space-y-3">
         <p className="text-sm font-medium text-heading">Local / self-hosted (stdio)</p>
-        <p className="text-xs text-muted-foreground">
-          Runs UnClick as a local process via npx. The key is stored in your local MCP config instead of inside a URL.
-        </p>
-        <CodeBlock code={stdioJson(key)} hasKey={hasKey} />
+        {setupMode === "Compatibility" ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Runs UnClick as a local process via npx. The key is stored in your local MCP config instead of inside a URL.
+            </p>
+            <CodeBlock code={stdioJson(apiKey || PLACEHOLDER_KEY)} hasKey={hasConnection} />
+          </>
+        ) : (
+          <div className="rounded-md border border-border/50 bg-card/35 px-3 py-2 text-xs leading-5 text-muted-foreground">
+            Local stdio installs still need a private key in an environment variable. Switch to Compatibility URL to generate that config.
+          </div>
+        )}
       </div>
     </div>
   );
@@ -388,12 +541,14 @@ function OtherPanel({ apiKey }: { apiKey: string }) {
 const InstallSection = () => {
   const [platform, setPlatform] = useState<Platform>("Claude");
   const [claudeSurface, setClaudeSurface] = useState<ClaudeSurface>("Web");
+  const [setupMode, setSetupMode] = useState<SetupMode>("Public");
   const [apiKey, setApiKey] = useState<string>("");
 
   const hasKey = Boolean(apiKey);
+  const hasConnection = canUseMode(setupMode, apiKey);
 
   return (
-    <section id="install" className="relative mx-auto max-w-4xl px-6 py-24">
+    <section id="install" className="relative mx-auto max-w-4xl scroll-mt-20 px-6 py-24">
       <FadeIn>
         <span className="font-mono text-xs font-medium uppercase tracking-widest text-primary">
           Quick Install
@@ -401,19 +556,24 @@ const InstallSection = () => {
       </FadeIn>
       <FadeIn delay={0.05}>
         <h2 className="mt-4 text-3xl font-semibold tracking-tight sm:text-4xl">
-          Connect in under a minute.
+          Add UnClick without carrying a master key.
         </h2>
       </FadeIn>
       <FadeIn delay={0.1}>
         <p className="mt-3 max-w-xl text-body">
-          Pick your app. Paste one URL (or click one button). Done.
+          Start with one public MCP address. Use a compatibility URL only when your AI app still needs one.
         </p>
       </FadeIn>
 
-      {/* Signup */}
+      {/* Setup mode */}
       <FadeIn delay={0.15}>
-        <div className="mt-8">
-          <ApiKeySignup onKeyReady={setApiKey} />
+        <div className="mt-8 space-y-4">
+          <SetupModeSwitch setupMode={setupMode} onChange={setSetupMode} />
+          {setupMode === "Public" ? (
+            <PublicDoorSummary />
+          ) : (
+            <ApiKeySignup onKeyReady={setApiKey} />
+          )}
         </div>
       </FadeIn>
 
@@ -421,7 +581,7 @@ const InstallSection = () => {
       <FadeIn delay={0.2}>
         <div
           className={`mt-6 overflow-hidden rounded-xl border transition-all duration-300 ${
-            hasKey ? "border-border/60 bg-card/40" : "border-border/30 bg-card/20"
+            hasConnection ? "border-border/60 bg-card/40" : "border-border/30 bg-card/20"
           }`}
         >
           {/* Platform tabs */}
@@ -463,18 +623,18 @@ const InstallSection = () => {
           {/* Panel */}
           <div className="p-5">
             {platform === "Claude" && (
-              <ClaudePanel apiKey={apiKey} surface={claudeSurface} />
+              <ClaudePanel apiKey={apiKey} surface={claudeSurface} setupMode={setupMode} />
             )}
-            {platform === "ChatGPT" && <ChatGPTPanel apiKey={apiKey} />}
-            {platform === "Cursor" && <CursorPanel apiKey={apiKey} />}
-            {platform === "VS Code" && <VSCodePanel apiKey={apiKey} />}
-            {platform === "Other" && <OtherPanel apiKey={apiKey} />}
+            {platform === "ChatGPT" && <ChatGPTPanel apiKey={apiKey} setupMode={setupMode} />}
+            {platform === "Cursor" && <CursorPanel apiKey={apiKey} setupMode={setupMode} />}
+            {platform === "VS Code" && <VSCodePanel apiKey={apiKey} setupMode={setupMode} />}
+            {platform === "Other" && <OtherPanel apiKey={apiKey} setupMode={setupMode} />}
           </div>
 
-          {!hasKey && (
+          {!hasConnection && (
             <div className="border-t border-border/30 bg-card/40 px-5 py-3">
               <p className="text-center text-xs text-muted-foreground">
-                Enter your email above to unlock your install.
+                Enter your email above to unlock the compatibility URL.
               </p>
             </div>
           )}

--- a/src/components/home/BubbleHome.tsx
+++ b/src/components/home/BubbleHome.tsx
@@ -392,20 +392,22 @@ function JourneyField() {
       cy += (targetY - cy) * ease;
       cs += (scale - cs) * (ease + 0.007);
 
+      const installRect = document.getElementById("install")?.getBoundingClientRect();
+      const installFade = installRect ? interp(installRect.top, [vh * 0.62, vh * 0.95], [0, 1]) : 1;
       const visible = cs > 0.015 && sp < 0.985;
-      bubble.style.opacity = visible ? "1" : "0";
+      bubble.style.opacity = visible ? String(installFade) : "0";
       bubble.style.transform = `translate(${cx - (base * cs) / 2}px, ${cy - (base * cs) / 2}px)`;
       inner.style.transform = `scale(${cs})`;
 
       const ringOpacity = Math.max(0, 1 - Math.abs(sp - 0.955) * 26);
       const ringScale = 1 + Math.max(0, sp - 0.93) * 14;
-      ring.style.opacity = String(ringOpacity * 0.8);
+      ring.style.opacity = String(ringOpacity * 0.8 * installFade);
       ring.style.transform = `translate(${cx - 40}px, ${cy - 40}px) scale(${ringScale})`;
 
       // Hero bundle to the people.
       ctx.clearRect(0, 0, vw, vh);
       const gatherY = cy + (base * cs) / 2 - 6;
-      const peopleAlpha = interp(p, [0.05, 0.14], [1, 0]);
+      const peopleAlpha = interp(p, [0.05, 0.14], [1, 0]) * installFade;
       if (peopleAlpha > 0.01) {
         ctx.strokeStyle = `hsl(183 50% 62% / ${0.5 * peopleAlpha})`;
         ctx.lineWidth = 1.5;
@@ -441,7 +443,7 @@ function JourneyField() {
       }
       const mouthX = cx;
       const mouthY = cy + (base * cs) / 2 - 8;
-      const windowAlpha = interp(sp, [0.05, 0.11, 0.88, 0.94], [0, 1, 1, 0]);
+      const windowAlpha = interp(sp, [0.05, 0.11, 0.88, 0.94], [0, 1, 1, 0]) * installFade;
 
       let bestI = -1;
       let bestD = Infinity;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,20 +3,30 @@ import type { Session, User } from "@supabase/supabase-js";
 import { supabase } from "./supabase";
 import { posthog } from "./posthog";
 
-export async function signInWithMagicLink(email: string) {
+function authRedirectTo(nextPath?: string) {
+  const next =
+    nextPath && nextPath.startsWith("/") && !nextPath.startsWith("//")
+      ? nextPath
+      : "/admin";
+  const url = new URL(`${window.location.origin}/auth/callback`);
+  url.searchParams.set("next", next);
+  return url.toString();
+}
+
+export async function signInWithMagicLink(email: string, nextPath?: string) {
   return supabase.auth.signInWithOtp({
     email,
     options: {
-      emailRedirectTo: `${window.location.origin}/auth/callback`,
+      emailRedirectTo: authRedirectTo(nextPath),
     },
   });
 }
 
-export async function signInWithOAuth(provider: "google" | "azure") {
+export async function signInWithOAuth(provider: "google" | "azure", nextPath?: string) {
   return supabase.auth.signInWithOAuth({
     provider,
     options: {
-      redirectTo: `${window.location.origin}/auth/callback`,
+      redirectTo: authRedirectTo(nextPath),
     },
   });
 }

--- a/src/pages/AppDetail.tsx
+++ b/src/pages/AppDetail.tsx
@@ -87,9 +87,9 @@ const AppDetail = () => {
             <div className="mt-6 rounded-2xl border border-[#61C1C4]/20 bg-[#61C1C4]/[0.05] p-5">
               <p className="text-sm font-semibold text-white">How your AI uses {app.name}</p>
               <ul className="mt-2 space-y-1.5 text-xs leading-5 text-white/55">
-                <li>Ask in plain words and your AI picks {app.name} on its own when it fits.</li>
-                <li>Or name it: say "use {app.name}" and your AI reaches for it.</li>
-                <li>Turn it off in your admin Apps page any time to keep your AI away from it.</li>
+                <li>Your AI talks to UnClick. UnClick reaches {app.name} when the request fits.</li>
+                <li>Or name it: say "use {app.name}" and UnClick routes the request there.</li>
+                <li>Turn it off in your admin Apps page any time without reinstalling UnClick.</li>
               </ul>
             </div>
 
@@ -117,7 +117,7 @@ const AppDetail = () => {
               </div>
               <p className="mt-1.5 text-xs leading-5 text-white/55">
                 Most apps work straight away with nothing to set up. If {app.name} needs a login or
-                an API key, you add it once in Passport and your AI remembers it.
+                an API key, connect it once to UnClick and every paired AI app can use it through UnClick.
               </p>
               <Link
                 to="/admin/keychain"

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -17,14 +17,14 @@ const LIVE_TOOL_COUNT = LIVE_APPS.reduce((n, a) => n + a.toolCount, 0);
 // Super-simple-English induction so anyone gets what this page is in one read.
 function HowItWorks() {
   const points = [
-    { k: "It picks for you", v: "Ask your AI something like \"what's the weather\" or \"is my site up\". It finds the right app and uses it. You do not pick." },
-    { k: "Or name one", v: "Want a specific app? Just say it: \"use GitHub\". Your AI reaches for that one." },
-    { k: "Built-in apps just work", v: "Most apps need no setup. A few need you to connect once with a login or key." },
-    { k: "You stay in control", v: "All apps are on by default. Turn any of them off in your admin so your AI leaves it alone." },
+    { k: "One UnClick door", v: "Connect Claude, ChatGPT, Cursor, or Codex to UnClick once. They all reach the same app layer." },
+    { k: "Apps live inside UnClick", v: "GitHub, Gmail, Spotify, and the rest connect to UnClick, not separately to every AI app." },
+    { k: "Connect only when needed", v: "Built-in apps just work. Private apps ask for one login or key, then stay available." },
+    { k: "You stay in control", v: "Turn any app off, reconnect it, or remove it without reinstalling UnClick in your AI app." },
   ];
   return (
     <div className="mx-auto mb-8 max-w-6xl rounded-2xl border border-[#61C1C4]/20 bg-[#61C1C4]/[0.05] p-5">
-      <p className="text-sm font-semibold text-white">Your AI has these apps at arm's reach.</p>
+      <p className="text-sm font-semibold text-white">Your AI reaches apps through UnClick.</p>
       <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {points.map((p) => (
           <div key={p.k}>

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -26,6 +26,7 @@ export default function AuthCallbackPage() {
   const [params] = useSearchParams();
   const { session, loading } = useSession();
 
+  const nextPath = safeNext(params.get("next"));
   const urlError = params.get("error_description") || params.get("error");
   const [timedOut, setTimedOut] = useState(false);
   const tracked = useRef(false);
@@ -62,11 +63,11 @@ export default function AuthCallbackPage() {
         if (aal?.nextLevel === "aal2" && aal.currentLevel !== "aal2") {
           navigate("/auth/verify-mfa", { replace: true });
         } else {
-          navigate("/admin", { replace: true });
+          navigate(nextPath, { replace: true });
         }
       })();
     }
-  }, [loading, session, navigate]);
+  }, [loading, session, navigate, nextPath]);
 
   // If we've been waiting more than 8 seconds with no session and no
   // URL error, something went wrong silently - nudge the user back
@@ -118,4 +119,9 @@ export default function AuthCallbackPage() {
       <Footer />
     </div>
   );
+}
+
+function safeNext(value: string | null): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return "/admin";
+  return value;
 }

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -195,7 +195,7 @@ export default function ConnectPage() {
         error?:             string;
       };
       if (!res.ok) {
-        setMintError(body.error ?? "Could not get your Passport key.");
+      setMintError(body.error ?? "Could not get your UnClick connection key.");
         return;
       }
       if (body.api_key) {
@@ -223,7 +223,7 @@ export default function ConnectPage() {
       });
       const body = (await safeJson(res)) as { api_key?: string; error?: string };
       if (!res.ok || !body.api_key) {
-        setMintError(body.error ?? "Could not reset your Passport key.");
+        setMintError(body.error ?? "Could not reset your UnClick connection key.");
         return;
       }
       try { localStorage.setItem("unclick_api_key", body.api_key); } catch { /* ignore */ }
@@ -251,7 +251,7 @@ export default function ConnectPage() {
     if (!currentApiKey) {
       setPageState({
         kind:    "error",
-        message: "No UnClick API key found. Please add your API key below and try again.",
+        message: "No UnClick connection key found. Add the key below and try again.",
       });
       return;
     }
@@ -297,10 +297,10 @@ export default function ConnectPage() {
         <main className="flex min-h-[60vh] items-center justify-center px-6">
           <div className="text-center space-y-4 max-w-md">
             <p className="text-body text-lg">
-              {platform ? `This Passport service is not listed yet: ${platform}` : "No Passport service specified."}
+              {platform ? `This app is not listed yet: ${platform}` : "No app specified."}
             </p>
-            <Link to="/admin/keychain" className="text-primary hover:underline text-sm">
-              Back to Passport
+            <Link to="/admin/apps" className="text-primary hover:underline text-sm">
+              Back to apps
             </Link>
           </div>
         </main>
@@ -342,8 +342,8 @@ export default function ConnectPage() {
             ))}
           </div>
 
-          <Link to="/admin/keychain" className="inline-block text-sm text-body hover:text-heading">
-            Back to Passport
+          <Link to="/admin/apps" className="inline-block text-sm text-body hover:text-heading">
+            Back to apps
           </Link>
         </div>
       </ConnectShell>
@@ -408,7 +408,7 @@ export default function ConnectPage() {
     e.preventDefault();
     const currentApiKey = apiKey.trim();
     if (!currentApiKey) {
-      setPageState({ kind: "error", message: "UnClick API key is required." });
+      setPageState({ kind: "error", message: "UnClick connection key is required." });
       return;
     }
 
@@ -484,24 +484,24 @@ export default function ConnectPage() {
   return (
     <ConnectShell connector={connector}>
       <div className="space-y-6">
-        {/* Passport key onboarding. */}
+        {/* Connection-key onboarding. */}
         {session && !apiKey ? (
           <div className="space-y-3">
             <p className="text-xs text-body leading-relaxed">
-              Your Passport key lives in your browser, not on our servers.
-              We only store a one-way fingerprint, so even we cannot read
-              your saved credentials. Only you can.
+              This connects {connector.name} to UnClick, not directly to one AI app.
+              The private key is used here to encrypt this app login so only your
+              UnClick connection can read it back.
             </p>
 
             {alreadyProvisioned ? (
               <>
                 <div className="rounded-lg border border-border/60 bg-card/40 p-4 space-y-2">
                   <p className="text-sm text-heading">
-                    You already have a Passport key on file.
+                    You already have an UnClick connection key on file.
                   </p>
                   <p className="text-xs text-body leading-relaxed">
                     Since the key lives only in your browser and you do not
-                    have it here, you can either mint a fresh one now or
+                    have it here, you can either make a fresh one now or
                     paste the existing one if you saved it elsewhere.
                   </p>
                 </div>
@@ -520,7 +520,7 @@ export default function ConnectPage() {
                       {resettingKey ? "Making a new key..." : "Make a new key"}
                     </span>
                     <span className="block text-xs text-muted-foreground">
-                      Replaces the old key. Any other devices using it will need the new one.
+                      Replaces the old key. Static MCP URLs using it will need the new one.
                     </span>
                   </span>
                 </button>
@@ -538,7 +538,7 @@ export default function ConnectPage() {
                       Paste my existing key
                     </span>
                     <span className="block text-xs text-muted-foreground">
-                      Keeps your existing key. No other devices break.
+                      Keeps your existing key. Existing compatibility URLs keep working.
                     </span>
                   </span>
                 </button>
@@ -556,7 +556,7 @@ export default function ConnectPage() {
                   </span>
                   <span className="flex-1">
                     <span className="block text-sm font-semibold text-heading">
-                      {mintingKey ? "Getting your key..." : "Get my Passport key"}
+                      {mintingKey ? "Getting your key..." : "Get my UnClick connection key"}
                     </span>
                     <span className="block text-xs text-muted-foreground">
                       Fresh key, saved to this browser.
@@ -587,7 +587,7 @@ export default function ConnectPage() {
             {showManualPaste && (
               <div className="space-y-1.5 border border-border/60 rounded-lg p-4 bg-card/40">
                 <Label htmlFor="api_key" className="text-sm text-heading">
-                  Your UnClick Passport key
+                  Your UnClick connection key
                 </Label>
                 <Input
                   id="api_key"
@@ -607,10 +607,10 @@ export default function ConnectPage() {
         ) : (
           <div className="space-y-1.5 border border-border/60 rounded-lg p-4 bg-card/40">
             <Label htmlFor="api_key" className="text-sm text-heading">
-              Your UnClick Passport key
+              Your UnClick connection key
             </Label>
             <p className="text-xs text-muted-foreground">
-              Needed once in this browser so Passport can store access securely.{" "}
+              Needed once in this browser so UnClick can store this app login securely.{" "}
               <Link to="/" className="text-primary hover:underline">Get one here.</Link>
             </p>
             <Input
@@ -770,13 +770,13 @@ function ConnectShell({
           {/* Header */}
           <header className="text-center space-y-4">
             <Link
-              to="/admin/keychain"
+              to="/admin/apps"
               className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-heading"
             >
               <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
               </svg>
-              Passport
+              Apps
             </Link>
 
             <div className="w-14 h-14 rounded-xl bg-primary/10 border border-primary/25 flex items-center justify-center mx-auto">
@@ -806,7 +806,7 @@ function ConnectShell({
           </div>
 
           <p className="text-center text-xs text-muted-foreground">
-            Your login details are stored encrypted. Only your API key can read them back.
+            Stored for your UnClick account. Your AI apps use it through UnClick after you approve it.
           </p>
         </div>
       </main>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import FadeIn from "@/components/FadeIn";
@@ -22,9 +22,11 @@ import { track } from "@/lib/analytics";
 export default function LoginPage() {
   useCanonical("https://unclick.world/login");
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { session, loading: sessionLoading } = useSession();
 
-  const [email, setEmail] = useState("");
+  const nextPath = safeNext(searchParams.get("next"));
+  const [email, setEmail] = useState(searchParams.get("email") ?? "");
   const [busy, setBusy] = useState<"magic" | "google" | "azure" | null>(null);
   const [error, setError] = useState("");
   const [sent, setSent] = useState(false);
@@ -32,9 +34,9 @@ export default function LoginPage() {
   // If already authenticated, bounce to memory admin.
   useEffect(() => {
     if (!sessionLoading && session) {
-      navigate("/admin", { replace: true });
+      navigate(nextPath, { replace: true });
     }
-  }, [sessionLoading, session, navigate]);
+  }, [sessionLoading, session, navigate, nextPath]);
 
   async function handleMagicLink(e: React.FormEvent) {
     e.preventDefault();
@@ -47,7 +49,7 @@ export default function LoginPage() {
     setBusy("magic");
     track("login_started", { method: "magic" });
     try {
-      await signInWithMagicLink(trimmed);
+      await signInWithMagicLink(trimmed, nextPath);
       setSent(true);
       posthog.capture("signin_started", { method: "magic_link" });
     } catch (err) {
@@ -63,7 +65,7 @@ export default function LoginPage() {
     track("login_started", { method: provider });
     posthog.capture("signin_started", { method: provider });
     try {
-      await signInWithOAuth(provider);
+      await signInWithOAuth(provider, nextPath);
       // Redirect happens via Supabase. Nothing else to do here.
     } catch (err) {
       setError(err instanceof Error ? err.message : "Couldn't start sign in. Try again.");
@@ -192,6 +194,11 @@ export default function LoginPage() {
       <Footer />
     </div>
   );
+}
+
+function safeNext(value: string | null): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return "/admin";
+  return value;
 }
 
 function GoogleIcon({ className }: { className?: string }) {

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Check, Copy, ExternalLink, Loader2, ShieldCheck } from "lucide-react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Button } from "@/components/ui/button";
+import { useSession } from "@/lib/auth";
+
+const PUBLIC_MCP_URL = "https://unclick.world/api/mcp";
+const STORAGE_KEY = "unclick_api_key";
+
+type ProfileResponse = {
+  api_key?: { prefix?: string | null } | null;
+  generated_api_key?: string | null;
+  email?: string | null;
+  error?: string;
+};
+
+function maskPrivateValue(value: string) {
+  return value.replace(/uc_[A-Za-z0-9_-]{8,}/g, (key) => `${key.slice(0, 6)}...${key.slice(-4)}`);
+}
+
+export default function PairingCompletePage() {
+  const navigate = useNavigate();
+  const { session, loading } = useSession();
+  const [apiKey, setApiKey] = useState("");
+  const [email, setEmail] = useState("");
+  const [loadingProfile, setLoadingProfile] = useState(false);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState<"public" | "compat" | null>(null);
+
+  useEffect(() => {
+    if (!loading && !session) {
+      navigate(`/login?next=${encodeURIComponent("/pair/connected")}`, { replace: true });
+    }
+  }, [loading, navigate, session]);
+
+  useEffect(() => {
+    if (!session) return;
+    let cancelled = false;
+
+    (async () => {
+      setLoadingProfile(true);
+      setError("");
+      try {
+        const res = await fetch("/api/memory-admin?action=admin_profile", {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        const body = (await res.json().catch(() => ({}))) as ProfileResponse;
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(body.error ?? "Your sign-in worked, but we could not prepare the connection yet.");
+          return;
+        }
+        setEmail(body.email ?? session.user.email ?? "");
+        if (body.generated_api_key) {
+          setApiKey(body.generated_api_key);
+          try {
+            localStorage.setItem(STORAGE_KEY, body.generated_api_key);
+          } catch {
+            // Ignore private browsing storage failures.
+          }
+        } else if (body.api_key?.prefix) {
+          try {
+            const cached = localStorage.getItem(STORAGE_KEY) ?? "";
+            if (cached.startsWith(body.api_key.prefix)) setApiKey(cached);
+          } catch {
+            // Ignore.
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Network error.");
+        }
+      } finally {
+        if (!cancelled) setLoadingProfile(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [session]);
+
+  async function copy(value: string, key: "public" | "compat") {
+    await navigator.clipboard.writeText(value);
+    setCopied(key);
+    window.setTimeout(() => setCopied(null), 1800);
+  }
+
+  const compatibilityUrl = apiKey ? `${PUBLIC_MCP_URL}?key=${apiKey}` : "";
+  const displayCompatibilityUrl = compatibilityUrl ? maskPrivateValue(compatibilityUrl) : "";
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navbar />
+      <main className="mx-auto flex min-h-[72vh] w-full max-w-2xl items-center px-4 py-20">
+        <section className="w-full rounded-2xl border border-border/60 bg-card/45 p-6 shadow-lg sm:p-8">
+          {loading || loadingProfile ? (
+            <div className="py-10 text-center">
+              <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" />
+              <h1 className="mt-4 text-xl font-semibold text-heading">Preparing UnClick</h1>
+              <p className="mt-1 text-sm text-muted-foreground">One moment.</p>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="text-center">
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/15">
+                  <Check className="h-6 w-6 text-primary" />
+                </div>
+                <h1 className="mt-4 text-2xl font-semibold text-heading">UnClick is ready</h1>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {email ? `${email} is signed in. ` : ""}
+                  Return to your AI app. If it asks to pair again, use the compatibility URL below.
+                </p>
+              </div>
+
+              {error ? (
+                <div className="rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-100">
+                  {error}
+                </div>
+              ) : null}
+
+              <div className="rounded-xl border border-primary/25 bg-primary/5 p-4">
+                <div className="flex items-start gap-3">
+                  <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <div>
+                    <p className="text-sm font-semibold text-heading">Use the public door first</p>
+                    <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                      This address carries no personal key. If your AI app supports pairing, it can stay forever.
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-3 flex items-stretch gap-2">
+                  <code className="min-w-0 flex-1 truncate rounded-md border border-border/50 bg-background/50 px-3 py-2 font-mono text-xs text-heading">
+                    {PUBLIC_MCP_URL}
+                  </code>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="shrink-0 bg-primary text-black hover:opacity-90"
+                    onClick={() => void copy(PUBLIC_MCP_URL, "public")}
+                  >
+                    <Copy className="mr-1.5 h-3.5 w-3.5" />
+                    {copied === "public" ? "Copied" : "Copy"}
+                  </Button>
+                </div>
+              </div>
+
+              <details className="rounded-xl border border-border/60 bg-background/25 p-4">
+                <summary className="cursor-pointer text-sm font-semibold text-heading">
+                  If your AI app only accepts a static URL
+                </summary>
+                <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                  Use this compatibility URL for now. It contains a private connection key, so the full value stays hidden on screen.
+                </p>
+                {compatibilityUrl ? (
+                  <div className="mt-3 flex items-stretch gap-2">
+                    <code className="min-w-0 flex-1 truncate rounded-md border border-border/50 bg-card/60 px-3 py-2 font-mono text-xs text-heading">
+                      {displayCompatibilityUrl}
+                    </code>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="shrink-0"
+                      onClick={() => void copy(compatibilityUrl, "compat")}
+                    >
+                      <Copy className="mr-1.5 h-3.5 w-3.5" />
+                      {copied === "compat" ? "Copied" : "Copy"}
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="mt-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-100">
+                    This browser does not have the private key available. Open the installer to make a fresh compatibility URL.
+                  </p>
+                )}
+              </details>
+
+              <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+                <Button asChild className="bg-primary text-black hover:opacity-90">
+                  <Link to="/admin/apps">
+                    Connect apps
+                    <ExternalLink className="ml-2 h-3.5 w-3.5" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline">
+                  <Link to="/#install">Open installer</Link>
+                </Button>
+              </div>
+            </div>
+          )}
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/admin/AdminEcosystemPages.tsx
+++ b/src/pages/admin/AdminEcosystemPages.tsx
@@ -293,11 +293,11 @@ export function AdminAppsIntro() {
       <div className="flex items-start gap-3">
         <AppWindow className="mt-0.5 h-4 w-4 shrink-0 text-[#61C1C4]" />
         <div>
-          <p className="text-sm font-semibold text-white">Apps are what UnClick can use. Actions are what each app can do.</p>
+          <p className="text-sm font-semibold text-white">Apps connect to UnClick once.</p>
           <p className="mt-1 text-sm leading-6 text-white/55">
-            Click any app row to expand its actions right here, or click its name to open its page.
-            Your AI picks the right app on its own, or you can ask for one by name. Every app is on by
-            default; untick one to stop your AI using it.
+            Your AI app talks to UnClick. UnClick reaches GitHub, Gmail, Spotify, and the rest from here.
+            Click any row to see its actions, connect private apps once, or untick one to keep every
+            paired AI app away from it.
           </p>
         </div>
       </div>

--- a/src/pages/admin/AdminYou.test.tsx
+++ b/src/pages/admin/AdminYou.test.tsx
@@ -113,14 +113,15 @@ describe("AdminYou API key card", () => {
     vi.restoreAllMocks();
   });
 
-  it("shows clear copy actions when the raw API key is available", async () => {
+  it("shows public and compatibility copy actions when the raw API key is available", async () => {
     stubFetch("uc_test_1234567890");
 
     renderPage();
 
-    expect(await screen.findByRole("button", { name: /Copy API key/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Copy MCP URL/i })).toBeInTheDocument();
-    expect(screen.getByText(/Copy it now or copy the ready-made MCP URL/i)).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Copy public URL/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Copy compatibility URL/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Copy key/i })).toBeInTheDocument();
+    expect(screen.getByText(/Use the public MCP door first/i)).toBeInTheDocument();
     await waitForInitialAdminYouFetches();
   });
 
@@ -130,7 +131,8 @@ describe("AdminYou API key card", () => {
     renderPage();
 
     expect(await screen.findByText(/stores only a hash after setup/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Create new copyable key/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Rotate compatibility key/i })).toBeInTheDocument();
+    expect(screen.getByText(/public MCP door is unchanged/i)).toBeInTheDocument();
     await waitForInitialAdminYouFetches();
   });
 

--- a/src/pages/admin/AdminYou.tsx
+++ b/src/pages/admin/AdminYou.tsx
@@ -552,6 +552,7 @@ export default function AdminYou() {
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const [keyRevealed, setKeyRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [publicMcpCopied, setPublicMcpCopied] = useState(false);
   const [mcpCopied, setMcpCopied] = useState(false);
   const revealTimerRef = useRef<number | null>(null);
   const [reissuing, setReissuing] = useState(false);
@@ -729,6 +730,16 @@ export default function AdminYou() {
       await navigator.clipboard.writeText(`https://unclick.world/api/mcp?key=${generatedKey}`);
       setMcpCopied(true);
       window.setTimeout(() => setMcpCopied(false), 2_000);
+    } catch {
+      // Browser can block clipboard writes in some contexts; fail silent.
+    }
+  }
+
+  async function handleCopyPublicMcpUrl() {
+    try {
+      await navigator.clipboard.writeText("https://unclick.world/api/mcp");
+      setPublicMcpCopied(true);
+      window.setTimeout(() => setPublicMcpCopied(false), 2_000);
     } catch {
       // Browser can block clipboard writes in some contexts; fail silent.
     }
@@ -951,7 +962,7 @@ export default function AdminYou() {
     { id: "you-profile", label: "Profile", icon: User, ready: Boolean(user?.email) },
     { id: "you-about", label: "About You", icon: Fingerprint, ready: Boolean(savedAboutYou?.text) },
     { id: "you-style", label: "AI Style", icon: Sparkles, ready: Boolean(savedAiStyle) },
-    { id: "you-api-key", label: "API Key", icon: KeyRound, ready: Boolean(generatedKey || profile?.api_key?.is_active) },
+    { id: "you-api-key", label: "Connection", icon: KeyRound, ready: Boolean(generatedKey || profile?.api_key?.is_active) },
     { id: "you-my-data", label: "My Data", icon: Database, ready: true },
   ];
 
@@ -1381,11 +1392,11 @@ export default function AdminYou() {
             </div>
           </section>
 
-          {/* API Key card */}
+          {/* Connection card */}
           <section id="you-api-key" className="scroll-mt-24 rounded-xl border border-white/[0.06] bg-white/[0.03] p-6">
             <h2 className="flex items-center gap-2 text-sm font-semibold text-white">
               <KeyRound className="h-4 w-4 text-[#E2B93B]" />
-              My API Key
+              UnClick connection
               <span className="rounded-full border border-white/[0.08] bg-white/[0.04] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white/45">
                 Connection
               </span>
@@ -1396,9 +1407,9 @@ export default function AdminYou() {
                 <div className="rounded-lg border border-[#E2B93B]/30 bg-[#E2B93B]/5 p-4">
                   <div className="flex items-start gap-2 text-xs text-[#E2B93B]">
                     <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span>Your UnClick API key. Copy it now or copy the ready-made MCP URL below. Revealing the key is optional and auto-hides after 60 seconds. Signing out clears this local copy.</span>
+                    <span>This is your private compatibility key. Use the public MCP door first; reveal this only when an AI app still needs a static URL.</span>
                   </div>
-                  <label className="mt-3 block text-[11px] font-semibold uppercase tracking-wider text-white/40">API key</label>
+                  <label className="mt-3 block text-[11px] font-semibold uppercase tracking-wider text-white/40">Private compatibility key</label>
                   <div className="mt-1.5 flex flex-col gap-2 sm:flex-row sm:items-stretch">
                     <code className="flex min-w-0 flex-1 items-center overflow-x-auto rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 font-mono text-xs text-white">
                       {keyRevealed ? generatedKey : maskValue(generatedKey)}
@@ -1418,18 +1429,31 @@ export default function AdminYou() {
                         title="Copy key to clipboard"
                       >
                         {copied ? <Check className="h-3.5 w-3.5 text-green-400" /> : <Copy className="h-3.5 w-3.5" />}
-                        {copied ? "Copied" : "Copy API key"}
+                        {copied ? "Copied" : "Copy key"}
                       </button>
                     </div>
                   </div>
                 </div>
 
                 <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
-                  <h3 className="text-sm font-medium text-white">Connect your agent</h3>
+                  <h3 className="text-sm font-medium text-white">Connect an AI app</h3>
                   <p className="mt-1 text-xs leading-5 text-white/50">
-                    Add this as a Remote MCP Server in your AI agent's MCP settings.
+                    Start with the public door. It has no personal key in the URL.
                   </p>
-                  <label className="mt-3 block text-[11px] font-semibold uppercase tracking-wider text-white/40">Remote MCP Server URL</label>
+                  <label className="mt-3 block text-[11px] font-semibold uppercase tracking-wider text-white/40">Public MCP door</label>
+                  <div className="mt-1.5 flex flex-col gap-2 sm:flex-row sm:items-stretch">
+                    <code className="flex min-w-0 flex-1 items-center overflow-x-auto rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 font-mono text-xs text-white/70">
+                      https://unclick.world/api/mcp
+                    </code>
+                    <button
+                      onClick={handleCopyPublicMcpUrl}
+                      className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg border border-[#61C1C4]/35 bg-[#61C1C4]/10 px-3 py-2 text-xs font-semibold text-[#9edfe1] transition-colors hover:bg-[#61C1C4]/15"
+                    >
+                      {publicMcpCopied ? <Check className="h-3.5 w-3.5 text-green-400" /> : <Copy className="h-3.5 w-3.5" />}
+                      {publicMcpCopied ? "Copied" : "Copy public URL"}
+                    </button>
+                  </div>
+                  <label className="mt-4 block text-[11px] font-semibold uppercase tracking-wider text-white/40">Compatibility URL</label>
                   <div className="mt-1.5 flex flex-col gap-2 sm:flex-row sm:items-stretch">
                     <code className="flex min-w-0 flex-1 items-center overflow-x-auto rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 font-mono text-xs text-white/70">
                       https://unclick.world/api/mcp?key={keyRevealed ? generatedKey : maskValue(generatedKey)}
@@ -1439,18 +1463,18 @@ export default function AdminYou() {
                       className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg border border-white/[0.08] bg-white/[0.04] px-3 py-2 text-xs font-semibold text-white/80 transition-colors hover:bg-white/[0.08]"
                     >
                       {mcpCopied ? <Check className="h-3.5 w-3.5 text-green-400" /> : <Copy className="h-3.5 w-3.5" />}
-                      {mcpCopied ? "Copied" : "Copy MCP URL"}
+                      {mcpCopied ? "Copied" : "Copy compatibility URL"}
                     </button>
                   </div>
                   <p className="mt-2 text-xs text-white/40">
-                    Once connected, your agent loads your memory at the start of every conversation.
+                    Rotating this key can break compatibility URLs. The public door is the long-term path that avoids that.
                   </p>
                 </div>
               </div>
             ) : profile?.api_key ? (
               <div className="mt-4 space-y-4">
                 <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
-                  <label className="block text-[11px] font-semibold uppercase tracking-wider text-white/40">API key</label>
+                  <label className="block text-[11px] font-semibold uppercase tracking-wider text-white/40">Private compatibility key</label>
                   <div className="mt-1.5 flex flex-col gap-2 sm:flex-row sm:items-stretch">
                     <code className="flex min-w-0 flex-1 items-center rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 font-mono text-xs text-white/60">
                       {profile.api_key.prefix}{"•".repeat(16)}
@@ -1460,13 +1484,12 @@ export default function AdminYou() {
                       disabled={reissuing}
                       className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg border border-[#61C1C4]/35 bg-[#61C1C4]/10 px-3 py-2 text-xs font-semibold text-[#9edfe1] transition-colors hover:bg-[#61C1C4]/15 disabled:opacity-50"
                     >
-                      {reissuing ? "Creating..." : "Create new copyable key"}
+                      {reissuing ? "Creating..." : "Rotate compatibility key"}
                     </button>
                   </div>
                   <p className="mt-2 text-[11px] leading-5 text-[#888]">
-                    For security, UnClick stores only a hash after setup, not the old raw key. If this browser lost the
-                    copyable value, create a new copyable key. The old key is invalidated, and saved Connections may need
-                    to be reconnected or re-saved.
+                    For security, UnClick stores only a hash after setup, not the old raw key. Rotating creates a fresh
+                    private key and invalidates static compatibility URLs that used the old one. The public MCP door is unchanged.
                   </p>
                   {reissueError && <p className="mt-1 text-[11px] text-red-400">{reissueError}</p>}
                 </div>
@@ -1500,7 +1523,7 @@ export default function AdminYou() {
             ) : (
               <div className="mt-4 rounded-lg border border-dashed border-white/[0.08] p-4 text-center">
                 <p className="text-xs text-[#666]">
-                  Preparing your API key. Refresh this page if it does not appear within a few seconds.
+                  Preparing your connection. Refresh this page if it does not appear within a few seconds.
                 </p>
               </div>
             )}


### PR DESCRIPTION
Summary:
- make https://unclick.world/api/mcp the primary LLM_MCP_UNCLICK address
- move private key URLs into compatibility mode and mask them on screen
- add pairing complete route and public MCP pairing tests

Verification:
- npx vitest run src/__tests__/public-mcp-door-copy.test.ts api/mcp-public-pairing.test.ts
- npm run build
- local browser check confirmed new installer copy and masked private values