### PR TITLE
[codex] Make Higgsfield setup action explicit

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16134,8 +16134,8 @@
     },
     {
       "source": "src/pages/admin/AdminSeatHeartbeat.tsx",
-      "hash": "78d5057027a1",
-      "bytes": 11750
+      "hash": "232071cb463f",
+      "bytes": 11711
     },
     {
       "source": "src/pages/admin/AdminSeatsLocal.tsx",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -80,7 +80,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | src/pages/admin/AdminSeatsApiRouting.tsx | 4caf939d9bed | 22147 |
 | src/pages/admin/AdminSeatsApiUsage.tsx | 5bfc0414856f | 16509 |
 | src/pages/admin/AdminSeatsApi.tsx | 0ba01613eeed | 37681 |
-| src/pages/admin/AdminSeatHeartbeat.tsx | 78d5057027a1 | 11750 |
+| src/pages/admin/AdminSeatHeartbeat.tsx | 232071cb463f | 11711 |
 | src/pages/admin/AdminSeatsLocal.tsx | 720301565c67 | 37209 |
 | src/pages/admin/AdminSeatsSubscription.tsx | 8511bc4559db | 25328 |
 | src/pages/admin/AdminAgents.tsx | 6df58623daf6 | 49162 |

--- a/docs/connectors/managed-connections.md
+++ b/docs/connectors/managed-connections.md
@@ -1,6 +1,6 @@
 # Managed Connections
 
-Managed Connections let customers connect apps once and use them from any PC signed into UnClick, without UnClick storing raw app keys or tokens. This is not the old Passport-as-vault model: UnClick stores a connection record and status, while the managed provider owns the sensitive app access.
+Managed Connections let customers connect apps once and use them from any PC signed into UnClick, without UnClick storing raw app keys or tokens. UnClick stores a connection record and status, while the managed provider owns the sensitive app access.
 
 ## Runtime Switches
 

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -3929,19 +3929,19 @@
     "tools": [
       {
         "name": "higgsfield_generate_video",
-        "description": "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
+        "description": "Generate a Higgsfield video from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
       },
       {
         "name": "higgsfield_generate_image",
-        "description": "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
+        "description": "Generate a Higgsfield image from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
       },
       {
         "name": "higgsfield_get_styles",
-        "description": "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call."
+        "description": "List available Higgsfield styles using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
       },
       {
         "name": "higgsfield_get_status",
-        "description": "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call."
+        "description": "Check the status of a Higgsfield generation by ID using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
       }
     ]
   },

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -3943,19 +3943,19 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "higgsfield_generate_video",
-        "description": "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
+        "description": "Generate a Higgsfield video from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
       },
       {
         "name": "higgsfield_generate_image",
-        "description": "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
+        "description": "Generate a Higgsfield image from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
       },
       {
         "name": "higgsfield_get_styles",
-        "description": "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call."
+        "description": "List available Higgsfield styles using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
       },
       {
         "name": "higgsfield_get_status",
-        "description": "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call."
+        "description": "Check the status of a Higgsfield generation by ID using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
       }
     ]
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -17057,12 +17057,12 @@ export const ADDITIONAL_TOOLS = [
   // ── higgsfield-tool.ts ────────────────────────────────────────────────────────
   {
     name: "higgsfield_generate_video",
-    description: "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account.",
+    description: "Generate a Higgsfield video from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
         prompt: { type: "string", description: "Text description of the video to generate" },
         style: { type: "string", description: "Soul Style name (use higgsfield_get_styles to list available styles)" },
         duration: { type: "number", description: "Video duration in seconds" },
@@ -17075,12 +17075,12 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "higgsfield_generate_image",
-    description: "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account.",
+    description: "Generate a Higgsfield image from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
         prompt: { type: "string", description: "Text description of the image to generate" },
         style: { type: "string", description: "Style name (use higgsfield_get_styles to list available styles)" },
         width: { type: "number", description: "Image width in pixels" },
@@ -17093,24 +17093,24 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "higgsfield_get_styles",
-    description: "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call.",
+    description: "List available Higgsfield styles using a Higgsfield Cloud API key saved in UnClick or supplied for this call.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
       },
       required: [],
     },
   },
   {
     name: "higgsfield_get_status",
-    description: "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call.",
+    description: "Check the status of a Higgsfield generation by ID using a Higgsfield Cloud API key saved in UnClick or supplied for this call.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also connect Higgsfield in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
         generation_id: { type: "string", description: "Generation ID returned by higgsfield_generate_video or higgsfield_generate_image" },
       },
       required: ["generation_id"],

--- a/src/components/apps/AppsTable.test.tsx
+++ b/src/components/apps/AppsTable.test.tsx
@@ -99,6 +99,24 @@ describe("AppsTable", () => {
     expect(onStatusClick).toHaveBeenCalledWith(expect.objectContaining({ slug: "github" }));
   });
 
+  it("admin mode shows hosted MCP setup rows as an action, not a connected/manage state", () => {
+    const onOpenSetup = vi.fn();
+    renderTable(
+      <AppsTable
+        apps={[APPS[0]]}
+        mode="admin"
+        statusOf={() => ({ label: "Setup", tone: "border-sky-300/25 bg-sky-300/10 text-sky-100" })}
+        actionOf={() => ({ label: "Open setup", onClick: onOpenSetup })}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Open setup" });
+    expect(screen.queryByRole("button", { name: "Setup" })).not.toBeInTheDocument();
+    expect(button).not.toHaveAttribute("title", "Click to manage this connection");
+    fireEvent.click(button);
+    expect(onOpenSetup).toHaveBeenCalledTimes(1);
+  });
+
   it("admin mode exposes manage and disconnect controls on expanded connected rows", () => {
     const onManage = vi.fn();
     const onDisconnect = vi.fn();

--- a/src/components/apps/AppsTable.tsx
+++ b/src/components/apps/AppsTable.tsx
@@ -41,7 +41,7 @@ interface AppsTableProps {
   onToggle?: (slug: string, next: boolean) => void;
   onToggleAll?: (next: boolean) => void;
   statusOf?: (app: AppEntry) => AppStatus | null;
-  /** Admin mode: the single status-column chip. It states the truth AND does the action: Connect / Add key when unconnected, the proven status label (Connected / Key saved) when connected, click always opens the wizard. null = built-in, falls back to the plain status pill. */
+  /** Admin mode: the single status-column chip. It says the action until connected (Connect / Open setup / Add key), then the proven status label. null = built-in, falls back to the plain status pill. */
   actionOf?: (app: AppEntry) => { label: string; onClick: () => void } | null;
   /** Admin mode: shown in expanded connected rows so unlinking an app is discoverable. */
   disconnectOf?: (app: AppEntry) => { label: string; onClick: () => void } | null;
@@ -249,12 +249,12 @@ export function AppsTable({ apps, mode, enabled, onToggle, onToggleAll, statusOf
                   {app.toolCount}
                 </span>
                 <div className="flex items-center justify-end gap-1.5">
-                  {/* One chip per row: it states the truth AND does the action.
+                  {/* One chip per row: action until connected, verified status once connected.
                       (Was an action button next to a status pill; for unconnected
                       rows the pair said the same thing twice.) */}
                   {isAdmin ? (() => {
                     if (action) {
-                      const hasConnection = action.label !== "Connect" && action.label !== "Add key";
+                      const hasConnection = action.label === "Manage";
                       return (
                         <button
                           type="button"

--- a/src/data/app-catalog.generated.json
+++ b/src/data/app-catalog.generated.json
@@ -5558,19 +5558,19 @@
       "tools": [
         {
           "name": "higgsfield_generate_video",
-          "description": "Generate a Higgsfield video from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
+          "description": "Generate a Higgsfield video from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
         },
         {
           "name": "higgsfield_generate_image",
-          "description": "Generate a Higgsfield image from a prompt using the Higgsfield API key connected in UnClick or supplied for this call. Higgsfield bills usage to the connected Higgsfield account."
+          "description": "Generate a Higgsfield image from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
         },
         {
           "name": "higgsfield_get_styles",
-          "description": "List available Higgsfield styles using the Higgsfield API key connected in UnClick or supplied for this call."
+          "description": "List available Higgsfield styles using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
         },
         {
           "name": "higgsfield_get_status",
-          "description": "Check the status of a Higgsfield generation by ID using the Higgsfield API key connected in UnClick or supplied for this call."
+          "description": "Check the status of a Higgsfield generation by ID using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
         }
       ],
       "level": 5,

--- a/src/lib/appCatalog.test.ts
+++ b/src/lib/appCatalog.test.ts
@@ -53,7 +53,8 @@ describe("app catalog integrity", () => {
   it("keeps Higgsfield UnClick actions separate from the hosted MCP setup path", () => {
     const higgsfield = getApp("higgsfield");
     const actionCopy = higgsfield?.tools.map((tool) => tool.description).join(" ") ?? "";
-    expect(actionCopy).toContain("connected in UnClick");
+    expect(actionCopy).toContain("Higgsfield Cloud API key saved in UnClick");
+    expect(actionCopy).not.toContain("connected in UnClick");
     expect(actionCopy).not.toContain("mcp.higgsfield.ai");
   });
 });

--- a/src/pages/admin/AdminSeatHeartbeat.tsx
+++ b/src/pages/admin/AdminSeatHeartbeat.tsx
@@ -29,7 +29,7 @@ export const HEARTBEAT_SHORTCUT_PROMPT =
 export const HEARTBEAT_MASTER_PROMPT = `MASTER: UnClick Action Heartbeat
 
 Role:
-Run as the UnClick Action Heartbeat builder-capable tether. This is not the old read-only watcher. Each wake should move one highest-value safe step with proof.
+Run as the UnClick Action Heartbeat builder-capable tether. Each wake should move one highest-value safe step with proof.
 
 Induction:
 You are entering the UnClick Bubble. Fresh state beats pasted chat. Save or confirm the wake turn, load Memory, then read Orchestrator, Boardroom, Jobs, dispatches, and signals before deciding. Boardroom Jobs are the work source. Orchestrator is context, not queue authority.


### PR DESCRIPTION
## Summary
- show hosted MCP rows as an explicit Open setup action instead of treating Setup as a connected/manage state
- clarify Higgsfield API fallback copy as Higgsfield Cloud API-key usage, separate from hosted MCP setup
- remove old-vault/internal-history wording from product/docs surfaces

## Verification
- npm test
- npm run lint (passes with existing warnings)
- npm run build
- node scripts/generate-app-catalog.mjs --check
- node scripts/generate-connector-setup.mjs --check
- npm run brainmap:check
- npm run prepare:wiring --workspace=@unclick/mcp-server -- --check
- local Playwright smoke for /apps/higgsfield verified corrected copy and absence of old-vault/internal-broker wording