### PR TITLE
[codex] Harden generic MCP OAuth handshake

### DIFF
--- a/api/lib/mcp-oauth.ts
+++ b/api/lib/mcp-oauth.ts
@@ -12,6 +12,9 @@ export const MCP_OAUTH_REGISTRATION_ENDPOINT = "https://unclick.world/api/mcp/oa
 const ACCESS_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30;
 const REFRESH_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 90;
 const AUTH_CODE_TTL_SECONDS = 10 * 60;
+const CLIENT_REGISTRATION_TTL_SECONDS = 60 * 60 * 24;
+const CLIENT_ID_PREFIX = "unclick-mcp-";
+export const MCP_OAUTH_MAX_REDIRECT_URI_LENGTH = 2048;
 
 type McpOAuthTokenKind = "code" | "access" | "refresh";
 
@@ -28,6 +31,17 @@ export interface McpOAuthTokenPayload {
   redirect_uri?: string;
   scope: string;
   sub: string;
+  v: 1;
+}
+
+export interface McpOAuthClientRegistrationPayload {
+  client_name: string;
+  exp: number;
+  iat: number;
+  iss: string;
+  jti: string;
+  kind: "client";
+  redirect_uris: string[];
   v: 1;
 }
 
@@ -81,6 +95,74 @@ function createSignedToken(
   };
   const encodedPayload = base64UrlEncode(JSON.stringify(payload));
   return `${encodedPayload}.${signPayload(encodedPayload, env)}`;
+}
+
+export function createMcpOAuthClientId(input: {
+  clientName?: string;
+  redirectUris?: string[];
+}, env: NodeJS.ProcessEnv): { client_id: string; client_id_issued_at: number } {
+  const iat = nowSeconds();
+  const payload: McpOAuthClientRegistrationPayload = {
+    client_name: (input.clientName?.trim() || "MCP client").slice(0, 120),
+    exp: iat + CLIENT_REGISTRATION_TTL_SECONDS,
+    iat,
+    iss: MCP_OAUTH_ISSUER,
+    jti: randomBytes(16).toString("base64url"),
+    kind: "client",
+    redirect_uris: input.redirectUris ?? [],
+    v: 1,
+  };
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  return {
+    client_id: `${CLIENT_ID_PREFIX}${encodedPayload}.${signPayload(encodedPayload, env)}`,
+    client_id_issued_at: iat,
+  };
+}
+
+export function verifyMcpOAuthClientId(
+  clientId: string,
+  env: NodeJS.ProcessEnv,
+  now = nowSeconds(),
+): McpOAuthClientRegistrationPayload | null {
+  if (!clientId.startsWith(CLIENT_ID_PREFIX)) return null;
+  const token = clientId.slice(CLIENT_ID_PREFIX.length);
+  const [encodedPayload, signature] = token.split(".");
+  if (!encodedPayload || !signature) throw new Error("Invalid MCP OAuth client registration.");
+
+  let payload: McpOAuthClientRegistrationPayload;
+  try {
+    payload = JSON.parse(base64UrlDecode(encodedPayload)) as McpOAuthClientRegistrationPayload;
+  } catch {
+    throw new Error("Invalid MCP OAuth client registration.");
+  }
+
+  if (
+    payload.v !== 1 ||
+    payload.kind !== "client" ||
+    payload.iss !== MCP_OAUTH_ISSUER ||
+    typeof payload.client_name !== "string" ||
+    typeof payload.exp !== "number" ||
+    !Array.isArray(payload.redirect_uris) ||
+    payload.redirect_uris.some((uri) => typeof uri !== "string")
+  ) {
+    throw new Error("Invalid MCP OAuth client registration.");
+  }
+
+  const expectedSignature = signPayload(encodedPayload, env);
+  const actual = Buffer.from(signature, "utf8");
+  const expected = Buffer.from(expectedSignature, "utf8");
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    throw new Error("MCP OAuth client registration signature mismatch.");
+  }
+
+  if (payload.exp < now) throw new Error("MCP OAuth client registration expired.");
+  return payload;
+}
+
+export function validateRegisteredRedirectUri(clientId: string, redirectUri: string, env: NodeJS.ProcessEnv): boolean {
+  const registration = verifyMcpOAuthClientId(clientId, env);
+  if (!registration) return true;
+  return registration.redirect_uris.length === 0 || registration.redirect_uris.includes(redirectUri);
 }
 
 export function verifyMcpOAuthToken(
@@ -189,6 +271,7 @@ export function normalizeMcpOAuthScope(scope?: string): string {
 
 export function isSafeOAuthRedirectUri(value: unknown): value is string {
   if (typeof value !== "string" || !value) return false;
+  if (value.length > MCP_OAUTH_MAX_REDIRECT_URI_LENGTH) return false;
   try {
     const url = new URL(value);
     if (url.protocol === "https:") return true;
@@ -237,13 +320,13 @@ export function authorizationServerMetadata() {
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none"],
     scopes_supported: [MCP_OAUTH_SCOPE],
-    client_id_metadata_document_supported: true,
     authorization_response_iss_parameter_supported: true,
   };
 }
 
 export function mcpOAuthWwwAuthenticate(error?: string): string {
   const params = [
+    `realm="mcp"`,
     `resource_metadata="${MCP_OAUTH_PROTECTED_RESOURCE_METADATA_URL}"`,
     `scope="${MCP_OAUTH_SCOPE}"`,
   ];

--- a/api/mcp-oauth-authorize.ts
+++ b/api/mcp-oauth-authorize.ts
@@ -9,6 +9,7 @@ import {
   MCP_OAUTH_ISSUER,
   MCP_OAUTH_RESOURCE,
   normalizeMcpOAuthScope,
+  validateRegisteredRedirectUri,
 } from "./lib/mcp-oauth.js";
 
 function sha256hex(input: string): string {
@@ -111,6 +112,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (responseType !== "code") return res.status(400).json({ error: "response_type must be code" });
   if (!clientId) return res.status(400).json({ error: "client_id required" });
   if (!isSafeOAuthRedirectUri(redirectUri)) return res.status(400).json({ error: "redirect_uri is not allowed" });
+  try {
+    if (!validateRegisteredRedirectUri(clientId, redirectUri, process.env)) {
+      return res.status(400).json({ error: "redirect_uri was not registered for this client" });
+    }
+  } catch {
+    return res.status(400).json({ error: "client_id is not a valid UnClick MCP registration" });
+  }
   if (resource && resource !== MCP_OAUTH_RESOURCE) return res.status(400).json({ error: "resource must be the UnClick MCP URL" });
   if (!codeChallenge || codeChallengeMethod !== "S256") {
     return res.status(400).json({ error: "PKCE S256 code challenge required" });

--- a/api/mcp-oauth-register.ts
+++ b/api/mcp-oauth-register.ts
@@ -1,9 +1,16 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { randomBytes } from "node:crypto";
-import { isSafeOAuthRedirectUri } from "./lib/mcp-oauth.js";
+import { createMcpOAuthClientId, isSafeOAuthRedirectUri } from "./lib/mcp-oauth.js";
 
 function asStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
+  ].slice(0, 10);
 }
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
@@ -20,11 +27,18 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: "redirect_uris must be https, localhost, or 127.0.0.1 URLs" });
   }
 
-  const now = Math.floor(Date.now() / 1000);
+  const clientName = typeof body.client_name === "string" ? body.client_name : "MCP client";
+  let registeredClient;
+  try {
+    registeredClient = createMcpOAuthClientId({ clientName, redirectUris }, process.env);
+  } catch {
+    return res.status(500).json({ error: "MCP OAuth signing secret is not configured" });
+  }
+
   return res.status(201).json({
-    client_id: `unclick-mcp-${randomBytes(16).toString("base64url")}`,
-    client_id_issued_at: now,
-    client_name: typeof body.client_name === "string" ? body.client_name : "MCP client",
+    client_id: registeredClient.client_id,
+    client_id_issued_at: registeredClient.client_id_issued_at,
+    client_name: clientName,
     redirect_uris: redirectUris,
     grant_types: ["authorization_code", "refresh_token"],
     response_types: ["code"],

--- a/api/mcp-oauth.test.ts
+++ b/api/mcp-oauth.test.ts
@@ -5,13 +5,17 @@ import {
   authorizationServerMetadata,
   createMcpOAuthAccessToken,
   createMcpOAuthAuthorizationCode,
+  createMcpOAuthClientId,
   createMcpOAuthRefreshToken,
   isSafeOAuthRedirectUri,
   MCP_OAUTH_RESOURCE,
   protectedResourceMetadata,
+  validateRegisteredRedirectUri,
+  verifyMcpOAuthClientId,
   verifyMcpOAuthToken,
   verifyPkceS256,
 } from "./lib/mcp-oauth";
+import { peekRpc } from "./mcp";
 
 function s256(verifier: string) {
   return createHash("sha256").update(verifier, "utf8").digest("base64url");
@@ -29,6 +33,13 @@ describe("MCP OAuth generic URL support", () => {
     expect(auth.token_endpoint).toBe("https://unclick.world/api/mcp/oauth/token");
     expect(auth.registration_endpoint).toBe("https://unclick.world/api/mcp/oauth/register");
     expect(auth.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(auth).not.toHaveProperty("client_id_metadata_document_supported");
+  });
+
+  it("challenges the initial MCP handshake before protected connection setup", () => {
+    expect(peekRpc({ jsonrpc: "2.0", id: 1, method: "initialize" }).authRequired).toBe(true);
+    expect(peekRpc({ jsonrpc: "2.0", id: 2, method: "tools/call" }).authRequired).toBe(true);
+    expect(peekRpc({ jsonrpc: "2.0", id: 3, method: "tools/list" }).authRequired).toBe(false);
   });
 
   it("signs OAuth codes and bearer tokens against the MCP resource", () => {
@@ -63,6 +74,24 @@ describe("MCP OAuth generic URL support", () => {
     expect(isSafeOAuthRedirectUri("http://127.0.0.1:1234/callback")).toBe(true);
     expect(isSafeOAuthRedirectUri("http://evil.example/callback")).toBe(false);
     expect(isSafeOAuthRedirectUri("javascript:alert(1)")).toBe(false);
+    expect(isSafeOAuthRedirectUri(`https://example.com/${"a".repeat(2048)}`)).toBe(false);
+  });
+
+  it("binds dynamic client registrations to their redirect URIs", () => {
+    const env = { MCP_OAUTH_SIGNING_SECRET: "test-secret" } as NodeJS.ProcessEnv;
+    const registered = createMcpOAuthClientId(
+      {
+        clientName: "MCP Inspector",
+        redirectUris: ["https://client.example/callback"],
+      },
+      env,
+    );
+
+    const payload = verifyMcpOAuthClientId(registered.client_id, env);
+    expect(payload?.client_name).toBe("MCP Inspector");
+    expect(payload?.redirect_uris).toEqual(["https://client.example/callback"]);
+    expect(validateRegisteredRedirectUri(registered.client_id, "https://client.example/callback", env)).toBe(true);
+    expect(validateRegisteredRedirectUri(registered.client_id, "https://evil.example/callback", env)).toBe(false);
   });
 
   it("routes OAuth discovery and token endpoints before the app fallback", () => {

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -56,10 +56,11 @@ function sha256hex(input: string): string {
   return crypto.createHash("sha256").update(input).digest("hex");
 }
 
-// Tool execution must require a valid api_key. Protocol/lifecycle calls and
-// unknown methods are allowed through so the MCP SDK can return the proper
-// JSON-RPC response codes (for example -32601 for method not found).
-const AUTH_REQUIRED_METHODS = new Set<string>(["tools/call"]);
+// Protected remote MCP clients need the OAuth challenge during the initial
+// handshake, not only after a user tries to invoke a tool. `tools/list` stays
+// public as a compatibility discovery path for clients that do not yet support
+// MCP OAuth, but `initialize` and `tools/call` require an authenticated context.
+const AUTH_REQUIRED_METHODS = new Set<string>(["initialize", "tools/call"]);
 
 type JsonRpcId = string | number | null;
 
@@ -235,7 +236,7 @@ export function pairingToolResult(args: Record<string, unknown>, pairId?: string
 // responses (JSON-RPC 2.0 § 5.1 requires id equality) and (2) decide whether
 // the request is attempting protected tool execution. Batches are handled
 // conservatively: any protected or malformed entry forces auth.
-function peekRpc(body: unknown): { id: JsonRpcId; authRequired: boolean } {
+export function peekRpc(body: unknown): { id: JsonRpcId; authRequired: boolean } {
   const entries = Array.isArray(body) ? body : [body];
   let id: JsonRpcId = null;
   let firstHasId = false;


### PR DESCRIPTION
## Summary
- make unauthenticated MCP `initialize` return the OAuth `WWW-Authenticate` challenge so capable clients start web sign-in during connection setup
- keep unauthenticated `tools/list` as a compatibility discovery fallback for older clients
- bind dynamic OAuth client registrations to their registered redirect URIs using signed client ids
- stop advertising client-id metadata-document support until that path is fully validated
- add `realm="mcp"` and input bounds for redirect URI registration

## Validation
- `npx vitest run api/mcp-oauth.test.ts api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts`
- `npm run build`
- `npm run brainmap:check`
- `git diff --check`

## Why
The generic URL should take OAuth-capable clients from `https://unclick.world/api/mcp` to web sign-in immediately, not wait until the first tool invocation.