### PR TITLE
[codex] Polish Higgsfield setup copy

### DIFF
--- a/packages/mcp-server/src/connector-setup.test.ts
+++ b/packages/mcp-server/src/connector-setup.test.ts
@@ -52,7 +52,8 @@ describe("connector-setup registry + resolver", () => {
   it("points Higgsfield setup at Cloud API keys and explains hosted MCP honestly", () => {
     const r = notConnectedFor("higgsfield");
     expect(CONNECTOR_SETUP.higgsfield.setupUrl).toBe("https://cloud.higgsfield.ai/api-keys");
-    expect(r.how_to_connect.join(" ")).toContain("hosted MCP uses Higgsfield's own account sign-in");
+    expect(r.how_to_connect.join(" ")).toContain("MCP uses Higgsfield account sign-in");
+    expect(r.how_to_connect.join(" ")).toContain("UnClick to run Higgsfield API actions");
     expect(r.how_to_connect.join(" ")).toContain("HIGGSFIELD_API_KEY");
   });
 });

--- a/packages/mcp-server/src/connector-setup.ts
+++ b/packages/mcp-server/src/connector-setup.ts
@@ -232,7 +232,7 @@ export const CONNECTOR_SETUP: Record<string, ConnectorSetup> = {
     arg:         "api_key",
     envVar:      "HIGGSFIELD_API_KEY",
     setupUrl:    "https://cloud.higgsfield.ai/api-keys",
-    note:        "Higgsfield's hosted MCP uses Higgsfield's own account sign-in. Use an API key here only for UnClick-routed API actions; it does not connect the hosted MCP session back to UnClick.",
+    note:        "Higgsfield's MCP uses Higgsfield account sign-in in your AI app. Add a Cloud API key here only when you want UnClick to run Higgsfield API actions.",
   },
   kling: {
     displayName: "Kling",

--- a/src/components/apps/ConnectAppModal.test.tsx
+++ b/src/components/apps/ConnectAppModal.test.tsx
@@ -109,14 +109,14 @@ describe("ConnectAppModal", () => {
     });
     expect(screen.getByRole("heading", { name: /set up higgsfield/i })).toBeInTheDocument();
     expect(screen.getByText(/use higgsfield's mcp setup/i)).toBeInTheDocument();
-    expect(screen.getByText(/cannot mark it connected here yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/no api key is needed for this mcp path/i)).toBeInTheDocument();
     expect(screen.queryByText(/vault/i)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /open higgsfield mcp setup/i })).toHaveAttribute(
       "href",
       "https://higgsfield.ai/mcp",
     );
-    expect(screen.getByRole("button", { name: /one-click login coming soon/i })).toBeDisabled();
-    expect(screen.getByText(/api key fallback/i)).toBeInTheDocument();
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/unclick api actions/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /where do i get my api key/i })).toHaveAttribute(
       "href",
       "https://cloud.higgsfield.ai/api-keys",

--- a/src/components/apps/ConnectAppModal.tsx
+++ b/src/components/apps/ConnectAppModal.tsx
@@ -237,7 +237,7 @@ export function ConnectAppModal({
                 Higgsfield there. It uses your Higgsfield account, plan, and credits.
               </p>
               <p className="mt-1 text-white/45">
-                Because this sign-in happens with Higgsfield, UnClick cannot mark it connected here yet.
+                No API key is needed for this MCP path. Higgsfield manages that sign-in in your AI app.
               </p>
               <a
                 href="https://higgsfield.ai/mcp"
@@ -251,28 +251,18 @@ export function ConnectAppModal({
             </div>
 
             <div className="rounded-lg border border-white/[0.08] bg-white/[0.025] px-3 py-3">
-              <p className="font-semibold text-white">UnClick-wide login</p>
+              <p className="font-semibold text-white">Use it across your AI apps</p>
               <p className="mt-1 text-white/55">
-                This is the future one-click path. When it is available for Higgsfield, this dialog will open a
-                real sign-in window and the app will show as connected across your UnClick devices.
+                Add the same Higgsfield MCP URL anywhere your AI app supports MCP connectors. For UnClick-run
+                actions on every device, add a Cloud API key below.
               </p>
-              <div className="mt-2 flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  disabled
-                  className="rounded-md border border-white/[0.08] px-2.5 py-1.5 text-[11px] font-semibold text-white/35"
-                >
-                  One-click login coming soon
-                </button>
-                {disconnectButton}
-              </div>
             </div>
 
             <div className="rounded-lg border border-amber-300/15 bg-amber-300/[0.04] px-3 py-3">
-              <p className="font-semibold text-white">API key fallback</p>
+              <p className="font-semibold text-white">UnClick API actions</p>
               <p className="mt-1 text-white/55">
-                Use this only if you specifically want UnClick-routed Higgsfield API actions. It is separate from
-                the hosted MCP account login above.
+                Use this only if you want UnClick itself to run Higgsfield image and video actions. It is separate
+                from Higgsfield's MCP account login above.
               </p>
               {setupUrl && (
                 <a

--- a/src/components/apps/appDetailExtras.tsx
+++ b/src/components/apps/appDetailExtras.tsx
@@ -60,9 +60,8 @@ function HiggsfieldPanel(): ReactNode {
       </div>
       <p className="mt-1.5 text-xs leading-5 text-white/55">
         Higgsfield has two useful setup paths today. For subscription-based MCP, add Higgsfield's MCP URL
-        to your AI app and sign in with Higgsfield there. For UnClick-routed actions, add a Higgsfield
-        Cloud API key in UnClick. One-click account login will appear here when Higgsfield supports a
-        managed connection in UnClick.
+        to your AI app and sign in with Higgsfield there. That uses your Higgsfield account, plan, and
+        credits. For UnClick-routed actions, add a Higgsfield Cloud API key in UnClick.
       </p>
 
       <div className="mt-4 grid gap-4 md:grid-cols-2">
@@ -76,19 +75,19 @@ function HiggsfieldPanel(): ReactNode {
             ]}
           />
           <CommandStack
-            label="UnClick-wide login"
+            label="Subscription MCP"
             commands={[
-              "Coming soon for Higgsfield",
-              "Will show Connected after a real sign-in",
-              "No API key needed when this is available",
+              "No API key needed for the MCP path",
+              "Uses your Higgsfield subscription or credits",
+              "Managed by Higgsfield in your AI app",
             ]}
           />
           <CommandStack
-            label="API key fallback"
+            label="UnClick API actions"
             commands={[
               "Create a Higgsfield Cloud API key",
               "https://cloud.higgsfield.ai/api-keys",
-              "Paste it only for UnClick-routed API actions",
+              "Paste it only when you want UnClick to run Higgsfield actions",
             ]}
           />
         </div>

--- a/src/data/connector-setup.generated.json
+++ b/src/data/connector-setup.generated.json
@@ -195,7 +195,7 @@
       "arg": "api_key",
       "envVar": "HIGGSFIELD_API_KEY",
       "setupUrl": "https://cloud.higgsfield.ai/api-keys",
-      "note": "Higgsfield's hosted MCP uses Higgsfield's own account sign-in. Use an API key here only for UnClick-routed API actions; it does not connect the hosted MCP session back to UnClick."
+      "note": "Higgsfield's MCP uses Higgsfield account sign-in in your AI app. Add a Cloud API key here only when you want UnClick to run Higgsfield API actions."
     },
     "kling": {
       "displayName": "Kling",


### PR DESCRIPTION
## Summary
- Removes the remaining confusing Higgsfield "coming soon" / "cannot mark connected" setup language.
- Frames the two real customer paths clearly: Higgsfield subscription MCP in the AI app, or Higgsfield Cloud API key for UnClick-run actions.
- Updates connector setup help and regression tests so the old wording does not return.

## Checks run locally
- npm test
- npm run lint
- npm run build
- npm run brainmap:check
- node scripts/generate-app-catalog.mjs --check
- node scripts/generate-connector-setup.mjs --check
- npm run prepare:wiring --workspace=@unclick/mcp-server -- --check
- npx vitest run src/components/apps/ConnectAppModal.test.tsx src/components/apps/appLenses.test.ts src/components/apps/AppsTable.test.tsx src/lib/appCatalog.test.ts
- npx vitest run src/connector-setup.test.ts src/higgsfield-tool.test.ts (from packages/mcp-server)

Note: an earlier over-broad npm wrapper invocation passed Vitest but then failed because file arguments were passed to the Node ESM guard; the normal npm test command passed afterward.
