### PR TITLE
[codex] Wrap Higgsfield MCP native params

### DIFF
--- a/packages/mcp-server/src/higgsfield-tool.test.ts
+++ b/packages/mcp-server/src/higgsfield-tool.test.ts
@@ -113,10 +113,12 @@ describe("higgsfield connector resilience (L2)", () => {
         const params = body.params as Record<string, unknown>;
         expect(params.name).toBe("generate_image");
         expect(params.arguments).toMatchObject({
+          params: {
           prompt: "a studio photo of a dog",
           model: "nano_banana_pro",
           resolution: "2k",
           aspect_ratio: "4:3",
+          },
         });
         return jsonResponse({
           jsonrpc: "2.0",

--- a/packages/mcp-server/src/higgsfield-tool.ts
+++ b/packages/mcp-server/src/higgsfield-tool.ts
@@ -429,7 +429,7 @@ async function callNativeHiggsfieldTool(
     const called = await mcpRequest({
       credentials: session.credentials,
       method: "tools/call",
-      params: { name: toolName, arguments: toolArgs },
+      params: { name: toolName, arguments: { params: toolArgs } },
       sessionId: session.sessionId,
     });
     return stampMeta({
@@ -450,7 +450,7 @@ async function callNativeHiggsfieldTool(
     const called = await mcpRequest({
       credentials: session.credentials,
       method: "tools/call",
-      params: { name: toolName, arguments: toolArgs },
+      params: { name: toolName, arguments: { params: toolArgs } },
       sessionId: session.sessionId,
     });
     return stampMeta({


### PR DESCRIPTION
## What changed
- Wrap native Higgsfield MCP tool arguments as `{ params: ... }` when UnClick calls Higgsfield's hosted MCP.
- Keep UnClick's public tool response metadata unchanged so customers still see the friendly request fields.
- Update the Higgsfield connector test to lock this native MCP call shape.

## Why
A live production smoke test reached the customer's signed-in Higgsfield MCP account, but Higgsfield rejected the call with `Invalid arguments ... path ["params"]`. Their native `generate_image` tool expects the payload inside a `params` object.

## Validation
- `npm run build --workspace=@unclick/mcp-server`
- `npm test --workspace=@unclick/mcp-server`
