### PR TITLE
[codex] Add managed app connections broker

### DIFF
--- a/api/credentials.ts
+++ b/api/credentials.ts
@@ -28,6 +28,10 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import * as crypto from "crypto";
+import {
+  fetchManagedConnectionCredentials,
+  type ManagedConnectionRow,
+} from "./lib/managed-connections.js";
 
 // ─── Crypto helpers ───────────────────────────────────────────────────────────
 
@@ -142,6 +146,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const rows = data as Array<Record<string, unknown>>;
     if (!rows || rows.length === 0) {
+      const managedUrl = `${supabaseUrl}/rest/v1/managed_app_connections?api_key_hash=eq.${encodeURIComponent(apiKeyHash)}&platform_slug=eq.${encodeURIComponent(platform)}&status=eq.connected&select=id,platform_slug,provider,provider_config_key,external_connection_id,auth_mode,status,account_label,scope_summary,last_checked_at,connected_at,created_at,updated_at,metadata&order=updated_at.desc.nullslast&limit=1`;
+      const managed = await supabaseFetch(managedUrl, "GET", supabaseHeaders(serviceRoleKey));
+      const managedRows = managed.ok ? (managed.data as ManagedConnectionRow[]) : [];
+      const managedConnection = managedRows[0];
+      if (managedConnection) {
+        const brokerResult = await fetchManagedConnectionCredentials({ connection: managedConnection });
+        if (brokerResult.ok && brokerResult.credentials) {
+          return res.status(200).json(brokerResult.credentials);
+        }
+        return res.status(brokerResult.status || 502).json({
+          error: brokerResult.error ?? "Managed connection could not provide credentials.",
+          setup_url: `https://unclick.world/admin/apps?lens=connected`,
+        });
+      }
+
       return res.status(404).json({
         error:     label
           ? `No credentials stored for platform "${platform}" with label "${label}".`

--- a/api/lib/managed-connections.test.ts
+++ b/api/lib/managed-connections.test.ts
@@ -1,0 +1,155 @@
+import * as crypto from "crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  beginManagedConnection,
+  fetchManagedConnectionCredentials,
+  managedConnectionAvailableForPlatform,
+  managedConnectionsConfigured,
+  normalizeManagedCredentials,
+  providerConfigKeyForPlatform,
+  verifyNangoWebhookSignature,
+} from "./managed-connections";
+
+const TENANT = {
+  apiKeyHash: "hash_123",
+  userId: "user_123",
+  email: "person@example.com",
+};
+
+describe("managed connections broker helper", () => {
+  it("stays off until a broker secret is configured", async () => {
+    expect(managedConnectionsConfigured({})).toBe(false);
+    const result = await beginManagedConnection({
+      platform: "higgsfield",
+      appName: "Higgsfield",
+      tenant: TENANT,
+      returnUrl: "https://unclick.world/admin/apps?lens=connected",
+      env: {},
+    });
+    expect(result).toMatchObject({ ok: false, code: "broker_not_configured" });
+  });
+
+  it("uses platform-specific provider config overrides", () => {
+    expect(providerConfigKeyForPlatform("higgsfield", { NANGO_PROVIDER_CONFIG_HIGGSFIELD: "hf-prod" })).toBe("hf-prod");
+    expect(providerConfigKeyForPlatform("higgsfield", { NANGO_PROVIDER_CONFIG_PREFIX: "unclick-" })).toBe("unclick-higgsfield");
+    expect(providerConfigKeyForPlatform("higgsfield", {})).toBe("higgsfield");
+  });
+
+  it("only enables the broker UI for configured or allowlisted apps", () => {
+    expect(managedConnectionAvailableForPlatform("higgsfield", { NANGO_SECRET_KEY: "secret" })).toBe(false);
+    expect(managedConnectionAvailableForPlatform("higgsfield", {
+      NANGO_SECRET_KEY: "secret",
+      NANGO_PROVIDER_CONFIG_HIGGSFIELD: "higgsfield-prod",
+    })).toBe(true);
+    expect(managedConnectionAvailableForPlatform("github", {
+      NANGO_SECRET_KEY: "secret",
+      NANGO_MANAGED_PLATFORMS: "higgsfield, github",
+    })).toBe(true);
+    expect(managedConnectionAvailableForPlatform("slack", {
+      NANGO_SECRET_KEY: "secret",
+      NANGO_MANAGED_PLATFORMS: "higgsfield, github",
+    })).toBe(false);
+  });
+
+  it("creates a connect session without sending customer secrets", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          data: {
+            connect_link: "https://connect.nango.dev/session/abc",
+            expires_at: "2026-06-16T09:00:00Z",
+          },
+        }),
+      }),
+    );
+
+    const result = await beginManagedConnection({
+      platform: "higgsfield",
+      appName: "Higgsfield",
+      tenant: TENANT,
+      returnUrl: "https://unclick.world/admin/apps?lens=connected",
+      env: { NANGO_SECRET_KEY: "secret", NANGO_PROVIDER_CONFIG_HIGGSFIELD: "higgsfield-prod" },
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      provider_config_key: "higgsfield-prod",
+      connect_url: "https://connect.nango.dev/session/abc",
+    });
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const request = JSON.parse(String(requestInit.body));
+    expect(request.allowed_integrations).toEqual(["higgsfield-prod"]);
+    expect(request.tags).toMatchObject({
+      unclick_api_key_hash: "hash_123",
+      unclick_platform_slug: "higgsfield",
+    });
+    expect(JSON.stringify(request)).not.toContain("secret");
+    expect(JSON.stringify(request)).not.toMatch(/password|access_token|refresh_token/i);
+  });
+
+  it("normalizes common broker credential shapes for existing tools", () => {
+    expect(normalizeManagedCredentials({
+      credentials: {
+        accessToken: "access",
+        refreshToken: "refresh",
+        apiKey: "key",
+        raw: { tenant_id: "tenant" },
+      },
+    })).toEqual({
+      access_token: "access",
+      refresh_token: "refresh",
+      api_key: "key",
+      tenant_id: "tenant",
+    });
+  });
+
+  it("does not mistake connection metadata for credentials", () => {
+    expect(normalizeManagedCredentials({
+      id: "conn_123",
+      provider_config_key: "higgsfield-prod",
+      platform_slug: "higgsfield",
+    })).toEqual({});
+  });
+
+  it("fetches managed credentials with the provider config header", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: { credentials: { apiKey: "hf-key" } } }),
+      }),
+    );
+
+    const result = await fetchManagedConnectionCredentials({
+      connection: {
+        platform_slug: "higgsfield",
+        provider: "nango",
+        provider_config_key: "higgsfield-prod",
+        external_connection_id: "conn_123",
+        status: "connected",
+      },
+      env: { NANGO_SECRET_KEY: "secret" },
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).toMatchObject({ ok: true, credentials: { api_key: "hf-key" } });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.nango.dev/connection/conn_123",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "Provider-Config-Key": "higgsfield-prod" }),
+      }),
+    );
+  });
+
+  it("verifies signed webhook bodies", () => {
+    const rawBody = Buffer.from(JSON.stringify({ hello: "world" }));
+    const secret = "webhook-secret";
+    const signature = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+    expect(verifyNangoWebhookSignature({ rawBody, signature, secret })).toBe(true);
+    expect(verifyNangoWebhookSignature({ rawBody, signature: "00", secret })).toBe(false);
+  });
+});

--- a/api/lib/managed-connections.ts
+++ b/api/lib/managed-connections.ts
@@ -1,0 +1,336 @@
+import * as crypto from "crypto";
+
+export const MANAGED_CONNECTION_PROVIDER = "nango";
+
+const DEFAULT_NANGO_BASE_URL = "https://api.nango.dev";
+
+export interface ManagedConnectionTenant {
+  apiKeyHash: string;
+  userId: string | null;
+  email?: string | null;
+}
+
+export interface ManagedConnectionRow {
+  id?: string | null;
+  platform_slug: string;
+  provider: string | null;
+  provider_config_key?: string | null;
+  external_connection_id: string;
+  auth_mode?: string | null;
+  status: string;
+  account_label?: string | null;
+  scope_summary?: string | null;
+  last_checked_at?: string | null;
+  connected_at?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export type ManagedConnectionStartResult =
+  | {
+      ok: true;
+      provider: typeof MANAGED_CONNECTION_PROVIDER;
+      provider_config_key: string;
+      connect_url: string;
+      session_token?: string | null;
+      expires_at?: string | null;
+    }
+  | {
+      ok: false;
+      status: number;
+      code: "broker_not_configured" | "broker_error";
+      message: string;
+    };
+
+export interface ManagedConnectionCredentialResult {
+  ok: boolean;
+  status: number;
+  credentials?: Record<string, string>;
+  error?: string;
+}
+
+export interface ManagedConnectionConfig {
+  provider: typeof MANAGED_CONNECTION_PROVIDER;
+  baseUrl: string;
+  secretKey: string;
+  webhookSecret: string | null;
+}
+
+export function managedConnectionsConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.NANGO_SECRET_KEY?.trim());
+}
+
+export function readManagedConnectionConfig(env: NodeJS.ProcessEnv = process.env): ManagedConnectionConfig | null {
+  const secretKey = env.NANGO_SECRET_KEY?.trim();
+  if (!secretKey) return null;
+  return {
+    provider: MANAGED_CONNECTION_PROVIDER,
+    baseUrl: (env.NANGO_BASE_URL ?? DEFAULT_NANGO_BASE_URL).replace(/\/+$/, ""),
+    secretKey,
+    webhookSecret: env.NANGO_WEBHOOK_SECRET?.trim() || null,
+  };
+}
+
+export function providerConfigKeyForPlatform(platform: string, env: NodeJS.ProcessEnv = process.env): string {
+  const envKey = `NANGO_PROVIDER_CONFIG_${platform.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+  const configured = env[envKey]?.trim();
+  if (configured) return configured;
+  const prefix = env.NANGO_PROVIDER_CONFIG_PREFIX?.trim() ?? "";
+  return `${prefix}${platform}`;
+}
+
+export function managedConnectionAvailableForPlatform(platform: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (!managedConnectionsConfigured(env)) return false;
+  const envKey = `NANGO_PROVIDER_CONFIG_${platform.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+  if (env[envKey]?.trim()) return true;
+  const allowlist = env.NANGO_MANAGED_PLATFORMS?.trim();
+  if (!allowlist) return false;
+  if (allowlist === "*") return true;
+  const normalized = platform.toLowerCase();
+  return allowlist
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean)
+    .includes(normalized);
+}
+
+export async function beginManagedConnection(input: {
+  platform: string;
+  appName: string;
+  tenant: ManagedConnectionTenant;
+  returnUrl: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+}): Promise<ManagedConnectionStartResult> {
+  const env = input.env ?? process.env;
+  const config = readManagedConnectionConfig(env);
+  if (!config) {
+    return {
+      ok: false,
+      status: 501,
+      code: "broker_not_configured",
+      message: "Managed Connections is not switched on for this workspace yet. Nothing was saved.",
+    };
+  }
+
+  const providerConfigKey = providerConfigKeyForPlatform(input.platform, env);
+  const fetcher = input.fetchImpl ?? fetch;
+  const tags = {
+    unclick_api_key_hash: input.tenant.apiKeyHash,
+    unclick_user_id: input.tenant.userId ?? "",
+    unclick_platform_slug: input.platform,
+    unclick_app_name: input.appName,
+  };
+
+  const response = await fetcher(`${config.baseUrl}/connect/sessions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.secretKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      end_user: {
+        id: input.tenant.apiKeyHash,
+        ...(input.tenant.email ? { email: input.tenant.email } : {}),
+      },
+      allowed_integrations: [providerConfigKey],
+      tags,
+      return_url: input.returnUrl,
+    }),
+  });
+
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      code: "broker_error",
+      message: typeof body.error === "string"
+        ? body.error
+        : `Managed connection provider rejected the request (${response.status}).`,
+    };
+  }
+
+  const data = isRecord(body.data) ? body.data : body;
+  const connectUrl =
+    stringField(data, "connect_link") ??
+    stringField(data, "connect_url") ??
+    stringField(data, "connectUrl") ??
+    stringField(data, "url") ??
+    stringField(data, "link");
+
+  if (!connectUrl) {
+    return {
+      ok: false,
+      status: 502,
+      code: "broker_error",
+      message: "Managed connection provider did not return a connect link.",
+    };
+  }
+
+  return {
+    ok: true,
+    provider: MANAGED_CONNECTION_PROVIDER,
+    provider_config_key: providerConfigKey,
+    connect_url: connectUrl,
+    session_token: stringField(data, "token") ?? stringField(data, "session_token"),
+    expires_at: stringField(data, "expires_at") ?? stringField(data, "expiresAt"),
+  };
+}
+
+export async function fetchManagedConnectionCredentials(input: {
+  connection: ManagedConnectionRow;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+}): Promise<ManagedConnectionCredentialResult> {
+  const env = input.env ?? process.env;
+  const config = readManagedConnectionConfig(env);
+  if (!config) {
+    return { ok: false, status: 501, error: "Managed connection provider is not configured." };
+  }
+  if (input.connection.provider && input.connection.provider !== MANAGED_CONNECTION_PROVIDER) {
+    return { ok: false, status: 400, error: `Unsupported managed connection provider "${input.connection.provider}".` };
+  }
+
+  const providerConfigKey =
+    input.connection.provider_config_key ||
+    providerConfigKeyForPlatform(input.connection.platform_slug, env);
+  const fetcher = input.fetchImpl ?? fetch;
+  const url = `${config.baseUrl}/connection/${encodeURIComponent(input.connection.external_connection_id)}`;
+  const response = await fetcher(url, {
+    headers: {
+      Authorization: `Bearer ${config.secretKey}`,
+      "Provider-Config-Key": providerConfigKey,
+    },
+  });
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: typeof body.error === "string" ? body.error : `Managed connection lookup failed (${response.status}).`,
+    };
+  }
+
+  const credentials = normalizeManagedCredentials(body);
+  if (Object.keys(credentials).length === 0) {
+    return { ok: false, status: 502, error: "Managed connection returned no usable credential fields." };
+  }
+
+  return { ok: true, status: 200, credentials };
+}
+
+export async function disconnectManagedConnection(input: {
+  connection: ManagedConnectionRow;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+}): Promise<{ ok: boolean; status: number; error?: string }> {
+  const env = input.env ?? process.env;
+  const config = readManagedConnectionConfig(env);
+  if (!config) return { ok: true, status: 204 };
+  if (input.connection.provider && input.connection.provider !== MANAGED_CONNECTION_PROVIDER) {
+    return { ok: true, status: 204 };
+  }
+
+  const providerConfigKey =
+    input.connection.provider_config_key ||
+    providerConfigKeyForPlatform(input.connection.platform_slug, env);
+  const fetcher = input.fetchImpl ?? fetch;
+  const url = `${config.baseUrl}/connection/${encodeURIComponent(input.connection.external_connection_id)}`;
+  const response = await fetcher(url, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${config.secretKey}`,
+      "Provider-Config-Key": providerConfigKey,
+    },
+  });
+  if (response.ok || response.status === 404) return { ok: true, status: response.status };
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  return {
+    ok: false,
+    status: response.status,
+    error: typeof body.error === "string" ? body.error : `Managed disconnect failed (${response.status}).`,
+  };
+}
+
+export function normalizeManagedCredentials(payload: Record<string, unknown>): Record<string, string> {
+  const data = isRecord(payload.data) ? payload.data : null;
+  const connection = isRecord(payload.connection) ? payload.connection : null;
+  const dataConnection = data && isRecord(data.connection) ? data.connection : null;
+  const source: Record<string, unknown> =
+    isRecord(payload.credentials) ? payload.credentials :
+    connection && isRecord(connection.credentials) ? connection.credentials :
+    data && isRecord(data.credentials) ? data.credentials :
+    dataConnection && isRecord(dataConnection.credentials) ? dataConnection.credentials :
+    data && hasCredentialLikeField(data) ? data :
+    hasCredentialLikeField(payload) ? payload :
+    {};
+
+  const out: Record<string, string> = {};
+  function copyField(key: string, value: unknown) {
+    if (typeof value !== "string" || value.trim() === "") return;
+    out[key] = value.trim();
+  }
+
+  if (isRecord(source.raw)) {
+    for (const [key, value] of Object.entries(source.raw)) copyField(key, value);
+  }
+  for (const [key, value] of Object.entries(source)) {
+    if (key === "raw" || key === "type" || key === "expires_at") continue;
+    if (key === "accessToken" || key === "refreshToken" || key === "apiKey") continue;
+    copyField(key, value);
+  }
+
+  if (!out.access_token) {
+    copyField("access_token", source.accessToken);
+  }
+  if (!out.refresh_token) {
+    copyField("refresh_token", source.refreshToken);
+  }
+  if (!out.api_key) {
+    copyField("api_key", source.apiKey ?? source.key ?? source.token ?? source.access_token ?? source.accessToken);
+  }
+
+  return out;
+}
+
+function hasCredentialLikeField(record: Record<string, unknown>): boolean {
+  return [
+    "apiKey",
+    "api_key",
+    "key",
+    "token",
+    "accessToken",
+    "access_token",
+    "refreshToken",
+    "refresh_token",
+    "credentials",
+  ].some((key) => typeof record[key] === "string" && record[key].trim() !== "");
+}
+
+export function verifyNangoWebhookSignature(input: {
+  rawBody: Buffer;
+  signature: string | string[] | undefined;
+  secret: string;
+}): boolean {
+  const signature = Array.isArray(input.signature) ? input.signature[0] : input.signature;
+  if (!signature) return false;
+  const expected = crypto
+    .createHmac("sha256", input.secret)
+    .update(input.rawBody)
+    .digest("hex");
+  const normalized = signature.replace(/^sha256=/i, "");
+  const actualBuffer = Buffer.from(normalized, "hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
+  return actualBuffer.length === expectedBuffer.length && crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/api/managed-connection-webhook.ts
+++ b/api/managed-connection-webhook.ts
@@ -1,0 +1,138 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import {
+  MANAGED_CONNECTION_PROVIDER,
+  readManagedConnectionConfig,
+  verifyNangoWebhookSignature,
+} from "./lib/managed-connections.js";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Cache-Control", "private, no-store, max-age=0, must-revalidate");
+  res.setHeader("CDN-Cache-Control", "no-store");
+  res.setHeader("Vercel-CDN-Cache-Control", "no-store");
+
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const brokerConfig = readManagedConnectionConfig();
+  if (!supabaseUrl || !serviceRoleKey || !brokerConfig?.webhookSecret) {
+    return res.status(500).json({ error: "Managed connection webhook is not configured." });
+  }
+
+  const rawBody = await readRawBody(req);
+  const signature =
+    req.headers["x-nango-signature"] ??
+    req.headers["x-nango-hmac-sha256"] ??
+    req.headers["x-signature"];
+  if (!verifyNangoWebhookSignature({ rawBody, signature, secret: brokerConfig.webhookSecret })) {
+    return res.status(401).json({ error: "Invalid webhook signature." });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(rawBody.toString("utf8")) as Record<string, unknown>;
+  } catch {
+    return res.status(400).json({ error: "Invalid JSON payload." });
+  }
+
+  const connection = asRecord(payload.connection) ?? asRecord(payload.data) ?? payload;
+  const tags =
+    asRecord(payload.tags) ??
+    asRecord(connection.tags) ??
+    asRecord(asRecord(payload.end_user)?.tags) ??
+    {};
+  const apiKeyHash = stringField(tags, "unclick_api_key_hash");
+  const platform = stringField(tags, "unclick_platform_slug") ?? stringField(connection, "platform_slug");
+  const externalConnectionId =
+    stringField(connection, "connection_id") ??
+    stringField(connection, "connectionId") ??
+    stringField(connection, "id") ??
+    stringField(payload, "connection_id") ??
+    stringField(payload, "connectionId");
+  const providerConfigKey =
+    stringField(connection, "provider_config_key") ??
+    stringField(connection, "providerConfigKey") ??
+    stringField(payload, "provider_config_key") ??
+    stringField(payload, "providerConfigKey");
+
+  if (!apiKeyHash || !platform || !externalConnectionId) {
+    return res.status(202).json({ ignored: true, reason: "Missing UnClick routing tags." });
+  }
+
+  const now = new Date().toISOString();
+  const event = stringField(payload, "type") ?? stringField(payload, "event") ?? stringField(payload, "operation") ?? "unknown";
+  const failed = payload.success === false || Boolean(payload.error) || Boolean(connection.error);
+  const deleted = /delete|remove|revoke|disconnect/i.test(event);
+  const status = deleted ? "revoked" : failed ? "error" : "connected";
+  const accountLabel =
+    stringField(connection, "end_user_email") ??
+    stringField(connection, "accountName") ??
+    stringField(connection, "account_label") ??
+    stringField(tags, "unclick_app_name");
+  const scopeSummary =
+    Array.isArray(connection.scopes) ? connection.scopes.map(String).join(", ") :
+    stringField(connection, "scope") ??
+    null;
+
+  const row = {
+    api_key_hash: apiKeyHash,
+    platform_slug: platform,
+    provider: MANAGED_CONNECTION_PROVIDER,
+    provider_config_key: providerConfigKey,
+    external_connection_id: externalConnectionId,
+    auth_mode: stringField(connection, "auth_mode") ?? "managed_oauth",
+    status,
+    account_label: accountLabel,
+    scope_summary: scopeSummary,
+    last_checked_at: now,
+    connected_at: status === "connected" ? now : null,
+    updated_at: now,
+    metadata: {
+      provider_event: event,
+      provider_environment: stringField(payload, "environment"),
+      provider_config_key: providerConfigKey,
+    },
+  };
+
+  const url = `${supabaseUrl}/rest/v1/managed_app_connections?on_conflict=api_key_hash,platform_slug,provider,external_connection_id`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      "Content-Type": "application/json",
+      Prefer: "resolution=merge-duplicates,return=representation",
+    },
+    body: JSON.stringify(row),
+  });
+
+  if (!response.ok) {
+    return res.status(502).json({ error: "Could not save managed connection status." });
+  }
+
+  return res.status(200).json({ success: true, platform, status });
+}
+
+function readRawBody(req: VercelRequest): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function stringField(record: Record<string, unknown> | null | undefined, key: string): string | null {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -138,6 +138,14 @@ import {
   shouldIncludeThroughputMetrics,
 } from "./lib/throughput-observability.js";
 import {
+  beginManagedConnection,
+  disconnectManagedConnection,
+  managedConnectionAvailableForPlatform,
+  managedConnectionsConfigured,
+  providerConfigKeyForPlatform,
+  type ManagedConnectionRow,
+} from "./lib/managed-connections.js";
+import {
   attachBuildDeskIdempotencyKey,
   findBuildDeskRowByIdempotencyKey,
   parseBuildDeskIdempotencyKey,
@@ -5329,7 +5337,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           .select("id, platform_slug, label, is_valid, last_tested_at, created_at, updated_at")
           .eq("api_key_hash", tenant.apiKeyHash);
 
-        type AdminCredentialSource = "platform_credentials" | "user_credentials" | "mixed";
+        const managedQ = await supabase
+          .from("managed_app_connections")
+          .select("id, platform_slug, provider, provider_config_key, external_connection_id, auth_mode, status, account_label, scope_summary, last_checked_at, connected_at, created_at, updated_at, metadata")
+          .eq("api_key_hash", tenant.apiKeyHash)
+          .in("status", ["connected", "pending"]);
+        // New deployments may briefly run before the migration is applied. In
+        // that window the managed path simply stays invisible instead of
+        // breaking the Apps page.
+        const managedRows = managedQ.error ? [] : (managedQ.data ?? []);
+
+        type AdminCredentialSource = "platform_credentials" | "user_credentials" | "managed_app_connections" | "mixed";
         type AdminCredentialSummary = {
           id: string | null;
           is_valid: boolean;
@@ -5338,6 +5356,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           source: AdminCredentialSource;
           created_at: string | null;
           updated_at: string | null;
+          managed?: {
+            provider: string;
+            provider_config_key: string | null;
+            external_connection_id: string;
+            auth_mode: string;
+            status: string;
+            account_label: string | null;
+            scope_summary: string | null;
+            connected_at: string | null;
+          } | null;
         };
 
         function timestampScore(value: unknown): number {
@@ -5347,7 +5375,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         }
 
         function credentialScore(cred: AdminCredentialSummary): number {
+          const managedBoost = cred.source === "managed_app_connections" ? 100_000_000_000_000 : 0;
           return (cred.is_valid ? 1_000_000_000_000_000 : 0)
+            + managedBoost
             + (cred.last_tested_at ? 1_000_000_000_000 : 0)
             + Math.max(timestampScore(cred.updated_at), timestampScore(cred.created_at));
         }
@@ -5391,9 +5421,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           });
         }
 
+        for (const row of managedRows as Array<ManagedConnectionRow>) {
+          mergeCredential(row.platform_slug, {
+            id: row.id ?? null,
+            is_valid: row.status === "connected",
+            last_tested_at: row.last_checked_at ?? row.connected_at ?? null,
+            label: row.account_label ?? null,
+            source: "managed_app_connections",
+            created_at: row.created_at ?? null,
+            updated_at: row.updated_at ?? null,
+            managed: {
+              provider: row.provider ?? "nango",
+              provider_config_key: row.provider_config_key ?? null,
+              external_connection_id: row.external_connection_id,
+              auth_mode: row.auth_mode ?? "managed_oauth",
+              status: row.status,
+              account_label: row.account_label ?? null,
+              scope_summary: row.scope_summary ?? null,
+              connected_at: row.connected_at ?? null,
+            },
+          });
+        }
+
         const enrichedConnectors = (connectors ?? []).map((pc) => ({
           ...pc,
           credential: credMap.get(pc.id as string) ?? null,
+          supports_managed_connection: pc.auth_type
+            ? managedConnectionAvailableForPlatform(pc.id as string)
+            : false,
+          managed_provider_config_key: pc.auth_type
+            ? providerConfigKeyForPlatform(pc.id as string)
+            : null,
         }));
 
         // Apps the user has turned off (enforced by the MCP server).
@@ -5407,6 +5465,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           metering: meteringMap,
           connectors: enrichedConnectors,
           disabled_apps: (appState?.disabled_apps as string[] | undefined) ?? [],
+          managed_connections: {
+            enabled: managedConnectionsConfigured(),
+            provider: "nango",
+          },
         });
       }
 
@@ -5428,6 +5490,54 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           );
         if (upErr) throw upErr;
         return res.status(200).json({ success: true, disabled_apps: disabled });
+      }
+
+      case "admin_begin_managed_connection": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const tenant = await resolveSessionTenant(req, supabaseUrl, supabaseKey, supabase);
+        if (!tenant) return res.status(401).json({ error: "Not signed in" });
+
+        const body = (req.body ?? {}) as Record<string, unknown>;
+        const platform = typeof body.platform === "string" ? body.platform.trim().toLowerCase() : "";
+        if (!platform) return res.status(400).json({ error: "platform is required" });
+
+        const { data: connRows } = await supabase
+          .from("platform_connectors")
+          .select("id, name, auth_type")
+          .eq("id", platform)
+          .limit(1);
+        const connectorRow = (connRows ?? [])[0] as { id: string; name: string; auth_type: string | null } | undefined;
+        if (!connectorRow) return res.status(404).json({ error: `Unknown platform "${platform}".` });
+        if (!connectorRow.auth_type) return res.status(400).json({ error: `${connectorRow.name} does not need a connection.` });
+        if (!managedConnectionAvailableForPlatform(platform)) {
+          return res.status(501).json({
+            error: `${connectorRow.name} is not configured for one-click connection yet.`,
+            code: "managed_platform_not_configured",
+          });
+        }
+
+        const origin = typeof req.headers.origin === "string" && req.headers.origin
+          ? req.headers.origin
+          : "https://unclick.world";
+        const result = await beginManagedConnection({
+          platform,
+          appName: connectorRow.name,
+          tenant,
+          returnUrl: `${origin}/admin/apps?lens=connected`,
+        });
+
+        if (!result.ok) {
+          return res.status(result.status).json({ error: result.message, code: result.code });
+        }
+
+        return res.status(200).json({
+          success: true,
+          platform,
+          provider: result.provider,
+          provider_config_key: result.provider_config_key,
+          connect_url: result.connect_url,
+          expires_at: result.expires_at ?? null,
+        });
       }
 
       // Connect an app from the admin Apps page: live-test the credential against
@@ -5513,6 +5623,30 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const platform = typeof body.platform === "string" ? body.platform.trim().toLowerCase() : "";
         if (!platform) return res.status(400).json({ error: "platform is required" });
 
+        const managedLookup = await supabase
+          .from("managed_app_connections")
+          .select("id, platform_slug, provider, provider_config_key, external_connection_id, auth_mode, status, account_label, scope_summary, last_checked_at, connected_at, created_at, updated_at, metadata")
+          .eq("api_key_hash", tenant.apiKeyHash)
+          .eq("platform_slug", platform);
+        const managedRows = managedLookup.error ? [] : ((managedLookup.data ?? []) as ManagedConnectionRow[]);
+        const brokerDisconnects = await Promise.all(
+          managedRows.map((connection) => disconnectManagedConnection({ connection })),
+        );
+        const brokerDisconnectFailed = brokerDisconnects.find((result) => !result.ok);
+        if (brokerDisconnectFailed) {
+          return res.status(502).json({
+            error: brokerDisconnectFailed.error ?? "Managed connection provider could not disconnect this app.",
+          });
+        }
+
+        const managedDelete = await supabase
+          .from("managed_app_connections")
+          .delete()
+          .eq("api_key_hash", tenant.apiKeyHash)
+          .eq("platform_slug", platform)
+          .select("id, account_label");
+        if (managedDelete.error && managedRows.length > 0) throw managedDelete.error;
+
         const userDelete = await supabase
           .from("user_credentials")
           .delete()
@@ -5531,10 +5665,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         const userRows = (userDelete.data ?? []) as Array<{ id?: string; label?: string | null }>;
         const platformRows = (platformDelete.data ?? []) as Array<{ id?: string; label?: string | null }>;
+        const managedDeletedRows = (managedDelete.data ?? []) as Array<{ id?: string; account_label?: string | null }>;
 
         try {
-          const auditRows = userRows.length > 0
-            ? userRows.map((row) => ({
+          const credentialAuditRows = userRows.map((row) => ({
               actor_user_id: tenant.userId,
               api_key_hash: tenant.apiKeyHash,
               action: "disconnect_app",
@@ -5543,8 +5677,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               label: row.label ?? null,
               success: true,
               metadata: { surface: "admin_apps" },
-            }))
-            : [{
+            }));
+          const managedAuditRows = managedDeletedRows.map((row) => ({
+            actor_user_id: tenant.userId,
+            api_key_hash: tenant.apiKeyHash,
+            action: "disconnect_managed_app",
+            credential_id: row.id ?? null,
+            platform_slug: platform,
+            label: row.account_label ?? null,
+            success: true,
+            metadata: { surface: "admin_apps", provider: "nango" },
+          }));
+          const fallbackAuditRows = userRows.length === 0 && managedDeletedRows.length === 0
+            ? [{
               actor_user_id: tenant.userId,
               api_key_hash: tenant.apiKeyHash,
               action: "disconnect_app",
@@ -5553,7 +5698,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               label: null,
               success: true,
               metadata: { surface: "admin_apps", legacy_rows_deleted: platformRows.length },
-            }];
+            }]
+            : [];
+          const auditRows = [...credentialAuditRows, ...managedAuditRows, ...fallbackAuditRows];
           await supabase.from("backstagepass_audit").insert(auditRows);
         } catch {
           // Audit is best-effort here; deleting the connection is the user action.
@@ -5565,6 +5712,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           deleted: {
             connections: userRows.length,
             app_records: platformRows.length,
+            managed_connections: managedDeletedRows.length,
           },
         });
       }

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16148,8 +16148,8 @@
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",
-      "hash": "5a780df7b10f",
-      "bytes": 10785
+      "hash": "6f44df1712dc",
+      "bytes": 12333
     },
     {
       "source": "src/pages/admin/AdminAuditLog.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -86,7 +86,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAgents.tsx | 6df58623daf6 | 49162 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 5ba37cf2abff | 11567 |
-| src/pages/admin/AdminTools.tsx | 5a780df7b10f | 10785 |
+| src/pages/admin/AdminTools.tsx | 6f44df1712dc | 12333 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3d245def3231 | 13772 |

--- a/docs/connectors/managed-connections.md
+++ b/docs/connectors/managed-connections.md
@@ -1,0 +1,27 @@
+# Managed Connections
+
+Managed Connections let customers connect apps once and use them from any PC signed into UnClick, without UnClick storing raw app keys or tokens.
+
+## Runtime Switches
+
+- `NANGO_SECRET_KEY`: enables the managed connection broker.
+- `NANGO_WEBHOOK_SECRET`: verifies broker webhooks sent to `/api/managed-connection-webhook`.
+- `NANGO_PROVIDER_CONFIG_HIGGSFIELD`: enables the customer-facing one-click Higgsfield connection path.
+- `NANGO_MANAGED_PLATFORMS`: optional comma-separated allowlist for broker-backed apps, for example `higgsfield,github`.
+- `NANGO_MANAGED_PLATFORMS=*`: enables the broker path for every auth-required app. Use only after provider configs exist for every app.
+- `NANGO_PROVIDER_CONFIG_PREFIX`: optional prefix used when deriving provider config names from app slugs.
+
+## Data Boundary
+
+The `managed_app_connections` table stores tenant scope, app slug, provider config, external connection id, status, and non-secret metadata. Raw customer app access stays with the managed connection provider and is fetched only at tool-call time.
+
+## Rollout Shape
+
+Start with one app, such as Higgsfield:
+
+1. Configure the broker provider for Higgsfield.
+2. Set `NANGO_PROVIDER_CONFIG_HIGGSFIELD`.
+3. Apply the `managed_app_connections` migration.
+4. Point broker webhooks at `/api/managed-connection-webhook`.
+5. Verify the admin Apps row shows `Connect`, then `Connected`, and offers `Disconnect`.
+

--- a/src/components/apps/ConnectAppModal.test.tsx
+++ b/src/components/apps/ConnectAppModal.test.tsx
@@ -149,6 +149,19 @@ describe("ConnectAppModal", () => {
     expect(screen.queryByPlaceholderText(/paste/i)).not.toBeInTheDocument();
   });
 
+  it("uses the managed connection path when the broker is available", async () => {
+    const onStartManagedConnection = vi.fn(() => Promise.resolve());
+    renderModal({
+      connector: { id: "alphavantage", auth_type: "api_key", setup_url: null, supports_managed_connection: true },
+      onStartManagedConnection,
+    });
+    expect(screen.getByText(/work on every pc signed into unclick/i)).toBeInTheDocument();
+    expect(screen.getByText(/managed connection provider handles the sensitive access/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/paste/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /connect alpha vantage/i }));
+    expect(onStartManagedConnection).toHaveBeenCalled();
+  });
+
   it("offers reconnect and disconnect for an existing OAuth connection", async () => {
     const onDisconnect = vi.fn(() => Promise.resolve());
     renderModal({

--- a/src/components/apps/ConnectAppModal.tsx
+++ b/src/components/apps/ConnectAppModal.tsx
@@ -28,6 +28,7 @@ export interface ConnectableConnector {
   id: string;
   auth_type?: "oauth2" | "api_key" | "bot_token";
   setup_url?: string | null;
+  supports_managed_connection?: boolean;
   credential?: { is_valid: boolean; last_tested_at: string | null } | null;
 }
 
@@ -41,6 +42,7 @@ interface ConnectAppModalProps {
   isConnected?: boolean;
   statusLabel?: string | null;
   onDisconnect?: () => Promise<void> | void;
+  onStartManagedConnection?: () => Promise<void> | void;
 }
 
 type Outcome =
@@ -65,18 +67,22 @@ export function ConnectAppModal({
   isConnected = false,
   statusLabel = null,
   onDisconnect,
+  onStartManagedConnection,
 }: ConnectAppModalProps) {
   const setup = CONNECTOR_SETUP[app.slug];
   const [credential, setCredential] = useState("");
   const [busy, setBusy] = useState(false);
   const [disconnectBusy, setDisconnectBusy] = useState(false);
+  const [managedBusy, setManagedBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
+  const [managedError, setManagedError] = useState<string | null>(null);
   const [outcome, setOutcome] = useState<Outcome | null>(null);
 
   const credentialLabel = setup?.credential ?? "API key";
   const setupUrl = setup?.setupUrl ?? connector.setup_url ?? null;
   const isOAuth = connector.auth_type === "oauth2";
+  const usesManagedConnection = connector.supports_managed_connection === true && Boolean(onStartManagedConnection);
 
   async function submit() {
     const apiKey = readLocalApiKey();
@@ -140,6 +146,19 @@ export function ConnectAppModal({
     }
   }
 
+  async function startManagedConnection() {
+    if (!onStartManagedConnection) return;
+    setManagedBusy(true);
+    setManagedError(null);
+    try {
+      await onStartManagedConnection();
+    } catch (e) {
+      setManagedError(e instanceof Error ? e.message : "Connect failed.");
+    } finally {
+      setManagedBusy(false);
+    }
+  }
+
   const disconnectButton = isConnected && onDisconnect ? (
     <button
       type="button"
@@ -176,7 +195,37 @@ export function ConnectAppModal({
           </div>
         )}
 
-        {isOAuth ? (
+        {usesManagedConnection ? (
+          <div className="text-xs leading-5 text-white/60">
+            <p>
+              {isConnected
+                ? `Reconnect ${app.name} if you want to refresh permissions or switch accounts.`
+                : `Connect ${app.name} once. It will work on every PC signed into UnClick.`}
+            </p>
+            <p className="mt-2 text-[11px] leading-4 text-white/45">
+              UnClick stores a connection record. The managed connection provider handles the sensitive access.
+            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void startManagedConnection()}
+                disabled={managedBusy}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[#61C1C4] px-3 py-2 font-medium text-black hover:bg-[#61C1C4]/90 disabled:opacity-50"
+              >
+                {managedBusy && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                {managedBusy ? "Opening..." : isConnected ? `Reconnect ${app.name}` : `Connect ${app.name}`}
+                {!managedBusy && <ExternalLink className="h-3.5 w-3.5" />}
+              </button>
+              {disconnectButton}
+            </div>
+            {managedError && (
+              <p role="alert" className="mt-2 text-[11px] text-red-400">{managedError}</p>
+            )}
+            {disconnectError && (
+              <p role="alert" className="mt-2 text-[11px] text-red-400">{disconnectError}</p>
+            )}
+          </div>
+        ) : isOAuth ? (
           <div className="text-xs leading-5 text-white/60">
             <p>
               {isConnected

--- a/src/components/apps/appLenses.test.ts
+++ b/src/components/apps/appLenses.test.ts
@@ -18,10 +18,17 @@ const oauthConnected: LensConnector = {
 const keySaved: LensConnector = { auth_type: "api_key", credential: { is_valid: true, last_tested_at: null } };
 const keyTested: LensConnector = { auth_type: "api_key", credential: { is_valid: true, last_tested_at: "2026-06-12" } };
 const botNoCred: LensConnector = { auth_type: "bot_token", credential: null };
+const managedNoCred: LensConnector = { auth_type: "api_key", supports_managed_connection: true, credential: null };
+const managedConnected: LensConnector = {
+  auth_type: "api_key",
+  supports_managed_connection: true,
+  credential: { is_valid: true, last_tested_at: "2026-06-16", source: "managed_app_connections" },
+};
 
 describe("appLenses", () => {
   it("classifies setup kinds from auth_type", () => {
     expect(setupKindOf(oauthNoCred)).toBe("signin");
+    expect(setupKindOf(managedNoCred)).toBe("signin");
     expect(setupKindOf(keySaved)).toBe("key");
     expect(setupKindOf(botNoCred)).toBe("key");
     expect(setupKindOf(undefined)).toBe("builtin");
@@ -31,13 +38,16 @@ describe("appLenses", () => {
     expect(isConnected(keySaved)).toBe(true);
     expect(isConnected(keyTested)).toBe(true);
     expect(isConnected(oauthConnected)).toBe(true);
+    expect(isConnected(managedConnected)).toBe(true);
     expect(isConnected(oauthNoCred)).toBe(false);
     expect(isConnected(undefined)).toBe(false);
   });
 
   it("buttons say the action: Connect / Add key / Manage / nothing", () => {
     expect(actionLabelFor(oauthNoCred)).toBe("Connect");
+    expect(actionLabelFor(managedNoCred)).toBe("Connect");
     expect(actionLabelFor(oauthConnected)).toBe("Manage");
+    expect(actionLabelFor(managedConnected)).toBe("Manage");
     expect(actionLabelFor(botNoCred)).toBe("Add key");
     expect(actionLabelFor(keyTested)).toBe("Manage");
     expect(actionLabelFor(undefined)).toBe(null);
@@ -54,6 +64,7 @@ describe("appLenses", () => {
     // built-in apps are not "not connected": there is nothing to connect
     expect(matchesLens(a, "not-connected", undefined)).toBe(false);
     expect(matchesLens(a, "signin", oauthNoCred)).toBe(true);
+    expect(matchesLens(a, "signin", managedNoCred)).toBe(true);
     expect(matchesLens(a, "key", botNoCred)).toBe(true);
     expect(matchesLens(a, "builtin", undefined)).toBe(true);
   });

--- a/src/components/apps/appLenses.ts
+++ b/src/components/apps/appLenses.ts
@@ -16,11 +16,12 @@ export type SetupKind = "signin" | "key" | "builtin";
 /** Minimal connector shape the lenses need; matches the admin_tools API rows. */
 export interface LensConnector {
   auth_type?: "oauth2" | "api_key" | "bot_token";
+  supports_managed_connection?: boolean;
   credential: {
     id?: string | null;
     is_valid: boolean;
     last_tested_at: string | null;
-    source?: "platform_credentials" | "user_credentials" | "mixed";
+    source?: "platform_credentials" | "user_credentials" | "managed_app_connections" | "mixed";
   } | null;
 }
 
@@ -48,6 +49,7 @@ export const POPULAR_SLUGS: ReadonlySet<string> = new Set([
 
 export function setupKindOf(connector: LensConnector | undefined): SetupKind {
   if (!connector?.auth_type) return "builtin";
+  if (connector.supports_managed_connection) return "signin";
   return connector.auth_type === "oauth2" ? "signin" : "key";
 }
 

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -16,11 +16,23 @@ interface Connector {
   id: string;
   auth_type?: "oauth2" | "api_key" | "bot_token";
   setup_url?: string | null;
+  supports_managed_connection?: boolean;
+  managed_provider_config_key?: string | null;
   credential: {
     id?: string | null;
     is_valid: boolean;
     last_tested_at: string | null;
-    source?: "platform_credentials" | "user_credentials" | "mixed";
+    source?: "platform_credentials" | "user_credentials" | "managed_app_connections" | "mixed";
+    managed?: {
+      provider: string;
+      provider_config_key: string | null;
+      external_connection_id: string;
+      auth_mode: string;
+      status: string;
+      account_label: string | null;
+      scope_summary: string | null;
+      connected_at: string | null;
+    } | null;
   } | null;
 }
 
@@ -127,6 +139,9 @@ export default function AdminToolsPage() {
   function statusOf(app: { slug: string }): AppStatus | null {
     const c = connectorBySlug.get(app.slug);
     if (!c) return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
+    if (c.credential?.source === "managed_app_connections" && c.credential.is_valid) {
+      return { label: "Connected", tone: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100" };
+    }
     // OAuth connections are created by a successful provider sign-in, so they
     // should read as connected even before a later tool-use timestamp exists.
     if (c.credential?.is_valid && (c.auth_type === "oauth2" || c.credential.last_tested_at)) {
@@ -136,6 +151,7 @@ export default function AdminToolsPage() {
       return { label: "Added", tone: "border-sky-300/25 bg-sky-300/10 text-sky-100" };
     }
     if (c.auth_type === "oauth2") return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
+    if (c.supports_managed_connection) return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     if (c.auth_type) return { label: "Add access", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
   }
@@ -184,6 +200,19 @@ export default function AdminToolsPage() {
     if (!res.ok) throw new Error(body.error ?? `Disconnect failed with ${res.status}.`);
     await refreshStatus();
     setConnectTarget(null);
+  }
+
+  async function beginManagedConnection(slug: string) {
+    if (!session) throw new Error("Sign in again to connect apps.");
+    const res = await fetch("/api/memory-admin?action=admin_begin_managed_connection", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${session.access_token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: slug }),
+    });
+    const body = (await res.json().catch(() => ({}))) as { connect_url?: string; error?: string };
+    if (!res.ok) throw new Error(body.error ?? `Connect failed with ${res.status}.`);
+    if (!body.connect_url) throw new Error("The connection provider did not return a sign-in link.");
+    window.location.assign(body.connect_url);
   }
 
   const counts = useMemo(() => lensCounts(APP_CATALOG, connectorBySlug), [connectorBySlug]);
@@ -244,6 +273,7 @@ export default function AdminToolsPage() {
           isConnected={Boolean(connectorBySlug.get(connectTarget.slug)?.credential?.is_valid)}
           statusLabel={statusOf(connectTarget)?.label ?? null}
           onDisconnect={() => disconnectApp(connectTarget.slug)}
+          onStartManagedConnection={() => beginManagedConnection(connectTarget.slug)}
         />
       )}
 

--- a/supabase/migrations/20260616083000_managed_app_connections.sql
+++ b/supabase/migrations/20260616083000_managed_app_connections.sql
@@ -1,0 +1,87 @@
+-- Managed app connections are broker pointers, not raw credential storage.
+--
+-- The sensitive token/key/session lives with the managed auth provider. UnClick
+-- stores only the tenant scope, platform, provider connection id, and health
+-- metadata needed to show "Connected" consistently across devices.
+
+CREATE TABLE IF NOT EXISTS managed_app_connections (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  api_key_hash TEXT NOT NULL,
+  platform_slug TEXT NOT NULL,
+  provider TEXT NOT NULL DEFAULT 'nango',
+  provider_config_key TEXT,
+  external_connection_id TEXT NOT NULL,
+  auth_mode TEXT NOT NULL DEFAULT 'managed_oauth',
+  status TEXT NOT NULL DEFAULT 'pending',
+  account_label TEXT,
+  scope_summary TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  connected_at TIMESTAMPTZ,
+  last_checked_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT managed_app_connections_status_check
+    CHECK (status IN ('pending', 'connected', 'revoked', 'error')),
+  CONSTRAINT managed_app_connections_auth_mode_check
+    CHECK (auth_mode IN ('managed_oauth', 'managed_api_key', 'external_mcp')),
+  CONSTRAINT managed_app_connections_unique
+    UNIQUE (api_key_hash, platform_slug, provider, external_connection_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_managed_app_connections_lookup
+  ON managed_app_connections (api_key_hash, platform_slug, status);
+
+CREATE INDEX IF NOT EXISTS idx_managed_app_connections_external
+  ON managed_app_connections (provider, provider_config_key, external_connection_id);
+
+ALTER TABLE managed_app_connections ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'managed_app_connections'
+      AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all"
+      ON managed_app_connections
+      FOR ALL TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'managed_app_connections'
+      AND policyname = 'block_anon_access'
+  ) THEN
+    CREATE POLICY "block_anon_access"
+      ON managed_app_connections
+      FOR ALL TO anon
+      USING (false)
+      WITH CHECK (false);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'managed_app_connections'
+      AND policyname = 'block_authenticated_direct_access'
+  ) THEN
+    CREATE POLICY "block_authenticated_direct_access"
+      ON managed_app_connections
+      FOR ALL TO authenticated
+      USING (false)
+      WITH CHECK (false);
+  END IF;
+END $$;
+
+COMMENT ON TABLE managed_app_connections IS
+  'Broker-backed app connections. Stores provider connection pointers and status only, never raw customer secrets.';
+
+COMMENT ON COLUMN managed_app_connections.external_connection_id IS
+  'Opaque id from the managed auth provider. Not a token, key, or password.';
+
+COMMENT ON COLUMN managed_app_connections.metadata IS
+  'Non-secret provider metadata for status and diagnostics. Do not store credentials here.';


### PR DESCRIPTION
## Summary
- add broker-backed managed app connections so customers can connect Higgsfield and future apps once across PCs
- store only provider connection pointers/status in UnClick; raw customer app access stays with the managed provider
- wire Admin Apps status/connect/reconnect/disconnect plus tool-call credential lookup through the broker path
- add the managed_app_connections migration, broker webhook, tests, and rollout notes

## Safety / rollout
- one-click broker UI only appears for explicitly configured/allowlisted apps such as Higgsfield
- migration blocks anon/authenticated direct table access and documents that credentials must not be stored in metadata
- existing API-key/OAuth paths remain as fallback when the broker is not configured

## Verification
- npx vitest run api/lib/managed-connections.test.ts src/components/apps/ConnectAppModal.test.tsx src/components/apps/appLenses.test.ts api/credentials.test.ts src/pages/admin/AdminTools.test.tsx
- npx eslint api/lib/managed-connections.ts api/lib/managed-connections.test.ts api/managed-connection-webhook.ts api/memory-admin.ts api/credentials.ts src/components/apps/ConnectAppModal.tsx src/components/apps/ConnectAppModal.test.tsx src/components/apps/appLenses.ts src/components/apps/appLenses.test.ts src/pages/admin/AdminTools.tsx
- npm run build
- npm run test -- --runInBand

## Live notes
After merge, Vercel auto-deploys main and apply-migrations.yml applies the new Supabase migration. The broker path still needs production env vars before it appears: NANGO_SECRET_KEY, NANGO_WEBHOOK_SECRET, and NANGO_PROVIDER_CONFIG_HIGGSFIELD.
