### PR TITLE
[codex] Add path paired public MCP URL

### DIFF
--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { VercelRequest } from "@vercel/node";
+import { readFileSync } from "node:fs";
 import {
   pairedMcpUrl,
   pairingLoginUrl,
@@ -45,11 +46,12 @@ describe("public MCP pairing door", () => {
     expect(cookie).toContain("SameSite=None");
   });
 
-  it("accepts a paired URL as a stable one-URL client handoff", () => {
+  it("accepts a paired path URL as a stable one-URL client handoff", () => {
     const pairId = createPublicMcpPairId();
     const url = new URL(pairedMcpUrl(pairId));
     const req = {
-      query: { pair: pairId },
+      query: {},
+      url: `/api/mcp/p/${pairId}`,
       headers: {
         cookie: `${PUBLIC_MCP_PAIR_COOKIE}=${createPublicMcpPairId()}`,
         "mcp-session-id": createPublicMcpPairId(),
@@ -57,10 +59,36 @@ describe("public MCP pairing door", () => {
     };
 
     expect(url.origin).toBe("https://unclick.world");
-    expect(url.pathname).toBe("/api/mcp");
-    expect(url.searchParams.get("pair")).toBe(pairId);
+    expect(url.pathname).toBe(`/api/mcp/p/${pairId}`);
     expect(url.toString()).not.toContain("key=");
     expect(publicPairIdFromRequest(req as unknown as VercelRequest)).toBe(pairId);
+  });
+
+  it("keeps query pair ids working for older paired links", () => {
+    const pairId = createPublicMcpPairId();
+    const req = {
+      query: { pair: pairId },
+      url: "/api/mcp",
+      headers: {
+        cookie: `${PUBLIC_MCP_PAIR_COOKIE}=${createPublicMcpPairId()}`,
+        "mcp-session-id": createPublicMcpPairId(),
+      },
+    };
+
+    expect(publicPairIdFromRequest(req as unknown as VercelRequest)).toBe(pairId);
+  });
+
+  it("routes paired path URLs to the MCP handler on Vercel", () => {
+    const config = JSON.parse(readFileSync("vercel.json", "utf8")) as {
+      rewrites?: Array<{ source: string; destination: string }>;
+    };
+    const rewrites = config.rewrites ?? [];
+    const pathRewriteIndex = rewrites.findIndex((rewrite) => rewrite.source === "/api/mcp/p/:pair");
+    const plainRewriteIndex = rewrites.findIndex((rewrite) => rewrite.source === "/api/mcp");
+
+    expect(pathRewriteIndex).toBeGreaterThanOrEqual(0);
+    expect(plainRewriteIndex).toBeGreaterThan(pathRewriteIndex);
+    expect(rewrites[pathRewriteIndex]?.destination).toBe("/api/mcp");
   });
 
   it("explains paired URLs without pretending they are API keys", () => {
@@ -70,7 +98,7 @@ describe("public MCP pairing door", () => {
 
     expect(text).toContain("not paired");
     expect(text).toContain("https://unclick.world/login");
-    expect(text).toContain("https://unclick.world/api/mcp?pair=");
+    expect(text).toContain("https://unclick.world/api/mcp/p/");
     expect(text).toContain("Compatibility URL");
     expect(text).toContain("does not contain your API key");
     expect(text).toContain(pairId);

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -17,8 +17,9 @@
  *       The session user_id is resolved to an api_keys row via
  *       api_keys.user_id FK; that row's key_hash becomes the tenancy
  *       context, so memory routing is identical to the api_key path.
- *     - Public MCP pairing id carried by ?pair=, mcp-session-id, or cookie
- *       after the user opens the generated sign-in link and completes pairing.
+ *     - Public MCP pairing id carried by /api/mcp/p/:pair, ?pair=,
+ *       mcp-session-id, or cookie after the user opens the generated sign-in
+ *       link and completes pairing.
  *   Body: MCP JSON-RPC message (initialize, tools/list, tools/call, etc.)
  *
  * The endpoint is stateless - each request spins up a fresh MCP server
@@ -116,6 +117,19 @@ function readCookie(cookieHeader: string | undefined, name: string): string | nu
   return null;
 }
 
+function publicPairIdFromPath(req: VercelRequest): string | null {
+  if (!req.url) return null;
+  try {
+    const url = new URL(req.url, "https://unclick.world");
+    const match = /^\/api\/mcp\/p\/([^/?#]+)$/.exec(url.pathname);
+    if (!match) return null;
+    const decoded = decodeURIComponent(match[1] ?? "");
+    return isValidPublicMcpPairId(decoded) ? decoded.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
 export function publicPairIdFromRequest(req: VercelRequest): string | null {
   const pairRaw = req.query.pair;
   const fromQuery =
@@ -125,6 +139,9 @@ export function publicPairIdFromRequest(req: VercelRequest): string | null {
         ? pairRaw[0]
         : undefined;
   if (isValidPublicMcpPairId(fromQuery)) return fromQuery.trim();
+
+  const fromPath = publicPairIdFromPath(req);
+  if (fromPath) return fromPath;
 
   const fromCookie = readCookie(req.headers.cookie, PUBLIC_MCP_PAIR_COOKIE);
   if (isValidPublicMcpPairId(fromCookie)) return fromCookie.trim();
@@ -163,9 +180,7 @@ export function pairingLoginUrl(email?: string, pairId?: string): string {
 
 export function pairedMcpUrl(pairId?: string): string {
   if (!isValidPublicMcpPairId(pairId)) return "https://unclick.world/api/mcp";
-  const url = new URL("https://unclick.world/api/mcp");
-  url.searchParams.set("pair", pairId.trim());
-  return url.toString();
+  return `https://unclick.world/api/mcp/p/${encodeURIComponent(pairId.trim())}`;
 }
 
 export function pairingToolResult(args: Record<string, unknown>, pairId?: string) {

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16533,8 +16533,8 @@
     },
     {
       "source": "src/pages/PairingComplete.tsx",
-      "hash": "949ea3a024f1",
-      "bytes": 10572
+      "hash": "0d4cb44a44f0",
+      "bytes": 10689
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -163,7 +163,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Memory.tsx | 6ad6ab79dad3 | 19343 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
-| src/pages/PairingComplete.tsx | 949ea3a024f1 | 10572 |
+| src/pages/PairingComplete.tsx | 0d4cb44a44f0 | 10689 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -20,6 +20,7 @@ describe("public MCP door copy", () => {
     const src = pairingPage();
 
     expect(src).toContain("Use this paired URL for this AI app");
+    expect(src).toContain("${PUBLIC_MCP_URL}/p/");
     expect(src).toContain("revokable pairing token");
     expect(src).toContain("Fallback for older AI apps");
     expect(src).toContain("contains a private connection key");

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -27,6 +27,10 @@ function maskPrivateValue(value: string) {
     .replace(
       /(pair=)([A-Za-z0-9_-]{6})[A-Za-z0-9_-]{8,}([A-Za-z0-9_-]{4})/g,
       "$1$2...$3",
+    )
+    .replace(
+      /(\/api\/mcp\/p\/)([A-Za-z0-9_-]{6})[A-Za-z0-9_-]{8,}([A-Za-z0-9_-]{4})/g,
+      "$1$2...$3",
     );
 }
 
@@ -129,7 +133,7 @@ export default function PairingCompletePage() {
   const displayCompatibilityUrl = compatibilityUrl ? maskPrivateValue(compatibilityUrl) : "";
   const pairedMcpUrl =
     pairId && publicPairStatus === "paired"
-      ? `${PUBLIC_MCP_URL}?pair=${encodeURIComponent(pairId)}`
+      ? `${PUBLIC_MCP_URL}/p/${encodeURIComponent(pairId)}`
       : "";
   const primaryMcpUrl = pairedMcpUrl || PUBLIC_MCP_URL;
   const displayPrimaryMcpUrl = pairedMcpUrl ? maskPrivateValue(pairedMcpUrl) : PUBLIC_MCP_URL;

--- a/vercel.json
+++ b/vercel.json
@@ -39,6 +39,7 @@
     { "source": "/api/oauth-init",         "destination": "/api/oauth-init" },
     { "source": "/api/oauth-callback",     "destination": "/api/oauth-callback" },
     { "source": "/api/credentials",        "destination": "/api/credentials" },
+    { "source": "/api/mcp/p/:pair",       "destination": "/api/mcp" },
     { "source": "/api/mcp",               "destination": "/api/mcp" },
     { "source": "/og-image.svg",  "destination": "/og-image.svg" },
     { "source": "/og-image.png",  "destination": "/og-image.png" },


### PR DESCRIPTION
## What changed
- Changes the paired MCP connector URL from `?pair=...` to `/api/mcp/p/<pair>` so clients that drop query strings can still retain the pairing marker.
- Keeps existing `?pair=...`, cookie, and `mcp-session-id` support working.
- Adds a Vercel rewrite for `/api/mcp/p/:pair` to the MCP handler.
- Updates the pairing success page masking/copy and tests.
- Regenerates the UnClick brainmap.

## Why
Claude still reported pairing-only after PR #1521. The likely remaining failure mode is that the connector stores the path but drops or ignores query parameters. A path-style paired URL gives Claude a more durable URL while keeping the token revokable and not using the private API key.

## Validation
- `npx vitest run api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts`
- `npm run build`
- `npm run brainmap:generate && npm run brainmap:check`