### PR TITLE
[codex] Add generic MCP OAuth flow

### DIFF
--- a/api/lib/mcp-oauth.ts
+++ b/api/lib/mcp-oauth.ts
@@ -1,0 +1,252 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export const MCP_OAUTH_ISSUER = "https://unclick.world";
+export const MCP_OAUTH_RESOURCE = "https://unclick.world/api/mcp";
+export const MCP_OAUTH_SCOPE = "unclick:mcp";
+export const MCP_OAUTH_PROTECTED_RESOURCE_METADATA_URL =
+  "https://unclick.world/.well-known/oauth-protected-resource/api/mcp";
+export const MCP_OAUTH_AUTHORIZATION_ENDPOINT = "https://unclick.world/mcp/authorize";
+export const MCP_OAUTH_TOKEN_ENDPOINT = "https://unclick.world/api/mcp/oauth/token";
+export const MCP_OAUTH_REGISTRATION_ENDPOINT = "https://unclick.world/api/mcp/oauth/register";
+
+const ACCESS_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30;
+const REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 90;
+const AUTH_CODE_TTL_SECONDS = 10 * 60;
+
+type McpOAuthTokenKind = "code" | "access" | "refresh";
+
+export interface McpOAuthTokenPayload {
+  aud: string;
+  client_id?: string;
+  code_challenge?: string;
+  code_challenge_method?: "S256";
+  exp: number;
+  iat: number;
+  iss: string;
+  jti: string;
+  kind: McpOAuthTokenKind;
+  redirect_uri?: string;
+  scope: string;
+  sub: string;
+  v: 1;
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function base64UrlEncode(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function base64UrlDecode(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function signingSecret(env: NodeJS.ProcessEnv): string {
+  const secret =
+    env.MCP_OAUTH_SIGNING_SECRET ??
+    env.UNCLICK_OAUTH_SIGNING_SECRET ??
+    env.SUPABASE_SERVICE_ROLE_KEY ??
+    "";
+  if (!secret) throw new Error("MCP OAuth signing secret is not configured.");
+  return secret;
+}
+
+function signPayload(encodedPayload: string, env: NodeJS.ProcessEnv): string {
+  return createHmac("sha256", signingSecret(env)).update(encodedPayload, "utf8").digest("base64url");
+}
+
+function createSignedToken(
+  input: Omit<McpOAuthTokenPayload, "aud" | "exp" | "iat" | "iss" | "jti" | "v"> & {
+    ttlSeconds: number;
+  },
+  env: NodeJS.ProcessEnv,
+): string {
+  const iat = nowSeconds();
+  const payload: McpOAuthTokenPayload = {
+    aud: MCP_OAUTH_RESOURCE,
+    exp: iat + input.ttlSeconds,
+    iat,
+    iss: MCP_OAUTH_ISSUER,
+    jti: randomBytes(16).toString("base64url"),
+    kind: input.kind,
+    scope: normalizeMcpOAuthScope(input.scope),
+    sub: input.sub,
+    v: 1,
+    ...(input.client_id ? { client_id: input.client_id } : {}),
+    ...(input.redirect_uri ? { redirect_uri: input.redirect_uri } : {}),
+    ...(input.code_challenge ? { code_challenge: input.code_challenge } : {}),
+    ...(input.code_challenge_method ? { code_challenge_method: input.code_challenge_method } : {}),
+  };
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  return `${encodedPayload}.${signPayload(encodedPayload, env)}`;
+}
+
+export function verifyMcpOAuthToken(
+  token: string,
+  expectedKind: McpOAuthTokenKind,
+  env: NodeJS.ProcessEnv,
+  now = nowSeconds(),
+): McpOAuthTokenPayload {
+  const [encodedPayload, signature] = token.split(".");
+  if (!encodedPayload || !signature) throw new Error("Invalid MCP OAuth token.");
+
+  let payload: McpOAuthTokenPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encodedPayload)) as McpOAuthTokenPayload;
+  } catch {
+    throw new Error("Invalid MCP OAuth token.");
+  }
+
+  if (
+    payload.v !== 1 ||
+    payload.kind !== expectedKind ||
+    payload.iss !== MCP_OAUTH_ISSUER ||
+    payload.aud !== MCP_OAUTH_RESOURCE ||
+    typeof payload.sub !== "string" ||
+    typeof payload.exp !== "number" ||
+    typeof payload.scope !== "string"
+  ) {
+    throw new Error("Invalid MCP OAuth token.");
+  }
+
+  const expectedSignature = signPayload(encodedPayload, env);
+  const actual = Buffer.from(signature, "utf8");
+  const expected = Buffer.from(expectedSignature, "utf8");
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    throw new Error("MCP OAuth token signature mismatch.");
+  }
+
+  if (payload.exp < now) throw new Error("MCP OAuth token expired.");
+  return payload;
+}
+
+export function createMcpOAuthAuthorizationCode(input: {
+  clientId: string;
+  codeChallenge: string;
+  redirectUri: string;
+  scope?: string;
+  userId: string;
+}, env: NodeJS.ProcessEnv): string {
+  return createSignedToken(
+    {
+      client_id: input.clientId,
+      code_challenge: input.codeChallenge,
+      code_challenge_method: "S256",
+      kind: "code",
+      redirect_uri: input.redirectUri,
+      scope: input.scope ?? MCP_OAUTH_SCOPE,
+      sub: input.userId,
+      ttlSeconds: AUTH_CODE_TTL_SECONDS,
+    },
+    env,
+  );
+}
+
+export function createMcpOAuthAccessToken(input: {
+  scope?: string;
+  userId: string;
+}, env: NodeJS.ProcessEnv): { access_token: string; expires_in: number } {
+  return {
+    access_token: createSignedToken(
+      {
+        kind: "access",
+        scope: input.scope ?? MCP_OAUTH_SCOPE,
+        sub: input.userId,
+        ttlSeconds: ACCESS_TOKEN_TTL_SECONDS,
+      },
+      env,
+    ),
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+  };
+}
+
+export function createMcpOAuthRefreshToken(input: {
+  scope?: string;
+  userId: string;
+}, env: NodeJS.ProcessEnv): { refresh_token: string } {
+  return {
+    refresh_token: createSignedToken(
+      {
+        kind: "refresh",
+        scope: input.scope ?? MCP_OAUTH_SCOPE,
+        sub: input.userId,
+        ttlSeconds: REFRESH_TOKEN_TTL_SECONDS,
+      },
+      env,
+    ),
+  };
+}
+
+export function normalizeMcpOAuthScope(scope?: string): string {
+  const parts = String(scope ?? "")
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return parts.includes(MCP_OAUTH_SCOPE) ? parts.join(" ") : [MCP_OAUTH_SCOPE, ...parts].join(" ");
+}
+
+export function isSafeOAuthRedirectUri(value: unknown): value is string {
+  if (typeof value !== "string" || !value) return false;
+  try {
+    const url = new URL(value);
+    if (url.protocol === "https:") return true;
+    if (url.protocol !== "http:") return false;
+    return ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function verifyPkceS256(codeVerifier: string, codeChallenge: string): boolean {
+  if (!codeVerifier || !codeChallenge) return false;
+  const digest = createHash("sha256").update(codeVerifier, "utf8").digest("base64url");
+  return digest === codeChallenge;
+}
+
+export function appendOAuthResponseParams(
+  redirectUri: string,
+  params: Record<string, string | undefined>,
+): string {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+export function protectedResourceMetadata() {
+  return {
+    resource: MCP_OAUTH_RESOURCE,
+    authorization_servers: [MCP_OAUTH_ISSUER],
+    bearer_methods_supported: ["header"],
+    scopes_supported: [MCP_OAUTH_SCOPE],
+    resource_documentation: "https://unclick.world/docs",
+  };
+}
+
+export function authorizationServerMetadata() {
+  return {
+    issuer: MCP_OAUTH_ISSUER,
+    authorization_endpoint: MCP_OAUTH_AUTHORIZATION_ENDPOINT,
+    token_endpoint: MCP_OAUTH_TOKEN_ENDPOINT,
+    registration_endpoint: MCP_OAUTH_REGISTRATION_ENDPOINT,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: [MCP_OAUTH_SCOPE],
+    client_id_metadata_document_supported: true,
+    authorization_response_iss_parameter_supported: true,
+  };
+}
+
+export function mcpOAuthWwwAuthenticate(error?: string): string {
+  const params = [
+    `resource_metadata="${MCP_OAUTH_PROTECTED_RESOURCE_METADATA_URL}"`,
+    `scope="${MCP_OAUTH_SCOPE}"`,
+  ];
+  if (error) params.push(`error="${error}"`);
+  return `Bearer ${params.join(", ")}`;
+}

--- a/api/mcp-oauth-authorize.ts
+++ b/api/mcp-oauth-authorize.ts
@@ -1,0 +1,146 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createHash, randomBytes } from "node:crypto";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { effectiveMemoryTier } from "../packages/mcp-server/src/memory/quota-policy.js";
+import {
+  appendOAuthResponseParams,
+  createMcpOAuthAuthorizationCode,
+  isSafeOAuthRedirectUri,
+  MCP_OAUTH_ISSUER,
+  MCP_OAUTH_RESOURCE,
+  normalizeMcpOAuthScope,
+} from "./lib/mcp-oauth.js";
+
+function sha256hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function getSupabaseEnv(): { url: string; key: string } | null {
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+  return url && key ? { url, key } : null;
+}
+
+function bearerFrom(req: VercelRequest): string {
+  return String(req.headers.authorization ?? "").replace(/^Bearer\s+/i, "").trim();
+}
+
+async function resolveSessionUser(
+  req: VercelRequest,
+  supabaseUrl: string,
+  serviceRoleKey: string,
+): Promise<{ id: string; email: string | null } | null> {
+  const token = bearerFrom(req);
+  if (!token || token.startsWith("uc_") || token.startsWith("agt_")) return null;
+  try {
+    const scoped = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data, error } = await scoped.auth.getUser(token);
+    if (error || !data?.user) return null;
+    return { id: data.user.id, email: data.user.email ?? null };
+  } catch {
+    return null;
+  }
+}
+
+async function ensureActiveApiKeyForUser(
+  supabase: SupabaseClient,
+  userId: string,
+  email: string | null,
+): Promise<boolean> {
+  const existing = await supabase
+    .from("api_keys")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .limit(1)
+    .maybeSingle();
+  if (!existing.error && existing.data) return true;
+
+  const rawKey = `uc_${randomBytes(16).toString("hex")}`;
+  const insert = await supabase
+    .from("api_keys")
+    .insert({
+      user_id: userId,
+      key_hash: sha256hex(rawKey),
+      key_prefix: rawKey.slice(0, 8),
+      label: "mcp-oauth",
+      tier: effectiveMemoryTier("free", email),
+      is_active: true,
+      usage_count: 0,
+    })
+    .select("id")
+    .maybeSingle();
+
+  if (!insert.error && insert.data) return true;
+
+  const retry = await supabase
+    .from("api_keys")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("is_active", true)
+    .limit(1)
+    .maybeSingle();
+  return !retry.error && Boolean(retry.data);
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "https://unclick.world");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+  res.setHeader("Cache-Control", "no-store");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+
+  const env = getSupabaseEnv();
+  if (!env) return res.status(500).json({ error: "Supabase is not configured" });
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const clientId = String(body.client_id ?? "").trim();
+  const redirectUri = String(body.redirect_uri ?? "").trim();
+  const responseType = String(body.response_type ?? "").trim();
+  const state = typeof body.state === "string" ? body.state : undefined;
+  const scope = normalizeMcpOAuthScope(typeof body.scope === "string" ? body.scope : undefined);
+  const resource = typeof body.resource === "string" ? body.resource.trim() : "";
+  const codeChallenge = String(body.code_challenge ?? "").trim();
+  const codeChallengeMethod = String(body.code_challenge_method ?? "").trim();
+
+  if (responseType !== "code") return res.status(400).json({ error: "response_type must be code" });
+  if (!clientId) return res.status(400).json({ error: "client_id required" });
+  if (!isSafeOAuthRedirectUri(redirectUri)) return res.status(400).json({ error: "redirect_uri is not allowed" });
+  if (resource && resource !== MCP_OAUTH_RESOURCE) return res.status(400).json({ error: "resource must be the UnClick MCP URL" });
+  if (!codeChallenge || codeChallengeMethod !== "S256") {
+    return res.status(400).json({ error: "PKCE S256 code challenge required" });
+  }
+
+  const user = await resolveSessionUser(req, env.url, env.key);
+  if (!user) return res.status(401).json({ error: "Sign in required" });
+
+  const supabase = createClient(env.url, env.key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const hasKey = await ensureActiveApiKeyForUser(supabase, user.id, user.email);
+  if (!hasKey) return res.status(409).json({ error: "Could not prepare UnClick account key" });
+
+  const code = createMcpOAuthAuthorizationCode(
+    {
+      clientId,
+      codeChallenge,
+      redirectUri,
+      scope,
+      userId: user.id,
+    },
+    process.env,
+  );
+
+  return res.status(200).json({
+    redirect_to: appendOAuthResponseParams(redirectUri, {
+      code,
+      state,
+      iss: MCP_OAUTH_ISSUER,
+    }),
+  });
+}

--- a/api/mcp-oauth-register.ts
+++ b/api/mcp-oauth-register.ts
@@ -1,0 +1,33 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { randomBytes } from "node:crypto";
+import { isSafeOAuthRedirectUri } from "./lib/mcp-oauth.js";
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST") return res.status(405).json({ error: "POST required" });
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const redirectUris = asStringArray(body.redirect_uris);
+  if (redirectUris.length > 0 && redirectUris.some((uri) => !isSafeOAuthRedirectUri(uri))) {
+    return res.status(400).json({ error: "redirect_uris must be https, localhost, or 127.0.0.1 URLs" });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  return res.status(201).json({
+    client_id: `unclick-mcp-${randomBytes(16).toString("base64url")}`,
+    client_id_issued_at: now,
+    client_name: typeof body.client_name === "string" ? body.client_name : "MCP client",
+    redirect_uris: redirectUris,
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  });
+}

--- a/api/mcp-oauth-token.ts
+++ b/api/mcp-oauth-token.ts
@@ -1,0 +1,95 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import {
+  createMcpOAuthAccessToken,
+  createMcpOAuthRefreshToken,
+  MCP_OAUTH_RESOURCE,
+  verifyMcpOAuthToken,
+  verifyPkceS256,
+} from "./lib/mcp-oauth.js";
+
+function bodyParams(body: unknown): URLSearchParams {
+  if (typeof body === "string") return new URLSearchParams(body);
+  if (body && typeof body === "object") {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+      if (typeof value === "string") params.set(key, value);
+    }
+    return params;
+  }
+  return new URLSearchParams();
+}
+
+function oauthError(res: VercelResponse, status: number, error: string, description?: string) {
+  return res.status(status).json({
+    error,
+    ...(description ? { error_description: description } : {}),
+  });
+}
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Cache-Control", "no-store");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "POST") return oauthError(res, 405, "invalid_request", "POST required");
+
+  const params = bodyParams(req.body);
+  const grantType = params.get("grant_type") ?? "";
+
+  if (grantType === "authorization_code") {
+    const code = params.get("code") ?? "";
+    const redirectUri = params.get("redirect_uri") ?? "";
+    const clientId = params.get("client_id") ?? "";
+    const codeVerifier = params.get("code_verifier") ?? "";
+    const resource = params.get("resource") ?? MCP_OAUTH_RESOURCE;
+
+    if (resource !== MCP_OAUTH_RESOURCE) return oauthError(res, 400, "invalid_target", "Invalid resource");
+
+    let payload;
+    try {
+      payload = verifyMcpOAuthToken(code, "code", process.env);
+    } catch (err) {
+      return oauthError(res, 400, "invalid_grant", err instanceof Error ? err.message : "Invalid code");
+    }
+
+    if (payload.redirect_uri !== redirectUri || payload.client_id !== clientId) {
+      return oauthError(res, 400, "invalid_grant", "Authorization code was issued for a different client");
+    }
+    if (!verifyPkceS256(codeVerifier, payload.code_challenge ?? "")) {
+      return oauthError(res, 400, "invalid_grant", "PKCE verification failed");
+    }
+
+    const access = createMcpOAuthAccessToken({ scope: payload.scope, userId: payload.sub }, process.env);
+    const refresh = createMcpOAuthRefreshToken({ scope: payload.scope, userId: payload.sub }, process.env);
+    return res.status(200).json({
+      token_type: "Bearer",
+      scope: payload.scope,
+      access_token: access.access_token,
+      expires_in: access.expires_in,
+      refresh_token: refresh.refresh_token,
+    });
+  }
+
+  if (grantType === "refresh_token") {
+    const refreshToken = params.get("refresh_token") ?? "";
+    let payload;
+    try {
+      payload = verifyMcpOAuthToken(refreshToken, "refresh", process.env);
+    } catch (err) {
+      return oauthError(res, 400, "invalid_grant", err instanceof Error ? err.message : "Invalid refresh token");
+    }
+    const access = createMcpOAuthAccessToken({ scope: payload.scope, userId: payload.sub }, process.env);
+    const refresh = createMcpOAuthRefreshToken({ scope: payload.scope, userId: payload.sub }, process.env);
+    return res.status(200).json({
+      token_type: "Bearer",
+      scope: payload.scope,
+      access_token: access.access_token,
+      expires_in: access.expires_in,
+      refresh_token: refresh.refresh_token,
+    });
+  }
+
+  return oauthError(res, 400, "unsupported_grant_type", "Use authorization_code or refresh_token");
+}

--- a/api/mcp-oauth.test.ts
+++ b/api/mcp-oauth.test.ts
@@ -1,0 +1,88 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  authorizationServerMetadata,
+  createMcpOAuthAccessToken,
+  createMcpOAuthAuthorizationCode,
+  createMcpOAuthRefreshToken,
+  isSafeOAuthRedirectUri,
+  MCP_OAUTH_RESOURCE,
+  protectedResourceMetadata,
+  verifyMcpOAuthToken,
+  verifyPkceS256,
+} from "./lib/mcp-oauth";
+
+function s256(verifier: string) {
+  return createHash("sha256").update(verifier, "utf8").digest("base64url");
+}
+
+describe("MCP OAuth generic URL support", () => {
+  it("publishes protected-resource and authorization-server metadata for the generic MCP URL", () => {
+    const resource = protectedResourceMetadata();
+    const auth = authorizationServerMetadata();
+
+    expect(resource.resource).toBe("https://unclick.world/api/mcp");
+    expect(resource.authorization_servers).toEqual(["https://unclick.world"]);
+    expect(resource.bearer_methods_supported).toContain("header");
+    expect(auth.authorization_endpoint).toBe("https://unclick.world/mcp/authorize");
+    expect(auth.token_endpoint).toBe("https://unclick.world/api/mcp/oauth/token");
+    expect(auth.registration_endpoint).toBe("https://unclick.world/api/mcp/oauth/register");
+    expect(auth.code_challenge_methods_supported).toEqual(["S256"]);
+  });
+
+  it("signs OAuth codes and bearer tokens against the MCP resource", () => {
+    const env = { MCP_OAUTH_SIGNING_SECRET: "test-secret" } as NodeJS.ProcessEnv;
+    const verifier = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+    const code = createMcpOAuthAuthorizationCode(
+      {
+        clientId: "client-1",
+        codeChallenge: s256(verifier),
+        redirectUri: "https://client.example/callback",
+        userId: "user-1",
+      },
+      env,
+    );
+
+    const codePayload = verifyMcpOAuthToken(code, "code", env);
+    expect(codePayload.aud).toBe(MCP_OAUTH_RESOURCE);
+    expect(codePayload.client_id).toBe("client-1");
+    expect(codePayload.redirect_uri).toBe("https://client.example/callback");
+    expect(verifyPkceS256(verifier, codePayload.code_challenge ?? "")).toBe(true);
+
+    const access = createMcpOAuthAccessToken({ userId: "user-1" }, env);
+    const refresh = createMcpOAuthRefreshToken({ userId: "user-1" }, env);
+    expect(verifyMcpOAuthToken(access.access_token, "access", env).sub).toBe("user-1");
+    expect(verifyMcpOAuthToken(refresh.refresh_token, "refresh", env).sub).toBe("user-1");
+  });
+
+  it("keeps redirect URIs constrained enough for dynamic MCP clients", () => {
+    expect(isSafeOAuthRedirectUri("https://chatgpt.com/callback")).toBe(true);
+    expect(isSafeOAuthRedirectUri("https://grok.com/callback")).toBe(true);
+    expect(isSafeOAuthRedirectUri("http://localhost:1234/callback")).toBe(true);
+    expect(isSafeOAuthRedirectUri("http://127.0.0.1:1234/callback")).toBe(true);
+    expect(isSafeOAuthRedirectUri("http://evil.example/callback")).toBe(false);
+    expect(isSafeOAuthRedirectUri("javascript:alert(1)")).toBe(false);
+  });
+
+  it("routes OAuth discovery and token endpoints before the app fallback", () => {
+    const config = JSON.parse(readFileSync("vercel.json", "utf8")) as {
+      rewrites?: Array<{ source: string; destination: string }>;
+    };
+    const rewrites = config.rewrites ?? [];
+    const sources = rewrites.map((rewrite) => rewrite.source);
+    const fallbackIndex = sources.indexOf("/((?!.*\\.).*)");
+
+    for (const source of [
+      "/.well-known/oauth-protected-resource/api/mcp",
+      "/.well-known/oauth-authorization-server",
+      "/api/mcp/oauth/authorize",
+      "/api/mcp/oauth/register",
+      "/api/mcp/oauth/token",
+    ]) {
+      const index = sources.indexOf(source);
+      expect(index).toBeGreaterThanOrEqual(0);
+      expect(index).toBeLessThan(fallbackIndex);
+    }
+  });
+});

--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -107,9 +107,11 @@ describe("public MCP pairing door", () => {
 
     expect(text).toContain("not paired");
     expect(text).toContain("https://unclick.world/login");
+    expect(text).toContain("Preferred server URL for every AI app");
+    expect(text).toContain("https://unclick.world/api/mcp");
     expect(text).toContain("https://unclick.world/api/mcp/p/");
     expect(text).toContain("asks for a fresh link");
-    expect(text).toContain("did not keep the paired MCP session");
+    expect(text).toContain("did not keep the web sign-in session");
     expect(text).toContain("Compatibility URL");
     expect(text).toContain("does not contain your API key");
     expect(text).toContain(pairId);

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -9,6 +9,7 @@
  *   Content-Type: application/json
  *   Auth (any of):
  *     - Authorization: Bearer <unclick_api_key>         (agents, preferred)
+ *     - Authorization: Bearer <mcp_oauth_access_token>  (remote MCP OAuth)
  *     - ?key=<unclick_api_key> query param              (for clients whose
  *       "Add custom connector" dialog accepts a URL only, e.g. Claude.ai
  *       and ChatGPT's Connectors UI)
@@ -42,6 +43,10 @@ import {
   PUBLIC_MCP_PAIR_COOKIE,
   publicMcpPairDeviceId,
 } from "./lib/public-mcp-pairing.js";
+import {
+  mcpOAuthWwwAuthenticate,
+  verifyMcpOAuthToken,
+} from "./lib/mcp-oauth.js";
 import {
   effectiveMemoryTier,
   isMemoryQuotaExemptEmail,
@@ -168,6 +173,10 @@ function attachPublicPairHeaders(res: VercelResponse, pairId: string): void {
   res.setHeader("mcp-session-id", pairId);
 }
 
+function attachMcpOAuthChallenge(res: VercelResponse, error?: string): void {
+  res.setHeader("WWW-Authenticate", mcpOAuthWwwAuthenticate(error));
+}
+
 function ensurePublicPairId(req: VercelRequest, res: VercelResponse): string {
   const existing = publicPairIdFromRequest(req);
   const pairId = existing ?? createPublicMcpPairId();
@@ -209,10 +218,13 @@ export function pairingToolResult(args: Record<string, unknown>, pairId?: string
           "",
           "Sign in with email, Google, or Microsoft. When the page says UnClick is ready, try the tool again.",
           "",
-          "If this AI app asks for a fresh link, says it is still unpaired, or cannot call tools, it did not keep the paired MCP session. Do not keep opening new links. Reconnect the MCP server using this paired URL:",
+          "Preferred server URL for every AI app:",
+          "https://unclick.world/api/mcp",
+          "",
+          "If this AI app asks for a fresh link, says it is still unpaired, or cannot call tools, it did not keep the web sign-in session. Do not keep opening new links. Use this paired URL only as a fallback:",
           connectorUrl,
           "",
-          "The paired URL is revokable and does not contain your API key, but keep it private. The Compatibility URL on the page is a fallback for clients that cannot use paired URLs.",
+          "The paired URL is revokable and does not contain your API key, but keep it private. The Compatibility URL on the page is a last-resort fallback for clients that cannot use web sign-in or paired URLs.",
         ].join("\n"),
       },
     ],
@@ -426,6 +438,25 @@ async function validatePublicMcpPair(pairId: string): Promise<ApiKeyContext | nu
   return ctx;
 }
 
+async function validateMcpOAuthAccessToken(token: string): Promise<ApiKeyContext | null> {
+  let payload;
+  try {
+    payload = verifyMcpOAuthToken(token, "access", process.env);
+  } catch {
+    return null;
+  }
+
+  const env = getSupabaseEnv();
+  if (!env) return null;
+
+  const supabase = createClient(env.url, env.key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: userData } = await supabase.auth.admin.getUserById(payload.sub);
+  const email = userData?.user?.email ?? null;
+  return apiKeyContextForUser(supabase, payload.sub, email);
+}
+
 /**
  * Best-effort extraction of a Supabase access token out of the raw
  * cookie header. Supabase Auth names its cookie sb-<project>-auth-token
@@ -497,7 +528,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     "Access-Control-Allow-Headers",
     "Content-Type, Authorization, mcp-session-id"
   );
-  res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
+  res.setHeader("Access-Control-Expose-Headers", "mcp-session-id, WWW-Authenticate");
 
   if (req.method === "OPTIONS") {
     return res.status(204).end();
@@ -519,13 +550,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   // ── Auth ──────────────────────────────────────────────────────────────
-  // Three paths, tried in order:
+  // Auth paths, tried in order:
   //   1. Authorization: Bearer <unclick_api_key>   (agents)
-  //   2. ?key=<unclick_api_key> query param         (Claude.ai / ChatGPT
+  //   2. Authorization: Bearer <mcp_oauth_access_token>
+  //   3. ?key=<unclick_api_key> query param         (legacy clients
   //      connector UIs that can't set headers)
-  //   3. Supabase Auth session cookie               (browser on
+  //   4. Supabase Auth session cookie               (browser on
   //      unclick.world after Phase 2 sign in)
-  //   4. Public MCP pair id                         (paired URL/session after
+  //   5. Public MCP pair id                         (paired URL/session after
   //      the generated browser sign-in link binds this client to a user)
   //
   // The api_key paths produce an ApiKeyContext directly. The session
@@ -541,7 +573,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       : Array.isArray(keyRaw)
         ? (keyRaw[0] ?? "").trim()
         : "";
-  const apiKey = keyFromHeader || keyFromQuery;
+  const bearerToken = keyFromHeader;
+  const apiKey =
+    keyFromQuery ||
+    (bearerToken.startsWith("uc_") || bearerToken.startsWith("agt_") ? bearerToken : "");
   const method = singleRpcMethod(req.body);
   const toolName = singleToolName(req.body);
 
@@ -550,6 +585,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (apiKey) {
     ctx = await validateApiKey(apiKey);
     if (!ctx && peeked.authRequired) {
+      attachMcpOAuthChallenge(res, "invalid_token");
       return res.status(401).json({
         jsonrpc: "2.0",
         error: {
@@ -557,6 +593,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           message:
             "Invalid or revoked API key. Check that the key is correct and still active. " +
             "Manage keys at https://unclick.world",
+        },
+        id: peeked.id,
+      });
+    }
+  } else if (bearerToken) {
+    ctx = await validateMcpOAuthAccessToken(bearerToken);
+    if (!ctx && peeked.authRequired) {
+      attachMcpOAuthChallenge(res, "invalid_token");
+      return res.status(401).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32001,
+          message:
+            "Invalid or expired UnClick MCP OAuth token. Reconnect this MCP server using https://unclick.world/api/mcp.",
         },
         id: peeked.id,
       });
@@ -588,6 +638,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
     if (!ctx && peeked.authRequired) {
       const pairId = ensurePublicPairId(req, res);
+      attachMcpOAuthChallenge(res);
       const loginUrl = pairingLoginUrl(undefined, pairId);
       return res.status(401).json({
         jsonrpc: "2.0",
@@ -597,8 +648,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             "UnClick is installed but this AI app is not paired yet. " +
             `Call unclick_start_pairing, or open ${loginUrl}. ` +
             "After sign-in, try this MCP connection again. If the app asks for a fresh link " +
-            "after the ready page, it did not keep the pairing session; reconnect it with " +
-            "the paired URL or Compatibility URL shown on the ready page.",
+            "after the ready page, it did not keep the web sign-in session; keep " +
+            "https://unclick.world/api/mcp as the normal URL and use the paired URL or " +
+            "Compatibility URL only as fallback.",
         },
         id: peeked.id,
       });

--- a/api/oauth-authorization-server.ts
+++ b/api/oauth-authorization-server.ts
@@ -1,0 +1,13 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { authorizationServerMetadata } from "./lib/mcp-oauth.js";
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Content-Type", "application/json");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "GET") return res.status(405).json({ error: "GET required" });
+
+  return res.status(200).json(authorizationServerMetadata());
+}

--- a/api/oauth-protected-resource.ts
+++ b/api/oauth-protected-resource.ts
@@ -1,0 +1,13 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { protectedResourceMetadata } from "./lib/mcp-oauth.js";
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Content-Type", "application/json");
+
+  if (req.method === "OPTIONS") return res.status(204).end();
+  if (req.method !== "GET") return res.status(405).json({ error: "GET required" });
+
+  return res.status(200).json(protectedResourceMetadata());
+}

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -9,9 +9,9 @@
   },
   "counts": {
     "divisions": 12,
-    "inventory": 1130,
-    "source_manifest": 247,
-    "pages": 113,
+    "inventory": 1131,
+    "source_manifest": 248,
+    "pages": 114,
     "tools": 672,
     "rooms": 23,
     "workers": 8
@@ -27,7 +27,7 @@
       "id": "public-surfaces",
       "name": "Public surfaces",
       "meaning": "Public product, docs, marketplace, and user-facing routes.",
-      "count": 55
+      "count": 56
     },
     {
       "id": "tools",
@@ -3979,6 +3979,16 @@
       "meaning": "Sign-in page.",
       "source": "src/pages/Login.tsx",
       "route": "/login",
+      "tags": []
+    },
+    {
+      "id": "public-surfaces-public-page-mcp-authorize-src-pages-mcpauthorize-tsx-mcp-authorize",
+      "division": "Public surfaces",
+      "name": "Mcp Authorize",
+      "kind": "public page",
+      "meaning": "User-facing page for Mcp Authorize.",
+      "source": "src/pages/McpAuthorize.tsx",
+      "route": "/mcp/authorize",
       "tags": []
     },
     {
@@ -11958,6 +11968,12 @@
       "src/pages/Login.tsx"
     ],
     [
+      "/mcp/authorize",
+      "Mcp Authorize",
+      "User-facing page for Mcp Authorize.",
+      "src/pages/McpAuthorize.tsx"
+    ],
+    [
       "/memory/connect",
       "Memory Connect",
       "User-facing page for Memory Connect.",
@@ -15828,8 +15844,8 @@
     },
     {
       "source": "src/App.tsx",
-      "hash": "740ff54af7e4",
-      "bytes": 23350
+      "hash": "2863f617e2a0",
+      "bytes": 23496
     },
     {
       "source": "src/pages/admin/AdminShell.tsx",
@@ -16507,6 +16523,11 @@
       "bytes": 8743
     },
     {
+      "source": "src/pages/McpAuthorize.tsx",
+      "hash": "e72687e0881f",
+      "bytes": 3961
+    },
+    {
       "source": "src/pages/MemoryConnect.tsx",
       "hash": "128a2dddc94f",
       "bytes": 18504
@@ -16533,8 +16554,8 @@
     },
     {
       "source": "src/pages/PairingComplete.tsx",
-      "hash": "ec9b7e935895",
-      "bytes": 10833
+      "hash": "81739ed74b27",
+      "bytes": 10818
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -22,7 +22,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | docs/fleet-worker-roles.md | 760883150b3f | 4888 |
 | docs/adr/0005-two-layer-admin-gating.md | cefe739796f2 | 2186 |
 | docs/adr/0006-orchestrator-is-user-chat.md | ba6451ea1765 | 2034 |
-| src/App.tsx | 740ff54af7e4 | 23350 |
+| src/App.tsx | 2863f617e2a0 | 23496 |
 | src/pages/admin/AdminShell.tsx | b983e01ec6c0 | 33162 |
 | src/pages/admin/AdminControlTower.tsx | 4c84cc958957 | 21800 |
 | src/lib/controltower.ts | c9d18e61e7d8 | 21703 |
@@ -158,12 +158,13 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/InstallRecover.tsx | 56c822e69817 | 6971 |
 | src/pages/Jobsmith.tsx | d0763d5d4c38 | 62520 |
 | src/pages/Login.tsx | dce8bcccd23f | 8743 |
+| src/pages/McpAuthorize.tsx | e72687e0881f | 3961 |
 | src/pages/MemoryConnect.tsx | 128a2dddc94f | 18504 |
 | src/pages/MemorySetup.tsx | 8ecebdff32de | 20089 |
 | src/pages/Memory.tsx | 6ad6ab79dad3 | 19343 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
-| src/pages/PairingComplete.tsx | ec9b7e935895 | 10833 |
+| src/pages/PairingComplete.tsx | 81739ed74b27 | 10818 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |
@@ -266,7 +267,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | Division | Meaning | Items |
 | --- | --- | --- |
 | Admin surfaces | Private operator views and internal control panels. | 58 |
-| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 55 |
+| Public surfaces | Public product, docs, marketplace, and user-facing routes. | 56 |
 | Tools | MCP and gateway capabilities available to seats. | 672 |
 | Rooms | PinballWake and Boardroom lanes that route work. | 23 |
 | Workers and seats | Human and AI roles that move work through the system. | 11 |
@@ -403,6 +404,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | /i | Install Recover | User-facing page for Install Recover. | src/pages/InstallRecover.tsx |
 | /jobsmith | Jobsmith | User-facing page for Jobsmith. | src/pages/Jobsmith.tsx |
 | /login | Login | Sign-in page. | src/pages/Login.tsx |
+| /mcp/authorize | Mcp Authorize | User-facing page for Mcp Authorize. | src/pages/McpAuthorize.tsx |
 | /memory/connect | Memory Connect | User-facing page for Memory Connect. | src/pages/MemoryConnect.tsx |
 | /memory/setup-guide | Memory Setup Guide | User-facing page for Memory Setup Guide. | src/pages/MemorySetupGuide.tsx |
 | /memory/setup | Memory Setup | User-facing page for Memory Setup. | src/pages/MemorySetup.tsx |
@@ -1493,6 +1495,7 @@ Every seat should pass through this path before acting on UnClick work. It keeps
 | Public surfaces | public page | Jobsmith | User-facing page for Jobsmith. | /jobsmith | src/pages/Jobsmith.tsx |
 | Public surfaces | public page | Link In Bio | Tool page for Link In Bio. | /tools/link-in-bio | src/pages/tools/LinkInBio.tsx |
 | Public surfaces | public page | Login | Sign-in page. | /login | src/pages/Login.tsx |
+| Public surfaces | public page | Mcp Authorize | User-facing page for Mcp Authorize. | /mcp/authorize | src/pages/McpAuthorize.tsx |
 | Public surfaces | public page | Memory | Public memory product page. | /memory | src/pages/Memory.tsx |
 | Public surfaces | public page | Memory Connect | User-facing page for Memory Connect. | /memory/connect | src/pages/MemoryConnect.tsx |
 | Public surfaces | public page | Memory Setup | User-facing page for Memory Setup. | /memory/setup | src/pages/MemorySetup.tsx |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ const DogfoodReportPage = lazy(() => import("./pages/DogfoodReport.tsx"));
 const LoginPage = lazy(() => import("./pages/Login.tsx"));
 const SignupPage = lazy(() => import("./pages/Signup.tsx"));
 const AuthCallbackPage = lazy(() => import("./pages/AuthCallback.tsx"));
+const McpAuthorizePage = lazy(() => import("./pages/McpAuthorize.tsx"));
 const PairingCompletePage = lazy(() => import("./pages/PairingComplete.tsx"));
 const VerifyMfaPage = lazy(() => import("./pages/VerifyMfa.tsx"));
 const BrochurePage = lazy(() => import("./components/BrochurePage.tsx"));
@@ -343,6 +344,7 @@ const App = () => (
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/auth/callback" element={<AuthCallbackPage />} />
+          <Route path="/mcp/authorize" element={<McpAuthorizePage />} />
           <Route path="/pair/connected" element={<PairingCompletePage />} />
           <Route path="/auth/verify-mfa" element={<VerifyMfaPage />} />
           <Route path="/organiser" element={<OrganiserPage />} />

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 const installSection = () => readFileSync("src/components/InstallSection.tsx", "utf8");
 const pairingPage = () => readFileSync("src/pages/PairingComplete.tsx", "utf8");
+const authorizePage = () => readFileSync("src/pages/McpAuthorize.tsx", "utf8");
 
 describe("public MCP door copy", () => {
   it("makes the public URL the primary installer language", () => {
@@ -11,6 +12,7 @@ describe("public MCP door copy", () => {
     expect(src).toContain("Public door");
     expect(src).toContain("Compatibility URL");
     expect(src).toContain("No personal key in the URL");
+    expect(src).toContain("web sign-in");
     expect(src).toContain("Private value hidden on screen");
     expect(src).toContain("https://unclick.world/api/mcp");
     expect(src).toContain("?key=");
@@ -20,12 +22,22 @@ describe("public MCP door copy", () => {
     const src = pairingPage();
 
     expect(src).toContain("This pairing token is saved");
-    expect(src).toContain("Use this paired URL in the AI app");
+    expect(src).toContain("The normal MCP URL is still https://unclick.world/api/mcp");
+    expect(src).toContain("Fallback paired URL for this AI app");
     expect(src).toContain("${PUBLIC_MCP_URL}/p/");
-    expect(src).toContain("revokable pairing token");
+    expect(src).toContain("generic MCP URL cannot finish web sign-in");
     expect(src).toContain("Compatibility URL for older AI apps");
     expect(src).toContain("contains a private connection key");
     expect(src).not.toContain("Claude still");
     expect(src).not.toContain("master key");
+  });
+
+  it("uses explicit approval for the generic MCP web sign-in handoff", () => {
+    const src = authorizePage();
+
+    expect(src).toContain("Connect UnClick");
+    expect(src).toContain("Approve ${clientLabel}");
+    expect(src).toContain("onClick={handleConnect}");
+    expect(src).toContain("window.location.assign(data.redirect_to)");
   });
 });

--- a/src/components/InstallSection.tsx
+++ b/src/components/InstallSection.tsx
@@ -247,7 +247,7 @@ function ConnectionUrlNotice({ setupMode }: { setupMode: SetupMode }) {
   if (setupMode === "Public") {
     return (
       <div className="rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs text-primary/90">
-        Public door: no personal key in the URL. If your AI app cannot finish pairing yet, switch to Compatibility URL.
+        Public door: no personal key in the URL. Your AI app should open web sign-in and keep this same address.
       </div>
     );
   }
@@ -278,7 +278,7 @@ function SetupModeSwitch({
     {
       mode: "Compatibility",
       title: "Compatibility URL",
-      body: "Works in URL-only clients today. Uses a private key.",
+      body: "Fallback for clients that cannot complete web sign-in.",
     },
   ];
 
@@ -321,7 +321,7 @@ function PublicDoorSummary() {
     <div className="rounded-xl border border-primary/25 bg-primary/5 p-5">
       <p className="text-sm font-medium text-heading">Start with the public UnClick door</p>
       <p className="mt-1 text-xs leading-5 text-muted-foreground">
-        Add this same address first. If your AI app cannot finish pairing yet, switch to the Compatibility URL.
+        Add this same address first. If your AI app supports web sign-in, it should connect without any custom URL.
       </p>
       <div className="mt-3 flex items-stretch gap-2">
         <code className="min-w-0 flex-1 truncate rounded-md border border-border/50 bg-card/60 px-3 py-2 font-mono text-xs text-heading">

--- a/src/pages/McpAuthorize.tsx
+++ b/src/pages/McpAuthorize.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Loader2, ShieldCheck } from "lucide-react";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { useSession } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+
+type AuthorizeResponse = {
+  redirect_to?: string;
+  error?: string;
+};
+
+const REQUIRED_PARAMS = ["client_id", "redirect_uri", "response_type", "code_challenge", "code_challenge_method"];
+
+export default function McpAuthorizePage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { session, loading } = useSession();
+  const [error, setError] = useState("");
+  const [authorizing, setAuthorizing] = useState(false);
+
+  const nextPath = useMemo(() => {
+    const query = searchParams.toString();
+    return query ? `/mcp/authorize?${query}` : "/mcp/authorize";
+  }, [searchParams]);
+
+  const missingParam = useMemo(() => REQUIRED_PARAMS.find((key) => !searchParams.get(key)) ?? "", [searchParams]);
+  const clientLabel = searchParams.get("client_name") || "this MCP app";
+
+  useEffect(() => {
+    if (!loading && !session) {
+      navigate(`/login?next=${encodeURIComponent(nextPath)}`, { replace: true });
+    }
+  }, [loading, navigate, nextPath, session]);
+
+  const handleConnect = useCallback(async () => {
+    if (!session) return;
+    setError("");
+    if (missingParam) {
+      setError(`Missing ${missingParam}.`);
+      return;
+    }
+
+    setAuthorizing(true);
+    const body = Object.fromEntries(searchParams.entries());
+    try {
+      const res = await fetch("/api/mcp/oauth/authorize", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify(body),
+      });
+      const data = (await res.json().catch(() => ({}))) as AuthorizeResponse;
+      if (!res.ok || !data.redirect_to) {
+        setError(data.error ?? "Could not connect this MCP app.");
+        setAuthorizing(false);
+        return;
+      }
+      window.location.assign(data.redirect_to);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error.");
+      setAuthorizing(false);
+    }
+  }, [missingParam, searchParams, session]);
+
+  const hasBlockingError = Boolean(missingParam);
+  const displayError = error || (missingParam ? `Missing ${missingParam}.` : "");
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Navbar />
+      <main className="mx-auto flex min-h-[72vh] w-full max-w-xl items-center px-4 py-20">
+        <section className="w-full rounded-lg border border-border/60 bg-card/45 p-6 text-center shadow-lg sm:p-8">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/15">
+            {displayError ? (
+              <ShieldCheck className="h-6 w-6 text-primary" />
+            ) : (
+              <ShieldCheck className="h-6 w-6 text-primary" />
+            )}
+          </div>
+          <h1 className="mt-4 text-2xl font-semibold text-heading">
+            {displayError ? "Connection needs attention" : "Connect UnClick"}
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {displayError || `Approve ${clientLabel} to use your UnClick tools.`}
+          </p>
+          {!hasBlockingError ? (
+            <Button
+              className="mt-6 gap-2 bg-primary text-black hover:opacity-90"
+              disabled={loading || !session || authorizing}
+              onClick={handleConnect}
+            >
+              {authorizing ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+              {error ? "Try again" : "Connect UnClick"}
+            </Button>
+          ) : null}
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -159,7 +159,7 @@ export default function PairingCompletePage() {
                 <p className="mt-2 text-sm text-muted-foreground">
                   {email ? `${email} is signed in. ` : ""}
                   {publicPairStatus === "paired"
-                    ? "This pairing token is saved. If your AI app asks for another link or still cannot call tools, reconnect it with the paired URL below, then use the compatibility URL if needed."
+                    ? "This pairing token is saved. The normal MCP URL is still https://unclick.world/api/mcp. Use the paired URL below only if your AI app keeps asking for fresh links."
                     : "Return to your AI app and keep using the public MCP URL."}
                 </p>
               </div>
@@ -175,11 +175,11 @@ export default function PairingCompletePage() {
                   <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
                   <div>
                     <p className="text-sm font-semibold text-heading">
-                      {pairedMcpUrl ? "Use this paired URL in the AI app" : "Use the public door first"}
+                      {pairedMcpUrl ? "Fallback paired URL for this AI app" : "Use the public door first"}
                     </p>
                     <p className="mt-1 text-xs leading-5 text-muted-foreground">
                       {pairedMcpUrl
-                        ? "This address carries a revokable pairing token. It is not your API key, but keep it private."
+                        ? "Use this only if the generic MCP URL cannot finish web sign-in. It is not your API key, but keep it private."
                         : "This address carries no personal key. After pairing, it can stay forever."}
                     </p>
                     {publicPairStatus === "paired" ? (
@@ -208,7 +208,7 @@ export default function PairingCompletePage() {
                   Compatibility URL for older AI apps
                 </summary>
                 <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                  Use this if your AI app still cannot call tools after reconnecting with the paired URL. It contains a private connection key, so the full value stays hidden on screen.
+                  Use this only if your AI app cannot use web sign-in or paired URLs. It contains a private connection key, so the full value stays hidden on screen.
                 </p>
                 {compatibilityUrl ? (
                   <div className="mt-3 flex items-stretch gap-2">

--- a/vercel.json
+++ b/vercel.json
@@ -32,6 +32,10 @@
     }
   ],
   "rewrites": [
+    { "source": "/.well-known/oauth-protected-resource/api/mcp", "destination": "/api/oauth-protected-resource" },
+    { "source": "/.well-known/oauth-protected-resource",         "destination": "/api/oauth-protected-resource" },
+    { "source": "/.well-known/oauth-authorization-server",       "destination": "/api/oauth-authorization-server" },
+    { "source": "/.well-known/openid-configuration",             "destination": "/api/oauth-authorization-server" },
     { "source": "/sitemap.xml",   "destination": "/api/sitemap" },
     { "source": "/v1/arena/(.*)", "destination": "/api/arena" },
     { "source": "/v1/arena",      "destination": "/api/arena" },
@@ -39,6 +43,9 @@
     { "source": "/api/oauth-init",         "destination": "/api/oauth-init" },
     { "source": "/api/oauth-callback",     "destination": "/api/oauth-callback" },
     { "source": "/api/credentials",        "destination": "/api/credentials" },
+    { "source": "/api/mcp/oauth/authorize", "destination": "/api/mcp-oauth-authorize" },
+    { "source": "/api/mcp/oauth/register",  "destination": "/api/mcp-oauth-register" },
+    { "source": "/api/mcp/oauth/token",     "destination": "/api/mcp-oauth-token" },
     { "source": "/api/mcp/p/:pair",       "destination": "/api/mcp" },
     { "source": "/api/mcp",               "destination": "/api/mcp" },
     { "source": "/og-image.svg",  "destination": "/og-image.svg" },


### PR DESCRIPTION
## Summary
- add MCP OAuth protected-resource discovery for the generic `https://unclick.world/api/mcp` URL
- add web sign-in and token/register endpoints so capable AI apps can connect without custom MCP URLs or API keys in URLs
- keep paired/compatibility URLs as fallbacks only, and update install/pairing copy to say that clearly
- require an explicit Connect action before the browser handoff returns an OAuth code

## Validation
- `npx vitest run api/mcp-oauth.test.ts api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts`
- `npm run build`
- `npm run brainmap:generate`
- `npm run brainmap:check`
- `git diff --check`

## Notes
This follows MCP protected-resource discovery: the normal server URL stays generic, and clients that support MCP OAuth can discover the web sign-in flow from that URL.