### PR TITLE
[codex] show disconnect on connected apps

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16148,8 +16148,8 @@
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",
-      "hash": "c408e13f3c9e",
-      "bytes": 10180
+      "hash": "5a780df7b10f",
+      "bytes": 10785
     },
     {
       "source": "src/pages/admin/AdminAuditLog.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -86,7 +86,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAgents.tsx | 6df58623daf6 | 49162 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 5ba37cf2abff | 11567 |
-| src/pages/admin/AdminTools.tsx | c408e13f3c9e | 10180 |
+| src/pages/admin/AdminTools.tsx | 5a780df7b10f | 10785 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3d245def3231 | 13772 |

--- a/src/components/apps/AppsTable.test.tsx
+++ b/src/components/apps/AppsTable.test.tsx
@@ -99,6 +99,30 @@ describe("AppsTable", () => {
     expect(onStatusClick).toHaveBeenCalledWith(expect.objectContaining({ slug: "github" }));
   });
 
+  it("admin mode exposes manage and disconnect controls on expanded connected rows", () => {
+    const onManage = vi.fn();
+    const onDisconnect = vi.fn();
+    renderTable(
+      <AppsTable
+        apps={[APPS[0]]}
+        mode="admin"
+        statusOf={() => ({ label: "Connected", tone: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100" })}
+        actionOf={() => ({ label: "Manage", onClick: onManage })}
+        disconnectOf={() => ({ label: "Disconnect", onClick: onDisconnect })}
+      />,
+    );
+
+    const row = screen.getByText("GitHub").closest("[role='button']");
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    expect(onManage).toHaveBeenCalledTimes(1);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
   it("admin mode shows checkboxes + bulk controls and fires toggle callbacks", () => {
     const onToggle = vi.fn();
     const onToggleAll = vi.fn();

--- a/src/components/apps/AppsTable.tsx
+++ b/src/components/apps/AppsTable.tsx
@@ -43,6 +43,8 @@ interface AppsTableProps {
   statusOf?: (app: AppEntry) => AppStatus | null;
   /** Admin mode: the single status-column chip. It states the truth AND does the action: Connect / Add key when unconnected, the proven status label (Connected / Key saved) when connected, click always opens the wizard. null = built-in, falls back to the plain status pill. */
   actionOf?: (app: AppEntry) => { label: string; onClick: () => void } | null;
+  /** Admin mode: shown in expanded connected rows so unlinking an app is discoverable. */
+  disconnectOf?: (app: AppEntry) => { label: string; onClick: () => void } | null;
   /** admin: makes the status pill a button (used to open the connect wizard). */
   onStatusClick?: (app: AppEntry) => void;
   busy?: boolean;
@@ -67,7 +69,7 @@ function SortHeader({
   );
 }
 
-export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf, onStatusClick, actionOf, busy }: AppsTableProps) {
+export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf, onStatusClick, actionOf, disconnectOf, busy }: AppsTableProps) {
   const { query, setQuery, category, setCategory, network, setNetwork, sortKey, sortDir, toggleSort, filtered } = useAppFilter(apps);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [showRaw, setShowRaw] = useState(false);
@@ -201,6 +203,9 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
         {filtered.map((app) => {
           const on = isOn(app.slug);
           const status = statusOf?.(app) ?? null;
+          const action = actionOf?.(app) ?? null;
+          const disconnect = disconnectOf?.(app) ?? null;
+          const connected = action?.label === "Manage" && Boolean(disconnect);
           const quality = levelLabel(app.level);
           const open = isExpanded(app);
           return (
@@ -248,24 +253,23 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
                       (Was an action button next to a status pill; for unconnected
                       rows the pair said the same thing twice.) */}
                   {isAdmin ? (() => {
-                    const action = actionOf?.(app) ?? null;
                     if (action) {
-                      const connected = action.label !== "Connect" && action.label !== "Add key";
+                      const hasConnection = action.label !== "Connect" && action.label !== "Add key";
                       return (
                         <button
                           type="button"
-                          title={connected ? "Click to manage this connection" : undefined}
+                          title={hasConnection ? "Click to manage this connection" : undefined}
                           onClick={(e) => {
                             e.stopPropagation();
                             action.onClick();
                           }}
                           className={`rounded-md border px-2 py-0.5 text-[10px] font-semibold transition-opacity hover:opacity-80 ${
-                            connected && status
+                            hasConnection && status
                               ? status.tone
                               : "border-[#61C1C4]/25 bg-[#61C1C4]/15 text-[#9FE0E2]"
                           }`}
                         >
-                          {connected && status ? status.label : action.label}
+                          {hasConnection && status ? status.label : action.label}
                         </button>
                       );
                     }
@@ -300,6 +304,37 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
                   <div style={{ gridColumn: `${actionsColStart} / -1` }} className="min-w-0">
                     {/* Full, untruncated description first, so nothing is lost to the
                         single-line row above. The internet badge rides along. */}
+                    {isAdmin && connected && (
+                      <div className="mb-1.5 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-emerald-300/10 bg-emerald-300/[0.04] px-3 py-2">
+                        <span className="text-[11px] font-medium text-emerald-100">
+                          Connected
+                        </span>
+                        <span className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              action?.onClick();
+                            }}
+                            className="rounded-md border border-emerald-300/20 px-2 py-1 text-[10px] font-semibold text-emerald-100 transition-colors hover:bg-emerald-300/10 disabled:opacity-50"
+                          >
+                            Manage
+                          </button>
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              disconnect?.onClick();
+                            }}
+                            className="rounded-md border border-red-300/25 px-2 py-1 text-[10px] font-semibold text-red-100 transition-colors hover:bg-red-300/10 disabled:opacity-50"
+                          >
+                            {disconnect?.label ?? "Disconnect"}
+                          </button>
+                        </span>
+                      </div>
+                    )}
                     <div className="flex flex-wrap items-center gap-2 py-1.5">
                       <span className="text-[11px] leading-snug text-white/70">{app.blurb}</span>
                       <span

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -155,6 +155,24 @@ export default function AdminToolsPage() {
     return { label, onClick: () => setConnectTarget(app) };
   }
 
+  function disconnectActionOf(app: AppEntry) {
+    const connector = connectorBySlug.get(app.slug);
+    if (!connector?.credential?.is_valid) return null;
+    return {
+      label: "Disconnect",
+      onClick: () => {
+        if (!window.confirm(`Disconnect ${app.name}?`)) return;
+        setSaving(true);
+        setSaveError(null);
+        void disconnectApp(app.slug)
+          .catch((err) => {
+            setSaveError(err instanceof Error ? err.message : "Disconnect failed.");
+          })
+          .finally(() => setSaving(false));
+      },
+    };
+  }
+
   async function disconnectApp(slug: string) {
     if (!session) throw new Error("Sign in again to disconnect apps.");
     const res = await fetch("/api/memory-admin?action=admin_disconnect_app", {
@@ -212,6 +230,7 @@ export default function AdminToolsPage() {
         statusOf={statusOf}
         onStatusClick={handleStatusClick}
         actionOf={actionOf}
+        disconnectOf={disconnectActionOf}
         busy={saving}
       />
 


### PR DESCRIPTION
## Summary
- add explicit Manage and Disconnect controls to expanded connected app rows
- wire Disconnect to the existing app disconnect endpoint with a confirmation prompt
- add test coverage for visible manage/disconnect controls
- refresh generated brainmap metadata

## Verification
- npx vitest run src/components/apps/AppsTable.test.tsx src/pages/admin/AdminTools.test.tsx src/components/apps/ConnectAppModal.test.tsx src/components/apps/appLenses.test.ts
- npm run build
- npx eslint src/components/apps/AppsTable.tsx src/pages/admin/AdminTools.tsx (0 errors; existing AdminTools refresh warning remains)
- npm run brainmap:check
- npx vitest run --testTimeout 30000
- git diff --check