### PR TITLE
[codex] Normalize GitHub OAuth redirect URI

### DIFF
--- a/api/oauth-callback.ts
+++ b/api/oauth-callback.ts
@@ -32,6 +32,7 @@ import { verifyOAuthStateToken, type OAuthStatePayload } from "./oauth-state.js"
 // ─── Platform OAuth configs ────────────────────────────────────────────────────
 
 const OAUTH_API_KEY_COOKIE = "unclick_oauth_api_key";
+const GITHUB_CANONICAL_REDIRECT_URI = "https://unclick.world/api/oauth-callback";
 
 class OAuthRequestError extends Error {
   status = 400;
@@ -164,6 +165,23 @@ const PLATFORM_CONFIGS: Record<string, OAuthConfig> = {
 
 };
 
+function resolveRedirectUri(config: OAuthConfig, env: NodeJS.ProcessEnv): string {
+  const redirectUri = (env[config.redirectUriEnv] ?? "").trim();
+
+  if (config.redirectUriEnv === "GITHUB_REDIRECT_URI") {
+    try {
+      const url = new URL(redirectUri);
+      if (url.hostname === "unclick.world" && url.pathname === "/connect/github") {
+        return GITHUB_CANONICAL_REDIRECT_URI;
+      }
+    } catch {
+      // Let the normal missing/invalid redirect URI error handle this below.
+    }
+  }
+
+  return redirectUri;
+}
+
 // ─── Shopify special handling ─────────────────────────────────────────────────
 
 async function exchangeShopify(
@@ -202,7 +220,7 @@ async function exchangeCode(
 ): Promise<Record<string, string>> {
   const clientId     = env[config.clientIdEnv]     ?? "";
   const clientSecret = env[config.clientSecretEnv] ?? "";
-  const redirectUri  = env[config.redirectUriEnv]  ?? "";
+  const redirectUri  = resolveRedirectUri(config, env);
 
   if (!clientId || !clientSecret) {
     throw new Error(

--- a/api/oauth-init.test.ts
+++ b/api/oauth-init.test.ts
@@ -64,4 +64,31 @@ describe("oauth init", () => {
       process.env.GITHUB_REDIRECT_URI = previousRedirect;
     }
   });
+
+  it("normalizes the stale production GitHub redirect URI to the server callback", () => {
+    const previousSecret = process.env.GITHUB_CLIENT_SECRET;
+    const previousRedirect = process.env.GITHUB_REDIRECT_URI;
+    process.env.GITHUB_CLIENT_SECRET = "github-secret";
+    process.env.GITHUB_REDIRECT_URI = "https://unclick.world/connect/github";
+
+    try {
+      const response = createResponse();
+      handler(
+        {
+          method: "POST",
+          body: { platform: "github", api_key: "uc_test_account_key" },
+        } as never,
+        response.res as never
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(response.payload).toMatchObject({
+        success: true,
+        redirect_uri: "https://unclick.world/api/oauth-callback",
+      });
+    } finally {
+      process.env.GITHUB_CLIENT_SECRET = previousSecret;
+      process.env.GITHUB_REDIRECT_URI = previousRedirect;
+    }
+  });
 });

--- a/api/oauth-init.ts
+++ b/api/oauth-init.ts
@@ -19,6 +19,7 @@ const REDIRECT_URI_ENV: Record<string, string> = {
 
 const OAUTH_API_KEY_COOKIE = "unclick_oauth_api_key";
 const OAUTH_COOKIE_MAX_AGE_SECONDS = 10 * 60;
+const GITHUB_CANONICAL_REDIRECT_URI = "https://unclick.world/api/oauth-callback";
 
 function isValidAccountKey(value: string): boolean {
   return value.startsWith("uc_") || value.startsWith("agt_");
@@ -33,6 +34,23 @@ function serializeOAuthApiKeyCookie(apiKey: string): string {
     "Secure",
     "SameSite=Lax",
   ].join("; ");
+}
+
+function resolveRedirectUri(platform: string, redirectUriEnv: string, env: NodeJS.ProcessEnv): string {
+  const redirectUri = (env[redirectUriEnv] ?? "").trim();
+
+  if (platform === "github") {
+    try {
+      const url = new URL(redirectUri);
+      if (url.hostname === "unclick.world" && url.pathname === "/connect/github") {
+        return GITHUB_CANONICAL_REDIRECT_URI;
+      }
+    } catch {
+      // Fall through and let the missing/invalid env value fail below.
+    }
+  }
+
+  return redirectUri;
 }
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
@@ -67,7 +85,7 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     const redirectUriEnv = REDIRECT_URI_ENV[platform];
-    const redirectUri = redirectUriEnv ? process.env[redirectUriEnv] : "";
+    const redirectUri = redirectUriEnv ? resolveRedirectUri(platform, redirectUriEnv, process.env) : "";
     if (!redirectUri) {
       return res.status(500).json({ error: `${redirectUriEnv} must be set.` });
     }


### PR DESCRIPTION
## What changed
- Normalizes the stale production `GITHUB_REDIRECT_URI` value from `/connect/github` to `/api/oauth-callback` before building the GitHub authorization URL.
- Uses the same normalized redirect URI during the token exchange, so GitHub sees one consistent registered callback.
- Adds a regression test proving the stale production value is converted before it reaches the browser.

## Why
The first hotfix moved OAuth to the server callback flow, but live proof showed production still had the old redirect env value. This guard prevents that stale value from reintroducing GitHub's redirect warning while keeping the existing env setting untouched.

## Checks
- `npx vitest run api/oauth-state.test.ts api/oauth-init.test.ts`
- `npm run test:api-lib-esm-extension`
- `npm run brainmap:check`
- `npm run build`
