### PR TITLE
[codex] Fix GitHub OAuth redirect warning

### DIFF
--- a/api/oauth-callback.ts
+++ b/api/oauth-callback.ts
@@ -3,12 +3,16 @@
  * Vercel serverless function - exchanges OAuth authorization code for tokens
  * and stores them encrypted in Supabase via the credentials endpoint.
  *
+ * GET /api/oauth-callback
+ *   Handles provider redirects from registered OAuth apps, exchanges the code,
+ *   stores credentials, then redirects back to /connect/:platform.
+ *
  * POST /api/oauth-callback
  *   Body: {
  *     platform: string        // e.g. "xero"
  *     code:     string        // OAuth authorization code from platform redirect
  *     api_key:  string        // User's UnClick API key (used as encryption key)
- *     state?:   string        // CSRF state token (validated client-side before this call)
+ *     state?:   string        // CSRF state token verified server-side
  *   }
  *   Returns: { success: true, platform, message } or { error: string }
  *
@@ -23,9 +27,15 @@
  */
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { verifyOAuthStateToken } from "./oauth-state.js";
+import { verifyOAuthStateToken, type OAuthStatePayload } from "./oauth-state.js";
 
 // ─── Platform OAuth configs ────────────────────────────────────────────────────
+
+const OAUTH_API_KEY_COOKIE = "unclick_oauth_api_key";
+
+class OAuthRequestError extends Error {
+  status = 400;
+}
 
 interface OAuthConfig {
   tokenUrl:    string;
@@ -245,15 +255,146 @@ async function storeCredentials(
   }
 }
 
+// ─── Browser callback helpers ────────────────────────────────────────────────
+
+function firstQueryValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+function readCookie(req: VercelRequest, name: string): string {
+  const cookieHeader = req.headers.cookie ?? "";
+  const cookies = cookieHeader.split(";").map((cookie) => cookie.trim());
+  const prefix = `${name}=`;
+  for (const cookie of cookies) {
+    if (!cookie.startsWith(prefix)) continue;
+    return decodeURIComponent(cookie.slice(prefix.length));
+  }
+  return "";
+}
+
+function clearOAuthApiKeyCookie(): string {
+  return [
+    `${OAUTH_API_KEY_COOKIE}=`,
+    "Path=/api/oauth-callback",
+    "Max-Age=0",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
+function appendQuery(path: string, params: Record<string, string>): string {
+  const url = new URL(path, "https://unclick.world");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return `${url.pathname}${url.search}`;
+}
+
+function redirectBack(
+  res: VercelResponse,
+  statePayload: OAuthStatePayload | null,
+  params: Record<string, string>
+) {
+  const redirectPath = statePayload?.redirectPath?.startsWith("/connect/")
+    ? statePayload.redirectPath
+    : "/admin/apps";
+  res.setHeader("Set-Cookie", clearOAuthApiKeyCookie());
+  return res.redirect(302, appendQuery(redirectPath, params));
+}
+
+async function completeOAuthConnection(args: {
+  platform: string;
+  code: string;
+  apiKey: string;
+  state: string;
+  store?: string;
+  baseUrl: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<{ platform: string; statePayload: OAuthStatePayload }> {
+  const { platform, code, apiKey, state, store, baseUrl, env } = args;
+
+  if (!platform) throw new OAuthRequestError("platform is required.");
+  if (!code) throw new OAuthRequestError("code is required.");
+  if (!apiKey) throw new OAuthRequestError("api_key is required.");
+  if (!state) throw new OAuthRequestError("state is required.");
+
+  if (!apiKey.startsWith("uc_") && !apiKey.startsWith("agt_")) {
+    throw new OAuthRequestError("Invalid api_key format.");
+  }
+
+  const statePayload = verifyOAuthStateToken(state, env);
+  if (statePayload.platform !== platform) {
+    throw new OAuthRequestError("OAuth state platform mismatch.");
+  }
+  if (statePayload.redirectPath !== `/connect/${platform}`) {
+    throw new OAuthRequestError("OAuth state redirect mismatch.");
+  }
+
+  let credentials: Record<string, string>;
+
+  if (platform === "shopify") {
+    const verifiedStore = statePayload.store ?? store;
+    if (!verifiedStore) throw new OAuthRequestError("store is required for Shopify.");
+    credentials = await exchangeShopify(code, verifiedStore, env);
+  } else {
+    const config = PLATFORM_CONFIGS[platform];
+    if (!config) {
+      throw new OAuthRequestError(`OAuth not configured for platform "${platform}". Use the manual credential form instead.`);
+    }
+    credentials = await exchangeCode(config, code, env);
+  }
+
+  await storeCredentials(platform, credentials, apiKey, baseUrl);
+  return { platform, statePayload };
+}
+
 // ─── Main handler ─────────────────────────────────────────────────────────────
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader("Access-Control-Allow-Origin",  "https://unclick.world");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
   if (req.method === "OPTIONS") return res.status(204).end();
-  if (req.method !== "POST")    return res.status(405).json({ error: "Method not allowed." });
+  if (req.method !== "GET" && req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed." });
+  }
+
+  const baseUrl = process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "https://unclick.world";
+
+  if (req.method === "GET") {
+    const code = firstQueryValue(req.query.code);
+    const state = firstQueryValue(req.query.state);
+    const providerError = firstQueryValue(req.query.error_description)
+      || firstQueryValue(req.query.error)
+      || "";
+    let statePayload: OAuthStatePayload | null = null;
+
+    try {
+      if (state) statePayload = verifyOAuthStateToken(state, process.env);
+      if (providerError) {
+        return redirectBack(res, statePayload, { oauth_error: providerError });
+      }
+      if (!statePayload) throw new Error("Missing OAuth state. Please try again.");
+
+      await completeOAuthConnection({
+        platform: statePayload.platform,
+        code,
+        apiKey: readCookie(req, OAUTH_API_KEY_COOKIE),
+        state,
+        baseUrl,
+        env: process.env,
+      });
+
+      return redirectBack(res, statePayload, { connected: "1" });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Connection failed. Please try again.";
+      return redirectBack(res, statePayload, { oauth_error: message });
+    }
+  }
 
   const { platform, code, api_key, state, store } = (req.body ?? {}) as {
     platform?: string;
@@ -263,53 +404,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     store?:    string; // Shopify only
   };
 
-  if (!platform) return res.status(400).json({ error: "platform is required." });
-  if (!code)     return res.status(400).json({ error: "code is required." });
-  if (!api_key)  return res.status(400).json({ error: "api_key is required." });
-  if (!state)    return res.status(400).json({ error: "state is required." });
-
-  if (!api_key.startsWith("uc_") && !api_key.startsWith("agt_")) {
-    return res.status(400).json({ error: "Invalid api_key format." });
-  }
-
-  const baseUrl = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "https://unclick.world";
-
   try {
-    const statePayload = verifyOAuthStateToken(state, process.env);
-    if (statePayload.platform !== platform) {
-      return res.status(400).json({ error: "OAuth state platform mismatch." });
-    }
-    if (statePayload.redirectPath !== `/connect/${platform}`) {
-      return res.status(400).json({ error: "OAuth state redirect mismatch." });
-    }
-
-    let credentials: Record<string, string>;
-
-    if (platform === "shopify") {
-      const verifiedStore = statePayload.store ?? store;
-      if (!verifiedStore) return res.status(400).json({ error: "store is required for Shopify." });
-      credentials = await exchangeShopify(code, verifiedStore, process.env);
-    } else {
-      const config = PLATFORM_CONFIGS[platform];
-      if (!config) {
-        return res.status(400).json({
-          error: `OAuth not configured for platform "${platform}". Use the manual credential form instead.`,
-        });
-      }
-      credentials = await exchangeCode(config, code, process.env);
-    }
-
-    await storeCredentials(platform, credentials, api_key, baseUrl);
+    const result = await completeOAuthConnection({
+      platform: platform ?? "",
+      code: code ?? "",
+      apiKey: api_key ?? "",
+      state: state ?? "",
+      store,
+      baseUrl,
+      env: process.env,
+    });
 
     return res.status(200).json({
       success:  true,
-      platform,
-      message:  `Connected to ${platform} successfully.`,
+      platform: result.platform,
+      message:  `Connected to ${result.platform} successfully.`,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return res.status(500).json({ error: message });
+    const status = err instanceof OAuthRequestError ? err.status : 500;
+    return res.status(status).json({ error: message });
   }
 }

--- a/api/oauth-init.test.ts
+++ b/api/oauth-init.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import handler from "./oauth-init.js";
+
+function createResponse() {
+  const headers = new Map<string, string | string[]>();
+  let statusCode = 200;
+  let payload: unknown;
+
+  return {
+    res: {
+      setHeader(name: string, value: string | string[]) {
+        headers.set(name, value);
+        return this;
+      },
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json(value: unknown) {
+        payload = value;
+        return this;
+      },
+    },
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+    get headers() {
+      return headers;
+    },
+  };
+}
+
+describe("oauth init", () => {
+  it("returns the registered callback URI and stores the account key in a short-lived cookie", () => {
+    const previousSecret = process.env.GITHUB_CLIENT_SECRET;
+    const previousRedirect = process.env.GITHUB_REDIRECT_URI;
+    process.env.GITHUB_CLIENT_SECRET = "github-secret";
+    process.env.GITHUB_REDIRECT_URI = "https://unclick.world/api/oauth-callback";
+
+    try {
+      const response = createResponse();
+      handler(
+        {
+          method: "POST",
+          body: { platform: "github", api_key: "uc_test_account_key" },
+        } as never,
+        response.res as never
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.payload).toMatchObject({
+        success: true,
+        redirect_uri: "https://unclick.world/api/oauth-callback",
+      });
+      expect(String(response.headers.get("Set-Cookie"))).toContain("Path=/api/oauth-callback");
+      expect(String(response.headers.get("Set-Cookie"))).toContain("HttpOnly");
+      expect(String(response.headers.get("Set-Cookie"))).toContain("SameSite=Lax");
+      expect(String(response.headers.get("Set-Cookie"))).not.toContain("/connect/github");
+    } finally {
+      process.env.GITHUB_CLIENT_SECRET = previousSecret;
+      process.env.GITHUB_REDIRECT_URI = previousRedirect;
+    }
+  });
+});

--- a/api/oauth-init.ts
+++ b/api/oauth-init.ts
@@ -6,6 +6,35 @@ const ALLOWED_PLATFORMS = new Set([
   "spotify", "dropbox", "google-workspace", "microsoft-graph",
 ]);
 
+const REDIRECT_URI_ENV: Record<string, string> = {
+  github:            "GITHUB_REDIRECT_URI",
+  xero:              "XERO_REDIRECT_URI",
+  reddit:            "REDDIT_REDIRECT_URI",
+  shopify:           "SHOPIFY_REDIRECT_URI",
+  spotify:           "SPOTIFY_REDIRECT_URI",
+  dropbox:           "DROPBOX_REDIRECT_URI",
+  "google-workspace": "GOOGLE_WORKSPACE_REDIRECT_URI",
+  "microsoft-graph": "MICROSOFT_GRAPH_REDIRECT_URI",
+};
+
+const OAUTH_API_KEY_COOKIE = "unclick_oauth_api_key";
+const OAUTH_COOKIE_MAX_AGE_SECONDS = 10 * 60;
+
+function isValidAccountKey(value: string): boolean {
+  return value.startsWith("uc_") || value.startsWith("agt_");
+}
+
+function serializeOAuthApiKeyCookie(apiKey: string): string {
+  return [
+    `${OAUTH_API_KEY_COOKIE}=${encodeURIComponent(apiKey)}`,
+    "Path=/api/oauth-callback",
+    `Max-Age=${OAUTH_COOKIE_MAX_AGE_SECONDS}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
 export default function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader("Access-Control-Allow-Origin", "https://unclick.world");
   res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
@@ -14,13 +43,17 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === "OPTIONS") return res.status(204).end();
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed." });
 
-  const { platform, store } = (req.body ?? {}) as {
+  const { platform, store, api_key } = (req.body ?? {}) as {
     platform?: string;
     store?: string;
+    api_key?: string;
   };
 
   if (!platform || !ALLOWED_PLATFORMS.has(platform)) {
     return res.status(400).json({ error: "Unsupported OAuth platform." });
+  }
+  if (!api_key || !isValidAccountKey(api_key)) {
+    return res.status(400).json({ error: "A private UnClick account key is required." });
   }
 
   const normalizedStore =
@@ -33,6 +66,12 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
+    const redirectUriEnv = REDIRECT_URI_ENV[platform];
+    const redirectUri = redirectUriEnv ? process.env[redirectUriEnv] : "";
+    if (!redirectUri) {
+      return res.status(500).json({ error: `${redirectUriEnv} must be set.` });
+    }
+
     const state = createOAuthStateToken({
       platform,
       redirectPath: `/connect/${platform}`,
@@ -40,7 +79,8 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
       ...(normalizedStore ? { store: normalizedStore } : {}),
     });
 
-    return res.status(200).json({ success: true, state });
+    res.setHeader("Set-Cookie", serializeOAuthApiKeyCookie(api_key));
+    return res.status(200).json({ success: true, state, redirect_uri: redirectUri });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to initialize OAuth.";
     return res.status(500).json({ error: message });

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16353,8 +16353,8 @@
     },
     {
       "source": "src/pages/Connect.tsx",
-      "hash": "6ad4683037b9",
-      "bytes": 30418
+      "hash": "b495dbfaccdb",
+      "bytes": 30784
     },
     {
       "source": "src/pages/Crews.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -127,7 +127,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Apps.tsx | 65bd43917eab | 3135 |
 | src/pages/AuthCallback.tsx | e9ee37622f98 | 5086 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
-| src/pages/Connect.tsx | 6ad4683037b9 | 30418 |
+| src/pages/Connect.tsx | b495dbfaccdb | 30784 |
 | src/pages/Crews.tsx | d160a7924721 | 12800 |
 | src/pages/DeveloperDocs.tsx | 40631b01bc27 | 21214 |
 | src/pages/DeveloperSubmit.tsx | 8724b6d03268 | 12447 |

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -26,7 +26,7 @@ const VITE_ENV = import.meta.env as Record<string, string>;
 /** Returns the OAuth2 authorization URL for a platform, or null if client_id not configured. */
 function buildOAuthUrl(
   connector: ConnectorConfig,
-  redirectOrigin: string,
+  redirectUri: string,
   state: string
 ): string | null {
   if (connector.authType !== "oauth2") return null;
@@ -43,7 +43,6 @@ function buildOAuthUrl(
     authUrl = authUrl.replace("{store}", store);
   }
 
-  const redirectUri = `${redirectOrigin}/connect/${connector.slug}`;
   const params = new URLSearchParams({
     response_type: "code",
     client_id:     clientId,
@@ -177,6 +176,8 @@ export default function ConnectPage() {
   const [alreadyProvisioned, setAlreadyProvisioned] = useState(false);
   const [resettingKey, setResettingKey] = useState(false);
   const callbackFired                 = useRef(false);
+  const connectedParam                = searchParams.get("connected");
+  const oauthErrorParam               = searchParams.get("oauth_error");
 
   const { session } = useSession();
 
@@ -238,6 +239,16 @@ export default function ConnectPage() {
   }
 
   // -- Handle OAuth callback ------------------------------------------------
+  useEffect(() => {
+    if (connectedParam === "1") {
+      setPageState({ kind: "success" });
+      return;
+    }
+    if (oauthErrorParam) {
+      setPageState({ kind: "error", message: oauthErrorParam });
+    }
+  }, [connectedParam, oauthErrorParam]);
+
   useEffect(() => {
     if (!code || !connector || callbackFired.current) return;
     callbackFired.current = true;
@@ -396,7 +407,6 @@ export default function ConnectPage() {
   // -- Idle: show connect form ----------------------------------------------
 
   const isOAuth2          = connector.authType === "oauth2";
-  const origin            = window.location.origin;
   const oauthClientKey     = isOAuth2 ? VITE_ENV[`VITE_${connector.slug.toUpperCase().replace(/-/g, "_")}_CLIENT_ID`] : "";
   const oauthNotConfigured = isOAuth2 && !oauthClientKey && connector.slug !== "shopify";
 
@@ -450,12 +460,13 @@ export default function ConnectPage() {
         headers: { "Content-Type": "application/json" },
         body:    JSON.stringify({
           platform: connector.slug,
+          api_key:  apiKey.trim(),
           ...(normalizedStore ? { store: normalizedStore } : {}),
         }),
       });
 
-      const data = (await safeJson(res)) as { state?: string; error?: string };
-      if (!res.ok || !data.state) {
+      const data = (await safeJson(res)) as { state?: string; redirect_uri?: string; error?: string };
+      if (!res.ok || !data.state || !data.redirect_uri) {
         setPageState({ kind: "error", message: data.error ?? "Could not start the sign-in. Please try again." });
         return;
       }
@@ -464,7 +475,7 @@ export default function ConnectPage() {
         sessionStorage.setItem("shopify_store", normalizedStore);
       }
 
-      const url = buildOAuthUrl(connector, origin, data.state);
+      const url = buildOAuthUrl(connector, data.redirect_uri, data.state);
       if (!url) {
         setPageState({ kind: "error", message: `OAuth2 setup pending for ${connector.name}.` });
         return;


### PR DESCRIPTION
## What changed
- Uses `/api/oauth-init` to return the registered provider callback URL instead of deriving `/connect/:platform` in the browser.
- Stores the UnClick account key in a short-lived, HttpOnly, callback-scoped cookie so the server can finish the OAuth exchange after GitHub redirects back.
- Adds GET support to `/api/oauth-callback`, then redirects users back to the friendly `/connect/:platform` page with success or error state.
- Adds a focused test for the callback URL and cookie path.

## Why
GitHub warns when `redirect_uri` is not registered for the OAuth app. The connect page was sending `https://unclick.world/connect/github`; production should send the registered callback, then return the user to the connect page after the server stores credentials.

## Checks
- `npx vitest run api/oauth-state.test.ts api/oauth-init.test.ts`
- `npm run test:api-lib-esm-extension`
- `npm run brainmap:check`
- `npm run build`
