### PR TITLE
[codex] Make Higgsfield setup state honest

### DIFF
--- a/api/lib/managed-connections.ts
+++ b/api/lib/managed-connections.ts
@@ -110,7 +110,7 @@ export async function beginManagedConnection(input: {
       ok: false,
       status: 501,
       code: "broker_not_configured",
-      message: "Managed Connections is not switched on for this workspace yet. Nothing was saved.",
+      message: "Managed Connections is not available for this app yet. Nothing was saved.",
     };
   }
 

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16164,8 +16164,8 @@
     },
     {
       "source": "src/pages/admin/AdminTools.tsx",
-      "hash": "1b90e5775d00",
-      "bytes": 12508
+      "hash": "93fc8a56be0b",
+      "bytes": 12500
     },
     {
       "source": "src/pages/admin/AdminAuditLog.tsx",
@@ -16349,8 +16349,8 @@
     },
     {
       "source": "src/pages/AppDetail.tsx",
-      "hash": "6e542cff428b",
-      "bytes": 6635
+      "hash": "859e8c2a0639",
+      "bytes": 6986
     },
     {
       "source": "src/pages/Apps.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -86,7 +86,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminAgents.tsx | 6df58623daf6 | 49162 |
 | src/pages/admin/AdminAnalytics.tsx | dcc1351f518e | 10345 |
 | src/pages/admin/AdminAppTesting.tsx | 5ba37cf2abff | 11567 |
-| src/pages/admin/AdminTools.tsx | 1b90e5775d00 | 12508 |
+| src/pages/admin/AdminTools.tsx | 93fc8a56be0b | 12500 |
 | src/pages/admin/AdminAuditLog.tsx | 905775a1985d | 1446 |
 | src/pages/admin/AdminExpressBuild.tsx | 883d77d7b764 | 22924 |
 | src/pages/admin/AdminEcosystemPages.tsx | 3d245def3231 | 13772 |
@@ -123,7 +123,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminUsers.tsx | 222654ee0f22 | 866 |
 | src/pages/admin/AdminXGate.tsx | 193295e6e4dc | 26811 |
 | src/pages/admin/AdminYou.tsx | 4b186ef89df8 | 71460 |
-| src/pages/AppDetail.tsx | 6e542cff428b | 6635 |
+| src/pages/AppDetail.tsx | 859e8c2a0639 | 6986 |
 | src/pages/Apps.tsx | 65bd43917eab | 3135 |
 | src/pages/AuthCallback.tsx | e9ee37622f98 | 5086 |
 | src/pages/VerifyMfa.tsx | f5c6b05b7844 | 6545 |

--- a/packages/mcp-server/src/connector-setup.test.ts
+++ b/packages/mcp-server/src/connector-setup.test.ts
@@ -49,10 +49,10 @@ describe("connector-setup registry + resolver", () => {
     }
   });
 
-  it("points Higgsfield setup at Cloud API keys and names the hosted MCP as separate", () => {
+  it("points Higgsfield setup at Cloud API keys and explains hosted MCP honestly", () => {
     const r = notConnectedFor("higgsfield");
     expect(CONNECTOR_SETUP.higgsfield.setupUrl).toBe("https://cloud.higgsfield.ai/api-keys");
-    expect(r.how_to_connect.join(" ")).toContain("separate direct sign-in path outside UnClick");
+    expect(r.how_to_connect.join(" ")).toContain("hosted MCP uses Higgsfield's own account sign-in");
     expect(r.how_to_connect.join(" ")).toContain("HIGGSFIELD_API_KEY");
   });
 });

--- a/packages/mcp-server/src/connector-setup.ts
+++ b/packages/mcp-server/src/connector-setup.ts
@@ -232,7 +232,7 @@ export const CONNECTOR_SETUP: Record<string, ConnectorSetup> = {
     arg:         "api_key",
     envVar:      "HIGGSFIELD_API_KEY",
     setupUrl:    "https://cloud.higgsfield.ai/api-keys",
-    note:        "Higgsfield's hosted MCP is a separate direct sign-in path outside UnClick. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login.",
+    note:        "Higgsfield's hosted MCP uses Higgsfield's own account sign-in. Use an API key here only for UnClick-routed API actions; it does not connect the hosted MCP session back to UnClick.",
   },
   kling: {
     displayName: "Kling",

--- a/packages/mcp-server/src/higgsfield-tool.ts
+++ b/packages/mcp-server/src/higgsfield-tool.ts
@@ -1,7 +1,7 @@
 // Higgsfield AI API integration for the UnClick MCP server.
 // Uses the Higgsfield REST API via fetch - no external dependencies.
 // This REST connector accepts api_key or HIGGSFIELD_API_KEY. Higgsfield's hosted
-// MCP is a separate direct sign-in path at https://mcp.higgsfield.ai/mcp.
+// MCP uses Higgsfield's own account sign-in at https://mcp.higgsfield.ai/mcp.
 
 import { requireCredential } from "./connector-setup.js";
 import { type NotConnectedResult } from "./connection-help.js";

--- a/src/components/apps/ConnectAppModal.test.tsx
+++ b/src/components/apps/ConnectAppModal.test.tsx
@@ -102,18 +102,20 @@ describe("ConnectAppModal", () => {
     expect(await screen.findByText(/marked as added/i)).toBeInTheDocument();
   });
 
-  it("puts Higgsfield account login before the API key fallback", () => {
+  it("presents Higgsfield hosted MCP as setup until UnClick can verify it", () => {
     renderModal({
       app: HIGGSFIELD_APP,
       connector: { id: "higgsfield", auth_type: "api_key", setup_url: null, supports_hosted_mcp_connection: true },
     });
-    expect(screen.getByText(/use your higgsfield account login/i)).toBeInTheDocument();
-    expect(screen.getByText(/not the old unclick vault path/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /open higgsfield mcp login guide/i })).toHaveAttribute(
+    expect(screen.getByRole("heading", { name: /set up higgsfield/i })).toBeInTheDocument();
+    expect(screen.getByText(/use higgsfield's mcp setup/i)).toBeInTheDocument();
+    expect(screen.getByText(/cannot mark it connected here yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/vault/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open higgsfield mcp setup/i })).toHaveAttribute(
       "href",
       "https://higgsfield.ai/mcp",
     );
-    expect(screen.getByRole("button", { name: /higgsfield login not switched on yet/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /one-click login coming soon/i })).toBeDisabled();
     expect(screen.getByText(/api key fallback/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /where do i get my api key/i })).toHaveAttribute(
       "href",

--- a/src/components/apps/ConnectAppModal.tsx
+++ b/src/components/apps/ConnectAppModal.tsx
@@ -85,6 +85,7 @@ export function ConnectAppModal({
   const isOAuth = connector.auth_type === "oauth2";
   const usesManagedConnection = connector.supports_managed_connection === true && Boolean(onStartManagedConnection);
   const usesHostedMcpConnection = connector.supports_hosted_mcp_connection === true && !usesManagedConnection;
+  const modalVerb = usesHostedMcpConnection ? "Set up" : isConnected ? "Manage" : "Connect";
 
   async function submit() {
     const apiKey = readLocalApiKey();
@@ -181,7 +182,7 @@ export function ConnectAppModal({
         <div className="mb-4 flex items-center justify-between">
           <h3 className="flex items-center gap-2 text-sm font-semibold text-white">
             <KeyRound className="h-4 w-4 text-[#E2B93B]" />
-            {isConnected ? "Manage" : "Connect"} {app.name}
+            {modalVerb} {app.name}
           </h3>
           <button onClick={onClose} className="rounded-md p-1 text-[#888] transition-colors hover:bg-white/[0.04] hover:text-white" aria-label="Close">
             <X className="h-4 w-4" />
@@ -230,10 +231,13 @@ export function ConnectAppModal({
         ) : usesHostedMcpConnection ? (
           <div className="space-y-3 text-xs leading-5 text-white/60">
             <div className="rounded-lg border border-[#B8FF00]/20 bg-[#B8FF00]/[0.05] px-3 py-3">
-              <p className="font-semibold text-white">Use your {app.name} account login</p>
+              <p className="font-semibold text-white">Use {app.name}'s MCP setup</p>
               <p className="mt-1 text-white/55">
-                Higgsfield's MCP connection is an account sign-in. It uses the customer's own Higgsfield account, plan,
-                and credits. This is not the old UnClick vault path.
+                This opens Higgsfield's setup page so you can add its MCP URL to your AI app and sign in with
+                Higgsfield there. It uses your Higgsfield account, plan, and credits.
+              </p>
+              <p className="mt-1 text-white/45">
+                Because this sign-in happens with Higgsfield, UnClick cannot mark it connected here yet.
               </p>
               <a
                 href="https://higgsfield.ai/mcp"
@@ -241,7 +245,7 @@ export function ConnectAppModal({
                 rel="noopener noreferrer"
                 className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[#B8FF00]/30 bg-[#B8FF00]/10 px-2.5 py-1.5 text-[11px] font-semibold text-[#D6FF57] transition-colors hover:bg-[#B8FF00]/15"
               >
-                Open Higgsfield MCP login guide
+                Open Higgsfield MCP setup
                 <ExternalLink className="h-3 w-3" />
               </a>
             </div>
@@ -249,9 +253,8 @@ export function ConnectAppModal({
             <div className="rounded-lg border border-white/[0.08] bg-white/[0.025] px-3 py-3">
               <p className="font-semibold text-white">UnClick-wide login</p>
               <p className="mt-1 text-white/55">
-                The cross-PC login bridge is built as a managed connection, but it is not switched on for Higgsfield
-                in this workspace yet. When it is on, this dialog will show a real sign-in button and UnClick will
-                store only a connection record.
+                This is the future one-click path. When it is available for Higgsfield, this dialog will open a
+                real sign-in window and the app will show as connected across your UnClick devices.
               </p>
               <div className="mt-2 flex flex-wrap items-center gap-2">
                 <button
@@ -259,7 +262,7 @@ export function ConnectAppModal({
                   disabled
                   className="rounded-md border border-white/[0.08] px-2.5 py-1.5 text-[11px] font-semibold text-white/35"
                 >
-                  Higgsfield login not switched on yet
+                  One-click login coming soon
                 </button>
                 {disconnectButton}
               </div>

--- a/src/components/apps/appDetailExtras.tsx
+++ b/src/components/apps/appDetailExtras.tsx
@@ -59,29 +59,28 @@ function HiggsfieldPanel(): ReactNode {
         <p className="text-sm font-semibold text-white">Higgsfield setup options</p>
       </div>
       <p className="mt-1.5 text-xs leading-5 text-white/55">
-        Higgsfield has two real connection paths. The hosted MCP path is the subscription-friendly
-        account login: add Higgsfield's MCP URL to Claude or another MCP client, then sign in with
-        Higgsfield. The UnClick-wide login bridge is the same idea inside UnClick, but it only appears
-        after the managed broker is switched on. The API key path is a fallback for UnClick-routed API
-        actions, not the hosted MCP login.
+        Higgsfield has two useful setup paths today. For subscription-based MCP, add Higgsfield's MCP URL
+        to your AI app and sign in with Higgsfield there. For UnClick-routed actions, add a Higgsfield
+        Cloud API key in UnClick. One-click account login will appear here when Higgsfield supports a
+        managed connection in UnClick.
       </p>
 
       <div className="mt-4 grid gap-4 md:grid-cols-2">
         <div className="space-y-3">
           <CommandStack
-            label="Higgsfield hosted MCP login"
+            label="Higgsfield MCP setup"
             commands={[
               "Name: Higgsfield",
               "URL: https://mcp.higgsfield.ai/mcp",
-              "Connect, then sign in with your Higgsfield account",
+              "Sign in with Higgsfield when your AI app asks",
             ]}
           />
           <CommandStack
             label="UnClick-wide login"
             commands={[
-              "Uses the managed connection broker",
-              "Stores a connection record, not your Higgsfield login",
-              "Appears here when Higgsfield broker setup is switched on",
+              "Coming soon for Higgsfield",
+              "Will show Connected after a real sign-in",
+              "No API key needed when this is available",
             ]}
           />
           <CommandStack

--- a/src/components/apps/appLenses.test.ts
+++ b/src/components/apps/appLenses.test.ts
@@ -30,7 +30,7 @@ describe("appLenses", () => {
   it("classifies setup kinds from auth_type", () => {
     expect(setupKindOf(oauthNoCred)).toBe("signin");
     expect(setupKindOf(managedNoCred)).toBe("signin");
-    expect(setupKindOf(hostedMcpNoCred)).toBe("signin");
+    expect(setupKindOf(hostedMcpNoCred)).toBe("setup");
     expect(setupKindOf(keySaved)).toBe("key");
     expect(setupKindOf(botNoCred)).toBe("key");
     expect(setupKindOf(undefined)).toBe("builtin");
@@ -45,10 +45,10 @@ describe("appLenses", () => {
     expect(isConnected(undefined)).toBe(false);
   });
 
-  it("buttons say the action: Connect / Add key / Manage / nothing", () => {
+  it("buttons say the action: Connect / Open setup / Add key / Manage / nothing", () => {
     expect(actionLabelFor(oauthNoCred)).toBe("Connect");
     expect(actionLabelFor(managedNoCred)).toBe("Connect");
-    expect(actionLabelFor(hostedMcpNoCred)).toBe("Connect");
+    expect(actionLabelFor(hostedMcpNoCred)).toBe("Open setup");
     expect(actionLabelFor(oauthConnected)).toBe("Manage");
     expect(actionLabelFor(managedConnected)).toBe("Manage");
     expect(actionLabelFor(botNoCred)).toBe("Add key");
@@ -68,20 +68,23 @@ describe("appLenses", () => {
     expect(matchesLens(a, "not-connected", undefined)).toBe(false);
     expect(matchesLens(a, "signin", oauthNoCred)).toBe(true);
     expect(matchesLens(a, "signin", managedNoCred)).toBe(true);
-    expect(matchesLens(a, "signin", hostedMcpNoCred)).toBe(true);
+    expect(matchesLens(a, "signin", hostedMcpNoCred)).toBe(false);
+    expect(matchesLens(a, "setup", hostedMcpNoCred)).toBe(true);
     expect(matchesLens(a, "key", botNoCred)).toBe(true);
     expect(matchesLens(a, "builtin", undefined)).toBe(true);
   });
 
   it("applyLens filters one list and never forks it", () => {
-    const apps = [app("github"), app("builtin-calc"), app("xero")];
+    const apps = [app("github"), app("builtin-calc"), app("xero"), app("higgsfield")];
     const connectors = new Map<string, LensConnector>([
       ["github", oauthNoCred],
       ["xero", keyTested],
+      ["higgsfield", hostedMcpNoCred],
     ]);
-    expect(applyLens(apps, "all", connectors)).toHaveLength(3);
+    expect(applyLens(apps, "all", connectors)).toHaveLength(4);
     expect(applyLens(apps, "connected", connectors).map((a) => a.slug)).toEqual(["xero"]);
     expect(applyLens(apps, "signin", connectors).map((a) => a.slug)).toEqual(["github"]);
+    expect(applyLens(apps, "setup", connectors).map((a) => a.slug)).toEqual(["higgsfield"]);
     expect(applyLens(apps, "builtin", connectors).map((a) => a.slug)).toEqual(["builtin-calc"]);
   });
 
@@ -100,6 +103,7 @@ describe("appLenses", () => {
 
   it("parseAppLens is safe on junk", () => {
     expect(parseAppLens("connected")).toBe("connected");
+    expect(parseAppLens("setup")).toBe("setup");
     expect(parseAppLens("banana")).toBe("all");
     expect(parseAppLens(null)).toBe("all");
   });

--- a/src/components/apps/appLenses.ts
+++ b/src/components/apps/appLenses.ts
@@ -9,9 +9,9 @@
 
 import type { AppEntry } from "@/lib/appCatalog";
 
-export type AppLens = "all" | "popular" | "connected" | "not-connected" | "signin" | "key" | "builtin";
+export type AppLens = "all" | "popular" | "connected" | "not-connected" | "signin" | "setup" | "key" | "builtin";
 
-export type SetupKind = "signin" | "key" | "builtin";
+export type SetupKind = "signin" | "setup" | "key" | "builtin";
 
 /** Minimal connector shape the lenses need; matches the admin_tools API rows. */
 export interface LensConnector {
@@ -33,6 +33,7 @@ export const LENSES: ReadonlyArray<{ id: AppLens; label: string; group: "Library
   { id: "connected", label: "Connected", group: "Status" },
   { id: "not-connected", label: "Not connected", group: "Status" },
   { id: "signin", label: "Sign-in apps", group: "Setup" },
+  { id: "setup", label: "Setup guides", group: "Setup" },
   { id: "key", label: "Key apps", group: "Setup" },
   { id: "builtin", label: "Built-in", group: "Setup" },
 ];
@@ -50,7 +51,8 @@ export const POPULAR_SLUGS: ReadonlySet<string> = new Set([
 
 export function setupKindOf(connector: LensConnector | undefined): SetupKind {
   if (!connector?.auth_type) return "builtin";
-  if (connector.supports_managed_connection || connector.supports_hosted_mcp_connection) return "signin";
+  if (connector.supports_managed_connection) return "signin";
+  if (connector.supports_hosted_mcp_connection) return "setup";
   return connector.auth_type === "oauth2" ? "signin" : "key";
 }
 
@@ -63,10 +65,11 @@ export function isConnected(connector: LensConnector | undefined): boolean {
  * The action button label: buttons say the action, pills say the truth.
  * null = nothing to do (built-in apps).
  */
-export function actionLabelFor(connector: LensConnector | undefined): "Connect" | "Add key" | "Manage" | null {
+export function actionLabelFor(connector: LensConnector | undefined): "Connect" | "Open setup" | "Add key" | "Manage" | null {
   const kind = setupKindOf(connector);
   if (kind === "builtin") return null;
   if (isConnected(connector)) return "Manage";
+  if (kind === "setup") return "Open setup";
   return kind === "signin" ? "Connect" : "Add key";
 }
 
@@ -77,6 +80,7 @@ export function matchesLens(app: AppEntry, lens: AppLens, connector: LensConnect
     case "connected": return isConnected(connector);
     case "not-connected": return Boolean(connector) && !isConnected(connector);
     case "signin": return setupKindOf(connector) === "signin";
+    case "setup": return setupKindOf(connector) === "setup";
     case "key": return setupKindOf(connector) === "key";
     case "builtin": return setupKindOf(connector) === "builtin";
   }

--- a/src/data/connector-setup.generated.json
+++ b/src/data/connector-setup.generated.json
@@ -195,7 +195,7 @@
       "arg": "api_key",
       "envVar": "HIGGSFIELD_API_KEY",
       "setupUrl": "https://cloud.higgsfield.ai/api-keys",
-      "note": "Higgsfield's hosted MCP is a separate direct sign-in path outside UnClick. Use an API key here only for UnClick-routed API actions; it is separate from the hosted MCP login."
+      "note": "Higgsfield's hosted MCP uses Higgsfield's own account sign-in. Use an API key here only for UnClick-routed API actions; it does not connect the hosted MCP session back to UnClick."
     },
     "kling": {
       "displayName": "Kling",

--- a/src/pages/AppDetail.tsx
+++ b/src/pages/AppDetail.tsx
@@ -42,6 +42,7 @@ const AppDetail = () => {
   // Failing apps are hidden from the store list, but deep links still resolve.
   // Be upfront here instead of pretending the app works.
   const testResult = getAppTestResult(app.slug);
+  const usesHostedMcpSetup = app.slug === "higgsfield";
 
   return (
     <PageShell eyebrow={app.category} title={app.name} lede={app.blurb} halo={false}>
@@ -116,14 +117,15 @@ const AppDetail = () => {
                 <p className="text-sm font-semibold text-white">Connection</p>
               </div>
               <p className="mt-1.5 text-xs leading-5 text-white/55">
-                Most apps work straight away with nothing to set up. If {app.name} needs your account,
-                connect it from Apps, see when it is connected, and disconnect it any time.
+                {usesHostedMcpSetup
+                  ? `${app.name}'s hosted MCP setup happens with ${app.name}. Open Apps to see the setup guide, or add an API key for UnClick-routed actions. It only shows as connected when UnClick has a verified connection it can see.`
+                  : `Most apps work straight away with nothing to set up. If ${app.name} needs your account, manage it from Apps; UnClick shows the status it can verify.`}
               </p>
               <Link
                 to="/admin/apps"
                 className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-[#E2B93B]/30 bg-[#E2B93B]/10 px-3 py-1.5 text-xs font-semibold text-[#f0d577] transition-colors hover:bg-[#E2B93B]/15"
               >
-                <KeyRound className="h-3.5 w-3.5" /> Manage connections
+                <KeyRound className="h-3.5 w-3.5" /> {usesHostedMcpSetup ? "Open Apps setup" : "Manage connections"}
               </Link>
             </div>
 

--- a/src/pages/admin/AdminTools.tsx
+++ b/src/pages/admin/AdminTools.tsx
@@ -153,7 +153,7 @@ export default function AdminToolsPage() {
     }
     if (c.auth_type === "oauth2") return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     if (c.supports_managed_connection) return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
-    if (c.supports_hosted_mcp_connection) return { label: "Connect", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
+    if (c.supports_hosted_mcp_connection) return { label: "Setup", tone: "border-sky-300/25 bg-sky-300/10 text-sky-100" };
     if (c.auth_type) return { label: "Add access", tone: "border-amber-300/25 bg-amber-300/10 text-amber-100" };
     return { label: "Built-in", tone: "border-white/10 bg-white/[0.04] text-white/45" };
   }


### PR DESCRIPTION
## Summary
- moves hosted Higgsfield MCP out of the normal Connect flow and into a Setup/Open setup state
- removes internal vault/broker wording from customer-facing Higgsfield UI
- clarifies that hosted MCP sign-in happens with Higgsfield until UnClick can observe a real managed login
- keeps API key fallback separate for UnClick-routed API actions

## Checks
- npm run lint (existing warnings only)
- npm run build
- npm test
- npm run brainmap:check
- local browser smoke test for /apps/higgsfield