### PR TITLE
[codex] Fix public MCP paired URL fallback

### DIFF
--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { VercelRequest } from "@vercel/node";
 import {
+  pairedMcpUrl,
   pairingLoginUrl,
   pairingToolResult,
   PUBLIC_PAIRING_TOOL,
+  publicPairIdFromRequest,
 } from "./mcp";
 import {
   buildPublicMcpPairCookie,
@@ -42,15 +45,34 @@ describe("public MCP pairing door", () => {
     expect(cookie).toContain("SameSite=None");
   });
 
-  it("explains compatibility URLs without pretending they are the public door", () => {
+  it("accepts a paired URL as a stable one-URL client handoff", () => {
+    const pairId = createPublicMcpPairId();
+    const url = new URL(pairedMcpUrl(pairId));
+    const req = {
+      query: { pair: pairId },
+      headers: {
+        cookie: `${PUBLIC_MCP_PAIR_COOKIE}=${createPublicMcpPairId()}`,
+        "mcp-session-id": createPublicMcpPairId(),
+      },
+    };
+
+    expect(url.origin).toBe("https://unclick.world");
+    expect(url.pathname).toBe("/api/mcp");
+    expect(url.searchParams.get("pair")).toBe(pairId);
+    expect(url.toString()).not.toContain("key=");
+    expect(publicPairIdFromRequest(req as unknown as VercelRequest)).toBe(pairId);
+  });
+
+  it("explains paired URLs without pretending they are API keys", () => {
     const pairId = createPublicMcpPairId();
     const result = pairingToolResult({ email: "person@example.com" }, pairId);
     const text = result.content[0]?.text ?? "";
 
     expect(text).toContain("not paired");
     expect(text).toContain("https://unclick.world/login");
+    expect(text).toContain("https://unclick.world/api/mcp?pair=");
     expect(text).toContain("Compatibility URL");
-    expect(text).toContain("public URL");
+    expect(text).toContain("does not contain your API key");
     expect(text).toContain(pairId);
     expect(text).not.toContain("Bearer");
   });

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -17,8 +17,8 @@
  *       The session user_id is resolved to an api_keys row via
  *       api_keys.user_id FK; that row's key_hash becomes the tenancy
  *       context, so memory routing is identical to the api_key path.
- *     - Public MCP pairing id carried by mcp-session-id / cookie after
- *       the user opens the generated sign-in link and completes pairing.
+ *     - Public MCP pairing id carried by ?pair=, mcp-session-id, or cookie
+ *       after the user opens the generated sign-in link and completes pairing.
  *   Body: MCP JSON-RPC message (initialize, tools/list, tools/call, etc.)
  *
  * The endpoint is stateless - each request spins up a fresh MCP server
@@ -116,7 +116,16 @@ function readCookie(cookieHeader: string | undefined, name: string): string | nu
   return null;
 }
 
-function publicPairIdFromRequest(req: VercelRequest): string | null {
+export function publicPairIdFromRequest(req: VercelRequest): string | null {
+  const pairRaw = req.query.pair;
+  const fromQuery =
+    typeof pairRaw === "string"
+      ? pairRaw
+      : Array.isArray(pairRaw)
+        ? pairRaw[0]
+        : undefined;
+  if (isValidPublicMcpPairId(fromQuery)) return fromQuery.trim();
+
   const fromCookie = readCookie(req.headers.cookie, PUBLIC_MCP_PAIR_COOKIE);
   if (isValidPublicMcpPairId(fromCookie)) return fromCookie.trim();
 
@@ -152,9 +161,17 @@ export function pairingLoginUrl(email?: string, pairId?: string): string {
   return url.toString();
 }
 
+export function pairedMcpUrl(pairId?: string): string {
+  if (!isValidPublicMcpPairId(pairId)) return "https://unclick.world/api/mcp";
+  const url = new URL("https://unclick.world/api/mcp");
+  url.searchParams.set("pair", pairId.trim());
+  return url.toString();
+}
+
 export function pairingToolResult(args: Record<string, unknown>, pairId?: string) {
   const email = typeof args.email === "string" ? args.email.trim() : "";
   const loginUrl = pairingLoginUrl(email, pairId);
+  const connectorUrl = pairedMcpUrl(pairId);
   return {
     content: [
       {
@@ -167,7 +184,10 @@ export function pairingToolResult(args: Record<string, unknown>, pairId?: string
           "",
           "Sign in with email, Google, or Microsoft. When the page says UnClick is ready, return here and ask this AI app to list UnClick tools again.",
           "",
-          "Keep using the public URL: https://unclick.world/api/mcp. It does not carry a personal key. The Compatibility URL on the page is only a fallback for older clients.",
+          "If this AI app still shows only unclick_start_pairing, reconnect it with this paired URL:",
+          connectorUrl,
+          "",
+          "The paired URL is revokable and does not contain your API key, but keep it private. The Compatibility URL on the page is only a fallback for older clients.",
         ].join("\n"),
       },
     ],
@@ -480,7 +500,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   //      connector UIs that can't set headers)
   //   3. Supabase Auth session cookie               (browser on
   //      unclick.world after Phase 2 sign in)
-  //   4. Public MCP pair id                         (static public URL after
+  //   4. Public MCP pair id                         (paired URL/session after
   //      the generated browser sign-in link binds this client to a user)
   //
   // The api_key paths produce an ApiKeyContext directly. The session

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16533,8 +16533,8 @@
     },
     {
       "source": "src/pages/PairingComplete.tsx",
-      "hash": "9a16779c6aab",
-      "bytes": 9877
+      "hash": "949ea3a024f1",
+      "bytes": 10572
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -163,7 +163,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Memory.tsx | 6ad6ab79dad3 | 19343 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
-| src/pages/PairingComplete.tsx | 9a16779c6aab | 9877 |
+| src/pages/PairingComplete.tsx | 949ea3a024f1 | 10572 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -19,7 +19,8 @@ describe("public MCP door copy", () => {
   it("keeps the magic-link landing page honest about fallback URLs", () => {
     const src = pairingPage();
 
-    expect(src).toContain("Use the public door first");
+    expect(src).toContain("Use this paired URL for this AI app");
+    expect(src).toContain("revokable pairing token");
     expect(src).toContain("Fallback for older AI apps");
     expect(src).toContain("contains a private connection key");
     expect(src).not.toContain("master key");

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -22,7 +22,12 @@ type PublicPairResponse = {
 };
 
 function maskPrivateValue(value: string) {
-  return value.replace(/uc_[A-Za-z0-9_-]{8,}/g, (key) => `${key.slice(0, 6)}...${key.slice(-4)}`);
+  return value
+    .replace(/uc_[A-Za-z0-9_-]{8,}/g, (key) => `${key.slice(0, 6)}...${key.slice(-4)}`)
+    .replace(
+      /(pair=)([A-Za-z0-9_-]{6})[A-Za-z0-9_-]{8,}([A-Za-z0-9_-]{4})/g,
+      "$1$2...$3",
+    );
 }
 
 export default function PairingCompletePage() {
@@ -122,6 +127,12 @@ export default function PairingCompletePage() {
 
   const compatibilityUrl = apiKey ? `${PUBLIC_MCP_URL}?key=${apiKey}` : "";
   const displayCompatibilityUrl = compatibilityUrl ? maskPrivateValue(compatibilityUrl) : "";
+  const pairedMcpUrl =
+    pairId && publicPairStatus === "paired"
+      ? `${PUBLIC_MCP_URL}?pair=${encodeURIComponent(pairId)}`
+      : "";
+  const primaryMcpUrl = pairedMcpUrl || PUBLIC_MCP_URL;
+  const displayPrimaryMcpUrl = pairedMcpUrl ? maskPrivateValue(pairedMcpUrl) : PUBLIC_MCP_URL;
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -144,7 +155,7 @@ export default function PairingCompletePage() {
                 <p className="mt-2 text-sm text-muted-foreground">
                   {email ? `${email} is signed in. ` : ""}
                   {publicPairStatus === "paired"
-                    ? "This AI app is paired. Return to it and ask it to list UnClick tools again."
+                    ? "This AI app is paired. If it still shows one tool, reconnect it with the paired URL below."
                     : "Return to your AI app and keep using the public MCP URL."}
                 </p>
               </div>
@@ -159,9 +170,13 @@ export default function PairingCompletePage() {
                 <div className="flex items-start gap-3">
                   <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
                   <div>
-                    <p className="text-sm font-semibold text-heading">Use the public door first</p>
+                    <p className="text-sm font-semibold text-heading">
+                      {pairedMcpUrl ? "Use this paired URL for this AI app" : "Use the public door first"}
+                    </p>
                     <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                      This address carries no personal key. After pairing, it can stay forever.
+                      {pairedMcpUrl
+                        ? "This address carries a revokable pairing token. It is not your API key, but keep it private."
+                        : "This address carries no personal key. After pairing, it can stay forever."}
                     </p>
                     {publicPairStatus === "paired" ? (
                       <p className="mt-2 text-xs font-medium text-primary">Public pairing saved.</p>
@@ -170,13 +185,13 @@ export default function PairingCompletePage() {
                 </div>
                 <div className="mt-3 flex items-stretch gap-2">
                   <code className="min-w-0 flex-1 truncate rounded-md border border-border/50 bg-background/50 px-3 py-2 font-mono text-xs text-heading">
-                    {PUBLIC_MCP_URL}
+                    {displayPrimaryMcpUrl}
                   </code>
                   <Button
                     type="button"
                     size="sm"
                     className="shrink-0 bg-primary text-black hover:opacity-90"
-                    onClick={() => void copy(PUBLIC_MCP_URL, "public")}
+                    onClick={() => void copy(primaryMcpUrl, "public")}
                   >
                     <Copy className="mr-1.5 h-3.5 w-3.5" />
                     {copied === "public" ? "Copied" : "Copy"}


### PR DESCRIPTION
## What changed
- Allows the public MCP pairing id to be carried in the connector URL as `?pair=...`, so one-URL clients that drop cookies/session headers can still reconnect safely after browser pairing.
- Shows a masked paired URL on the pairing success page when the browser save succeeds.
- Updates pairing copy and tests so the paired URL is clearly revokable and not the user's API key.
- Regenerates the UnClick brainmap.

## Why
Claude showed `Public pairing saved` in the browser but still listed only `unclick_start_pairing`. Live smoke proved the server resolves the saved pair when the pair id is sent back, so the missing piece is a stable marker Claude will actually persist.

## Validation
- `npx vitest run api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts`
- `npm run build`
- `npm run brainmap:check`