### PR TITLE
[codex] Fix OAuth credential storage origin

### DIFF
--- a/api/oauth-callback.test.ts
+++ b/api/oauth-callback.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveCredentialStorageBaseUrl } from "./oauth-callback.js";
+
+describe("oauth callback credential storage origin", () => {
+  it("uses the canonical production origin instead of the Vercel deployment host", () => {
+    expect(
+      resolveCredentialStorageBaseUrl({
+        VERCEL_ENV: "production",
+        VERCEL_URL: "unclick-git-main-example.vercel.app",
+      } as NodeJS.ProcessEnv)
+    ).toBe("https://unclick.world");
+  });
+
+  it("keeps preview callbacks on their own deployment host", () => {
+    expect(
+      resolveCredentialStorageBaseUrl({
+        VERCEL_ENV: "preview",
+        VERCEL_URL: "unclick-git-branch-example.vercel.app",
+      } as NodeJS.ProcessEnv)
+    ).toBe("https://unclick-git-branch-example.vercel.app");
+  });
+
+  it("allows an explicit app origin override", () => {
+    expect(
+      resolveCredentialStorageBaseUrl({
+        VERCEL_ENV: "production",
+        VERCEL_URL: "unclick-git-main-example.vercel.app",
+        UNCLICK_APP_ORIGIN: "https://app.example.com/",
+      } as NodeJS.ProcessEnv)
+    ).toBe("https://app.example.com");
+  });
+});

--- a/api/oauth-callback.ts
+++ b/api/oauth-callback.ts
@@ -32,6 +32,7 @@ import { verifyOAuthStateToken, type OAuthStatePayload } from "./oauth-state.js"
 // ─── Platform OAuth configs ────────────────────────────────────────────────────
 
 const OAUTH_API_KEY_COOKIE = "unclick_oauth_api_key";
+const UNCLICK_APP_ORIGIN = "https://unclick.world";
 const GITHUB_CANONICAL_REDIRECT_URI = "https://unclick.world/api/oauth-callback";
 
 class OAuthRequestError extends Error {
@@ -275,6 +276,24 @@ async function storeCredentials(
 
 // ─── Browser callback helpers ────────────────────────────────────────────────
 
+function normalizeOrigin(value: string | undefined): string {
+  const trimmed = (value ?? "").trim().replace(/\/+$/, "");
+  if (!trimmed) return "";
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+export function resolveCredentialStorageBaseUrl(env: NodeJS.ProcessEnv): string {
+  const configuredOrigin =
+    normalizeOrigin(env.UNCLICK_APP_ORIGIN) ||
+    normalizeOrigin(env.SITE_URL) ||
+    normalizeOrigin(env.PUBLIC_SITE_URL);
+
+  if (configuredOrigin) return configuredOrigin;
+  if (env.VERCEL_ENV === "production") return UNCLICK_APP_ORIGIN;
+
+  return normalizeOrigin(env.VERCEL_URL) || UNCLICK_APP_ORIGIN;
+}
+
 function firstQueryValue(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
 }
@@ -302,7 +321,7 @@ function clearOAuthApiKeyCookie(): string {
 }
 
 function appendQuery(path: string, params: Record<string, string>): string {
-  const url = new URL(path, "https://unclick.world");
+  const url = new URL(path, UNCLICK_APP_ORIGIN);
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);
   }
@@ -379,9 +398,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: "Method not allowed." });
   }
 
-  const baseUrl = process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : "https://unclick.world";
+  const baseUrl = resolveCredentialStorageBaseUrl(process.env);
 
   if (req.method === "GET") {
     const code = firstQueryValue(req.query.code);

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16353,8 +16353,8 @@
     },
     {
       "source": "src/pages/Connect.tsx",
-      "hash": "b495dbfaccdb",
-      "bytes": 30784
+      "hash": "818da19c618a",
+      "bytes": 31549
     },
     {
       "source": "src/pages/Crews.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -127,7 +127,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Apps.tsx | 65bd43917eab | 3135 |
 | src/pages/AuthCallback.tsx | e9ee37622f98 | 5086 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |
-| src/pages/Connect.tsx | b495dbfaccdb | 30784 |
+| src/pages/Connect.tsx | 818da19c618a | 31549 |
 | src/pages/Crews.tsx | d160a7924721 | 12800 |
 | src/pages/DeveloperDocs.tsx | 40631b01bc27 | 21214 |
 | src/pages/DeveloperSubmit.tsx | 8724b6d03268 | 12447 |

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -159,7 +159,7 @@ function FieldInput({
 
 export default function ConnectPage() {
   const { platform }      = useParams<{ platform: string }>();
-  const [searchParams]    = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const code              = searchParams.get("code");
   const stateParam        = searchParams.get("state");
 
@@ -240,14 +240,25 @@ export default function ConnectPage() {
 
   // -- Handle OAuth callback ------------------------------------------------
   useEffect(() => {
+    let handledQueryState = false;
+
     if (connectedParam === "1") {
       setPageState({ kind: "success" });
-      return;
+      handledQueryState = true;
     }
-    if (oauthErrorParam) {
+
+    if (oauthErrorParam && !handledQueryState) {
       setPageState({ kind: "error", message: oauthErrorParam });
+      handledQueryState = true;
     }
-  }, [connectedParam, oauthErrorParam]);
+
+    if (handledQueryState) {
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.delete("connected");
+      nextParams.delete("oauth_error");
+      setSearchParams(nextParams, { replace: true });
+    }
+  }, [connectedParam, oauthErrorParam, searchParams, setSearchParams]);
 
   useEffect(() => {
     if (!code || !connector || callbackFired.current) return;
@@ -379,7 +390,16 @@ export default function ConnectPage() {
             variant="outline"
             size="sm"
             className="border-border/60 text-heading"
-            onClick={() => setPageState({ kind: "idle" })}
+            onClick={() => {
+              callbackFired.current = false;
+              const nextParams = new URLSearchParams(searchParams);
+              nextParams.delete("code");
+              nextParams.delete("state");
+              nextParams.delete("connected");
+              nextParams.delete("oauth_error");
+              setSearchParams(nextParams, { replace: true });
+              setPageState({ kind: "idle" });
+            }}
           >
             Try again
           </Button>


### PR DESCRIPTION
## Summary
- route production OAuth credential saves through the canonical unclick.world origin instead of the generated Vercel deployment host
- clear OAuth success/error query params so the Connect page does not stay stuck on an old failure
- add coverage for production, preview, and explicit origin override behavior

## Validation
- npx vitest run api/oauth-state.test.ts api/oauth-init.test.ts api/oauth-callback.test.ts
- npm run test:api-lib-esm-extension
- npm run brainmap:check
- npm run build
- npm run lint (warnings only, existing repo warnings)