### PR TITLE
[codex] Clarify Higgsfield connection flow

### DIFF
--- a/api/mcp-import.test.ts
+++ b/api/mcp-import.test.ts
@@ -5,5 +5,5 @@ describe("/api/mcp production import", () => {
     const mod = await import("./mcp");
 
     expect(typeof mod.default).toBe("function");
-  });
+  }, 60_000);
 });

--- a/api/memory-admin.ts
+++ b/api/memory-admin.ts
@@ -5509,6 +5509,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const enrichedConnectors = (connectors ?? []).map((pc) => ({
           ...pc,
           credential: credMap.get(pc.id as string) ?? null,
+          supports_hosted_mcp_connection: pc.id === "higgsfield",
           supports_managed_connection: pc.auth_type
             ? managedConnectionAvailableForPlatform(pc.id as string)
             : false,

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16148,8 +16148,8 @@
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",
-      "hash": "6f44df1712dc",
-      "bytes": 12333
+      "hash": "1b90e5775d00",
+      "bytes": 12508
     },
     {
       "source": "src/pages/admin/AdminAuditLog.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -86,7 +86,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAgents.tsx | 6df58623daf6 | 49162 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 5ba37cf2abff | 11567 |
-| src/pages/admin/AdminTools.tsx | 6f44df1712dc | 12333 |
+| src/pages/admin/AdminTools.tsx | 1b90e5775d00 | 12508 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3d245def3231 | 13772 |

--- a/docs/connectors/managed-connections.md
+++ b/docs/connectors/managed-connections.md
@@ -1,6 +1,6 @@
 # Managed Connections
 
-Managed Connections let customers connect apps once and use them from any PC signed into UnClick, without UnClick storing raw app keys or tokens.
+Managed Connections let customers connect apps once and use them from any PC signed into UnClick, without UnClick storing raw app keys or tokens. This is not the old Passport-as-vault model: UnClick stores a connection record and status, while the managed provider owns the sensitive app access.
 
 ## Runtime Switches
 
@@ -25,3 +25,4 @@ Start with one app, such as Higgsfield:
 4. Point broker webhooks at `/api/managed-connection-webhook`.
 5. Verify the admin Apps row shows `Connect`, then `Connected`, and offers `Disconnect`.
 
+Until those runtime switches are present, Higgsfield should remain in hosted-MCP/manual fallback mode: customers can use Higgsfield's own MCP sign-in directly, or paste an API key for UnClick-routed API actions, but UnClick must not imply account-wide Higgsfield login is connected.

--- a/packages/mcp-server/src/connector-setup.ts
+++ b/packages/mcp-server/src/connector-setup.ts
@@ -232,7 +232,7 @@ export const CONNECTOR_SETUP: Record<string, ConnectorSetup> = {
     arg:         "api_key",
     envVar:      "HIGGSFIELD_API_KEY",
     setupUrl:    "https://cloud.higgsfield.ai/api-keys",
-    note:        "Use a Higgsfield Cloud API key for the UnClick connector. Higgsfield bills generation usage to your Higgsfield account. The hosted MCP at https://mcp.higgsfield.ai/mcp is a separate direct sign-in path outside UnClick.",
+    note:        "Higgsfield's hosted MCP is an account sign-in path. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login.",
   },
   kling: {
     displayName: "Kling",

--- a/packages/mcp-server/src/connector-setup.ts
+++ b/packages/mcp-server/src/connector-setup.ts
@@ -232,7 +232,7 @@ export const CONNECTOR_SETUP: Record<string, ConnectorSetup> = {
     arg:         "api_key",
     envVar:      "HIGGSFIELD_API_KEY",
     setupUrl:    "https://cloud.higgsfield.ai/api-keys",
-    note:        "Higgsfield's hosted MCP is an account sign-in path. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login.",
+    note:        "Higgsfield's hosted MCP is a separate direct sign-in path outside UnClick. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login.",
   },
   kling: {
     displayName: "Kling",

--- a/src/components/apps/ConnectAppModal.test.tsx
+++ b/src/components/apps/ConnectAppModal.test.tsx
@@ -102,16 +102,24 @@ describe("ConnectAppModal", () => {
     expect(await screen.findByText(/marked as added/i)).toBeInTheDocument();
   });
 
-  it("sends Higgsfield users to Cloud API keys and treats hosted MCP as separate", () => {
+  it("puts Higgsfield account login before the API key fallback", () => {
     renderModal({
       app: HIGGSFIELD_APP,
-      connector: { id: "higgsfield", auth_type: "api_key", setup_url: null },
+      connector: { id: "higgsfield", auth_type: "api_key", setup_url: null, supports_hosted_mcp_connection: true },
     });
+    expect(screen.getByText(/use your higgsfield account login/i)).toBeInTheDocument();
+    expect(screen.getByText(/not the old unclick vault path/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open higgsfield mcp login guide/i })).toHaveAttribute(
+      "href",
+      "https://higgsfield.ai/mcp",
+    );
+    expect(screen.getByRole("button", { name: /higgsfield login not switched on yet/i })).toBeDisabled();
+    expect(screen.getByText(/api key fallback/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /where do i get my api key/i })).toHaveAttribute(
       "href",
       "https://cloud.higgsfield.ai/api-keys",
     );
-    expect(screen.getByText(/hosted MCP .* separate direct sign-in path outside UnClick/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /test api key/i })).toBeInTheDocument();
   });
 
   it("surfaces a rejection and stores nothing when the platform refuses the key", async () => {

--- a/src/components/apps/ConnectAppModal.tsx
+++ b/src/components/apps/ConnectAppModal.tsx
@@ -29,6 +29,7 @@ export interface ConnectableConnector {
   auth_type?: "oauth2" | "api_key" | "bot_token";
   setup_url?: string | null;
   supports_managed_connection?: boolean;
+  supports_hosted_mcp_connection?: boolean;
   credential?: { is_valid: boolean; last_tested_at: string | null } | null;
 }
 
@@ -83,6 +84,7 @@ export function ConnectAppModal({
   const setupUrl = setup?.setupUrl ?? connector.setup_url ?? null;
   const isOAuth = connector.auth_type === "oauth2";
   const usesManagedConnection = connector.supports_managed_connection === true && Boolean(onStartManagedConnection);
+  const usesHostedMcpConnection = connector.supports_hosted_mcp_connection === true && !usesManagedConnection;
 
   async function submit() {
     const apiKey = readLocalApiKey();
@@ -221,6 +223,112 @@ export function ConnectAppModal({
             {managedError && (
               <p role="alert" className="mt-2 text-[11px] text-red-400">{managedError}</p>
             )}
+            {disconnectError && (
+              <p role="alert" className="mt-2 text-[11px] text-red-400">{disconnectError}</p>
+            )}
+          </div>
+        ) : usesHostedMcpConnection ? (
+          <div className="space-y-3 text-xs leading-5 text-white/60">
+            <div className="rounded-lg border border-[#B8FF00]/20 bg-[#B8FF00]/[0.05] px-3 py-3">
+              <p className="font-semibold text-white">Use your {app.name} account login</p>
+              <p className="mt-1 text-white/55">
+                Higgsfield's MCP connection is an account sign-in. It uses the customer's own Higgsfield account, plan,
+                and credits. This is not the old UnClick vault path.
+              </p>
+              <a
+                href="https://higgsfield.ai/mcp"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[#B8FF00]/30 bg-[#B8FF00]/10 px-2.5 py-1.5 text-[11px] font-semibold text-[#D6FF57] transition-colors hover:bg-[#B8FF00]/15"
+              >
+                Open Higgsfield MCP login guide
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+
+            <div className="rounded-lg border border-white/[0.08] bg-white/[0.025] px-3 py-3">
+              <p className="font-semibold text-white">UnClick-wide login</p>
+              <p className="mt-1 text-white/55">
+                The cross-PC login bridge is built as a managed connection, but it is not switched on for Higgsfield
+                in this workspace yet. When it is on, this dialog will show a real sign-in button and UnClick will
+                store only a connection record.
+              </p>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  disabled
+                  className="rounded-md border border-white/[0.08] px-2.5 py-1.5 text-[11px] font-semibold text-white/35"
+                >
+                  Higgsfield login not switched on yet
+                </button>
+                {disconnectButton}
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-amber-300/15 bg-amber-300/[0.04] px-3 py-3">
+              <p className="font-semibold text-white">API key fallback</p>
+              <p className="mt-1 text-white/55">
+                Use this only if you specifically want UnClick-routed Higgsfield API actions. It is separate from
+                the hosted MCP account login above.
+              </p>
+              {setupUrl && (
+                <a
+                  href={setupUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-flex items-center gap-1 text-[11px] text-[#9be4e6] hover:underline"
+                >
+                  Where do I get my {credentialLabel}?
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
+              <input
+                type="password"
+                value={credential}
+                onChange={(e) => setCredential(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !busy) void submit();
+                }}
+                placeholder={`Paste ${credentialLabel} here`}
+                className="mt-3 w-full rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2 text-sm text-white placeholder:text-[#444] focus:border-[#E2B93B]/40 focus:outline-none"
+              />
+              {error && (
+                <p role="alert" className="mt-2 text-[11px] text-red-400">{error}</p>
+              )}
+              {outcome && (
+                <div
+                  role="status"
+                  className={`mt-3 flex items-start gap-2 rounded-lg border px-3 py-2 text-[11px] leading-4 ${
+                    outcome.kind === "connected"
+                      ? "border-emerald-300/25 bg-emerald-300/10 text-emerald-100"
+                      : outcome.kind === "saved_unproven"
+                        ? "border-amber-300/25 bg-amber-300/10 text-amber-100"
+                        : "border-red-400/30 bg-red-400/10 text-red-200"
+                  }`}
+                >
+                  {outcome.kind === "connected" && <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+                  {outcome.kind === "saved_unproven" && <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+                  {outcome.kind === "rejected" && <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />}
+                  <span>
+                    {outcome.kind === "connected" && <strong>Connected, live-tested. </strong>}
+                    {outcome.message}
+                  </span>
+                </div>
+              )}
+              <div className="mt-3 flex justify-end gap-2">
+                <button onClick={onClose} className="rounded-lg border border-white/[0.06] px-3 py-2 text-xs text-[#888] hover:text-white">
+                  {outcome && outcome.kind !== "rejected" ? "Done" : "Cancel"}
+                </button>
+                <button
+                  onClick={() => void submit()}
+                  disabled={busy}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-[#E2B93B] px-3 py-2 text-xs font-medium text-black hover:bg-[#E2B93B]/90 disabled:opacity-50"
+                >
+                  {busy && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                  {busy ? "Testing..." : "Test API key"}
+                </button>
+              </div>
+            </div>
             {disconnectError && (
               <p role="alert" className="mt-2 text-[11px] text-red-400">{disconnectError}</p>
             )}

--- a/src/components/apps/appDetailExtras.tsx
+++ b/src/components/apps/appDetailExtras.tsx
@@ -59,29 +59,37 @@ function HiggsfieldPanel(): ReactNode {
         <p className="text-sm font-semibold text-white">Higgsfield setup options</p>
       </div>
       <p className="mt-1.5 text-xs leading-5 text-white/55">
-        There are two separate ways to use Higgsfield. Connect an API key in UnClick when
-        you want UnClick to route Higgsfield actions. Add Higgsfield's hosted MCP directly
-        when you want Claude or another client to talk to Higgsfield without going through
-        UnClick. Both paths use your Higgsfield account, with credits, subscription, and
-        billing managed by Higgsfield.
+        Higgsfield has two real connection paths. The hosted MCP path is the subscription-friendly
+        account login: add Higgsfield's MCP URL to Claude or another MCP client, then sign in with
+        Higgsfield. The UnClick-wide login bridge is the same idea inside UnClick, but it only appears
+        after the managed broker is switched on. The API key path is a fallback for UnClick-routed API
+        actions, not the hosted MCP login.
       </p>
 
       <div className="mt-4 grid gap-4 md:grid-cols-2">
         <div className="space-y-3">
           <CommandStack
-            label="UnClick app connection"
-            commands={[
-              "Create a Higgsfield Cloud API key",
-              "https://cloud.higgsfield.ai/api-keys",
-              "Paste it in Apps to mark Higgsfield connected in UnClick",
-            ]}
-          />
-          <CommandStack
-            label="Higgsfield hosted MCP"
+            label="Higgsfield hosted MCP login"
             commands={[
               "Name: Higgsfield",
               "URL: https://mcp.higgsfield.ai/mcp",
               "Connect, then sign in with your Higgsfield account",
+            ]}
+          />
+          <CommandStack
+            label="UnClick-wide login"
+            commands={[
+              "Uses the managed connection broker",
+              "Stores a connection record, not your Higgsfield login",
+              "Appears here when Higgsfield broker setup is switched on",
+            ]}
+          />
+          <CommandStack
+            label="API key fallback"
+            commands={[
+              "Create a Higgsfield Cloud API key",
+              "https://cloud.higgsfield.ai/api-keys",
+              "Paste it only for UnClick-routed API actions",
             ]}
           />
         </div>

--- a/src/components/apps/appLenses.test.ts
+++ b/src/components/apps/appLenses.test.ts
@@ -19,6 +19,7 @@ const keySaved: LensConnector = { auth_type: "api_key", credential: { is_valid: 
 const keyTested: LensConnector = { auth_type: "api_key", credential: { is_valid: true, last_tested_at: "2026-06-12" } };
 const botNoCred: LensConnector = { auth_type: "bot_token", credential: null };
 const managedNoCred: LensConnector = { auth_type: "api_key", supports_managed_connection: true, credential: null };
+const hostedMcpNoCred: LensConnector = { auth_type: "api_key", supports_hosted_mcp_connection: true, credential: null };
 const managedConnected: LensConnector = {
   auth_type: "api_key",
   supports_managed_connection: true,
@@ -29,6 +30,7 @@ describe("appLenses", () => {
   it("classifies setup kinds from auth_type", () => {
     expect(setupKindOf(oauthNoCred)).toBe("signin");
     expect(setupKindOf(managedNoCred)).toBe("signin");
+    expect(setupKindOf(hostedMcpNoCred)).toBe("signin");
     expect(setupKindOf(keySaved)).toBe("key");
     expect(setupKindOf(botNoCred)).toBe("key");
     expect(setupKindOf(undefined)).toBe("builtin");
@@ -46,6 +48,7 @@ describe("appLenses", () => {
   it("buttons say the action: Connect / Add key / Manage / nothing", () => {
     expect(actionLabelFor(oauthNoCred)).toBe("Connect");
     expect(actionLabelFor(managedNoCred)).toBe("Connect");
+    expect(actionLabelFor(hostedMcpNoCred)).toBe("Connect");
     expect(actionLabelFor(oauthConnected)).toBe("Manage");
     expect(actionLabelFor(managedConnected)).toBe("Manage");
     expect(actionLabelFor(botNoCred)).toBe("Add key");
@@ -65,6 +68,7 @@ describe("appLenses", () => {
     expect(matchesLens(a, "not-connected", undefined)).toBe(false);
     expect(matchesLens(a, "signin", oauthNoCred)).toBe(true);
     expect(matchesLens(a, "signin", managedNoCred)).toBe(true);
+    expect(matchesLens(a, "signin", hostedMcpNoCred)).toBe(true);
     expect(matchesLens(a, "key", botNoCred)).toBe(true);
     expect(matchesLens(a, "builtin", undefined)).toBe(true);
   });

--- a/src/components/apps/appLenses.ts
+++ b/src/components/apps/appLenses.ts
@@ -17,6 +17,7 @@ export type SetupKind = "signin" | "key" | "builtin";
 export interface LensConnector {
   auth_type?: "oauth2" | "api_key" | "bot_token";
   supports_managed_connection?: boolean;
+  supports_hosted_mcp_connection?: boolean;
   credential: {
     id?: string | null;
     is_valid: boolean;
@@ -49,7 +50,7 @@ export const POPULAR_SLUGS: ReadonlySet<string> = new Set([
 
 export function setupKindOf(connector: LensConnector | undefined): SetupKind {
   if (!connector?.auth_type) return "builtin";
-  if (connector.supports_managed_connection) return "signin";
+  if (connector.supports_managed_connection || connector.supports_hosted_mcp_connection) return "signin";
   return connector.auth_type === "oauth2" ? "signin" : "key";
 }
 

--- a/src/data/connector-setup.generated.json
+++ b/src/data/connector-setup.generated.json
@@ -195,7 +195,7 @@
       "arg": "api_key",
       "envVar": "HIGGSFIELD_API_KEY",
       "setupUrl": "https://cloud.higgsfield.ai/api-keys",
-      "note": "Use a Higgsfield Cloud API key for the UnClick connector. Higgsfield bills generation usage to your Higgsfield account. The hosted MCP at https://mcp.higgsfield.ai/mcp is a separate direct sign-in path outside UnClick."
+      "note": "Higgsfield's hosted MCP is an account sign-in path. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login."
     },
     "kling": {
       "displayName": "Kling",

--- a/src/data/connector-setup.generated.json
+++ b/src/data/connector-setup.generated.json
@@ -195,7 +195,7 @@
       "arg": "api_key",
       "envVar": "HIGGSFIELD_API_KEY",
       "setupUrl": "https://cloud.higgsfield.ai/api-keys",
-      "note": "Higgsfield's hosted MCP is an account sign-in path. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login."
+      "note": "Higgsfield's hosted MCP is a separate direct sign-in path outside UnClick. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login."
     },
     "kling": {
       "displayName": "Kling",

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -17,6 +17,7 @@ interface Connector {
   auth_type?: "oauth2" | "api_key" | "bot_token";
   setup_url?: string | null;
   supports_managed_connection?: boolean;
+  supports_hosted_mcp_connection?: boolean;
   managed_provider_config_key?: string | null;
   credential: {
     id?: string | null;
@@ -152,6 +153,7 @@ export default function AdminToolsPage() {
     }
     if (c.auth_type === "oauth2") return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     if (c.supports_managed_connection) return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
+    if (c.supports_hosted_mcp_connection) return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     if (c.auth_type) return { label: "Add access", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
   }


### PR DESCRIPTION
## Summary
- make Higgsfield a customer-facing sign-in/connect app without pretending UnClick stores the subscription login
- separate Higgsfield hosted MCP login, future UnClick-wide managed login, and API key fallback in the app page and connect modal
- keep the old Passport/vault language out of the customer flow and document that managed connections store status/pointers, not raw credentials
- extend the MCP import smoke-test timeout to match observed runtime

## Verification
- npm test
- npm run lint (warnings only, existing lint warning set)
- npm run build
- npm run brainmap:check
- node scripts/generate-connector-setup.mjs --check
- npx vitest run src/components/apps/ConnectAppModal.test.tsx src/components/apps/appLenses.test.ts api/lib/managed-connections.test.ts api/mcp-import.test.ts