### PR TITLE
[codex] Fix app connection status

### DIFF
--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5310,17 +5310,84 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .from("platform_connectors")
           .select("*");
 
-        // SECURITY: tenant scope required, audit PR #128
-        const { data: creds } = await supabase
+        // SECURITY: tenant scope required, audit PR #128.
+        //
+        // Connections currently exist in two stores:
+        // - platform_credentials: the older admin Apps key path.
+        // - user_credentials: the /connect/:platform OAuth/manual path.
+        //
+        // The Apps page is the user-facing truth, so merge both here. This
+        // keeps GitHub OAuth, which is saved through /api/credentials, from
+        // looking disconnected on /admin/apps.
+        const { data: platformCreds } = await supabase
           .from("platform_credentials")
-          .select("platform, is_valid, last_tested_at")
+          .select("id, platform, label, is_valid, last_tested_at, created_at")
           .eq("key_hash", tenant.apiKeyHash);
 
-        const credMap = new Map<string, { is_valid: boolean; last_tested_at: string | null }>();
-        for (const c of creds ?? []) {
-          credMap.set(c.platform as string, {
-            is_valid: c.is_valid as boolean,
-            last_tested_at: c.last_tested_at as string | null,
+        const { data: userCreds } = await supabase
+          .from("user_credentials")
+          .select("id, platform_slug, label, is_valid, last_tested_at, created_at, updated_at")
+          .eq("api_key_hash", tenant.apiKeyHash);
+
+        type AdminCredentialSource = "platform_credentials" | "user_credentials" | "mixed";
+        type AdminCredentialSummary = {
+          id: string | null;
+          is_valid: boolean;
+          last_tested_at: string | null;
+          label: string | null;
+          source: AdminCredentialSource;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+
+        function timestampScore(value: unknown): number {
+          if (typeof value !== "string" || !value) return 0;
+          const parsed = Date.parse(value);
+          return Number.isFinite(parsed) ? parsed : 0;
+        }
+
+        function credentialScore(cred: AdminCredentialSummary): number {
+          return (cred.is_valid ? 1_000_000_000_000_000 : 0)
+            + (cred.last_tested_at ? 1_000_000_000_000 : 0)
+            + Math.max(timestampScore(cred.updated_at), timestampScore(cred.created_at));
+        }
+
+        const credMap = new Map<string, AdminCredentialSummary>();
+        function mergeCredential(platform: string, next: AdminCredentialSummary) {
+          const current = credMap.get(platform);
+          if (!current) {
+            credMap.set(platform, next);
+            return;
+          }
+
+          const winner = credentialScore(next) > credentialScore(current) ? next : current;
+          credMap.set(platform, {
+            ...winner,
+            source: current.source === next.source ? winner.source : "mixed",
+          });
+        }
+
+        for (const c of platformCreds ?? []) {
+          mergeCredential(c.platform as string, {
+            id: c.id as string,
+            is_valid: c.is_valid !== false,
+            last_tested_at: (c.last_tested_at as string | null) ?? null,
+            label: (c.label as string | null) ?? null,
+            source: "platform_credentials",
+            created_at: (c.created_at as string | null) ?? null,
+            updated_at: null,
+          });
+        }
+
+        for (const c of userCreds ?? []) {
+          mergeCredential(c.platform_slug as string, {
+            id: c.id as string,
+            is_valid: c.is_valid !== false,
+            last_tested_at: (c.last_tested_at as string | null) ?? null,
+            label: (c.label as string | null) ?? null,
+            source: "user_credentials",
+            created_at: (c.created_at as string | null) ?? null,
+            updated_at: (c.updated_at as string | null) ?? null,
           });
         }
 
@@ -5434,6 +5501,71 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           tested: !test.skipped,
           tested_at: test.skipped ? null : now,
           message: test.message,
+        });
+      }
+
+      case "admin_disconnect_app": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const platform = typeof body.platform === "string" ? body.platform.trim().toLowerCase() : "";
+        if (!platform) return res.status(400).json({ error: "platform is required" });
+
+        const userDelete = await supabase
+          .from("user_credentials")
+          .delete()
+          .eq("api_key_hash", tenant.apiKeyHash)
+          .eq("platform_slug", platform)
+          .select("id, label");
+        if (userDelete.error) throw userDelete.error;
+
+        const platformDelete = await supabase
+          .from("platform_credentials")
+          .delete()
+          .eq("key_hash", tenant.apiKeyHash)
+          .eq("platform", platform)
+          .select("id, label");
+        if (platformDelete.error) throw platformDelete.error;
+
+        const userRows = (userDelete.data ?? []) as Array<{ id?: string; label?: string | null }>;
+        const platformRows = (platformDelete.data ?? []) as Array<{ id?: string; label?: string | null }>;
+
+        try {
+          const auditRows = userRows.length > 0
+            ? userRows.map((row) => ({
+              actor_user_id: tenant.userId,
+              api_key_hash: tenant.apiKeyHash,
+              action: "disconnect_app",
+              credential_id: row.id ?? null,
+              platform_slug: platform,
+              label: row.label ?? null,
+              success: true,
+              metadata: { surface: "admin_apps" },
+            }))
+            : [{
+              actor_user_id: tenant.userId,
+              api_key_hash: tenant.apiKeyHash,
+              action: "disconnect_app",
+              credential_id: null,
+              platform_slug: platform,
+              label: null,
+              success: true,
+              metadata: { surface: "admin_apps", legacy_rows_deleted: platformRows.length },
+            }];
+          await supabase.from("backstagepass_audit").insert(auditRows);
+        } catch {
+          // Audit is best-effort here; deleting the connection is the user action.
+        }
+
+        return res.status(200).json({
+          success: true,
+          platform,
+          deleted: {
+            connections: userRows.length,
+            app_records: platformRows.length,
+          },
         });
       }
 

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16148,8 +16148,8 @@
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",
-      "hash": "93411db0999e",
-      "bytes": 9265
+      "hash": "c408e13f3c9e",
+      "bytes": 10180
     },
     {
       "source": "src/pages/admin/AdminAuditLog.tsx",
@@ -16233,8 +16233,8 @@
     },
     {
       "source": "src/pages/admin/AdminKeychain.tsx",
-      "hash": "c72e09c40746",
-      "bytes": 78137
+      "hash": "ae96146cbd10",
+      "bytes": 78184
     },
     {
       "source": "src/pages/admin/AdminMemory.tsx",
@@ -16333,8 +16333,8 @@
     },
     {
       "source": "src/pages/AppDetail.tsx",
-      "hash": "7d1bead9bac0",
-      "bytes": 6646
+      "hash": "6e542cff428b",
+      "bytes": 6635
     },
     {
       "source": "src/pages/Apps.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -86,7 +86,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAgents.tsx | 6df58623daf6 | 49162 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 5ba37cf2abff | 11567 |
-| src/pages/admin/AdminTools.tsx | 93411db0999e | 9265 |
+| src/pages/admin/AdminTools.tsx | c408e13f3c9e | 10180 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3d245def3231 | 13772 |
@@ -103,7 +103,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminDashboard.tsx | e38f909e6d5b | 7090 |
 | src/pages/admin/AdminJobs.tsx | 5d4ff9ca88ab | 75369 |
 | src/pages/admin/AdminJobsmith.tsx | fd2aad657f06 | 54734 |
-| src/pages/admin/AdminKeychain.tsx | c72e09c40746 | 78137 |
+| src/pages/admin/AdminKeychain.tsx | ae96146cbd10 | 78184 |
 | src/pages/admin/AdminMemory.tsx | 25b2ecae9ca8 | 10814 |
 | src/pages/admin/AdminModeration.tsx | 27cae956bcfd | 883 |
 | src/pages/admin/AdminOrchestratorLog.tsx | af0abb526002 | 12944 |
@@ -123,7 +123,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminUsers.tsx | 222654ee0f22 | 866 |
 | src/pages/admin/AdminXGate.tsx | 193295e6e4dc | 26811 |
 | src/pages/admin/AdminYou.tsx | 4b186ef89df8 | 71460 |
-| src/pages/AppDetail.tsx | 7d1bead9bac0 | 6646 |
+| src/pages/AppDetail.tsx | 6e542cff428b | 6635 |
 | src/pages/Apps.tsx | 65bd43917eab | 3135 |
 | src/pages/AuthCallback.tsx | e9ee37622f98 | 5086 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |

--- a/src/components/apps/ConnectAppModal.test.tsx
+++ b/src/components/apps/ConnectAppModal.test.tsx
@@ -45,7 +45,7 @@ describe("ConnectAppModal", () => {
 
   it("explains the proof-first contract and uses the registry's credential label", () => {
     renderModal();
-    expect(screen.getByText(/live-tested first and only stored/i)).toBeInTheDocument();
+    expect(screen.getByText(/tested first; if the platform accepts it/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/paste api key here/i)).toBeInTheDocument();
     // Setup link comes from the generated CONNECTOR_SETUP registry.
     expect(screen.getByRole("link", { name: /where do i get my api key/i })).toHaveAttribute(
@@ -89,7 +89,7 @@ describe("ConnectAppModal", () => {
     renderModal();
     fireEvent.change(screen.getByPlaceholderText(/paste api key here/i), { target: { value: "demo-key" } });
     fireEvent.click(screen.getByRole("button", { name: /test and connect/i }));
-    expect(await screen.findByText(/saved \(not proven\)/i)).toBeInTheDocument();
+    expect(await screen.findByText(/marked as added/i)).toBeInTheDocument();
   });
 
   it("surfaces a rejection and stores nothing when the platform refuses the key", async () => {
@@ -125,5 +125,22 @@ describe("ConnectAppModal", () => {
       "/connect/alphavantage",
     );
     expect(screen.queryByPlaceholderText(/paste/i)).not.toBeInTheDocument();
+  });
+
+  it("offers reconnect and disconnect for an existing OAuth connection", async () => {
+    const onDisconnect = vi.fn(() => Promise.resolve());
+    renderModal({
+      connector: { id: "github", auth_type: "oauth2", setup_url: null },
+      isConnected: true,
+      statusLabel: "Connected",
+      onDisconnect,
+    });
+    expect(screen.getByText(/Alpha Vantage is available/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /reconnect alpha vantage/i })).toHaveAttribute(
+      "href",
+      "/connect/alphavantage",
+    );
+    fireEvent.click(screen.getByRole("button", { name: /disconnect/i }));
+    expect(onDisconnect).toHaveBeenCalled();
   });
 });

--- a/src/components/apps/ConnectAppModal.tsx
+++ b/src/components/apps/ConnectAppModal.tsx
@@ -1,5 +1,5 @@
-// Connect wizard for apps that show "Needs key" / "Needs login" on the admin
-// Apps page. Click the status pill -> this modal opens -> paste the key ->
+// Connection wizard for apps that need setup on the admin Apps page. Click the
+// status pill -> this modal opens -> paste the key ->
 // Submit. The server (admin_connect_app) live-tests the credential against the
 // platform's test endpoint BEFORE storing it:
 //   - test passes  -> stored, green "Connected, live-tested"
@@ -28,6 +28,7 @@ export interface ConnectableConnector {
   id: string;
   auth_type?: "oauth2" | "api_key" | "bot_token";
   setup_url?: string | null;
+  credential?: { is_valid: boolean; last_tested_at: string | null } | null;
 }
 
 interface ConnectAppModalProps {
@@ -37,6 +38,9 @@ interface ConnectAppModalProps {
   onClose: () => void;
   /** Called after a credential was stored, so the caller can refresh statuses. */
   onSaved: () => void;
+  isConnected?: boolean;
+  statusLabel?: string | null;
+  onDisconnect?: () => Promise<void> | void;
 }
 
 type Outcome =
@@ -52,11 +56,22 @@ function readLocalApiKey(): string | null {
   }
 }
 
-export function ConnectAppModal({ app, connector, accessToken, onClose, onSaved }: ConnectAppModalProps) {
+export function ConnectAppModal({
+  app,
+  connector,
+  accessToken,
+  onClose,
+  onSaved,
+  isConnected = false,
+  statusLabel = null,
+  onDisconnect,
+}: ConnectAppModalProps) {
   const setup = CONNECTOR_SETUP[app.slug];
   const [credential, setCredential] = useState("");
   const [busy, setBusy] = useState(false);
+  const [disconnectBusy, setDisconnectBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const [outcome, setOutcome] = useState<Outcome | null>(null);
 
   const credentialLabel = setup?.credential ?? "API key";
@@ -98,7 +113,7 @@ export function ConnectAppModal({ app, connector, accessToken, onClose, onSaved 
       } else if (body.ok === null) {
         setOutcome({
           kind: "saved_unproven",
-          message: "Key saved and encrypted. This app has no automatic live test yet, so it is marked as saved (not proven) until its first real use.",
+          message: "Connection added. This app has no automatic live test yet, so it is marked as added until its first real use.",
         });
         setCredential("");
         onSaved();
@@ -112,6 +127,30 @@ export function ConnectAppModal({ app, connector, accessToken, onClose, onSaved 
     }
   }
 
+  async function disconnect() {
+    if (!onDisconnect) return;
+    setDisconnectBusy(true);
+    setDisconnectError(null);
+    try {
+      await onDisconnect();
+    } catch (e) {
+      setDisconnectError(e instanceof Error ? e.message : "Disconnect failed.");
+    } finally {
+      setDisconnectBusy(false);
+    }
+  }
+
+  const disconnectButton = isConnected && onDisconnect ? (
+    <button
+      type="button"
+      onClick={() => void disconnect()}
+      disabled={disconnectBusy}
+      className="rounded-lg border border-red-400/25 px-3 py-2 text-xs font-medium text-red-200 transition-colors hover:bg-red-400/10 disabled:opacity-50"
+    >
+      {disconnectBusy ? "Disconnecting..." : "Disconnect"}
+    </button>
+  ) : null;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4" onClick={onClose}>
       <div
@@ -121,28 +160,47 @@ export function ConnectAppModal({ app, connector, accessToken, onClose, onSaved 
         <div className="mb-4 flex items-center justify-between">
           <h3 className="flex items-center gap-2 text-sm font-semibold text-white">
             <KeyRound className="h-4 w-4 text-[#E2B93B]" />
-            Connect {app.name}
+            {isConnected ? "Manage" : "Connect"} {app.name}
           </h3>
           <button onClick={onClose} className="rounded-md p-1 text-[#888] transition-colors hover:bg-white/[0.04] hover:text-white" aria-label="Close">
             <X className="h-4 w-4" />
           </button>
         </div>
 
+        {isConnected && (
+          <div role="status" className="mb-3 flex items-start gap-2 rounded-lg border border-emerald-300/25 bg-emerald-300/10 px-3 py-2 text-[11px] leading-4 text-emerald-100">
+            <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              <strong>{statusLabel ?? "Connected"}.</strong> {app.name} is available while this app stays turned on.
+            </span>
+          </div>
+        )}
+
         {isOAuth ? (
           <div className="text-xs leading-5 text-white/60">
-            <p>{app.name} connects with a login instead of a pasted key.</p>
-            <a
-              href={`/connect/${app.slug}`}
-              className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#61C1C4] px-3 py-2 font-medium text-black hover:bg-[#61C1C4]/90"
-            >
-              Continue to {app.name} login
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
+            <p>
+              {isConnected
+                ? `Reconnect ${app.name} if you want to refresh permissions or switch accounts.`
+                : `${app.name} connects with a provider sign-in instead of a pasted key.`}
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <a
+                href={`/connect/${app.slug}`}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[#61C1C4] px-3 py-2 font-medium text-black hover:bg-[#61C1C4]/90"
+              >
+                {isConnected ? `Reconnect ${app.name}` : `Continue to ${app.name} login`}
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+              {disconnectButton}
+            </div>
+            {disconnectError && (
+              <p role="alert" className="mt-2 text-[11px] text-red-400">{disconnectError}</p>
+            )}
           </div>
         ) : (
           <>
             <p className="text-xs leading-5 text-white/60">
-              Paste your {app.name} {credentialLabel}. It is live-tested first and only stored (encrypted) when the platform accepts it.
+              Paste your {app.name} {credentialLabel}. It is tested first; if the platform accepts it, this app shows as connected.
             </p>
             {setup?.note && <p className="mt-2 text-[11px] leading-4 text-white/45">{setup.note}</p>}
             {setupUrl && (
@@ -195,18 +253,26 @@ export function ConnectAppModal({ app, connector, accessToken, onClose, onSaved 
             )}
 
             <div className="mt-4 flex justify-end gap-2">
-              <button onClick={onClose} className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] hover:text-white">
-                {outcome && outcome.kind !== "rejected" ? "Done" : "Cancel"}
-              </button>
-              <button
-                onClick={() => void submit()}
-                disabled={busy}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-[#E2B93B] px-3 py-2 text-xs font-medium text-black hover:bg-[#E2B93B]/90 disabled:opacity-50"
-              >
-                {busy && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-                {busy ? "Testing key..." : "Test and connect"}
-              </button>
+              <div className="mr-auto">
+                {disconnectButton}
+              </div>
+              <div className="flex gap-2">
+                <button onClick={onClose} className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] hover:text-white">
+                  {outcome && outcome.kind !== "rejected" ? "Done" : "Cancel"}
+                </button>
+                <button
+                  onClick={() => void submit()}
+                  disabled={busy}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-[#E2B93B] px-3 py-2 text-xs font-medium text-black hover:bg-[#E2B93B]/90 disabled:opacity-50"
+                >
+                  {busy && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                  {busy ? "Testing..." : isConnected ? "Test and update" : "Test and connect"}
+                </button>
+              </div>
             </div>
+            {disconnectError && (
+              <p role="alert" className="mt-2 text-[11px] text-red-400">{disconnectError}</p>
+            )}
           </>
         )}
       </div>

--- a/src/components/apps/appLenses.test.ts
+++ b/src/components/apps/appLenses.test.ts
@@ -11,6 +11,10 @@ const app = (slug: string): AppEntry => ({
 } as unknown as AppEntry);
 
 const oauthNoCred: LensConnector = { auth_type: "oauth2", credential: null };
+const oauthConnected: LensConnector = {
+  auth_type: "oauth2",
+  credential: { is_valid: true, last_tested_at: null, source: "user_credentials" },
+};
 const keySaved: LensConnector = { auth_type: "api_key", credential: { is_valid: true, last_tested_at: null } };
 const keyTested: LensConnector = { auth_type: "api_key", credential: { is_valid: true, last_tested_at: "2026-06-12" } };
 const botNoCred: LensConnector = { auth_type: "bot_token", credential: null };
@@ -26,12 +30,14 @@ describe("appLenses", () => {
   it("connected means a working credential, tested or not", () => {
     expect(isConnected(keySaved)).toBe(true);
     expect(isConnected(keyTested)).toBe(true);
+    expect(isConnected(oauthConnected)).toBe(true);
     expect(isConnected(oauthNoCred)).toBe(false);
     expect(isConnected(undefined)).toBe(false);
   });
 
   it("buttons say the action: Connect / Add key / Manage / nothing", () => {
     expect(actionLabelFor(oauthNoCred)).toBe("Connect");
+    expect(actionLabelFor(oauthConnected)).toBe("Manage");
     expect(actionLabelFor(botNoCred)).toBe("Add key");
     expect(actionLabelFor(keyTested)).toBe("Manage");
     expect(actionLabelFor(undefined)).toBe(null);

--- a/src/components/apps/appLenses.ts
+++ b/src/components/apps/appLenses.ts
@@ -16,7 +16,12 @@ export type SetupKind = "signin" | "key" | "builtin";
 /** Minimal connector shape the lenses need; matches the admin_tools API rows. */
 export interface LensConnector {
   auth_type?: "oauth2" | "api_key" | "bot_token";
-  credential: { is_valid: boolean; last_tested_at: string | null } | null;
+  credential: {
+    id?: string | null;
+    is_valid: boolean;
+    last_tested_at: string | null;
+    source?: "platform_credentials" | "user_credentials" | "mixed";
+  } | null;
 }
 
 /** One source array drives the rail, the chips, and the URL contract. */

--- a/src/pages/AppDetail.test.tsx
+++ b/src/pages/AppDetail.test.tsx
@@ -16,11 +16,11 @@ function renderAt(path: string) {
 afterEach(cleanup);
 
 describe("AppDetail", () => {
-  it("renders a real app's info, tools, and a Passport connect link", () => {
+  it("renders a real app's info, tools, and a connections link", () => {
     renderAt("/apps/github");
     expect(screen.getByRole("heading", { name: "GitHub", level: 2 })).toBeInTheDocument();
     expect(screen.getByText(/what GitHub can do/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Open Passport/i })).toHaveAttribute("href", "/admin/keychain");
+    expect(screen.getByRole("link", { name: /Manage connections/i })).toHaveAttribute("href", "/admin/apps");
     expect(screen.getByText(/How your AI uses GitHub/i)).toBeInTheDocument();
   });
 

--- a/src/pages/AppDetail.tsx
+++ b/src/pages/AppDetail.tsx
@@ -109,21 +109,21 @@ const AppDetail = () => {
               </div>
             </div>
 
-            {/* Connect it */}
+            {/* Connection */}
             <div className="mt-6 rounded-xl border border-white/[0.07] bg-white/[0.02] p-5">
               <div className="flex items-center gap-2">
                 <KeyRound className="h-4 w-4 text-[#E2B93B]" />
-                <p className="text-sm font-semibold text-white">Connect it</p>
+                <p className="text-sm font-semibold text-white">Connection</p>
               </div>
               <p className="mt-1.5 text-xs leading-5 text-white/55">
-                Most apps work straight away with nothing to set up. If {app.name} needs a login or
-                an API key, connect it once to UnClick and every paired AI app can use it through UnClick.
+                Most apps work straight away with nothing to set up. If {app.name} needs your account,
+                connect it from Apps, see when it is connected, and disconnect it any time.
               </p>
               <Link
-                to="/admin/keychain"
+                to="/admin/apps"
                 className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-3 py-1.5 text-xs font-semibold text-[#f0d577] transition-colors hover:bg-[#E2B93B]/15"
               >
-                <KeyRound className="h-3.5 w-3.5" /> Open Passport
+                <KeyRound className="h-3.5 w-3.5" /> Manage connections
               </Link>
             </div>
 

--- a/src/pages/admin/AdminKeychain.tsx
+++ b/src/pages/admin/AdminKeychain.tsx
@@ -1,7 +1,7 @@
 /**
- * AdminKeychain - Passport admin surface (/admin/keychain)
+ * AdminKeychain - Connections admin surface (/admin/keychain)
  *
- * Full CRUD on the user_credentials vault:
+ * Full CRUD on encrypted user_credentials connection records:
  *   - List every credential the signed-in user owns (metadata only)
  *   - Reveal one credential's plaintext values (requires the user's
  *     plaintext UnClick api_key, read from localStorage.unclick_api_key)
@@ -117,7 +117,7 @@ const PLATFORMS = [
   { slug: "zapier",     name: "Zapier",       category: "Productivity", desc: "Workflow automation" },
 ] as const;
 
-const CORE_PASSPORT_PLATFORMS = ["github", "vercel", "supabase"] as const;
+const CORE_CONNECTION_PLATFORMS = ["github", "vercel", "supabase"] as const;
 
 // Types
 
@@ -251,12 +251,12 @@ const INVENTORY_STATUS_BADGES: Record<SystemCredentialDisplayStatus, {
 }> = {
   untested: {
     label: "Untested",
-    description: "Name-only inventory; no safe health probe has confirmed this Passport entry yet.",
+    description: "Name-only inventory; no safe health probe has confirmed this connection yet.",
     className: "border-sky-500/20 bg-sky-500/10 text-sky-300",
   },
   manual_check_required: {
     label: "Manual check",
-    description: "Human review is needed before this Passport entry can claim health.",
+    description: "Human review is needed before this connection can claim health.",
     className: "border-amber-500/20 bg-amber-500/10 text-amber-300",
   },
 };
@@ -371,7 +371,7 @@ export default function AdminKeychain() {
       const body = await res.json();
       setCredentials(body.data ?? []);
     } catch (err) {
-      setError(scrubInternalNames(err instanceof Error ? err.message : "Failed to load Passport"));
+      setError(scrubInternalNames(err instanceof Error ? err.message : "Failed to load Connections"));
     } finally {
       setLoading(false);
     }
@@ -411,7 +411,7 @@ export default function AdminKeychain() {
         body: JSON.stringify({ platform: slug, label: manualLabel.trim() || null, api_key: apiKey, values }),
       });
       const body = await res.json() as { error?: string };
-      if (!res.ok) { setAddError(body.error ?? "Failed to add Passport access."); return; }
+      if (!res.ok) { setAddError(body.error ?? "Failed to add connection."); return; }
       setStarterOpen(false);
       resetAddModal();
       await fetchList();
@@ -541,9 +541,9 @@ export default function AdminKeychain() {
     }
   }
 
-  /** Server errors can echo internal route names; users should only see Passport. */
+  /** Server errors can echo internal route names; users should only see Connections. */
   function scrubInternalNames(message: string): string {
-    return message.replace(/backstagepass/gi, "Passport");
+    return message.replace(/backstagepass/gi, "Connections");
   }
 
   async function copyToClipboard(field: string, value: string) {
@@ -627,7 +627,7 @@ export default function AdminKeychain() {
   }, [credentials]);
 
   const sortedCredentials = useMemo(() => {
-    const coreOrder = new Map(CORE_PASSPORT_PLATFORMS.map((platform, index) => [platform, index]));
+    const coreOrder = new Map(CORE_CONNECTION_PLATFORMS.map((platform, index) => [platform, index]));
     return [...credentials].sort((a, b) => {
       const aCore = coreOrder.get(a.platform) ?? 99;
       const bCore = coreOrder.get(b.platform) ?? 99;
@@ -667,11 +667,11 @@ export default function AdminKeychain() {
     <div>
       <div className="mb-8 flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold text-white">Passport</h1>
+          <h1 className="text-2xl font-semibold text-white">Connections</h1>
           <p className="mt-1 text-sm text-[#888]">
-            Your service keys and logins, saved once, used by every Seat.{" "}
+            App access you have connected for the AI seats you approve.{" "}
             {credentials.length === 0
-              ? "Nothing saved yet."
+              ? "Nothing connected yet."
               : `${credentials.length} saved · ${healthyCount} healthy · ${attentionCount} need review.`}
           </p>
         </div>
@@ -700,9 +700,9 @@ export default function AdminKeychain() {
                 }}
                 className="block w-full rounded-md px-3 py-2 text-left transition-colors hover:bg-white/[0.05]"
               >
-                <span className="block text-xs font-semibold text-white">Export Passport</span>
+                <span className="block text-xs font-semibold text-white">Export connections</span>
                 <span className="mt-0.5 block text-[11px] leading-4 text-[#888]">
-                  Download an encrypted backup of your saved access.
+                  Download an encrypted backup of your saved connection data.
                 </span>
               </button>
               <button
@@ -738,7 +738,7 @@ export default function AdminKeychain() {
           </button>
         </div>
         <div className="grid gap-3 md:grid-cols-3">
-          {CORE_PASSPORT_PLATFORMS.map((platform) => {
+          {CORE_CONNECTION_PLATFORMS.map((platform) => {
             const cred = credentialByPlatform.get(platform);
             const platformInfo = PLATFORMS.find((item) => item.slug === platform);
             const health = cred ? credentialHealth(cred) : null;
@@ -764,7 +764,7 @@ export default function AdminKeychain() {
                 <p className="mt-3 text-[11px] text-[#777]">
                   {cred
                     ? `${credentialLastCheckDisplay(cred).label}: ${credentialLastCheckDisplay(cred).value}`
-                    : "Add once so all UnClick Seats can request this service through Passport."}
+                    : "Connect once so approved UnClick Seats can request this service when needed."}
                 </p>
                 <div className="mt-4">
                   {cred ? (
@@ -832,12 +832,12 @@ export default function AdminKeychain() {
       {loading ? (
         <div className="flex items-center gap-2 py-12 text-[#666]">
           <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm">Loading Passport...</span>
+          <span className="text-sm">Loading connections...</span>
         </div>
       ) : credentials.length === 0 ? (
         <div className="rounded-xl border border-dashed border-white/[0.08] bg-white/[0.03] p-8 text-center">
           <KeyRound className="mx-auto h-8 w-8 text-[#333]" />
-          <p className="mt-3 text-sm text-[#666]">No saved access yet</p>
+          <p className="mt-3 text-sm text-[#666]">No connections yet</p>
           <p className="mt-1 text-xs text-[#444]">
             Connect a platform or add a manual key or token.
           </p>
@@ -1061,7 +1061,7 @@ export default function AdminKeychain() {
           </span>
         </summary>
         <p className="mt-2 text-xs leading-5 text-[#888]">
-          Name-only map of the GitHub and Vercel runtime Passport entries that power workflows. This is for debugging and rotation planning, not day-to-day Passport setup.
+          Name-only map of the GitHub and Vercel runtime connections that power workflows. This is for debugging and rotation planning, not day-to-day setup.
           The statuses below are not live: they come from a name-only audit and no real connection test has run against them.
         </p>
         <div className="mt-4 grid gap-3 xl:grid-cols-2">
@@ -1154,15 +1154,15 @@ export default function AdminKeychain() {
         />
       )}
 
-      {/* Export Passport modal */}
+      {/* Export Connections modal */}
       {exportOpen && (() => {
         const pw       = exportPassword;
         const strength = exportPasswordStrength(pw);
         const canDownload = pw.length >= 12 && pw === exportConfirm;
         return (
-          <ModalShell title="Export Passport" onClose={() => { setExportOpen(false); setExportPassword(""); setExportConfirm(""); setExportError(null); }}>
+          <ModalShell title="Export connections" onClose={() => { setExportOpen(false); setExportPassword(""); setExportConfirm(""); setExportError(null); }}>
             <p className="mb-4 text-xs text-[#888]">
-              Download an encrypted backup of your Passport secrets. Set a password to protect the file.
+              Download an encrypted backup of your saved connection data. Set a password to protect the file.
             </p>
             <div className="space-y-3">
               <div>
@@ -1224,7 +1224,7 @@ export default function AdminKeychain() {
         );
       })()}
 
-      {/* Add Passport access modal */}
+      {/* Add connection modal */}
       {starterOpen && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
@@ -1237,7 +1237,7 @@ export default function AdminKeychain() {
           >
             {/* Header */}
             <div className="flex shrink-0 items-center justify-between border-b border-white/[0.06] px-5 py-4">
-              <h3 className="text-sm font-semibold text-white">Add Passport access</h3>
+              <h3 className="text-sm font-semibold text-white">Add connection</h3>
               <button
                 onClick={() => { setStarterOpen(false); resetAddModal(); }}
                 className="rounded-md p-1 text-[#888] transition-colors hover:bg-white/[0.04] hover:text-white"
@@ -1280,7 +1280,7 @@ export default function AdminKeychain() {
                 </div>
                 <div className="flex-1 overflow-y-auto px-4 pb-4">
                   <div className="space-y-3">
-                    {CORE_PASSPORT_PLATFORMS.some((platform) =>
+                    {CORE_CONNECTION_PLATFORMS.some((platform) =>
                       PLATFORMS.some((item) => item.slug === platform && (
                         !platformSearch ||
                         item.name.toLowerCase().includes(platformSearch.toLowerCase()) ||
@@ -1291,7 +1291,7 @@ export default function AdminKeychain() {
                       <div>
                         <p className="mb-1.5 px-1 text-[10px] font-semibold uppercase tracking-wider text-[#666]">Core services</p>
                         <div className="space-y-1">
-                          {CORE_PASSPORT_PLATFORMS.map((slug) => PLATFORMS.find((item) => item.slug === slug))
+                          {CORE_CONNECTION_PLATFORMS.map((slug) => PLATFORMS.find((item) => item.slug === slug))
                             .filter((p): p is (typeof PLATFORMS)[number] => Boolean(p))
                             .filter(
                               (p) =>
@@ -1320,7 +1320,7 @@ export default function AdminKeychain() {
                     <div>
                       <p className="mb-1.5 px-1 text-[10px] font-semibold uppercase tracking-wider text-[#666]">More services</p>
                       <div className="space-y-1">
-                    {PLATFORMS.filter((p) => !CORE_PASSPORT_PLATFORMS.includes(p.slug as typeof CORE_PASSPORT_PLATFORMS[number])).filter(
+                    {PLATFORMS.filter((p) => !CORE_CONNECTION_PLATFORMS.includes(p.slug as typeof CORE_CONNECTION_PLATFORMS[number])).filter(
                       (p) =>
                         !platformSearch ||
                         p.name.toLowerCase().includes(platformSearch.toLowerCase()) ||
@@ -1690,7 +1690,7 @@ function DeleteModal({
       <div className="mb-3 flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/5 p-3">
         <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
         <p className="text-xs text-red-400">
-          This permanently removes <span className="font-mono">{cred.platform}{cred.label ? ` [${cred.label}]` : ""}</span> from Passport. The audit log is preserved.
+          This permanently removes <span className="font-mono">{cred.platform}{cred.label ? ` [${cred.label}]` : ""}</span> from Connections. The audit log is preserved.
         </p>
       </div>
       {err && <p className="mt-2 text-[11px] text-red-400">{err}</p>}
@@ -1731,7 +1731,7 @@ function AuditDrawer({
         <div className="mb-4 flex items-center justify-between">
           <div>
             <h3 className="text-sm font-semibold text-white">Audit log</h3>
-            <p className="text-[11px] text-[#666]">Every reveal, update, and delete on your Passport secrets.</p>
+            <p className="text-[11px] text-[#666]">Every reveal, update, and delete for your saved connections.</p>
           </div>
           <button
             onClick={onClose}

--- a/src/pages/admin/AdminTools.test.tsx
+++ b/src/pages/admin/AdminTools.test.tsx
@@ -67,10 +67,10 @@ describe("AdminTools (Apps library)", () => {
     expect(screen.getByText("GitHub")).toBeInTheDocument();
   }, FULL_CATALOG_RENDER_TIMEOUT_MS);
 
-  it("links to Passport and the Skills Library instead of inlining everything", async () => {
+  it("links to Connections and the Skills Library instead of inlining everything", async () => {
     await renderAdminTools();
     expect(screen.getByRole("link", { name: /Skills Library/i })).toHaveAttribute("href", "/admin/skills");
-    expect(screen.getByRole("link", { name: /Passport/i })).toHaveAttribute("href", "/admin/keychain");
+    expect(screen.getByRole("link", { name: /Connections/i })).toHaveAttribute("href", "/admin/keychain");
   }, FULL_CATALOG_RENDER_TIMEOUT_MS);
 
   // The network filter chips and the connect wizard are covered by the cheap

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -16,7 +16,12 @@ interface Connector {
   id: string;
   auth_type?: "oauth2" | "api_key" | "bot_token";
   setup_url?: string | null;
-  credential: { is_valid: boolean; last_tested_at: string | null } | null;
+  credential: {
+    id?: string | null;
+    is_valid: boolean;
+    last_tested_at: string | null;
+    source?: "platform_credentials" | "user_credentials" | "mixed";
+  } | null;
 }
 
 export default function AdminToolsPage() {
@@ -122,17 +127,16 @@ export default function AdminToolsPage() {
   function statusOf(app: { slug: string }): AppStatus | null {
     const c = connectorBySlug.get(app.slug);
     if (!c) return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
-    // "Connected" (green) is reserved for credentials that passed a real live
-    // test. A stored key that was never probed shows as "Key saved" so the
-    // green tick is proof, not an assumption.
-    if (c.credential?.is_valid && c.credential.last_tested_at) {
+    // OAuth connections are created by a successful provider sign-in, so they
+    // should read as connected even before a later tool-use timestamp exists.
+    if (c.credential?.is_valid && (c.auth_type === "oauth2" || c.credential.last_tested_at)) {
       return { label: "Connected", tone: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100" };
     }
     if (c.credential?.is_valid) {
-      return { label: "Key saved", tone: "border-sky-300/25 bg-sky-300/10 text-sky-100" };
+      return { label: "Added", tone: "border-sky-300/25 bg-sky-300/10 text-sky-100" };
     }
-    if (c.auth_type === "oauth2") return { label: "Needs login", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
-    if (c.auth_type) return { label: "Needs key", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
+    if (c.auth_type === "oauth2") return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
+    if (c.auth_type) return { label: "Add access", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
   }
 
@@ -149,6 +153,19 @@ export default function AdminToolsPage() {
     const label = actionLabelFor(connectorBySlug.get(app.slug));
     if (!label) return null;
     return { label, onClick: () => setConnectTarget(app) };
+  }
+
+  async function disconnectApp(slug: string) {
+    if (!session) throw new Error("Sign in again to disconnect apps.");
+    const res = await fetch("/api/memory-admin?action=admin_disconnect_app", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${session.access_token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: slug }),
+    });
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    if (!res.ok) throw new Error(body.error ?? `Disconnect failed with ${res.status}.`);
+    await refreshStatus();
+    setConnectTarget(null);
   }
 
   const counts = useMemo(() => lensCounts(APP_CATALOG, connectorBySlug), [connectorBySlug]);
@@ -205,12 +222,15 @@ export default function AdminToolsPage() {
           accessToken={session.access_token}
           onClose={() => setConnectTarget(null)}
           onSaved={() => void refreshStatus()}
+          isConnected={Boolean(connectorBySlug.get(connectTarget.slug)?.credential?.is_valid)}
+          statusLabel={statusOf(connectTarget)?.label ?? null}
+          onDisconnect={() => disconnectApp(connectTarget.slug)}
         />
       )}
 
       {/* Slim footer: where keys and related libraries live */}
       <div className="mt-8 grid gap-3 sm:grid-cols-3">
-        <FooterLink to="/admin/keychain" icon={<KeyRound className="h-4 w-4 text-[#E2B93B]" />} title="Passport" desc="Add API keys and logins for apps that need them." />
+        <FooterLink to="/admin/keychain" icon={<KeyRound className="h-4 w-4 text-[#E2B93B]" />} title="Connections" desc="Manage app connections your AI is allowed to use." />
         <FooterLink to="/admin/skills" icon={<Sparkles className="h-4 w-4 text-[#61C1C4]" />} title="Skills Library" desc="Reusable skill packs your agents can install." />
         <FooterLink to="/admin/copypass" icon={<PenSquare className="h-4 w-4 text-fuchsia-300" />} title="CopyPass" desc="Quality checks for writing and copy." />
       </div>


### PR DESCRIPTION
## Summary
- merge app connection status from both existing connection stores so GitHub OAuth shows as connected in `/admin/apps`
- add a scoped app disconnect path and expose Disconnect from the Apps manage modal
- rename affected customer-facing surfaces from Passport/vault wording to Connections and route app detail pages back to Apps for management

## Root cause
GitHub OAuth saves through `/api/credentials` into `user_credentials`, but `/api/memory-admin?action=admin_tools` only read `platform_credentials`, so the Apps table could keep showing Connect after a successful provider sign-in.

## Verification
- `npx vitest run src/components/apps/appLenses.test.ts src/components/apps/ConnectAppModal.test.tsx src/pages/AppDetail.test.tsx src/pages/admin/AdminTools.test.tsx`
- `npm run build`
- `npx vitest run --testTimeout 30000`