### PR TITLE
Fix public MCP pairing handoff

### DIFF
--- a/api/lib/public-mcp-pairing.ts
+++ b/api/lib/public-mcp-pairing.ts
@@ -1,0 +1,38 @@
+import * as crypto from "crypto";
+
+export const PUBLIC_MCP_PAIR_COOKIE = "unclick_mcp_pair";
+export const PUBLIC_MCP_PAIR_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+const PUBLIC_MCP_PAIR_ID_RE = /^[A-Za-z0-9_-]{32,96}$/;
+
+export function createPublicMcpPairId(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+export function isValidPublicMcpPairId(value: unknown): value is string {
+  return typeof value === "string" && PUBLIC_MCP_PAIR_ID_RE.test(value.trim());
+}
+
+export function publicMcpPairDeviceId(pairId: string): string {
+  const trimmed = pairId.trim();
+  if (!isValidPublicMcpPairId(trimmed)) {
+    throw new Error("Invalid public MCP pair id");
+  }
+  const digest = crypto.createHash("sha256").update(trimmed).digest("hex");
+  return `public-mcp:${digest}`;
+}
+
+export function buildPublicMcpPairCookie(pairId: string): string {
+  const trimmed = pairId.trim();
+  if (!isValidPublicMcpPairId(trimmed)) {
+    throw new Error("Invalid public MCP pair id");
+  }
+  return [
+    `${PUBLIC_MCP_PAIR_COOKIE}=${trimmed}`,
+    "Path=/api/mcp",
+    `Max-Age=${PUBLIC_MCP_PAIR_MAX_AGE_SECONDS}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=None",
+  ].join("; ");
+}

--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -4,6 +4,12 @@ import {
   pairingToolResult,
   PUBLIC_PAIRING_TOOL,
 } from "./mcp";
+import {
+  buildPublicMcpPairCookie,
+  createPublicMcpPairId,
+  PUBLIC_MCP_PAIR_COOKIE,
+  publicMcpPairDeviceId,
+} from "./lib/public-mcp-pairing";
 
 describe("public MCP pairing door", () => {
   it("advertises a single safe setup tool for unpaired clients", () => {
@@ -12,25 +18,40 @@ describe("public MCP pairing door", () => {
     expect(PUBLIC_PAIRING_TOOL.description).not.toContain("API key");
   });
 
-  it("builds a magic-link landing URL without embedding a secret", () => {
-    const url = new URL(pairingLoginUrl("USER@Example.COM"));
+  it("builds a magic-link landing URL with a non-secret pair id", () => {
+    const pairId = createPublicMcpPairId();
+    const url = new URL(pairingLoginUrl("USER@Example.COM", pairId));
 
     expect(url.origin).toBe("https://unclick.world");
     expect(url.pathname).toBe("/login");
-    expect(url.searchParams.get("next")).toBe("/pair/connected");
+    expect(url.searchParams.get("next")).toBe(`/pair/connected?pair=${pairId}`);
     expect(url.searchParams.get("email")).toBe("user@example.com");
     expect(url.toString()).not.toContain("uc_");
     expect(url.toString()).not.toContain("key=");
   });
 
+  it("hashes the public pair id before storing it as a device id", () => {
+    const pairId = createPublicMcpPairId();
+    const deviceId = publicMcpPairDeviceId(pairId);
+    const cookie = buildPublicMcpPairCookie(pairId);
+
+    expect(deviceId).toMatch(/^public-mcp:[a-f0-9]{64}$/);
+    expect(deviceId).not.toContain(pairId);
+    expect(cookie).toContain(`${PUBLIC_MCP_PAIR_COOKIE}=${pairId}`);
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=None");
+  });
+
   it("explains compatibility URLs without pretending they are the public door", () => {
-    const result = pairingToolResult({ email: "person@example.com" });
+    const pairId = createPublicMcpPairId();
+    const result = pairingToolResult({ email: "person@example.com" }, pairId);
     const text = result.content[0]?.text ?? "";
 
     expect(text).toContain("not paired");
     expect(text).toContain("https://unclick.world/login");
     expect(text).toContain("Compatibility URL");
     expect(text).toContain("public URL");
+    expect(text).toContain(pairId);
     expect(text).not.toContain("Bearer");
   });
 });

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -17,6 +17,8 @@
  *       The session user_id is resolved to an api_keys row via
  *       api_keys.user_id FK; that row's key_hash becomes the tenancy
  *       context, so memory routing is identical to the api_key path.
+ *     - Public MCP pairing id carried by mcp-session-id / cookie after
+ *       the user opens the generated sign-in link and completes pairing.
  *   Body: MCP JSON-RPC message (initialize, tools/list, tools/call, etc.)
  *
  * The endpoint is stateless - each request spins up a fresh MCP server
@@ -25,10 +27,17 @@
 
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import * as crypto from "crypto";
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer } from "../packages/mcp-server/src/server.js";
 import { normalizeAcceptHeader } from "./lib/mcp-protocol.js";
+import {
+  buildPublicMcpPairCookie,
+  createPublicMcpPairId,
+  isValidPublicMcpPairId,
+  PUBLIC_MCP_PAIR_COOKIE,
+  publicMcpPairDeviceId,
+} from "./lib/public-mcp-pairing.js";
 import {
   effectiveMemoryTier,
   isMemoryQuotaExemptEmail,
@@ -49,7 +58,7 @@ export const PUBLIC_PAIRING_TOOL = {
   name: "unclick_start_pairing",
   title: "Connect UnClick",
   description:
-    "Use when this UnClick MCP connection is not paired yet. It gives the user the shortest safe sign-in path and explains when to use a compatibility URL.",
+    "Use when this UnClick MCP connection is not paired yet. It gives the user a safe sign-in link that completes the public URL pairing.",
   inputSchema: {
     type: "object" as const,
     additionalProperties: false,
@@ -90,18 +99,62 @@ function singleToolArgs(body: unknown): Record<string, unknown> {
     : {};
 }
 
-export function pairingLoginUrl(email?: string): string {
+function readCookie(cookieHeader: string | undefined, name: string): string | null {
+  if (!cookieHeader) return null;
+  const parts = cookieHeader.split(/;\s*/);
+  for (const part of parts) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() !== name) continue;
+    const raw = part.slice(eq + 1);
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  }
+  return null;
+}
+
+function publicPairIdFromRequest(req: VercelRequest): string | null {
+  const fromCookie = readCookie(req.headers.cookie, PUBLIC_MCP_PAIR_COOKIE);
+  if (isValidPublicMcpPairId(fromCookie)) return fromCookie.trim();
+
+  const header = req.headers["mcp-session-id"];
+  const fromHeader = Array.isArray(header) ? header[0] : header;
+  if (isValidPublicMcpPairId(fromHeader)) return fromHeader.trim();
+
+  return null;
+}
+
+function attachPublicPairHeaders(res: VercelResponse, pairId: string): void {
+  res.setHeader("Set-Cookie", buildPublicMcpPairCookie(pairId));
+  res.setHeader("mcp-session-id", pairId);
+}
+
+function ensurePublicPairId(req: VercelRequest, res: VercelResponse): string {
+  const existing = publicPairIdFromRequest(req);
+  const pairId = existing ?? createPublicMcpPairId();
+  attachPublicPairHeaders(res, pairId);
+  return pairId;
+}
+
+export function pairingLoginUrl(email?: string, pairId?: string): string {
   const url = new URL("https://unclick.world/login");
-  url.searchParams.set("next", "/pair/connected");
+  const next = new URL("/pair/connected", "https://unclick.world");
+  if (isValidPublicMcpPairId(pairId)) {
+    next.searchParams.set("pair", pairId.trim());
+  }
+  url.searchParams.set("next", `${next.pathname}${next.search}`);
   if (email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     url.searchParams.set("email", email.trim().toLowerCase());
   }
   return url.toString();
 }
 
-export function pairingToolResult(args: Record<string, unknown>) {
+export function pairingToolResult(args: Record<string, unknown>, pairId?: string) {
   const email = typeof args.email === "string" ? args.email.trim() : "";
-  const loginUrl = pairingLoginUrl(email);
+  const loginUrl = pairingLoginUrl(email, pairId);
   return {
     content: [
       {
@@ -112,9 +165,9 @@ export function pairingToolResult(args: Record<string, unknown>) {
           "Next step:",
           `Open ${loginUrl}`,
           "",
-          "Sign in with email, Google, or Microsoft. The page will show the safest working next step for this AI app.",
+          "Sign in with email, Google, or Microsoft. When the page says UnClick is ready, return here and ask this AI app to list UnClick tools again.",
           "",
-          "If this AI app asks to pair again or only accepts a static URL, use the Compatibility URL shown on that page. The public URL stays the long-term goal because it does not carry a personal key.",
+          "Keep using the public URL: https://unclick.world/api/mcp. It does not carry a personal key. The Compatibility URL on the page is only a fallback for older clients.",
         ].join("\n"),
       },
     ],
@@ -215,6 +268,36 @@ async function validateApiKey(apiKey: string): Promise<ApiKeyContext | null> {
   };
 }
 
+async function apiKeyContextForUser(
+  supabase: SupabaseClient,
+  userId: string,
+  email: string | null,
+): Promise<ApiKeyContext | null> {
+  const { data: keyRow, error: keyErr } = await supabase
+    .from("api_keys")
+    .select("key_hash, tier, is_active, last_used_at")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .order("last_used_at", { ascending: false, nullsFirst: false })
+    .limit(1)
+    .maybeSingle();
+  if (keyErr || !keyRow) return null;
+
+  supabase
+    .from("api_keys")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("key_hash", keyRow.key_hash)
+    .then(() => {});
+
+  return {
+    api_key_hash: keyRow.key_hash,
+    tier: effectiveMemoryTier(keyRow.tier ?? "free", email),
+    user_id: userId,
+    account_email: email,
+    memory_quota_exempt: isMemoryQuotaExemptEmail(email),
+  };
+}
+
 /**
  * Read the Supabase auth session cookie off the request, verify it
  * with supabase.auth.getUser(), then resolve to an api_keys tenancy
@@ -259,29 +342,43 @@ async function validateSessionCookie(
   // user_id where the old-shape api_keys.email matches an auth.users
   // row; the claim flow fills in the rest over time. Take the most
   // recently used key if the user has more than one.
-  const { data: keyRow, error: keyErr } = await supabase
-    .from("api_keys")
-    .select("key_hash, tier, is_active, last_used_at")
-    .eq("user_id", userId)
-    .eq("is_active", true)
-    .order("last_used_at", { ascending: false, nullsFirst: false })
-    .limit(1)
-    .maybeSingle();
-  if (keyErr || !keyRow) return null;
+  return apiKeyContextForUser(supabase, userId, userData.user.email ?? null);
+}
+
+async function validatePublicMcpPair(pairId: string): Promise<ApiKeyContext | null> {
+  if (!isValidPublicMcpPairId(pairId)) return null;
+  const env = getSupabaseEnv();
+  if (!env) return null;
+
+  const supabase = createClient(env.url, env.key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const deviceId = publicMcpPairDeviceId(pairId);
+  const { data: devices, error: deviceErr } = await supabase
+    .from("auth_devices")
+    .select("user_id")
+    .eq("device_id", deviceId)
+    .is("revoked_at", null)
+    .limit(2);
+  if (deviceErr || !devices || devices.length !== 1) return null;
+
+  const userId = (devices[0] as { user_id?: unknown }).user_id;
+  if (typeof userId !== "string" || !userId) return null;
+
+  const { data: userData } = await supabase.auth.admin.getUserById(userId);
+  const email = userData?.user?.email ?? null;
+  const ctx = await apiKeyContextForUser(supabase, userId, email);
+  if (!ctx) return null;
 
   supabase
-    .from("api_keys")
-    .update({ last_used_at: new Date().toISOString() })
-    .eq("key_hash", keyRow.key_hash)
+    .from("auth_devices")
+    .update({ last_seen_at: new Date().toISOString() })
+    .eq("device_id", deviceId)
+    .eq("user_id", userId)
     .then(() => {});
 
-  return {
-    api_key_hash: keyRow.key_hash,
-    tier: effectiveMemoryTier(keyRow.tier ?? "free", userData.user.email ?? null),
-    user_id: userId,
-    account_email: userData.user.email ?? null,
-    memory_quota_exempt: isMemoryQuotaExemptEmail(userData.user.email ?? null),
-  };
+  return ctx;
 }
 
 /**
@@ -383,6 +480,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   //      connector UIs that can't set headers)
   //   3. Supabase Auth session cookie               (browser on
   //      unclick.world after Phase 2 sign in)
+  //   4. Public MCP pair id                         (static public URL after
+  //      the generated browser sign-in link binds this client to a user)
   //
   // The api_key paths produce an ApiKeyContext directly. The session
   // cookie path resolves to the same ApiKeyContext shape via the
@@ -418,10 +517,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
   } else {
-    // No api_key supplied - try resolving via Supabase session cookie.
+    // No api_key supplied - try resolving via Supabase session cookie,
+    // then via the public MCP pairing id carried by mcp-session-id/cookie.
     // Unprotected protocol methods skip this so the MCP SDK can answer them.
     ctx = await validateSessionCookie(req);
+    const publicPairId = publicPairIdFromRequest(req);
+    if (!ctx && publicPairId) {
+      ctx = await validatePublicMcpPair(publicPairId);
+    }
     if (!ctx && method === "tools/list") {
+      ensurePublicPairId(req, res);
       return res.status(200).json({
         jsonrpc: "2.0",
         result: { tools: [PUBLIC_PAIRING_TOOL] },
@@ -429,25 +534,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
     if (!ctx && method === "tools/call" && toolName === PUBLIC_PAIRING_TOOL.name) {
+      const pairId = ensurePublicPairId(req, res);
       return res.status(200).json({
         jsonrpc: "2.0",
-        result: pairingToolResult(singleToolArgs(req.body)),
+        result: pairingToolResult(singleToolArgs(req.body), pairId),
         id: peeked.id,
       });
     }
     if (!ctx && peeked.authRequired) {
+      const pairId = ensurePublicPairId(req, res);
+      const loginUrl = pairingLoginUrl(undefined, pairId);
       return res.status(401).json({
         jsonrpc: "2.0",
         error: {
           code: -32001,
           message:
             "UnClick is installed but this AI app is not paired yet. " +
-            "Call unclick_start_pairing, or open https://unclick.world/login?next=%2Fpair%2Fconnected. " +
-            "If your client only accepts a static URL, use the Compatibility URL from https://unclick.world/#install.",
+            `Call unclick_start_pairing, or open ${loginUrl}. ` +
+            "After sign-in, keep using https://unclick.world/api/mcp.",
         },
         id: peeked.id,
       });
     }
+  }
+
+  if (!apiKey && !ctx) {
+    ensurePublicPairId(req, res);
   }
 
   // Inject per-request context. Vercel invocations are isolated processes,

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -21,6 +21,8 @@
  *   - update_business_context: Upsert a business context entry (POST)
  *   - admin_get_setup_guide: Returns client-specific onboarding instructions
  *                            for maximising memory auto-load (client param)
+ *   - public_mcp_pair: POST from signed-in browser with { pair_id } to bind
+ *                      the static public MCP URL to this account.
  *
  * BYOD / wizard actions (control plane, keyed by UnClick API key):
  *   - setup: POST with { api_key, service_role_key, supabase_url?, email? }
@@ -117,6 +119,10 @@ import { parseDueAtInput } from "./lib/todo-due.js";
 import { inferFishbowlJobPipeline } from "./lib/fishbowl-job-pipeline.js";
 import { statusFromFishbowlPost } from "./lib/fishbowl-status.js";
 import { buildRecallFactSections, isRecallVisibleFact } from "./lib/memory-recall-sections.js";
+import {
+  isValidPublicMcpPairId,
+  publicMcpPairDeviceId,
+} from "./lib/public-mcp-pairing.js";
 import {
   buildOrchestratorContext,
   mergeOrchestratorTodoRows,
@@ -4908,6 +4914,63 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           ai_style: aiStyle,
           about_you: aboutYou,
         });
+      }
+
+      case "public_mcp_pair": {
+        if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+        const user = await resolveSessionUser(req, supabaseUrl, supabaseKey);
+        if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+        const pairId = typeof req.body?.pair_id === "string" ? req.body.pair_id.trim() : "";
+        if (!isValidPublicMcpPairId(pairId)) {
+          return res.status(400).json({ error: "Invalid public pairing id" });
+        }
+
+        const keyRow = (await supabase
+          .from("api_keys")
+          .select("key_hash")
+          .eq("user_id", user.id)
+          .eq("is_active", true)
+          .order("last_used_at", { ascending: false, nullsFirst: false })
+          .limit(1)
+          .maybeSingle()).data as { key_hash: string | null } | null;
+        if (!keyRow?.key_hash) {
+          return res.status(409).json({ error: "No active UnClick key found for this account" });
+        }
+
+        const deviceId = publicMcpPairDeviceId(pairId);
+        const existing = await supabase
+          .from("auth_devices")
+          .select("user_id, revoked_at")
+          .eq("device_id", deviceId)
+          .limit(2);
+        if (existing.error) throw existing.error;
+        const activeOther = (existing.data ?? []).find((row) => {
+          const existingUserId = (row as { user_id?: unknown }).user_id;
+          const revokedAt = (row as { revoked_at?: unknown }).revoked_at;
+          return existingUserId !== user.id && !revokedAt;
+        });
+        if (activeOther) {
+          return res.status(409).json({ error: "This public pairing link is already connected" });
+        }
+
+        const nowIso = new Date().toISOString();
+        const upsert = await supabase
+          .from("auth_devices")
+          .upsert(
+            {
+              user_id: user.id,
+              device_id: deviceId,
+              device_name: "Public MCP connection",
+              paired_at: nowIso,
+              last_seen_at: nowIso,
+              revoked_at: null,
+            },
+            { onConflict: "user_id,device_id" },
+          );
+        if (upsert.error) throw upsert.error;
+
+        return res.status(200).json({ paired: true });
       }
 
       case "operator_timezone_update": {

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16533,8 +16533,8 @@
     },
     {
       "source": "src/pages/PairingComplete.tsx",
-      "hash": "39b115053aa5",
-      "bytes": 8270
+      "hash": "9a16779c6aab",
+      "bytes": 9877
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -163,7 +163,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Memory.tsx | 6ad6ab79dad3 | 19343 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
-| src/pages/PairingComplete.tsx | 39b115053aa5 | 8270 |
+| src/pages/PairingComplete.tsx | 9a16779c6aab | 9877 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -20,7 +20,7 @@ describe("public MCP door copy", () => {
     const src = pairingPage();
 
     expect(src).toContain("Use the public door first");
-    expect(src).toContain("If your AI app only accepts a static URL");
+    expect(src).toContain("Fallback for older AI apps");
     expect(src).toContain("contains a private connection key");
     expect(src).not.toContain("master key");
   });

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Check, Copy, ExternalLink, Loader2, ShieldCheck } from "lucide-react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
@@ -16,24 +16,33 @@ type ProfileResponse = {
   error?: string;
 };
 
+type PublicPairResponse = {
+  paired?: boolean;
+  error?: string;
+};
+
 function maskPrivateValue(value: string) {
   return value.replace(/uc_[A-Za-z0-9_-]{8,}/g, (key) => `${key.slice(0, 6)}...${key.slice(-4)}`);
 }
 
 export default function PairingCompletePage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { session, loading } = useSession();
   const [apiKey, setApiKey] = useState("");
   const [email, setEmail] = useState("");
   const [loadingProfile, setLoadingProfile] = useState(false);
   const [error, setError] = useState("");
+  const [publicPairStatus, setPublicPairStatus] = useState<"idle" | "none" | "paired" | "error">("idle");
   const [copied, setCopied] = useState<"public" | "compat" | null>(null);
+  const pairId = searchParams.get("pair") ?? "";
 
   useEffect(() => {
     if (!loading && !session) {
-      navigate(`/login?next=${encodeURIComponent("/pair/connected")}`, { replace: true });
+      const next = pairId ? `/pair/connected?pair=${encodeURIComponent(pairId)}` : "/pair/connected";
+      navigate(`/login?next=${encodeURIComponent(next)}`, { replace: true });
     }
-  }, [loading, navigate, session]);
+  }, [loading, navigate, pairId, session]);
 
   useEffect(() => {
     if (!session) return;
@@ -42,6 +51,7 @@ export default function PairingCompletePage() {
     (async () => {
       setLoadingProfile(true);
       setError("");
+      setPublicPairStatus(pairId ? "idle" : "none");
       try {
         const res = await fetch("/api/memory-admin?action=admin_profile", {
           headers: { Authorization: `Bearer ${session.access_token}` },
@@ -68,8 +78,30 @@ export default function PairingCompletePage() {
             // Ignore.
           }
         }
+
+        if (pairId) {
+          const pairRes = await fetch("/api/memory-admin?action=public_mcp_pair", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${session.access_token}`,
+            },
+            body: JSON.stringify({ pair_id: pairId }),
+          });
+          const pairBody = (await pairRes.json().catch(() => ({}))) as PublicPairResponse;
+          if (cancelled) return;
+          if (!pairRes.ok || !pairBody.paired) {
+            setPublicPairStatus("error");
+            setError(pairBody.error ?? "Your sign-in worked, but the public pairing could not be saved yet.");
+            return;
+          }
+          setPublicPairStatus("paired");
+        } else {
+          setPublicPairStatus("none");
+        }
       } catch (err) {
         if (!cancelled) {
+          setPublicPairStatus(pairId ? "error" : "none");
           setError(err instanceof Error ? err.message : "Network error.");
         }
       } finally {
@@ -80,7 +112,7 @@ export default function PairingCompletePage() {
     return () => {
       cancelled = true;
     };
-  }, [session]);
+  }, [pairId, session]);
 
   async function copy(value: string, key: "public" | "compat") {
     await navigator.clipboard.writeText(value);
@@ -111,7 +143,9 @@ export default function PairingCompletePage() {
                 <h1 className="mt-4 text-2xl font-semibold text-heading">UnClick is ready</h1>
                 <p className="mt-2 text-sm text-muted-foreground">
                   {email ? `${email} is signed in. ` : ""}
-                  Return to your AI app. If it asks to pair again, use the compatibility URL below.
+                  {publicPairStatus === "paired"
+                    ? "This AI app is paired. Return to it and ask it to list UnClick tools again."
+                    : "Return to your AI app and keep using the public MCP URL."}
                 </p>
               </div>
 
@@ -127,8 +161,11 @@ export default function PairingCompletePage() {
                   <div>
                     <p className="text-sm font-semibold text-heading">Use the public door first</p>
                     <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                      This address carries no personal key. If your AI app supports pairing, it can stay forever.
+                      This address carries no personal key. After pairing, it can stay forever.
                     </p>
+                    {publicPairStatus === "paired" ? (
+                      <p className="mt-2 text-xs font-medium text-primary">Public pairing saved.</p>
+                    ) : null}
                   </div>
                 </div>
                 <div className="mt-3 flex items-stretch gap-2">
@@ -149,7 +186,7 @@ export default function PairingCompletePage() {
 
               <details className="rounded-xl border border-border/60 bg-background/25 p-4">
                 <summary className="cursor-pointer text-sm font-semibold text-heading">
-                  If your AI app only accepts a static URL
+                  Fallback for older AI apps
                 </summary>
                 <p className="mt-2 text-xs leading-5 text-muted-foreground">
                   Use this compatibility URL for now. It contains a private connection key, so the full value stays hidden on screen.


### PR DESCRIPTION
## Summary
- Adds a random public MCP pairing id carried by `mcp-session-id` and cookie for keyless clients using `https://unclick.world/api/mcp`.
- Saves the signed-in browser pairing to `auth_devices` through a new `public_mcp_pair` action, storing only a hashed device id.
- Updates the pairing completion page and copy so the public URL remains the primary path and the private key URL is only a fallback.

## Verification
- `npx vitest run api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts`
- `npx eslint api/mcp.ts api/memory-admin.ts api/mcp-public-pairing.test.ts api/lib/public-mcp-pairing.ts src/pages/PairingComplete.tsx src/__tests__/public-mcp-door-copy.test.ts`
- `npm run brainmap:check`
- `npm run test:api-lib-esm-extension`
- `npm run test:brainmap`
- `npm run build`