### PR TITLE
[codex] Clarify Higgsfield connector setup

### DIFF
--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -3929,19 +3929,19 @@
     "tools": [
       {
         "name": "higgsfield_generate_video",
-        "description": "Generate a Higgsfield video from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
       },
       {
         "name": "higgsfield_generate_image",
-        "description": "Generate a Higgsfield image from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
       },
       {
         "name": "higgsfield_get_styles",
-        "description": "List available Higgsfield styles for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call."
       },
       {
         "name": "higgsfield_get_status",
-        "description": "Check the status of a Higgsfield generation by ID for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call."
       }
     ]
   },

--- a/packages/mcp-server/src/connector-setup.test.ts
+++ b/packages/mcp-server/src/connector-setup.test.ts
@@ -49,10 +49,10 @@ describe("connector-setup registry + resolver", () => {
     }
   });
 
-  it("points Higgsfield setup at the hosted MCP login path", () => {
+  it("points Higgsfield setup at Cloud API keys and names the hosted MCP as separate", () => {
     const r = notConnectedFor("higgsfield");
-    expect(CONNECTOR_SETUP.higgsfield.setupUrl).toBe("https://higgsfield.ai/mcp");
-    expect(r.how_to_connect.join(" ")).toContain("https://mcp.higgsfield.ai/mcp");
+    expect(CONNECTOR_SETUP.higgsfield.setupUrl).toBe("https://cloud.higgsfield.ai/api-keys");
+    expect(r.how_to_connect.join(" ")).toContain("separate direct sign-in path outside UnClick");
     expect(r.how_to_connect.join(" ")).toContain("HIGGSFIELD_API_KEY");
   });
 });

--- a/packages/mcp-server/src/connector-setup.ts
+++ b/packages/mcp-server/src/connector-setup.ts
@@ -231,8 +231,8 @@ export const CONNECTOR_SETUP: Record<string, ConnectorSetup> = {
     credential:  "API key",
     arg:         "api_key",
     envVar:      "HIGGSFIELD_API_KEY",
-    setupUrl:    "https://higgsfield.ai/mcp",
-    note:        "Customers connect their own Higgsfield account. Use api_key or HIGGSFIELD_API_KEY for UnClick's connector, or Higgsfield account login at https://mcp.higgsfield.ai/mcp for the hosted MCP.",
+    setupUrl:    "https://cloud.higgsfield.ai/api-keys",
+    note:        "Use a Higgsfield Cloud API key for the UnClick connector. Higgsfield bills generation usage to your Higgsfield account. The hosted MCP at https://mcp.higgsfield.ai/mcp is a separate direct sign-in path outside UnClick.",
   },
   kling: {
     displayName: "Kling",

--- a/packages/mcp-server/src/higgsfield-tool.ts
+++ b/packages/mcp-server/src/higgsfield-tool.ts
@@ -1,7 +1,7 @@
 // Higgsfield AI API integration for the UnClick MCP server.
 // Uses the Higgsfield REST API via fetch - no external dependencies.
-// This REST connector accepts api_key or HIGGSFIELD_API_KEY. Higgsfield's
-// hosted MCP path uses account login at https://mcp.higgsfield.ai/mcp.
+// This REST connector accepts api_key or HIGGSFIELD_API_KEY. Higgsfield's hosted
+// MCP is a separate direct sign-in path at https://mcp.higgsfield.ai/mcp.
 
 import { requireCredential } from "./connector-setup.js";
 import { type NotConnectedResult } from "./connection-help.js";

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -3943,19 +3943,19 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "higgsfield_generate_video",
-        "description": "Generate a Higgsfield video from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
       },
       {
         "name": "higgsfield_generate_image",
-        "description": "Generate a Higgsfield image from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
       },
       {
         "name": "higgsfield_get_styles",
-        "description": "List available Higgsfield styles for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call."
       },
       {
         "name": "higgsfield_get_status",
-        "description": "Check the status of a Higgsfield generation by ID for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+        "description": "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call."
       }
     ]
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -17057,12 +17057,12 @@ export const ADDITIONAL_TOOLS = [
   // ── higgsfield-tool.ts ────────────────────────────────────────────────────────
   {
     name: "higgsfield_generate_video",
-    description: "Generate a Higgsfield video from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp.",
+    description: "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield API key for this call. You can also set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
         prompt: { type: "string", description: "Text description of the video to generate" },
         style: { type: "string", description: "Soul Style name (use higgsfield_get_styles to list available styles)" },
         duration: { type: "number", description: "Video duration in seconds" },
@@ -17075,12 +17075,12 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "higgsfield_generate_image",
-    description: "Generate a Higgsfield image from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp.",
+    description: "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield API key for this call. You can also set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
         prompt: { type: "string", description: "Text description of the image to generate" },
         style: { type: "string", description: "Style name (use higgsfield_get_styles to list available styles)" },
         width: { type: "number", description: "Image width in pixels" },
@@ -17093,24 +17093,24 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "higgsfield_get_styles",
-    description: "List available Higgsfield styles for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp.",
+    description: "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield API key for this call. You can also set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
       },
       required: [],
     },
   },
   {
     name: "higgsfield_get_status",
-    description: "Check the status of a Higgsfield generation by ID for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp.",
+    description: "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield API key for this call. You can also set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
         generation_id: { type: "string", description: "Generation ID returned by higgsfield_generate_video or higgsfield_generate_image" },
       },
       required: ["generation_id"],

--- a/src/components/apps/ConnectAppModal.test.tsx
+++ b/src/components/apps/ConnectAppModal.test.tsx
@@ -17,6 +17,16 @@ const APP: AppEntry = {
 };
 
 const CONNECTOR = { id: "alphavantage", auth_type: "api_key" as const, setup_url: null };
+const HIGGSFIELD_APP: AppEntry = {
+  ...APP,
+  slug: "higgsfield",
+  name: "Higgsfield",
+  category: "AI",
+  blurb: "Create images, video, characters, and campaign assets.",
+  domain: "higgsfield.ai",
+  tools: [{ name: "higgsfield_generate_image", description: "Generate an image." }],
+  toolCount: 1,
+};
 
 function renderModal(overrides: Partial<Parameters<typeof ConnectAppModal>[0]> = {}) {
   return render(
@@ -90,6 +100,18 @@ describe("ConnectAppModal", () => {
     fireEvent.change(screen.getByPlaceholderText(/paste api key here/i), { target: { value: "demo-key" } });
     fireEvent.click(screen.getByRole("button", { name: /test and connect/i }));
     expect(await screen.findByText(/marked as added/i)).toBeInTheDocument();
+  });
+
+  it("sends Higgsfield users to Cloud API keys and treats hosted MCP as separate", () => {
+    renderModal({
+      app: HIGGSFIELD_APP,
+      connector: { id: "higgsfield", auth_type: "api_key", setup_url: null },
+    });
+    expect(screen.getByRole("link", { name: /where do i get my api key/i })).toHaveAttribute(
+      "href",
+      "https://cloud.higgsfield.ai/api-keys",
+    );
+    expect(screen.getByText(/hosted MCP .* separate direct sign-in path outside UnClick/i)).toBeInTheDocument();
   });
 
   it("surfaces a rejection and stores nothing when the platform refuses the key", async () => {

--- a/src/components/apps/appDetailExtras.tsx
+++ b/src/components/apps/appDetailExtras.tsx
@@ -56,23 +56,36 @@ function HiggsfieldPanel(): ReactNode {
     <div className="rounded-xl border border-[#B8FF00]/25 bg-[#B8FF00]/[0.04] p-5">
       <div className="flex items-center gap-2">
         <Cable className="h-4 w-4 text-[#B8FF00]" />
-        <p className="text-sm font-semibold text-white">Higgsfield MCP and CLI setup</p>
+        <p className="text-sm font-semibold text-white">Higgsfield setup options</p>
       </div>
       <p className="mt-1.5 text-xs leading-5 text-white/55">
-        Customers connect their own Higgsfield account. The hosted MCP uses Higgsfield account
-        login, while Codex, Cursor, OpenClaw, and Hermes can use the CLI plus skills path.
+        There are two separate ways to use Higgsfield. Connect an API key in UnClick when
+        you want UnClick to route Higgsfield actions. Add Higgsfield's hosted MCP directly
+        when you want Claude or another client to talk to Higgsfield without going through
+        UnClick. Both paths use your Higgsfield account, with credits, subscription, and
+        billing managed by Higgsfield.
       </p>
 
       <div className="mt-4 grid gap-4 md:grid-cols-2">
         <div className="space-y-3">
           <CommandStack
-            label="Hosted MCP"
+            label="UnClick app connection"
+            commands={[
+              "Create a Higgsfield Cloud API key",
+              "https://cloud.higgsfield.ai/api-keys",
+              "Paste it in Apps to mark Higgsfield connected in UnClick",
+            ]}
+          />
+          <CommandStack
+            label="Higgsfield hosted MCP"
             commands={[
               "Name: Higgsfield",
               "URL: https://mcp.higgsfield.ai/mcp",
-              "Connect, then sign in with the customer's Higgsfield account",
+              "Connect, then sign in with your Higgsfield account",
             ]}
           />
+        </div>
+        <div className="space-y-3">
           <CommandStack
             label="CLI and skills"
             commands={[
@@ -82,8 +95,6 @@ function HiggsfieldPanel(): ReactNode {
               "/higgsfield:generate",
             ]}
           />
-        </div>
-        <div className="space-y-3">
           <CommandStack
             label="OpenClaw"
             commands={[
@@ -105,12 +116,20 @@ function HiggsfieldPanel(): ReactNode {
 
       <div className="mt-4 flex flex-wrap gap-2">
         <a
-          href="https://higgsfield.ai/mcp"
+          href="https://cloud.higgsfield.ai/api-keys"
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1.5 rounded-md border border-[#B8FF00]/30 bg-[#B8FF00]/10 px-3 py-1.5 text-xs font-semibold text-[#D6FF57] transition-colors hover:bg-[#B8FF00]/15"
         >
-          <ExternalLink className="h-3.5 w-3.5" /> Higgsfield MCP guide
+          <ExternalLink className="h-3.5 w-3.5" /> Get API key
+        </a>
+        <a
+          href="https://higgsfield.ai/mcp"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-semibold text-white/65 transition-colors hover:bg-white/[0.07]"
+        >
+          <ExternalLink className="h-3.5 w-3.5" /> Hosted MCP guide
         </a>
         <a
           href="https://higgsfield.ai/cli"

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -5558,19 +5558,19 @@
       "tools": [
         {
           "name": "higgsfield_generate_video",
-          "description": "Generate a Higgsfield video from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+          "description": "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
         },
         {
           "name": "higgsfield_generate_image",
-          "description": "Generate a Higgsfield image from a prompt. Uses the customer's connected Higgsfield credentials; pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+          "description": "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
         },
         {
           "name": "higgsfield_get_styles",
-          "description": "List available Higgsfield styles for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+          "description": "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call."
         },
         {
           "name": "higgsfield_get_status",
-          "description": "Check the status of a Higgsfield generation by ID for the customer's connected account. Pass api_key or set HIGGSFIELD_API_KEY for UnClick, or use Higgsfield's hosted MCP login at https://mcp.higgsfield.ai/mcp."
+          "description": "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call."
         }
       ],
       "level": 5,

--- a/src/data/connector-setup.generated.json
+++ b/src/data/connector-setup.generated.json
@@ -194,8 +194,8 @@
       "credential": "API key",
       "arg": "api_key",
       "envVar": "HIGGSFIELD_API_KEY",
-      "setupUrl": "https://higgsfield.ai/mcp",
-      "note": "Customers connect their own Higgsfield account. Use api_key or HIGGSFIELD_API_KEY for UnClick's connector, or Higgsfield account login at https://mcp.higgsfield.ai/mcp for the hosted MCP."
+      "setupUrl": "https://cloud.higgsfield.ai/api-keys",
+      "note": "Use a Higgsfield Cloud API key for the UnClick connector. Higgsfield bills generation usage to your Higgsfield account. The hosted MCP at https://mcp.higgsfield.ai/mcp is a separate direct sign-in path outside UnClick."
     },
     "kling": {
       "displayName": "Kling",

--- a/src/lib/appCatalog.test.ts
+++ b/src/lib/appCatalog.test.ts
@@ -49,4 +49,11 @@ describe("app catalog integrity", () => {
   it("uses the real Higgsfield brand domain for its app icon", () => {
     expect(getApp("higgsfield")?.domain).toBe("higgsfield.ai");
   });
+
+  it("keeps Higgsfield UnClick actions separate from the hosted MCP setup path", () => {
+    const higgsfield = getApp("higgsfield");
+    const actionCopy = higgsfield?.tools.map((tool) => tool.description).join(" ") ?? "";
+    expect(actionCopy).toContain("connected in UnClick");
+    expect(actionCopy).not.toContain("mcp.higgsfield.ai");
+  });
 });


### PR DESCRIPTION
## What changed
- Separates the UnClick Higgsfield connector from Higgsfield's hosted MCP setup in customer-facing copy.
- Points the UnClick API-key setup link at Higgsfield Cloud API keys instead of the hosted MCP page.
- Updates Higgsfield tool descriptions so UnClick actions describe the API-key route only.
- Adds tests guarding the Higgsfield setup URL and action-copy separation.

## Why
The previous copy mixed API keys, env vars, and Higgsfield hosted MCP login into the same setup path. That made it look like connecting Higgsfield's own MCP would also connect the UnClick app, and it blurred who handles billing and credits.

## Validation
- npx vitest run src/components/apps/ConnectAppModal.test.tsx src/lib/appCatalog.test.ts packages/mcp-server/src/connector-setup.test.ts packages/mcp-server/src/higgsfield-tool.test.ts
- npx vitest run src/connector-setup.test.ts src/higgsfield-tool.test.ts (from packages/mcp-server)
- node scripts/generate-tool-index.mjs --check
- node scripts/generate-app-catalog.mjs --check
- node scripts/generate-connector-setup.mjs --check
- npm run brainmap:check
- npx eslint touched files (0 errors, existing appDetailExtras fast-refresh warnings)
- npm run build
- npx vitest run --testTimeout 30000
- npm run test:api-lib-esm-extension
- npm run test --workspace=@unclick/mcp-server

## Notes
Browser plugin verification could not attach to the in-app browser tab, so I verified the built assets directly for the new Higgsfield setup copy and links.
