### PR TITLE
[codex] Fix GitHub connect OAuth and key wording

### DIFF
--- a/api/arena.ts
+++ b/api/arena.ts
@@ -20,8 +20,8 @@ import { createClient } from "@supabase/supabase-js";
 import {
   decideAiProviderCall,
   type AiProviderCallDecision,
-} from "./lib/ai-provider-inventory";
-import { resolveModelForRole } from "./lib/model-routing/model-split";
+} from "./lib/ai-provider-inventory.js";
+import { resolveModelForRole } from "./lib/model-routing/model-split.js";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/api/backstagepass.ts
+++ b/api/backstagepass.ts
@@ -62,7 +62,7 @@ import * as crypto from "crypto";
 import {
   decideBackstagePassConnectionProbeProviderCall,
   type BackstagePassConnectionProbeProvider,
-} from "./lib/ai-provider-inventory";
+} from "./lib/ai-provider-inventory.js";
 
 // ─── Crypto helpers (mirror api/credentials.ts exactly) ───────────────────
 

--- a/api/memory/embed.ts
+++ b/api/memory/embed.ts
@@ -18,7 +18,7 @@ import { createClient } from "@supabase/supabase-js";
 import {
   decideAiProviderCall,
   type AiProviderCallDecision,
-} from "../lib/ai-provider-inventory";
+} from "../lib/ai-provider-inventory.js";
 
 const ALLOWED_TABLES = new Set([
   "mc_extracted_facts",

--- a/api/oauth-callback.ts
+++ b/api/oauth-callback.ts
@@ -23,7 +23,7 @@
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { verifyOAuthStateToken } from "./oauth-state";
+import { verifyOAuthStateToken } from "./oauth-state.js";
 
 // ─── Platform OAuth configs ────────────────────────────────────────────────────
 

--- a/api/oauth-init.ts
+++ b/api/oauth-init.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { createOAuthStateToken } from "./oauth-state";
+import { createOAuthStateToken } from "./oauth-state.js";
 
 const ALLOWED_PLATFORMS = new Set([
   "github", "xero", "reddit", "shopify",

--- a/api/oauth-state.test.ts
+++ b/api/oauth-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createOAuthStateToken, verifyOAuthStateToken } from "./oauth-state";
+import { createOAuthStateToken, verifyOAuthStateToken } from "./oauth-state.js";
 
 const env = {
   GITHUB_CLIENT_SECRET: "github-secret",

--- a/api/seats-api-usage.ts
+++ b/api/seats-api-usage.ts
@@ -21,7 +21,7 @@ import {
   summarizeSeatsApiUsage,
   type SeatsApiBudgetCap,
   type SeatsApiUsageInput,
-} from "../src/lib/seatsApiUsage";
+} from "../src/lib/seatsApiUsage.js";
 
 type Db = ReturnType<typeof createClient>;
 

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16353,8 +16353,8 @@
     },
     {
       "source": "src/pages/Connect.tsx",
-      "hash": "3597b15bc3d8",
-      "bytes": 30272
+      "hash": "6ad4683037b9",
+      "bytes": 30418
     },
     {
       "source": "src/pages/Crews.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -127,7 +127,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Apps.tsx | 65bd43917eab | 3135 |
 | src/pages/AuthCallback.tsx | e9ee37622f98 | 5086 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
-| src/pages/Connect.tsx | 3597b15bc3d8 | 30272 |
+| src/pages/Connect.tsx | 6ad4683037b9 | 30418 |
 | src/pages/Crews.tsx | d160a7924721 | 12800 |
 | src/pages/DeveloperDocs.tsx | 40631b01bc27 | 21214 |
 | src/pages/DeveloperSubmit.tsx | 8724b6d03268 | 12447 |

--- a/scripts/api-lib-esm-extension-guard.test.mjs
+++ b/scripts/api-lib-esm-extension-guard.test.mjs
@@ -7,8 +7,8 @@
 // Vercel's nodenext ESM loader is strict, so prod broke. The api/ workspace
 // has no typecheck/build gate in CI that mirrors Vercel's ESM resolution.
 //
-// This guard fails CI if any TypeScript or JavaScript source file under
-// api/lib/ contains a relative import (static or dynamic, value or type-only,
+// This guard fails CI if any TypeScript or JavaScript source file under the
+// production API surface contains a relative import (static or dynamic, value or type-only,
 // import or re-export) whose specifier does not carry an explicit recognised
 // extension. Test files (`*.test.ts`) are excluded because they run under vitest,
 // not Vercel.
@@ -26,7 +26,10 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
-const scanRoot = path.join(repoRoot, "api", "lib");
+const scanRoots = [
+  path.join(repoRoot, "api"),
+  path.join(repoRoot, "api", "lib"),
+];
 
 // Files of these extensions are scanned as source.
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".mjs", ".cjs"]);
@@ -117,12 +120,16 @@ test("guard regex catches the historical .js-omission bug shape", () => {
   assert.equal(hasAllowedExtension(fixedHits[0].specifier), true);
 });
 
-test("api/lib relative imports all carry an explicit ESM extension", () => {
-  const files = walkSourceFiles(scanRoot);
-  assert.ok(files.length > 0, `expected source files under ${path.relative(repoRoot, scanRoot)}`);
+test("production API relative imports all carry an explicit ESM extension", () => {
+  const files = [];
+  for (const scanRoot of scanRoots) {
+    files.push(...walkSourceFiles(scanRoot));
+  }
+  const uniqueFiles = Array.from(new Map(files.map((file) => [file.fullPath, file])).values());
+  assert.ok(uniqueFiles.length > 0, "expected production API source files");
 
   const offenders = [];
-  for (const { fullPath, relativePath } of files) {
+  for (const { fullPath, relativePath } of uniqueFiles) {
     const content = fs.readFileSync(fullPath, "utf8");
     for (const { specifier, offset } of findRelativeImports(content)) {
       if (hasAllowedExtension(specifier)) continue;
@@ -135,7 +142,7 @@ test("api/lib relative imports all carry an explicit ESM extension", () => {
     offenders,
     [],
     [
-      "Found relative imports in api/lib/ without an explicit .js extension.",
+      "Found production API relative imports without an explicit .js extension.",
       "Vercel's nodenext ESM loader will reject these at runtime with ERR_MODULE_NOT_FOUND",
       "(see PR #1047). Add the .js extension to each specifier:",
       ...offenders,

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -66,7 +66,7 @@ async function safeJson<T>(res: Response): Promise<T | { error: string }> {
     return {
       error: res.ok
         ? "The server sent an unexpected reply. Please try again."
-        : `Server error (${res.status}). Please try again - if this keeps happening, the ${"sign-in app"} may not be fully configured yet.`,
+        : `Server error (${res.status}). The app login setup is not starting cleanly yet. Use the token fallback for now, or try again after the OAuth settings are fixed.`,
     };
   }
 }
@@ -195,7 +195,7 @@ export default function ConnectPage() {
         error?:             string;
       };
       if (!res.ok) {
-      setMintError(body.error ?? "Could not get your UnClick connection key.");
+        setMintError(body.error ?? "Could not get your private UnClick account key.");
         return;
       }
       if (body.api_key) {
@@ -223,7 +223,7 @@ export default function ConnectPage() {
       });
       const body = (await safeJson(res)) as { api_key?: string; error?: string };
       if (!res.ok || !body.api_key) {
-        setMintError(body.error ?? "Could not reset your UnClick connection key.");
+        setMintError(body.error ?? "Could not reset your private UnClick account key.");
         return;
       }
       try { localStorage.setItem("unclick_api_key", body.api_key); } catch { /* ignore */ }
@@ -251,7 +251,7 @@ export default function ConnectPage() {
     if (!currentApiKey) {
       setPageState({
         kind:    "error",
-        message: "No UnClick connection key found. Add the key below and try again.",
+        message: "No private UnClick account key found. Add the key below and try again.",
       });
       return;
     }
@@ -408,7 +408,7 @@ export default function ConnectPage() {
     e.preventDefault();
     const currentApiKey = apiKey.trim();
     if (!currentApiKey) {
-      setPageState({ kind: "error", message: "UnClick connection key is required." });
+      setPageState({ kind: "error", message: "Private UnClick account key is required." });
       return;
     }
 
@@ -484,20 +484,20 @@ export default function ConnectPage() {
   return (
     <ConnectShell connector={connector}>
       <div className="space-y-6">
-        {/* Connection-key onboarding. */}
+        {/* Account-key onboarding. */}
         {session && !apiKey ? (
           <div className="space-y-3">
             <p className="text-xs text-body leading-relaxed">
-              This connects {connector.name} to UnClick, not directly to one AI app.
-              The private key is used here to encrypt this app login so only your
-              UnClick connection can read it back.
+              This connects {connector.name} to your UnClick account, not directly
+              to one AI app. This is your private UnClick account key, not a
+              disposable installer code.
             </p>
 
             {alreadyProvisioned ? (
               <>
                 <div className="rounded-lg border border-border/60 bg-card/40 p-4 space-y-2">
                   <p className="text-sm text-heading">
-                    You already have an UnClick connection key on file.
+                    You already have a private UnClick account key on file.
                   </p>
                   <p className="text-xs text-body leading-relaxed">
                     Since the key lives only in your browser and you do not
@@ -520,7 +520,7 @@ export default function ConnectPage() {
                       {resettingKey ? "Making a new key..." : "Make a new key"}
                     </span>
                     <span className="block text-xs text-muted-foreground">
-                      Replaces the old key. Static MCP URLs using it will need the new one.
+                      Replaces the old account key. Static MCP URLs using it will need the new one.
                     </span>
                   </span>
                 </button>
@@ -538,7 +538,7 @@ export default function ConnectPage() {
                       Paste my existing key
                     </span>
                     <span className="block text-xs text-muted-foreground">
-                      Keeps your existing key. Existing compatibility URLs keep working.
+                      Keeps your existing account key. Existing compatibility URLs keep working.
                     </span>
                   </span>
                 </button>
@@ -556,10 +556,10 @@ export default function ConnectPage() {
                   </span>
                   <span className="flex-1">
                     <span className="block text-sm font-semibold text-heading">
-                      {mintingKey ? "Getting your key..." : "Get my UnClick connection key"}
+                      {mintingKey ? "Getting your key..." : "Get my private UnClick account key"}
                     </span>
                     <span className="block text-xs text-muted-foreground">
-                      Fresh key, saved to this browser.
+                      Long-lived account key, saved to this browser.
                     </span>
                   </span>
                 </button>
@@ -577,7 +577,7 @@ export default function ConnectPage() {
                       I have one already
                     </span>
                     <span className="block text-xs text-muted-foreground">
-                      Paste your existing uc_ or agt_live_ key.
+                      Paste your existing uc_ or agt_live_ account key.
                     </span>
                   </span>
                 </button>
@@ -587,7 +587,7 @@ export default function ConnectPage() {
             {showManualPaste && (
               <div className="space-y-1.5 border border-border/60 rounded-lg p-4 bg-card/40">
                 <Label htmlFor="api_key" className="text-sm text-heading">
-                  Your UnClick connection key
+                  Private UnClick account key
                 </Label>
                 <Input
                   id="api_key"
@@ -607,10 +607,11 @@ export default function ConnectPage() {
         ) : (
           <div className="space-y-1.5 border border-border/60 rounded-lg p-4 bg-card/40">
             <Label htmlFor="api_key" className="text-sm text-heading">
-              Your UnClick connection key
+              Private UnClick account key
             </Label>
             <p className="text-xs text-muted-foreground">
-              Needed once in this browser so UnClick can store this app login securely.{" "}
+              Needed once in this browser so UnClick can save this app login to your account.{" "}
+              This is not a disposable installer code.{" "}
               <Link to="/" className="text-primary hover:underline">Get one here.</Link>
             </p>
             <Input

--- a/supabase/email-templates/README.md
+++ b/supabase/email-templates/README.md
@@ -1,0 +1,12 @@
+# UnClick Auth Email Settings
+
+Use these settings in Supabase Auth for the magic-link email.
+
+- Sender name: `UnClick`
+- From email: `no-reply@unclick.world`
+- Subject: `Your UnClick magic link`
+- Template: `magic-link.html`
+
+The inbox sender label comes from Supabase Auth email/SMTP settings, not from
+the HTML template. For production, configure custom SMTP so Gmail shows UnClick
+instead of the default Supabase Auth sender.

--- a/supabase/email-templates/magic-link.html
+++ b/supabase/email-templates/magic-link.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Sign in to UnClick</title>
+  <title>Your UnClick magic link</title>
 </head>
 <body style="margin:0; padding:0; background-color:#F5F5F5; font-family:Arial, Helvetica, sans-serif; -webkit-font-smoothing:antialiased;">
 
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;">
-    Your one-time sign-in link for UnClick. Expires in 15 minutes.
+    Your one-time UnClick magic link. Expires in 15 minutes.
   </div>
 
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#F5F5F5;">
@@ -33,11 +33,11 @@
             <td style="background-color:#FFFFFF; border:1px solid #E0E0E0; border-top:0; border-radius:0 0 12px 12px; padding:40px 32px;">
 
               <h1 style="margin:0 0 16px 0; font-family:Arial, Helvetica, sans-serif; font-size:24px; font-weight:600; line-height:1.3; color:#1A1A1A;">
-                Sign in to UnClick
+                Your UnClick magic link
               </h1>
 
               <p style="margin:0 0 32px 0; font-family:Arial, Helvetica, sans-serif; font-size:15px; line-height:1.6; color:#555555;">
-                Click the button below to sign in to your UnClick account. The link expires in 15 minutes and can only be used one time.
+                Click the button below to sign in to your UnClick account. The link expires in 15 minutes and can only be used once.
               </p>
 
               <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
@@ -49,7 +49,7 @@
                           <a href="{{ .ConfirmationURL }}"
                              target="_blank"
                              style="display:inline-block; padding:14px 36px; font-family:Arial, Helvetica, sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:8px; letter-spacing:0.2px;">
-                            Log In
+                            Sign in to UnClick
                           </a>
                         </td>
                       </tr>


### PR DESCRIPTION
## What changed
- Fixes production OAuth init/callback imports so Vercel's ESM loader can resolve the shared OAuth state helper.
- Expands the API ESM import guard to scan root API functions, not just api/lib.
- Clarifies app connection UI copy: the masked value is a private UnClick account key, not disposable installer confetti.
- Updates the Supabase magic-link email body wording and documents the required Supabase sender-name setting.

## Why
GitHub app connection was returning a production 500 from /api/oauth-init. This was consistent with missing .js extensions in serverless API imports, a class the old guard did not catch for root api/*.ts files.

## Validation
- npm run test:api-lib-esm-extension
- npx vitest run api/oauth-state.test.ts
- npm run build