### PR TITLE
Fix Higgsfield credential sync between OAuth and MCP

### DIFF
--- a/docs/connectors/oauth-connection-checklist.md
+++ b/docs/connectors/oauth-connection-checklist.md
@@ -1,0 +1,123 @@
+# OAuth App Connection Checklist
+
+Learnings from the Higgsfield connection saga. Use this checklist when adding
+any new OAuth/sign-in connector to prevent the same sync gaps.
+
+---
+
+## The problem pattern
+
+UnClick has three credential stores. If an OAuth connector writes to one but
+the tool reads from another, the user connects successfully but the tool says
+"not connected". This happened with Higgsfield because:
+
+1. OAuth callback stored the token in `user_credentials` (via `/api/credentials`)
+2. The tool used `requireCredential()` which only checks args + env vars
+3. `keychain_status` MCP tool only checked `platform_credentials` table
+
+---
+
+## Credential stores (know all three)
+
+| Store | Table | Written by | Read by |
+|-------|-------|-----------|---------|
+| OAuth/Connect path | `user_credentials` | `/api/oauth-callback`, `/api/credentials` POST | vault-bridge `resolveCredentials()`, `/api/credentials` GET, admin_tools merge |
+| Keychain path | `platform_credentials` | `keychain_connect` MCP tool | `keychain_status`, `keychainGetCredential()` |
+| Managed broker path | `managed_app_connections` | `/api/managed-connection-webhook` | `/api/credentials` GET fallback, admin_tools merge |
+
+---
+
+## Checklist for a new OAuth connector
+
+### 1. OAuth flow (api/)
+
+- [ ] Platform added to `ALLOWED_PLATFORMS` in `api/oauth-init.ts`
+- [ ] Token exchange logic added to `api/oauth-callback.ts` (either in
+      `PLATFORM_CONFIGS` or as a custom exchange function)
+- [ ] Redirect URI env vars documented (`{PLATFORM}_CLIENT_ID`,
+      `{PLATFORM}_CLIENT_SECRET`, `{PLATFORM}_REDIRECT_URI`)
+- [ ] `storeCredentials()` call stores the token with field names that match
+      what the tool expects
+
+### 2. Vault-bridge connector config (packages/mcp-server/src/connectors/)
+
+- [ ] Connector config file created: `connectors/{slug}.ts`
+- [ ] Config imported and registered in `connectors/index.ts` CONNECTORS map
+- [ ] `credentialFields[].key` matches the field name stored by OAuth callback
+      (e.g., `access_token`, not `api_key` if OAuth stores `access_token`)
+- [ ] `authType` set to `"oauth2"` so the UI and vault-bridge know the flow
+
+### 3. Tool uses vault-bridge (packages/mcp-server/src/{slug}-tool.ts)
+
+- [ ] Tool imports `resolveCredentials` from `./vault-bridge.js`
+- [ ] Tool calls `await resolveCredentials("{slug}", args)` instead of
+      `requireCredential("{slug}", args)`
+- [ ] Tool handles both `access_token` (from OAuth) and `api_key` (direct)
+      for backward compatibility
+- [ ] Error message includes setup URL for the Connect page
+
+### 4. Connector setup entry (connector-setup.ts)
+
+- [ ] `CONNECTOR_SETUP` row exists for the slug (used by `notConnectedFor()`
+      and the generic "not connected" card if vault-bridge is unavailable)
+- [ ] `setupUrl` points to the provider's key/token page
+
+### 5. Admin UI (src/pages/admin/)
+
+- [ ] `admin_tools` action in `api/memory-admin.ts` merges credentials from
+      all three stores for this platform
+- [ ] Admin UI correctly shows Connected/Add key/Setup based on the merged
+      credential source
+- [ ] If the platform has a hosted MCP (like Higgsfield), the UI separates
+      that option from the UnClick-stored credential
+
+### 6. Tool wiring (packages/mcp-server/src/tool-wiring.ts)
+
+- [ ] Tool descriptions say "Uses your connected {Platform} account or a
+      {credential type}" instead of implying API key is the only option
+- [ ] `api_key` parameter description says "Omit if {Platform} is already
+      connected in UnClick"
+
+### 7. Keychain status (keychain-tool.ts)
+
+- [ ] `keychainStatus()` checks `user_credentials` as fallback when
+      `platform_credentials` has no match (already implemented for all
+      platforms after the Higgsfield fix)
+
+### 8. Test coverage
+
+- [ ] Colocated test file exists: `{slug}-tool.test.ts`
+- [ ] Test covers credential resolution from both inline args and
+      vault-bridge
+- [ ] OAuth callback test covers the platform's token exchange
+
+---
+
+## Field name mapping gotcha
+
+The biggest pitfall: OAuth stores `access_token` but some tools expect
+`api_key`. The vault-bridge resolves by field key from the connector config.
+If the OAuth callback stores `{ access_token: "..." }` but the connector
+config has `credentialFields: [{ key: "api_key" }]`, the bridge will not
+match.
+
+Rule: the connector config's `credentialFields[].key` MUST match the field
+names stored by the OAuth callback. If the tool also accepts a direct
+`api_key` arg, handle that separately (check args.api_key first, then fall
+through to vault-bridge resolution).
+
+---
+
+## Quick diagnostic
+
+If a user reports "connected on dashboard but MCP says not connected":
+
+1. Check which table the credential is in: `user_credentials` or
+   `platform_credentials`
+2. Check if the tool uses `resolveCredentials()` (vault-bridge, reads
+   `user_credentials`) or `requireCredential()` (connector-setup, reads
+   only args + env)
+3. Check if the connector has a config in `connectors/index.ts` (required
+   for vault-bridge)
+4. Check if field names match between what OAuth stored and what the
+   connector config expects

--- a/docs/tool-index.generated.json
+++ b/docs/tool-index.generated.json
@@ -3929,19 +3929,19 @@
     "tools": [
       {
         "name": "higgsfield_generate_video",
-        "description": "Generate a Higgsfield video from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
+        "description": "Generate a Higgsfield video from a prompt. Uses your connected Higgsfield account or a Cloud API key."
       },
       {
         "name": "higgsfield_generate_image",
-        "description": "Generate a Higgsfield image from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
+        "description": "Generate a Higgsfield image from a prompt. Uses your connected Higgsfield account or a Cloud API key."
       },
       {
         "name": "higgsfield_get_styles",
-        "description": "List available Higgsfield styles using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
+        "description": "List available Higgsfield styles. Uses your connected Higgsfield account or a Cloud API key."
       },
       {
         "name": "higgsfield_get_status",
-        "description": "Check the status of a Higgsfield generation by ID using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
+        "description": "Check the status of a Higgsfield generation by ID. Uses your connected Higgsfield account or a Cloud API key."
       }
     ]
   },

--- a/packages/mcp-server/src/connectors/higgsfield.ts
+++ b/packages/mcp-server/src/connectors/higgsfield.ts
@@ -1,0 +1,22 @@
+import type { ConnectorConfig } from "./index.js";
+
+export const higgsFieldConnector: ConnectorConfig = {
+  name: "Higgsfield",
+  slug: "higgsfield",
+  authType: "oauth2",
+  description: "Create images, video, characters, and campaign assets with Higgsfield AI.",
+  scopes: ["openid", "email", "offline_access"],
+  authUrl: "https://mcp.higgsfield.ai/oauth2/authorize",
+  tokenUrl: "https://mcp.higgsfield.ai/oauth2/token",
+  credentialFields: [
+    {
+      key: "access_token",
+      label: "Access Token",
+      description: "OAuth2 bearer token from Higgsfield sign-in, or a Higgsfield Cloud API key.",
+      secret: true,
+      placeholder: "eyJhbG...",
+      findGuideUrl: "https://cloud.higgsfield.ai/api-keys",
+    },
+  ],
+  docsUrl: "https://higgsfield.ai/mcp",
+};

--- a/packages/mcp-server/src/connectors/index.ts
+++ b/packages/mcp-server/src/connectors/index.ts
@@ -51,6 +51,7 @@ import { notionConnector }     from "./notion.js";
 import { raindropConnector }   from "./raindrop.js";
 import { readwiseConnector }   from "./readwise.js";
 import { instapaperConnector } from "./instapaper.js";
+import { higgsFieldConnector } from "./higgsfield.js";
 
 export {
   xeroConnector,
@@ -71,20 +72,21 @@ export {
   raindropConnector,
   readwiseConnector,
   instapaperConnector,
+  higgsFieldConnector,
 };
 
 export const CONNECTORS: Record<string, ConnectorConfig> = {
-  xero:     xeroConnector,
-  shopify:  shopifyConnector,
-  telegram: telegramConnector,
-  discord:  discordConnector,
-  reddit:   redditConnector,
-  slack:    slackConnector,
-  bluesky:  blueskyConnector,
-  mastodon: mastodonConnector,
-  line:     lineConnector,
-  figma:    figmaConnector,
-  splitwise: splitwiseConnector,
+  xero:       xeroConnector,
+  shopify:    shopifyConnector,
+  telegram:   telegramConnector,
+  discord:    discordConnector,
+  reddit:     redditConnector,
+  slack:      slackConnector,
+  bluesky:    blueskyConnector,
+  mastodon:   mastodonConnector,
+  line:       lineConnector,
+  figma:      figmaConnector,
+  splitwise:  splitwiseConnector,
   clockify:   clockifyConnector,
   feedly:     feedlyConnector,
   monica:     monicaConnector,
@@ -92,4 +94,5 @@ export const CONNECTORS: Record<string, ConnectorConfig> = {
   raindrop:   raindropConnector,
   readwise:   readwiseConnector,
   instapaper: instapaperConnector,
+  higgsfield: higgsFieldConnector,
 };

--- a/packages/mcp-server/src/higgsfield-tool.ts
+++ b/packages/mcp-server/src/higgsfield-tool.ts
@@ -1,17 +1,37 @@
 // Higgsfield AI API integration for the UnClick MCP server.
 // Uses the Higgsfield REST API via fetch - no external dependencies.
-// This REST connector accepts api_key or HIGGSFIELD_API_KEY. Higgsfield's hosted
-// MCP uses Higgsfield's own account sign-in at https://mcp.higgsfield.ai/mcp.
+// Credentials are auto-resolved via vault-bridge:
+//   1. Inline args (api_key or access_token passed directly)
+//   2. Env vars  UNCLICK_HIGGSFIELD_ACCESS_TOKEN or HIGGSFIELD_API_KEY
+//   3. Local vault  key "higgsfield/access_token"
+//   4. Supabase  via UNCLICK_API_KEY + unclick.world/api/credentials
+//     (includes tokens stored by Higgsfield OAuth sign-in)
 
-import { requireCredential } from "./connector-setup.js";
-import { type NotConnectedResult } from "./connection-help.js";
+import { resolveCredentials } from "./vault-bridge.js";
 import { stampMeta } from "./connector-meta.js";
 const HF_API_BASE = "https://api.higgsfield.ai/v1";
 
-// ─── Auth validation ──────────────────────────────────────────────────────────
+// ─── Auth resolution ──────────────────────────────────────────────────────────
 
-function requireKey(args: Record<string, unknown>): string | NotConnectedResult {
-  return requireCredential("higgsfield", args);
+async function resolveKey(
+  args: Record<string, unknown>
+): Promise<string | Record<string, unknown>> {
+  const directKey = String(args.api_key ?? "").trim();
+  if (directKey) return directKey;
+
+  const resolved = await resolveCredentials("higgsfield", args);
+  if ("error" in resolved) return resolved;
+
+  const token =
+    String(resolved.access_token ?? "").trim() ||
+    String(resolved.api_key ?? "").trim();
+  if (!token) {
+    return {
+      error: "Higgsfield credentials not configured. Connect Higgsfield at https://unclick.world/admin/apps or pass api_key.",
+      setup: { web: "https://unclick.world/connect/higgsfield" },
+    };
+  }
+  return token;
 }
 
 // ─── API helpers ──────────────────────────────────────────────────────────────
@@ -83,7 +103,7 @@ async function hfPost<T>(apiKey: string, path: string, body: unknown): Promise<T
 // ─── Operations ───────────────────────────────────────────────────────────────
 
 export async function higgsfield_generate_video(args: Record<string, unknown>): Promise<unknown> {
-  const apiKey = requireKey(args);
+  const apiKey = await resolveKey(args);
   if (typeof apiKey !== "string") return apiKey;
   const prompt = String(args.prompt ?? "").trim();
   if (!prompt) throw new Error("prompt is required.");
@@ -107,7 +127,7 @@ export async function higgsfield_generate_video(args: Record<string, unknown>): 
 }
 
 export async function higgsfield_generate_image(args: Record<string, unknown>): Promise<unknown> {
-  const apiKey = requireKey(args);
+  const apiKey = await resolveKey(args);
   if (typeof apiKey !== "string") return apiKey;
   const prompt = String(args.prompt ?? "").trim();
   if (!prompt) throw new Error("prompt is required.");
@@ -131,7 +151,7 @@ export async function higgsfield_generate_image(args: Record<string, unknown>): 
 }
 
 export async function higgsfield_get_styles(args: Record<string, unknown>): Promise<unknown> {
-  const apiKey = requireKey(args);
+  const apiKey = await resolveKey(args);
   if (typeof apiKey !== "string") return apiKey;
   const data = await hfGet<{ styles?: unknown[]; data?: unknown[] }>(apiKey, "/styles");
 
@@ -143,7 +163,7 @@ export async function higgsfield_get_styles(args: Record<string, unknown>): Prom
 }
 
 export async function higgsfield_get_status(args: Record<string, unknown>): Promise<unknown> {
-  const apiKey = requireKey(args);
+  const apiKey = await resolveKey(args);
   if (typeof apiKey !== "string") return apiKey;
   const generationId = String(args.generation_id ?? "").trim();
   if (!generationId) throw new Error("generation_id is required.");

--- a/packages/mcp-server/src/keychain-tool.ts
+++ b/packages/mcp-server/src/keychain-tool.ts
@@ -476,7 +476,29 @@ async function keychainStatus(args: Record<string, unknown>): Promise<unknown> {
 
   if (!ok) return { error: "Failed to query credentials." };
 
-  const rows = data as Array<Record<string, unknown>>;
+  let rows = data as Array<Record<string, unknown>>;
+
+  // Fallback: also check user_credentials (OAuth/Connect flow store).
+  // The admin UI already merges both tables; keep the MCP tool consistent.
+  if ((!rows || rows.length === 0)) {
+    const ucUrl = `${supaUrl}/rest/v1/user_credentials?api_key_hash=eq.${encodeURIComponent(keyHash)}&select=platform_slug,label,is_valid,last_tested_at,created_at,updated_at`
+      + (platform ? `&platform_slug=eq.${encodeURIComponent(platform)}` : "");
+    const ucResult = await sbFetch(ucUrl, "GET", sbHeaders(serviceKey));
+    if (ucResult.ok) {
+      const ucRows = ucResult.data as Array<Record<string, unknown>>;
+      if (ucRows && ucRows.length > 0) {
+        rows = ucRows.map((r) => ({
+          platform:       r.platform_slug,
+          label:          r.label,
+          is_valid:       r.is_valid !== false,
+          last_tested_at: r.last_tested_at,
+          created_at:     r.created_at,
+          source:         "user_credentials",
+        }));
+      }
+    }
+  }
+
   if (!rows || rows.length === 0) {
     if (platform) {
       return { platform, connected: false, message: `No credential stored for "${platform}".` };

--- a/packages/mcp-server/src/memory/tool-index.generated.ts
+++ b/packages/mcp-server/src/memory/tool-index.generated.ts
@@ -3943,19 +3943,19 @@ export const TOOL_INDEX: ToolIndexEntry[] = [
     "tools": [
       {
         "name": "higgsfield_generate_video",
-        "description": "Generate a Higgsfield video from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
+        "description": "Generate a Higgsfield video from a prompt. Uses your connected Higgsfield account or a Cloud API key."
       },
       {
         "name": "higgsfield_generate_image",
-        "description": "Generate a Higgsfield image from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account."
+        "description": "Generate a Higgsfield image from a prompt. Uses your connected Higgsfield account or a Cloud API key."
       },
       {
         "name": "higgsfield_get_styles",
-        "description": "List available Higgsfield styles using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
+        "description": "List available Higgsfield styles. Uses your connected Higgsfield account or a Cloud API key."
       },
       {
         "name": "higgsfield_get_status",
-        "description": "Check the status of a Higgsfield generation by ID using a Higgsfield Cloud API key saved in UnClick or supplied for this call."
+        "description": "Check the status of a Higgsfield generation by ID. Uses your connected Higgsfield account or a Cloud API key."
       }
     ]
   },

--- a/packages/mcp-server/src/tool-wiring.ts
+++ b/packages/mcp-server/src/tool-wiring.ts
@@ -17057,12 +17057,12 @@ export const ADDITIONAL_TOOLS = [
   // ── higgsfield-tool.ts ────────────────────────────────────────────────────────
   {
     name: "higgsfield_generate_video",
-    description: "Generate a Higgsfield video from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account.",
+    description: "Generate a Higgsfield video from a prompt. Uses your connected Higgsfield account or a Cloud API key.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key. Omit if Higgsfield is already connected in UnClick." },
         prompt: { type: "string", description: "Text description of the video to generate" },
         style: { type: "string", description: "Soul Style name (use higgsfield_get_styles to list available styles)" },
         duration: { type: "number", description: "Video duration in seconds" },
@@ -17075,12 +17075,12 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "higgsfield_generate_image",
-    description: "Generate a Higgsfield image from a prompt using a Higgsfield Cloud API key saved in UnClick or supplied for this call. Higgsfield bills usage to that Higgsfield account.",
+    description: "Generate a Higgsfield image from a prompt. Uses your connected Higgsfield account or a Cloud API key.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key. Omit if Higgsfield is already connected in UnClick." },
         prompt: { type: "string", description: "Text description of the image to generate" },
         style: { type: "string", description: "Style name (use higgsfield_get_styles to list available styles)" },
         width: { type: "number", description: "Image width in pixels" },
@@ -17093,24 +17093,24 @@ export const ADDITIONAL_TOOLS = [
   },
   {
     name: "higgsfield_get_styles",
-    description: "List available Higgsfield styles using a Higgsfield Cloud API key saved in UnClick or supplied for this call.",
+    description: "List available Higgsfield styles. Uses your connected Higgsfield account or a Cloud API key.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key. Omit if Higgsfield is already connected in UnClick." },
       },
       required: [],
     },
   },
   {
     name: "higgsfield_get_status",
-    description: "Check the status of a Higgsfield generation by ID using a Higgsfield Cloud API key saved in UnClick or supplied for this call.",
+    description: "Check the status of a Higgsfield generation by ID. Uses your connected Higgsfield account or a Cloud API key.",
     inputSchema: {
       type: "object" as const,
       additionalProperties: false,
       properties: {
-        api_key: { type: "string", description: "Optional Higgsfield Cloud API key for this call. You can also save a Higgsfield API key in UnClick or set HIGGSFIELD_API_KEY on the MCP server." },
+        api_key: { type: "string", description: "Optional Higgsfield Cloud API key. Omit if Higgsfield is already connected in UnClick." },
         generation_id: { type: "string", description: "Generation ID returned by higgsfield_generate_video or higgsfield_generate_image" },
       },
       required: ["generation_id"],


### PR DESCRIPTION
## Summary

- **Root cause**: Higgsfield OAuth stores tokens in `user_credentials` table, but the MCP tool used `requireCredential()` which only checks inline args and env vars - never Supabase. Meanwhile `keychain_status` only checked `platform_credentials`. Result: user connects on dashboard, MCP says "not connected".
- **Fix**: Switch Higgsfield tool to vault-bridge (`resolveCredentials`), add connector config so vault-bridge knows about Higgsfield, and add `user_credentials` fallback to `keychain_status`.
- **Docs**: Added OAuth connection checklist to prevent the same gap for future connectors.

## Changes

| File | What changed |
|------|-------------|
| `packages/mcp-server/src/connectors/higgsfield.ts` | New connector config (authType oauth2, credentialField key `access_token`) |
| `packages/mcp-server/src/connectors/index.ts` | Register Higgsfield in CONNECTORS map |
| `packages/mcp-server/src/higgsfield-tool.ts` | Switch from `requireCredential` to `resolveCredentials` (vault-bridge), handle both `access_token` and `api_key` |
| `packages/mcp-server/src/keychain-tool.ts` | `keychainStatus()` falls back to `user_credentials` when `platform_credentials` has no match |
| `packages/mcp-server/src/tool-wiring.ts` | Update Higgsfield tool descriptions to reflect OAuth connection option |
| `docs/connectors/oauth-connection-checklist.md` | New checklist for adding OAuth connectors (learnings from Higgsfield saga) |

## Test plan

- [x] All 1881 root tests pass
- [x] All 7 MCP package tests pass (including 4 Higgsfield-specific)
- [x] Website build succeeds
- [ ] Manual: Connect Higgsfield via OAuth popup on /admin/apps, then call `higgsfield_get_styles` via MCP without passing api_key
- [ ] Manual: `keychain_status` with platform=higgsfield shows connected after OAuth sign-in
- [ ] Manual: Direct `api_key` arg still works (backward compat)

---
_Generated by [Claude Code](https://claude.ai/code/session_0185vFGgUyGNUYiYEHfRJQBZ)_