### PR TITLE
[codex] Clarify public MCP pairing recovery

### DIFF
--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -108,6 +108,8 @@ describe("public MCP pairing door", () => {
     expect(text).toContain("not paired");
     expect(text).toContain("https://unclick.world/login");
     expect(text).toContain("https://unclick.world/api/mcp/p/");
+    expect(text).toContain("asks for a fresh link");
+    expect(text).toContain("did not keep the paired MCP session");
     expect(text).toContain("Compatibility URL");
     expect(text).toContain("does not contain your API key");
     expect(text).toContain(pairId);

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -207,12 +207,12 @@ export function pairingToolResult(args: Record<string, unknown>, pairId?: string
           "Next step:",
           `Open ${loginUrl}`,
           "",
-          "Sign in with email, Google, or Microsoft. When the page says UnClick is ready, return here and ask this AI app to list UnClick tools again.",
+          "Sign in with email, Google, or Microsoft. When the page says UnClick is ready, try the tool again.",
           "",
-          "If this AI app still shows only unclick_start_pairing, reconnect it with this paired URL:",
+          "If this AI app asks for a fresh link, says it is still unpaired, or cannot call tools, it did not keep the paired MCP session. Do not keep opening new links. Reconnect the MCP server using this paired URL:",
           connectorUrl,
           "",
-          "The paired URL is revokable and does not contain your API key, but keep it private. The Compatibility URL on the page is only a fallback for older clients.",
+          "The paired URL is revokable and does not contain your API key, but keep it private. The Compatibility URL on the page is a fallback for clients that cannot use paired URLs.",
         ].join("\n"),
       },
     ],
@@ -596,8 +596,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           message:
             "UnClick is installed but this AI app is not paired yet. " +
             `Call unclick_start_pairing, or open ${loginUrl}. ` +
-            "After sign-in, keep using this MCP connection. If the client still " +
-            "cannot call tools, reconnect it with the paired URL or Compatibility URL shown on the ready page.",
+            "After sign-in, try this MCP connection again. If the app asks for a fresh link " +
+            "after the ready page, it did not keep the pairing session; reconnect it with " +
+            "the paired URL or Compatibility URL shown on the ready page.",
         },
         id: peeked.id,
       });

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16533,8 +16533,8 @@
     },
     {
       "source": "src/pages/PairingComplete.tsx",
-      "hash": "cc800aea3cd4",
-      "bytes": 10772
+      "hash": "ec9b7e935895",
+      "bytes": 10833
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -163,7 +163,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Memory.tsx | 6ad6ab79dad3 | 19343 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
-| src/pages/PairingComplete.tsx | cc800aea3cd4 | 10772 |
+| src/pages/PairingComplete.tsx | ec9b7e935895 | 10833 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -19,11 +19,13 @@ describe("public MCP door copy", () => {
   it("keeps the magic-link landing page honest about fallback URLs", () => {
     const src = pairingPage();
 
-    expect(src).toContain("Use this paired URL for this AI app");
+    expect(src).toContain("This pairing token is saved");
+    expect(src).toContain("Use this paired URL in the AI app");
     expect(src).toContain("${PUBLIC_MCP_URL}/p/");
     expect(src).toContain("revokable pairing token");
-    expect(src).toContain("Compatibility URL for stubborn AI apps");
+    expect(src).toContain("Compatibility URL for older AI apps");
     expect(src).toContain("contains a private connection key");
+    expect(src).not.toContain("Claude still");
     expect(src).not.toContain("master key");
   });
 });

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -159,7 +159,7 @@ export default function PairingCompletePage() {
                 <p className="mt-2 text-sm text-muted-foreground">
                   {email ? `${email} is signed in. ` : ""}
                   {publicPairStatus === "paired"
-                    ? "This AI app is paired. If Claude still cannot call tools, reconnect it with the paired URL below, then use the compatibility URL if needed."
+                    ? "This pairing token is saved. If your AI app asks for another link or still cannot call tools, reconnect it with the paired URL below, then use the compatibility URL if needed."
                     : "Return to your AI app and keep using the public MCP URL."}
                 </p>
               </div>
@@ -175,7 +175,7 @@ export default function PairingCompletePage() {
                   <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
                   <div>
                     <p className="text-sm font-semibold text-heading">
-                      {pairedMcpUrl ? "Use this paired URL for this AI app" : "Use the public door first"}
+                      {pairedMcpUrl ? "Use this paired URL in the AI app" : "Use the public door first"}
                     </p>
                     <p className="mt-1 text-xs leading-5 text-muted-foreground">
                       {pairedMcpUrl
@@ -205,10 +205,10 @@ export default function PairingCompletePage() {
 
               <details className="rounded-xl border border-border/60 bg-background/25 p-4">
                 <summary className="cursor-pointer text-sm font-semibold text-heading">
-                  Compatibility URL for stubborn AI apps
+                  Compatibility URL for older AI apps
                 </summary>
                 <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                  Use this if Claude still cannot call tools after pairing. It contains a private connection key, so the full value stays hidden on screen.
+                  Use this if your AI app still cannot call tools after reconnecting with the paired URL. It contains a private connection key, so the full value stays hidden on screen.
                 </p>
                 {compatibilityUrl ? (
                   <div className="mt-3 flex items-stretch gap-2">


### PR DESCRIPTION
## Summary
- remove Claude-specific wording from the public MCP ready page
- explain the Grok-style loop: if an AI app asks for a fresh link after the ready page, it did not keep the paired MCP session
- point users to reconnect with the paired URL first, then the Compatibility URL only as fallback

## Validation
- `npx vitest run api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts`
- `npm run build`
- `npm run brainmap:check`
- `git diff --check`

## Notes
This does not loosen auth. A brand-new unpaired MCP request still cannot be magically attached to a browser pairing without the pair token, cookie, session header, or paired URL.