### PR TITLE
[codex] Keep static MCP URL primary

### DIFF
--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -70,7 +70,9 @@ describe("public MCP pairing door", () => {
     expect(url.origin).toBe("https://unclick.world");
     expect(url.pathname).toBe(`/api/mcp/p/${pairId}`);
     expect(url.toString()).not.toContain("key=");
-    expect(publicPairIdFromRequest(req as unknown as VercelRequest)).toBe(pairId);
+    expect(publicPairIdFromRequest(req as unknown as VercelRequest)).toBe(
+      pairId,
+    );
   });
 
   it("keeps query pair ids working for older paired links", () => {
@@ -84,7 +86,9 @@ describe("public MCP pairing door", () => {
       },
     };
 
-    expect(publicPairIdFromRequest(req as unknown as VercelRequest)).toBe(pairId);
+    expect(publicPairIdFromRequest(req as unknown as VercelRequest)).toBe(
+      pairId,
+    );
   });
 
   it("routes paired path URLs to the MCP handler on Vercel", () => {
@@ -92,15 +96,19 @@ describe("public MCP pairing door", () => {
       rewrites?: Array<{ source: string; destination: string }>;
     };
     const rewrites = config.rewrites ?? [];
-    const pathRewriteIndex = rewrites.findIndex((rewrite) => rewrite.source === "/api/mcp/p/:pair");
-    const plainRewriteIndex = rewrites.findIndex((rewrite) => rewrite.source === "/api/mcp");
+    const pathRewriteIndex = rewrites.findIndex(
+      (rewrite) => rewrite.source === "/api/mcp/p/:pair",
+    );
+    const plainRewriteIndex = rewrites.findIndex(
+      (rewrite) => rewrite.source === "/api/mcp",
+    );
 
     expect(pathRewriteIndex).toBeGreaterThanOrEqual(0);
     expect(plainRewriteIndex).toBeGreaterThan(pathRewriteIndex);
     expect(rewrites[pathRewriteIndex]?.destination).toBe("/api/mcp");
   });
 
-  it("explains paired URLs without pretending they are API keys", () => {
+  it("keeps the static MCP URL primary in pairing tool copy", () => {
     const pairId = createPublicMcpPairId();
     const result = pairingToolResult({ email: "person@example.com" }, pairId);
     const text = result.content[0]?.text ?? "";
@@ -109,12 +117,8 @@ describe("public MCP pairing door", () => {
     expect(text).toContain("https://unclick.world/login");
     expect(text).toContain("Preferred server URL for every AI app");
     expect(text).toContain("https://unclick.world/api/mcp");
-    expect(text).toContain("https://unclick.world/api/mcp/p/");
-    expect(text).toContain("asks for a fresh link");
-    expect(text).toContain("did not keep the web sign-in session");
-    expect(text).toContain("Compatibility URL");
-    expect(text).toContain("does not contain your API key");
-    expect(text).toContain(pairId);
+    expect(text).toContain("ready page has private fallback options");
+    expect(text).not.toContain("https://unclick.world/api/mcp/p/");
     expect(text).not.toContain("Bearer");
   });
 });

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -75,7 +75,8 @@ export const PUBLIC_PAIRING_TOOL = {
     properties: {
       email: {
         type: "string",
-        description: "Optional email address to pre-fill on the UnClick sign-in page.",
+        description:
+          "Optional email address to pre-fill on the UnClick sign-in page.",
       },
     },
   },
@@ -84,7 +85,9 @@ export const PUBLIC_PAIRING_TOOL = {
 export function publicToolsForUnpairedClient() {
   return [
     PUBLIC_PAIRING_TOOL,
-    ...ADVERTISED_TOOLS_SAFE.filter((tool) => tool.name !== PUBLIC_PAIRING_TOOL.name),
+    ...ADVERTISED_TOOLS_SAFE.filter(
+      (tool) => tool.name !== PUBLIC_PAIRING_TOOL.name,
+    ),
   ];
 }
 
@@ -116,7 +119,10 @@ function singleToolArgs(body: unknown): Record<string, unknown> {
     : {};
 }
 
-function readCookie(cookieHeader: string | undefined, name: string): string | null {
+function readCookie(
+  cookieHeader: string | undefined,
+  name: string,
+): string | null {
   if (!cookieHeader) return null;
   const parts = cookieHeader.split(/;\s*/);
   for (const part of parts) {
@@ -203,10 +209,12 @@ export function pairedMcpUrl(pairId?: string): string {
   return `https://unclick.world/api/mcp/p/${encodeURIComponent(pairId.trim())}`;
 }
 
-export function pairingToolResult(args: Record<string, unknown>, pairId?: string) {
+export function pairingToolResult(
+  args: Record<string, unknown>,
+  pairId?: string,
+) {
   const email = typeof args.email === "string" ? args.email.trim() : "";
   const loginUrl = pairingLoginUrl(email, pairId);
-  const connectorUrl = pairedMcpUrl(pairId);
   return {
     content: [
       {
@@ -222,10 +230,7 @@ export function pairingToolResult(args: Record<string, unknown>, pairId?: string
           "Preferred server URL for every AI app:",
           "https://unclick.world/api/mcp",
           "",
-          "If this AI app asks for a fresh link, says it is still unpaired, or cannot call tools, it did not keep the web sign-in session. Do not keep opening new links. Use this paired URL only as a fallback:",
-          connectorUrl,
-          "",
-          "The paired URL is revokable and does not contain your API key, but keep it private. The Compatibility URL on the page is a last-resort fallback for clients that cannot use web sign-in or paired URLs.",
+          "If this AI app still shows only Connect UnClick after the ready page, do not keep opening new links. Keep https://unclick.world/api/mcp as the normal server URL. The ready page has private fallback options only for older apps that cannot keep web sign-in.",
         ].join("\n"),
       },
     ],
@@ -236,7 +241,10 @@ export function pairingToolResult(args: Record<string, unknown>, pairId?: string
 // responses (JSON-RPC 2.0 § 5.1 requires id equality) and (2) decide whether
 // the request is attempting protected tool execution. Batches are handled
 // conservatively: any protected or malformed entry forces auth.
-export function peekRpc(body: unknown): { id: JsonRpcId; authRequired: boolean } {
+export function peekRpc(body: unknown): {
+  id: JsonRpcId;
+  authRequired: boolean;
+} {
   const entries = Array.isArray(body) ? body : [body];
   let id: JsonRpcId = null;
   let firstHasId = false;
@@ -302,7 +310,9 @@ async function validateApiKey(apiKey: string): Promise<ApiKeyContext | null> {
   let accountEmail: string | null = null;
   if (data.user_id) {
     try {
-      const { data: userData } = await supabase.auth.admin.getUserById(data.user_id);
+      const { data: userData } = await supabase.auth.admin.getUserById(
+        data.user_id,
+      );
       accountEmail = userData.user?.email ?? null;
     } catch {
       accountEmail = null;
@@ -392,7 +402,8 @@ async function validateSessionCookie(
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  const { data: userData, error: userErr } = await supabase.auth.getUser(accessToken);
+  const { data: userData, error: userErr } =
+    await supabase.auth.getUser(accessToken);
   if (userErr || !userData?.user) return null;
   const userId = userData.user.id;
 
@@ -403,7 +414,9 @@ async function validateSessionCookie(
   return apiKeyContextForUser(supabase, userId, userData.user.email ?? null);
 }
 
-async function validatePublicMcpPair(pairId: string): Promise<ApiKeyContext | null> {
+async function validatePublicMcpPair(
+  pairId: string,
+): Promise<ApiKeyContext | null> {
   if (!isValidPublicMcpPairId(pairId)) return null;
   const env = getSupabaseEnv();
   if (!env) return null;
@@ -439,7 +452,9 @@ async function validatePublicMcpPair(pairId: string): Promise<ApiKeyContext | nu
   return ctx;
 }
 
-async function validateMcpOAuthAccessToken(token: string): Promise<ApiKeyContext | null> {
+async function validateMcpOAuthAccessToken(
+  token: string,
+): Promise<ApiKeyContext | null> {
   let payload;
   try {
     payload = verifyMcpOAuthToken(token, "access", process.env);
@@ -479,7 +494,11 @@ function extractSupabaseAccessToken(cookieHeader: string): string | null {
       if (Array.isArray(parsed) && typeof parsed[0] === "string") {
         return parsed[0];
       }
-      if (parsed && typeof parsed === "object" && typeof (parsed as { access_token?: unknown }).access_token === "string") {
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof (parsed as { access_token?: unknown }).access_token === "string"
+      ) {
         return (parsed as { access_token: string }).access_token;
       }
     } catch {
@@ -491,7 +510,10 @@ function extractSupabaseAccessToken(cookieHeader: string): string | null {
   return null;
 }
 
-export function applyMcpRequestEnv(apiKey: string, ctx: ApiKeyContext | null): void {
+export function applyMcpRequestEnv(
+  apiKey: string,
+  ctx: ApiKeyContext | null,
+): void {
   if (apiKey && ctx) {
     process.env.UNCLICK_API_KEY = apiKey;
   } else {
@@ -506,7 +528,9 @@ export function applyMcpRequestEnv(apiKey: string, ctx: ApiKeyContext | null): v
     } else {
       delete process.env.UNCLICK_ACCOUNT_EMAIL;
     }
-    process.env.UNCLICK_MEMORY_QUOTA_EXEMPT = ctx.memory_quota_exempt ? "true" : "false";
+    process.env.UNCLICK_MEMORY_QUOTA_EXEMPT = ctx.memory_quota_exempt
+      ? "true"
+      : "false";
     if (ctx.user_id) {
       process.env.UNCLICK_USER_ID = ctx.user_id;
     } else {
@@ -527,9 +551,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "Content-Type, Authorization, mcp-session-id"
+    "Content-Type, Authorization, mcp-session-id",
   );
-  res.setHeader("Access-Control-Expose-Headers", "mcp-session-id, WWW-Authenticate");
+  res.setHeader(
+    "Access-Control-Expose-Headers",
+    "mcp-session-id, WWW-Authenticate",
+  );
 
   if (req.method === "OPTIONS") {
     return res.status(204).end();
@@ -544,7 +571,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       jsonrpc: "2.0",
       error: {
         code: -32601,
-        message: "Method Not Allowed. POST to this endpoint with an MCP JSON-RPC message.",
+        message:
+          "Method Not Allowed. POST to this endpoint with an MCP JSON-RPC message.",
       },
       id: peeked.id,
     });
@@ -577,7 +605,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const bearerToken = keyFromHeader;
   const apiKey =
     keyFromQuery ||
-    (bearerToken.startsWith("uc_") || bearerToken.startsWith("agt_") ? bearerToken : "");
+    (bearerToken.startsWith("uc_") || bearerToken.startsWith("agt_")
+      ? bearerToken
+      : "");
   const method = singleRpcMethod(req.body);
   const toolName = singleToolName(req.body);
 
@@ -629,7 +659,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         id: peeked.id,
       });
     }
-    if (!ctx && method === "tools/call" && toolName === PUBLIC_PAIRING_TOOL.name) {
+    if (
+      !ctx &&
+      method === "tools/call" &&
+      toolName === PUBLIC_PAIRING_TOOL.name
+    ) {
       const pairId = ensurePublicPairId(req, res);
       return res.status(200).json({
         jsonrpc: "2.0",

--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16554,8 +16554,8 @@
     },
     {
       "source": "src/pages/PairingComplete.tsx",
-      "hash": "81739ed74b27",
-      "bytes": 10818
+      "hash": "93f97943a8a3",
+      "bytes": 12470
     },
     {
       "source": "src/pages/Pricing.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -164,7 +164,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/Memory.tsx | 6ad6ab79dad3 | 19343 |
 | src/pages/NewToAI.tsx | 4fdcf1fa25d2 | 13105 |
 | src/pages/Organiser.tsx | ae35be237d83 | 16581 |
-| src/pages/PairingComplete.tsx | 81739ed74b27 | 10818 |
+| src/pages/PairingComplete.tsx | 93f97943a8a3 | 12470 |
 | src/pages/Pricing.tsx | b9834637502c | 8724 |
 | src/pages/Privacy.tsx | a8d0decbfea8 | 11446 |
 | src/pages/Signup.tsx | bb69e5123b4b | 8623 |

--- a/src/__tests__/public-mcp-door-copy.test.ts
+++ b/src/__tests__/public-mcp-door-copy.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const installSection = () => readFileSync("src/components/InstallSection.tsx", "utf8");
+const installSection = () =>
+  readFileSync("src/components/InstallSection.tsx", "utf8");
 const pairingPage = () => readFileSync("src/pages/PairingComplete.tsx", "utf8");
 const authorizePage = () => readFileSync("src/pages/McpAuthorize.tsx", "utf8");
 
@@ -21,11 +22,19 @@ describe("public MCP door copy", () => {
   it("keeps the magic-link landing page honest about fallback URLs", () => {
     const src = pairingPage();
 
-    expect(src).toContain("This pairing token is saved");
-    expect(src).toContain("The normal MCP URL is still https://unclick.world/api/mcp");
-    expect(src).toContain("Fallback paired URL for this AI app");
+    expect(src).toContain(
+      "Pairing saved. Keep using https://unclick.world/api/mcp",
+    );
+    expect(src).toContain("Use this static MCP URL");
+    expect(src).toContain(
+      "Same address for Claude, Grok, ChatGPT, Cursor, and any",
+    );
+    expect(src).toContain("MCP client. No personal key in the URL");
+    expect(src).toContain("const primaryMcpUrl = PUBLIC_MCP_URL");
+    expect(src).toContain("Private fallback for stubborn AI apps");
     expect(src).toContain("${PUBLIC_MCP_URL}/p/");
-    expect(src).toContain("generic MCP URL cannot finish web sign-in");
+    expect(src).toContain("Keep the static URL as the normal");
+    expect(src).toContain("path. This private fallback is revokable");
     expect(src).toContain("Compatibility URL for older AI apps");
     expect(src).toContain("contains a private connection key");
     expect(src).not.toContain("Claude still");

--- a/src/pages/PairingComplete.tsx
+++ b/src/pages/PairingComplete.tsx
@@ -23,7 +23,10 @@ type PublicPairResponse = {
 
 function maskPrivateValue(value: string) {
   return value
-    .replace(/uc_[A-Za-z0-9_-]{8,}/g, (key) => `${key.slice(0, 6)}...${key.slice(-4)}`)
+    .replace(
+      /uc_[A-Za-z0-9_-]{8,}/g,
+      (key) => `${key.slice(0, 6)}...${key.slice(-4)}`,
+    )
     .replace(
       /(pair=)([A-Za-z0-9_-]{6})[A-Za-z0-9_-]{8,}([A-Za-z0-9_-]{4})/g,
       "$1$2...$3",
@@ -42,13 +45,19 @@ export default function PairingCompletePage() {
   const [email, setEmail] = useState("");
   const [loadingProfile, setLoadingProfile] = useState(false);
   const [error, setError] = useState("");
-  const [publicPairStatus, setPublicPairStatus] = useState<"idle" | "none" | "paired" | "error">("idle");
-  const [copied, setCopied] = useState<"public" | "compat" | null>(null);
+  const [publicPairStatus, setPublicPairStatus] = useState<
+    "idle" | "none" | "paired" | "error"
+  >("idle");
+  const [copied, setCopied] = useState<"public" | "paired" | "compat" | null>(
+    null,
+  );
   const pairId = searchParams.get("pair") ?? "";
 
   useEffect(() => {
     if (!loading && !session) {
-      const next = pairId ? `/pair/connected?pair=${encodeURIComponent(pairId)}` : "/pair/connected";
+      const next = pairId
+        ? `/pair/connected?pair=${encodeURIComponent(pairId)}`
+        : "/pair/connected";
       navigate(`/login?next=${encodeURIComponent(next)}`, { replace: true });
     }
   }, [loading, navigate, pairId, session]);
@@ -68,7 +77,10 @@ export default function PairingCompletePage() {
         const body = (await res.json().catch(() => ({}))) as ProfileResponse;
         if (cancelled) return;
         if (!res.ok) {
-          setError(body.error ?? "Your sign-in worked, but we could not prepare the connection yet.");
+          setError(
+            body.error ??
+              "Your sign-in worked, but we could not prepare the connection yet.",
+          );
           return;
         }
         setEmail(body.email ?? session.user.email ?? "");
@@ -89,19 +101,27 @@ export default function PairingCompletePage() {
         }
 
         if (pairId) {
-          const pairRes = await fetch("/api/memory-admin?action=public_mcp_pair", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${session.access_token}`,
+          const pairRes = await fetch(
+            "/api/memory-admin?action=public_mcp_pair",
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${session.access_token}`,
+              },
+              body: JSON.stringify({ pair_id: pairId }),
             },
-            body: JSON.stringify({ pair_id: pairId }),
-          });
-          const pairBody = (await pairRes.json().catch(() => ({}))) as PublicPairResponse;
+          );
+          const pairBody = (await pairRes
+            .json()
+            .catch(() => ({}))) as PublicPairResponse;
           if (cancelled) return;
           if (!pairRes.ok || !pairBody.paired) {
             setPublicPairStatus("error");
-            setError(pairBody.error ?? "Your sign-in worked, but the public pairing could not be saved yet.");
+            setError(
+              pairBody.error ??
+                "Your sign-in worked, but the public pairing could not be saved yet.",
+            );
             return;
           }
           setPublicPairStatus("paired");
@@ -123,20 +143,22 @@ export default function PairingCompletePage() {
     };
   }, [pairId, session]);
 
-  async function copy(value: string, key: "public" | "compat") {
+  async function copy(value: string, key: "public" | "paired" | "compat") {
     await navigator.clipboard.writeText(value);
     setCopied(key);
     window.setTimeout(() => setCopied(null), 1800);
   }
 
   const compatibilityUrl = apiKey ? `${PUBLIC_MCP_URL}?key=${apiKey}` : "";
-  const displayCompatibilityUrl = compatibilityUrl ? maskPrivateValue(compatibilityUrl) : "";
+  const displayCompatibilityUrl = compatibilityUrl
+    ? maskPrivateValue(compatibilityUrl)
+    : "";
   const pairedMcpUrl =
     pairId && publicPairStatus === "paired"
       ? `${PUBLIC_MCP_URL}/p/${encodeURIComponent(pairId)}`
       : "";
-  const primaryMcpUrl = pairedMcpUrl || PUBLIC_MCP_URL;
-  const displayPrimaryMcpUrl = pairedMcpUrl ? maskPrivateValue(pairedMcpUrl) : PUBLIC_MCP_URL;
+  const primaryMcpUrl = PUBLIC_MCP_URL;
+  const displayPrimaryMcpUrl = PUBLIC_MCP_URL;
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -146,7 +168,9 @@ export default function PairingCompletePage() {
           {loading || loadingProfile ? (
             <div className="py-10 text-center">
               <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" />
-              <h1 className="mt-4 text-xl font-semibold text-heading">Preparing UnClick</h1>
+              <h1 className="mt-4 text-xl font-semibold text-heading">
+                Preparing UnClick
+              </h1>
               <p className="mt-1 text-sm text-muted-foreground">One moment.</p>
             </div>
           ) : (
@@ -155,11 +179,13 @@ export default function PairingCompletePage() {
                 <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/15">
                   <Check className="h-6 w-6 text-primary" />
                 </div>
-                <h1 className="mt-4 text-2xl font-semibold text-heading">UnClick is ready</h1>
+                <h1 className="mt-4 text-2xl font-semibold text-heading">
+                  UnClick is ready
+                </h1>
                 <p className="mt-2 text-sm text-muted-foreground">
                   {email ? `${email} is signed in. ` : ""}
                   {publicPairStatus === "paired"
-                    ? "This pairing token is saved. The normal MCP URL is still https://unclick.world/api/mcp. Use the paired URL below only if your AI app keeps asking for fresh links."
+                    ? "Pairing saved. Keep using https://unclick.world/api/mcp in the AI app. Private fallbacks are only for apps that cannot keep web sign-in."
                     : "Return to your AI app and keep using the public MCP URL."}
                 </p>
               </div>
@@ -175,15 +201,16 @@ export default function PairingCompletePage() {
                   <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
                   <div>
                     <p className="text-sm font-semibold text-heading">
-                      {pairedMcpUrl ? "Fallback paired URL for this AI app" : "Use the public door first"}
+                      Use this static MCP URL
                     </p>
                     <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                      {pairedMcpUrl
-                        ? "Use this only if the generic MCP URL cannot finish web sign-in. It is not your API key, but keep it private."
-                        : "This address carries no personal key. After pairing, it can stay forever."}
+                      Same address for Claude, Grok, ChatGPT, Cursor, and any
+                      MCP client. No personal key in the URL.
                     </p>
                     {publicPairStatus === "paired" ? (
-                      <p className="mt-2 text-xs font-medium text-primary">Public pairing saved.</p>
+                      <p className="mt-2 text-xs font-medium text-primary">
+                        Public pairing saved.
+                      </p>
                     ) : null}
                   </div>
                 </div>
@@ -203,12 +230,43 @@ export default function PairingCompletePage() {
                 </div>
               </div>
 
+              {pairedMcpUrl ? (
+                <details className="rounded-xl border border-border/60 bg-background/25 p-4">
+                  <summary className="cursor-pointer text-sm font-semibold text-heading">
+                    Private fallback for stubborn AI apps
+                  </summary>
+                  <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                    Use this only if the same AI app still shows only Connect
+                    UnClick after sign-in. Keep the static URL as the normal
+                    path. This private fallback is revokable and should stay
+                    private.
+                  </p>
+                  <div className="mt-3 flex items-stretch gap-2">
+                    <code className="min-w-0 flex-1 truncate rounded-md border border-border/50 bg-card/60 px-3 py-2 font-mono text-xs text-heading">
+                      {maskPrivateValue(pairedMcpUrl)}
+                    </code>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="shrink-0"
+                      onClick={() => void copy(pairedMcpUrl, "paired")}
+                    >
+                      <Copy className="mr-1.5 h-3.5 w-3.5" />
+                      {copied === "paired" ? "Copied" : "Copy"}
+                    </Button>
+                  </div>
+                </details>
+              ) : null}
+
               <details className="rounded-xl border border-border/60 bg-background/25 p-4">
                 <summary className="cursor-pointer text-sm font-semibold text-heading">
                   Compatibility URL for older AI apps
                 </summary>
                 <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                  Use this only if your AI app cannot use web sign-in or paired URLs. It contains a private connection key, so the full value stays hidden on screen.
+                  Use this only if your AI app cannot use web sign-in or paired
+                  URLs. It contains a private connection key, so the full value
+                  stays hidden on screen.
                 </p>
                 {compatibilityUrl ? (
                   <div className="mt-3 flex items-stretch gap-2">
@@ -228,13 +286,17 @@ export default function PairingCompletePage() {
                   </div>
                 ) : (
                   <p className="mt-3 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-xs text-amber-100">
-                    This browser does not have the private key available. Open the installer to make a fresh compatibility URL.
+                    This browser does not have the private key available. Open
+                    the installer to make a fresh compatibility URL.
                   </p>
                 )}
               </details>
 
               <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
-                <Button asChild className="bg-primary text-black hover:opacity-90">
+                <Button
+                  asChild
+                  className="bg-primary text-black hover:opacity-90"
+                >
                   <Link to="/admin/apps">
                     Connect apps
                     <ExternalLink className="ml-2 h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- keep https://unclick.world/api/mcp as the primary copy target after pairing
- move /api/mcp/p/... into a collapsed private fallback section on the ready page
- stop printing the private /p/... MCP server URL from unclick_start_pairing tool output
- update copy tests and brainmap outputs

## Verification
- npx vitest run api/mcp-oauth.test.ts api/mcp-public-pairing.test.ts src/__tests__/public-mcp-door-copy.test.ts
- npm run build
- npm run brainmap:check
- git diff --check