### PR TITLE
[codex] Harden public MCP tool discovery

### DIFF
--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -7,6 +7,7 @@ import {
   pairingToolResult,
   PUBLIC_PAIRING_TOOL,
   publicPairIdFromRequest,
+  publicToolsForUnpairedClient,
 } from "./mcp";
 import {
   buildPublicMcpPairCookie,
@@ -16,10 +17,18 @@ import {
 } from "./lib/public-mcp-pairing";
 
 describe("public MCP pairing door", () => {
-  it("advertises a single safe setup tool for unpaired clients", () => {
+  it("advertises setup plus the normal catalog for unpaired clients", () => {
     expect(PUBLIC_PAIRING_TOOL.name).toBe("unclick_start_pairing");
     expect(PUBLIC_PAIRING_TOOL.description).toContain("not paired yet");
     expect(PUBLIC_PAIRING_TOOL.description).not.toContain("API key");
+
+    const tools = publicToolsForUnpairedClient();
+    const names = tools.map((tool) => tool.name);
+    expect(names[0]).toBe("unclick_start_pairing");
+    expect(names).toContain("load_memory");
+    expect(names).toContain("search_memory");
+    expect(new Set(names).size).toBe(names.length);
+    expect(tools.length).toBeGreaterThan(10);
   });
 
   it("builds a magic-link landing URL with a non-secret pair id", () => {

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -30,7 +30,10 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 import * as crypto from "crypto";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { createServer } from "../packages/mcp-server/src/server.js";
+import {
+  ADVERTISED_TOOLS_SAFE,
+  createServer,
+} from "../packages/mcp-server/src/server.js";
 import { normalizeAcceptHeader } from "./lib/mcp-protocol.js";
 import {
   buildPublicMcpPairCookie,
@@ -71,6 +74,13 @@ export const PUBLIC_PAIRING_TOOL = {
     },
   },
 };
+
+export function publicToolsForUnpairedClient() {
+  return [
+    PUBLIC_PAIRING_TOOL,
+    ...ADVERTISED_TOOLS_SAFE.filter((tool) => tool.name !== PUBLIC_PAIRING_TOOL.name),
+  ];
+}
 
 function singleRpc(body: unknown): Record<string, unknown> | null {
   if (!body || typeof body !== "object" || Array.isArray(body)) return null;
@@ -564,7 +574,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       ensurePublicPairId(req, res);
       return res.status(200).json({
         jsonrpc: "2.0",
-        result: { tools: [PUBLIC_PAIRING_TOOL] },
+        result: { tools: publicToolsForUnpairedClient() },
         id: peeked.id,
       });
     }
@@ -586,7 +596,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           message:
             "UnClick is installed but this AI app is not paired yet. " +
             `Call unclick_start_pairing, or open ${loginUrl}. ` +
-            "After sign-in, keep using https://unclick.world/api/mcp.",
+            "After sign-in, keep using this MCP connection. If the client still " +
+            "cannot call tools, reconnect it with the paired URL or Compatibility URL shown on the ready page.",
         },
         id: peeked.id,
       });

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16533,8 +16533,8 @@
     },
     {
       "source": "src/pages/PairingComplete.tsx",
-      "hash": "0d4cb44a44f0",
-      "bytes": 10689
+      "hash": "cc800aea3cd4",
+      "bytes": 10772
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -163,7 +163,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Memory.tsx | 6ad6ab79dad3 | 19343 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
-| src/pages/PairingComplete.tsx | 0d4cb44a44f0 | 10689 |
+| src/pages/PairingComplete.tsx | cc800aea3cd4 | 10772 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -22,7 +22,7 @@ describe("public MCP door copy", () => {
     expect(src).toContain("Use this paired URL for this AI app");
     expect(src).toContain("${PUBLIC_MCP_URL}/p/");
     expect(src).toContain("revokable pairing token");
-    expect(src).toContain("Fallback for older AI apps");
+    expect(src).toContain("Compatibility URL for stubborn AI apps");
     expect(src).toContain("contains a private connection key");
     expect(src).not.toContain("master key");
   });

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -159,7 +159,7 @@ export default function PairingCompletePage() {
                 <p className="mt-2 text-sm text-muted-foreground">
                   {email ? `${email} is signed in. ` : ""}
                   {publicPairStatus === "paired"
-                    ? "This AI app is paired. If it still shows one tool, reconnect it with the paired URL below."
+                    ? "This AI app is paired. If Claude still cannot call tools, reconnect it with the paired URL below, then use the compatibility URL if needed."
                     : "Return to your AI app and keep using the public MCP URL."}
                 </p>
               </div>
@@ -205,10 +205,10 @@ export default function PairingCompletePage() {
 
               <details className="rounded-xl border border-border/60 bg-background/25 p-4">
                 <summary className="cursor-pointer text-sm font-semibold text-heading">
-                  Fallback for older AI apps
+                  Compatibility URL for stubborn AI apps
                 </summary>
                 <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                  Use this compatibility URL for now. It contains a private connection key, so the full value stays hidden on screen.
+                  Use this if Claude still cannot call tools after pairing. It contains a private connection key, so the full value stays hidden on screen.
                 </p>
                 {compatibilityUrl ? (
                   <div className="mt-3 flex items-stretch gap-2">


### PR DESCRIPTION
## What changed
- Unpaired public MCP clients now receive the normal UnClick tool catalog plus `unclick_start_pairing`.
- Protected tool calls still require a valid API key, Supabase session, or public pair id before anything runs.
- Pairing guidance now points Claude users to the paired URL first and the Compatibility URL if the client cache/identity handoff stays stuck.

## Why
Claude appears to cache the first `tools/list` response. If the first response only contains `unclick_start_pairing`, pairing can succeed in the browser while Claude still believes UnClick has only one tool. Advertising the catalog up front avoids that one-tool cache trap while preserving the execution gate.

## Validation
- `npx vitest run api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts`
- `npm run build`
- `npm run brainmap:generate && npm run brainmap:check`