### PR TITLE
Fix MCP pairing for stateless clients (Grok)

### DIFF
--- a/api/mcp-oauth.test.ts
+++ b/api/mcp-oauth.test.ts
@@ -38,8 +38,8 @@ describe("MCP OAuth generic URL support", () => {
 
   it("marks initialize and tools/call as auth-considered by peekRpc", () => {
     // peekRpc flags initialize and tools/call as authRequired so the handler
-    // can enforce the OAuth challenge on the bearer-token path. For bare
-    // public clients (no bearer, no api key) the handler overrides this for
+    // can enforce the OAuth challenge on the bearer-token path. Both the
+    // bearer-token and bare-public-client branches override this for
     // initialize to allow discovery-mode handshake without exposing tenant
     // data. See the pairing test suite for handler-level coverage.
     expect(peekRpc({ jsonrpc: "2.0", id: 1, method: "initialize" }).authRequired).toBe(true);

--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -119,7 +119,8 @@ describe("public MCP pairing door", () => {
     expect(text).toContain("Preferred server URL for every AI app");
     expect(text).toContain("https://unclick.world/api/mcp");
     expect(text).toContain("ready page has private fallback options");
-    expect(text).not.toContain("https://unclick.world/api/mcp/p/");
+    expect(text).toContain("https://unclick.world/api/mcp/p/");
+    expect(text).toContain("session state");
     expect(text).not.toContain("Bearer");
   });
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -646,6 +646,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   } else if (bearerToken) {
     ctx = await validateMcpOAuthAccessToken(bearerToken);
+    if (!ctx) {
+      const publicPairId = publicPairIdFromRequest(req);
+      if (publicPairId) {
+        ctx = await validatePublicMcpPair(publicPairId);
+      }
+    }
     if (!ctx && method === "initialize") {
       ensurePublicPairId(req, res);
       return res.status(200).json({

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -635,6 +635,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   } else if (bearerToken) {
     ctx = await validateMcpOAuthAccessToken(bearerToken);
+    if (!ctx && method === "initialize") {
+      ensurePublicPairId(req, res);
+      return res.status(200).json({
+        jsonrpc: "2.0",
+        result: {
+          protocolVersion: "2025-03-26",
+          capabilities: { tools: {} },
+          serverInfo: { name: "@unclick/mcp-server", version: "0.3.0" },
+        },
+        id: peeked.id,
+      });
+    }
     if (!ctx && peeked.authRequired) {
       attachMcpOAuthChallenge(res, "invalid_token");
       return res.status(401).json({

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -220,23 +220,34 @@ export function pairingToolResult(
 ) {
   const email = typeof args.email === "string" ? args.email.trim() : "";
   const loginUrl = pairingLoginUrl(email, pairId);
+  const lines = [
+    "UnClick is installed, but this AI app is not paired to an UnClick account yet.",
+    "",
+    "Next step:",
+    `Open ${loginUrl}`,
+    "",
+    "Sign in with email, Google, or Microsoft. When the page says UnClick is ready, try the tool again.",
+    "",
+    "Preferred server URL for every AI app:",
+    "https://unclick.world/api/mcp",
+  ];
+  if (isValidPublicMcpPairId(pairId)) {
+    lines.push(
+      "",
+      "If tools still fail after sign-in, this AI app may not keep session state between requests.",
+      `Reconfigure this MCP server with the paired URL instead: ${pairedMcpUrl(pairId)}`,
+      "The paired URL embeds the connection identity in the path so no cookies or headers are needed.",
+    );
+  }
+  lines.push(
+    "",
+    "The ready page has private fallback options only for older apps that cannot keep web sign-in.",
+  );
   return {
     content: [
       {
         type: "text",
-        text: [
-          "UnClick is installed, but this AI app is not paired to an UnClick account yet.",
-          "",
-          "Next step:",
-          `Open ${loginUrl}`,
-          "",
-          "Sign in with email, Google, or Microsoft. When the page says UnClick is ready, try the tool again.",
-          "",
-          "Preferred server URL for every AI app:",
-          "https://unclick.world/api/mcp",
-          "",
-          "If this AI app still shows only Connect UnClick after the ready page, do not keep opening new links. Keep https://unclick.world/api/mcp as the normal server URL. The ready page has private fallback options only for older apps that cannot keep web sign-in.",
-        ].join("\n"),
+        text: lines.join("\n"),
       },
     ],
   };


### PR DESCRIPTION
## Summary

Fixes three independent gaps that prevent stateless MCP clients (Grok) from authenticating via the public pairing flow.

**Commit 1: Discovery-mode initialize for stale OAuth tokens**
- Clients that cache OAuth state from previous attempts send a stale bearer token on retry, routing to the bearer-token branch instead of the bare-public-client branch where the original discovery-mode fix (PR #1533) lives.
- Adds the same discovery-mode initialize handler to the bearer-token branch.

**Commit 2: Paired URL fallback in pairing tool result**
- Clients like Grok don't echo `mcp-session-id` headers or store cookies between requests. The pair ID is lost on every request, so browser pairing never matches.
- The `unclick_start_pairing` tool result now includes the paired URL (`/api/mcp/p/<pairId>`) as a fallback, telling the user to reconfigure the MCP server with that URL if tools still fail after sign-in. The paired URL embeds the connection identity in the path, requiring no cookies or headers.

**Commit 3: Pair ID fallback in bearer-token branch**
- When a client uses the paired URL but also sends a stale OAuth bearer token, the bearer-token branch previously ignored the pair ID and returned 401.
- Now falls through to pair ID resolution before returning 401, so paired URLs work even with leftover OAuth state.

## Expected Grok flow after this PR

1. User adds `https://unclick.world/api/mcp` to Grok
2. Grok completes `initialize` (discovery mode) and `tools/list`
3. Tool call returns 401 with "Call unclick_start_pairing"
4. Grok calls `unclick_start_pairing` - gets login URL AND paired URL
5. User signs in via browser
6. User reconfigures Grok with the paired URL from step 4
7. All tools work - pair ID is in the URL path, no state needed

## Test plan

- [x] All 1,104 API tests pass
- [x] All 20 pairing + OAuth tests pass
- [ ] Test Grok on preview: static URL -> pairing flow -> paired URL reconfigure
- [ ] Test Claude Desktop still works via static URL
- [ ] Verify no regression for API key and OAuth bearer token auth paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjKAn5oAQVfa145SLrW9z4