### PR TITLE
Add connector readiness XPass guard

### DIFF
--- a/docs/UnClick-brainmap.generated.json
+++ b/docs/UnClick-brainmap.generated.json
@@ -16754,8 +16754,8 @@
     },
     {
       "source": "scripts/pinballwake-xpass-gate-room.mjs",
-      "hash": "576e3adc43b6",
-      "bytes": 34902
+      "hash": "dd9f6112cdcd",
+      "bytes": 35072
     },
     {
       "source": "packages/mcp-server/src/abn-tool.ts",

--- a/docs/UnClick-brainmap.generated.md
+++ b/docs/UnClick-brainmap.generated.md
@@ -200,7 +200,7 @@ Internal admin only. Auto-generated from tracked source so new AI seats can unde
 | scripts/pinballwake-rollback-room.mjs | c63e73fd2716 | 4158 |
 | scripts/pinballwake-stale-room.mjs | 8927de850588 | 3880 |
 | scripts/pinballwake-worker-registry-room.mjs | e8c9f4a764e3 | 20616 |
-| scripts/pinballwake-xpass-gate-room.mjs | 576e3adc43b6 | 34902 |
+| scripts/pinballwake-xpass-gate-room.mjs | dd9f6112cdcd | 35072 |
 | packages/mcp-server/src/abn-tool.ts | 981031e37dee | 6329 |
 | packages/mcp-server/src/abstract-holidays-tool.ts | 3d58cdb9aa5a | 1559 |
 | packages/mcp-server/src/abuseipdb-tool.ts | c3c7f2d8566c | 6263 |

--- a/docs/adding-a-connector.md
+++ b/docs/adding-a-connector.md
@@ -137,6 +137,9 @@ must pass `npm run check:app-connections`, or
 `node scripts/check-app-connection-readiness.mjs --platform=<slug>` for a single
 slug. This checks catalog visibility, provider-login UX, setup-pending fallback,
 OAuth start/callback parity, credential storage, and MCP/keychain status parity.
+Before calling production live, also run
+`node scripts/check-app-connection-readiness.mjs --platform=<slug> --live-url=https://unclick.world`
+so missing provider client ID/secret env vars are caught before users find them.
 
 ---
 
@@ -236,6 +239,7 @@ cd ../.. && npm run brainmap:check                                # brainmap in 
 node scripts/generate-app-catalog.mjs --check                     # app catalog in sync
 npx vitest run src/lib/appCatalog.test.ts src/lib/appCatalog.copyqc.test.ts   # catalog integrity + simple-English copy
 npm run check:app-connections                                     # login-first app readiness and keychain parity
+node scripts/check-app-connection-readiness.mjs --platform=<slug> --live-url=https://unclick.world # production OAuth env proof
 ```
 
 The MCP `test` script chains the `--check` gates; if it exits non-zero after the
@@ -273,6 +277,8 @@ are doing the full OAuth flow. Confirm the slug is not already in
 - [ ] `connector-setup.ts`: `CONNECTOR_SETUP` row
 - [ ] `generate-app-catalog.mjs`: category bucket (+ name/blurb/domain)
 - [ ] Login-first/OAuth app: `npm run check:app-connections` or single-platform readiness check
+- [ ] Public OAuth app: live readiness check with `--live-url=https://unclick.world`
+- [ ] XPass: ConnectorPass receipt is present for connector/OAuth/keychain changes
 - [ ] (optional) L3 registry / L4 signal
 - [ ] Regenerate in order: tool-index -> ladder -> app-catalog -> connector-setup -> brainmap
 - [ ] `tsc` + MCP `test` chain + `brainmap:check` + app-catalog `--check` + frontend catalog tests

--- a/docs/connectors/app-connection-readiness.md
+++ b/docs/connectors/app-connection-readiness.md
@@ -28,6 +28,12 @@ For one app:
 node scripts/check-app-connection-readiness.mjs --platform=vercel
 ```
 
+For production env proof:
+
+```bash
+node scripts/check-app-connection-readiness.mjs --platform=supabase --live-url=https://unclick.world
+```
+
 The guard verifies:
 
 - The app exists in `src/data/app-catalog.generated.json` in a real category.
@@ -51,6 +57,9 @@ The guard verifies:
   `packages/mcp-server/src/keychain-tool.ts` all see the same connection
   sources: `platform_credentials`, `user_credentials`, and
   `managed_app_connections`.
+- When `--live-url` is passed, production `/api/oauth-init` returns a
+  provider-ready login payload and not `setup_pending`. This catches the exact
+  "code is live, Vercel env is missing client ID/client secret" failure.
 
 Regression tests live in:
 
@@ -67,6 +76,7 @@ Connector login work is now routed through the XPass gate room. Changes touching
 OAuth app connections, credential storage, connect pages, catalog/icon
 visibility, or keychain status select:
 
+- ConnectorPass for the combined app-bubble connection contract
 - TestPass for deterministic readiness proof
 - UXPass for login and fallback experience
 - FlowPass for the OAuth journey
@@ -80,12 +90,14 @@ visibility, or keychain status select:
 Before telling a user "live":
 
 1. Run `npm run check:app-connections`.
-2. Confirm the app appears in `/admin/apps` search.
-3. Open `/connect/:slug` and confirm provider login is the primary path.
-4. Confirm setup-pending errors keep the token fallback visible.
-5. After connecting, check the app status from the MCP/keychain side, not only
+2. Run the production check:
+   `node scripts/check-app-connection-readiness.mjs --platform=<slug> --live-url=https://unclick.world`.
+3. Confirm the app appears in `/admin/apps` search.
+4. Open `/connect/:slug` and confirm provider login is the primary path.
+5. Confirm setup-pending errors keep the token fallback visible.
+6. After connecting, check the app status from the MCP/keychain side, not only
    the dashboard badge.
-6. For production, confirm the deployed alias is live and the same checks pass
+7. For production, confirm the deployed alias is live and the same checks pass
    against the production account context.
 
 ## Provider notes

--- a/packages/mcp-server/src/xpass-aggregated-verdict-tool.test.ts
+++ b/packages/mcp-server/src/xpass-aggregated-verdict-tool.test.ts
@@ -77,6 +77,31 @@ describe("xpass_aggregated_verdict", () => {
     expect(result.receipt?.full_checklist?.some((item) => item.check === "fidelitypass" && item.status === "N/A")).toBe(true);
   });
 
+  it("routes connector OAuth work through ConnectorPass readiness proof", async () => {
+    const result = await xpassAggregatedVerdict({
+      target: { type: "pr", id: "1522", sha: "connector-head" },
+      title: "Supabase Vercel app connection rollout",
+      description: "Provider login, token fallback, connected badge, and keychain parity must agree.",
+      changed_files: [
+        "src/lib/connectors.ts",
+        "api/oauth-init.ts",
+        "src/pages/Connect.tsx",
+        "packages/mcp-server/src/keychain-tool.ts",
+        "scripts/check-app-connection-readiness.mjs",
+      ],
+    }) as XPassResult;
+
+    expect(result.verdict).toBe("pending");
+    expect(result.missing_checks).toContain("connectorpass");
+    expect(result.missing_checks).toContain("uxpass");
+    expect(result.missing_checks).toContain("flowpass");
+    expect(result.missing_checks).toContain("securitypass");
+    expect(result.missing_checks).toContain("rotatepass");
+    expect(result.missing_checks).toContain("commonsensepass");
+    expect(result.receipt?.full_checklist?.some((item) => item.check === "connectorpass" && item.status === "MISSING")).toBe(true);
+    expect(result.receipt?.action_needed?.join("\n")).toMatch(/Run ConnectorPass/);
+  });
+
   it("fails stale receipts generated for an older head", async () => {
     const result = await xpassAggregatedVerdict({
       target: { type: "pr", id: "547", sha: "new-head" },

--- a/packages/mcp-server/src/xpass-aggregated-verdict-tool.ts
+++ b/packages/mcp-server/src/xpass-aggregated-verdict-tool.ts
@@ -7,6 +7,7 @@ const CHECK_ORDER = [
   "flowpass",
   "securitypass",
   "rotatepass",
+  "connectorpass",
   "copypass",
   "fidelitypass",
   "seopass",
@@ -61,6 +62,7 @@ const CHECK_LABELS: Record<XPassCheck, string> = {
   flowpass: "FlowPass",
   securitypass: "SecurityPass",
   rotatepass: "RotatePass",
+  connectorpass: "ConnectorPass",
   copypass: "CopyPass",
   fidelitypass: "FidelityPass",
   seopass: "SEOPass",
@@ -89,6 +91,7 @@ const PASS_PRODUCT_CHECKS = new Map<string, XPassCheck>([
   ["uxpass", "uxpass"],
   ["wakepass", "wakepass"],
   ["rotatepass", "rotatepass"],
+  ["connectorpass", "connectorpass"],
 ]);
 
 const ENTERPRISE_READINESS_TERMS = [
@@ -100,6 +103,41 @@ const ENTERPRISE_READINESS_TERMS = [
   "model inventory",
   "technical documentation",
   "training data",
+];
+
+const APP_CONNECTION_SURFACE_PATHS = [
+  "src/lib/connectors.ts",
+  "src/data/app-catalog.generated.json",
+  "src/data/connector-setup.generated.json",
+  "src/pages/connect",
+  "src/components/apps/connectappmodal",
+  "src/components/apps/appicon",
+  "packages/mcp-server/src/connector-setup.ts",
+  "packages/mcp-server/src/keychain-tool.ts",
+  "scripts/check-app-connection-readiness",
+  "api/oauth-init.ts",
+  "api/oauth-callback.ts",
+  "api/oauth-state.ts",
+  "api/credentials.ts",
+  "api/lib/managed-connections",
+  "api/memory-admin.ts",
+];
+
+const APP_CONNECTION_TERMS = [
+  "app connection",
+  "app connector",
+  "connector rollout",
+  "connect page",
+  "provider login",
+  "oauth login",
+  "oauth setup",
+  "keychain parity",
+  "token fallback",
+  "connected badge",
+  "setup pending",
+  "managed connection",
+  "compatibility connector",
+  "hosted mcp",
 ];
 
 const COUNCIL_TRIGGER_TERMS = [
@@ -464,6 +502,11 @@ function selectXPassChecks(input: Record<string, unknown> = {}): SelectedCheck[]
     const pathWords = path.replace(/[/_.-]+/g, " ");
     const passProduct = passProductForPath(path);
 
+    if (appConnectionSurface(path, allText)) {
+      addAppConnectionReasons(reasons, path);
+      if (codeFile(path) && !testFile(path)) addReason(reasons, "sloppass", `app connection implementation quality surface: ${path}`);
+    }
+
     if (passProduct) {
       addReason(reasons, "testpass", `XPass product implementation needs proof tests: ${path}`);
       addReason(reasons, passProduct, `XPass product should dogfood its own specialist check: ${path}`);
@@ -541,6 +584,7 @@ function selectXPassChecks(input: Record<string, unknown> = {}): SelectedCheck[]
   }
 
   if (hasAny(allText, ["mcp", "tool", "tools", "connector", "connectors", "api endpoint", "native endpoint"])) addReason(reasons, "testpass", "target text mentions tools/connectors/MCP");
+  if (hasAny(allText, APP_CONNECTION_TERMS)) addAppConnectionReasons(reasons, "target text mentions app connection readiness");
   if (hasAny(allText, ["ui", "visual", "screen", "screenshots", "dashboard", "admin page", "admin ui", "admin screen", "admin dashboard", "layout", "spacing", "typography", "mobile", "responsive", "accessibility", "wcag", "keyboard", "screen reader", "focus", "target size"])) addReason(reasons, "uipass", "target text mentions UI/visual changes");
   if (hasAny(allText, ["ux", "usability", "easy to use", "journey", "navigation", "onboarding", "form", "forms", "feedback", "recovery", "confusion", "task completion", "user path"])) addReason(reasons, "uxpass", "target text mentions UX/journey changes");
   if (hasAny(allText, ["flow", "journey", "path", "route", "checkout", "signup", "sign up", "onboarding", "handoff", "navigation", "funnel", "success state", "failure state"])) addReason(reasons, "flowpass", "target text mentions journey/flow completion");
@@ -729,6 +773,21 @@ function passProductForPath(path: string): XPassCheck | "" {
 
 function enterpriseReadinessSurface(path: string, allText: string): boolean {
   return path.includes("enterprise") || path.includes("compliance") || path.startsWith("public/enterprise/") || hasAny(allText, ENTERPRISE_READINESS_TERMS);
+}
+
+function appConnectionSurface(path: string, allText: string): boolean {
+  return APP_CONNECTION_SURFACE_PATHS.some((surfacePath) => path.includes(surfacePath))
+    || (path.startsWith("supabase/migrations/") && hasAny(allText, APP_CONNECTION_TERMS));
+}
+
+function addAppConnectionReasons(map: Map<XPassCheck, Set<string>>, reason: string): void {
+  addReason(map, "connectorpass", `app connector readiness proof: ${reason}`);
+  addReason(map, "testpass", `app connection readiness needs deterministic proof: ${reason}`);
+  addReason(map, "uxpass", `provider login and fallback UX surface: ${reason}`);
+  addReason(map, "flowpass", `OAuth login journey surface: ${reason}`);
+  addReason(map, "securitypass", `credential/OAuth storage surface: ${reason}`);
+  addReason(map, "rotatepass", `credential lifecycle/redaction surface: ${reason}`);
+  addReason(map, "commonsensepass", `connected badge must match tool-facing keychain proof: ${reason}`);
 }
 
 function normalizeCheckName(value: unknown): string {

--- a/scripts/check-app-connection-readiness.mjs
+++ b/scripts/check-app-connection-readiness.mjs
@@ -46,6 +46,10 @@ function getArgValue(name, fallback = "") {
   return found ? found.slice(prefix.length) : fallback;
 }
 
+function hasFlag(name) {
+  return process.argv.includes(`--${name}`);
+}
+
 function getPlatformArgs() {
   return process.argv
     .filter((arg) => arg.startsWith("--platform="))
@@ -162,6 +166,26 @@ function addCheck(checks, name, ok, message, details = {}) {
 
 function missingChecks(checks) {
   return checks.filter((check) => check.status !== "pass");
+}
+
+function receiptBlockers(receipt) {
+  return [
+    ...missingChecks(receipt.global_checks).map((check) => ({ scope: "global", ...check })),
+    ...receipt.platform_results.flatMap((result) => missingChecks(result.checks).map((check) => ({
+      scope: result.platform,
+      ...check,
+    }))),
+  ];
+}
+
+function refreshReceiptStatus(receipt) {
+  for (const result of receipt.platform_results) {
+    result.status = missingChecks(result.checks).length === 0 ? "pass" : "blocker";
+  }
+  const blockers = receiptBlockers(receipt);
+  receipt.status = blockers.length === 0 ? "pass" : "blocker";
+  receipt.action_needed = blockers.map((check) => `${check.scope}: ${check.name} - ${check.message}`);
+  return receipt;
 }
 
 async function readSourceFile(cwd, sourcePath) {
@@ -404,37 +428,114 @@ export function evaluateConnectionReadinessSources(
     });
   }
 
-  const blockers = [
-    ...missingChecks(globalChecks).map((check) => ({ scope: "global", ...check })),
-    ...results.flatMap((result) => missingChecks(result.checks).map((check) => ({
-      scope: result.platform,
-      ...check,
-    }))),
-  ];
-
-  return {
+  return refreshReceiptStatus({
     kind: "app_connection_readiness_receipt_v1",
     generated_at: now,
-    status: blockers.length === 0 ? "pass" : "blocker",
+    status: "pass",
     platforms,
     global_checks: globalChecks,
     platform_results: results,
-    action_needed: blockers.map((check) => `${check.scope}: ${check.name} - ${check.message}`),
-  };
+    action_needed: [],
+  });
+}
+
+function normalizeLiveUrl(liveUrl) {
+  const trimmed = String(liveUrl ?? "").trim();
+  if (!trimmed) return "";
+  return trimmed.replace(/\/+$/, "");
+}
+
+function missingText(data) {
+  const missingFields = Array.isArray(data?.missing_fields)
+    ? data.missing_fields
+    : (data?.missing ? [data.missing] : []);
+  return missingFields.length ? missingFields.join(",") : "unknown";
+}
+
+export async function addLiveConnectionReadinessChecks(receipt, options = {}) {
+  const liveUrl = normalizeLiveUrl(options.liveUrl ?? process.env.APP_CONNECTION_LIVE_URL);
+  if (!liveUrl) return receipt;
+
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    addCheck(
+      receipt.global_checks,
+      "live_fetch_available",
+      false,
+      "Live app-connection readiness needs a fetch implementation."
+    );
+    return refreshReceiptStatus(receipt);
+  }
+
+  const apiKey = String(options.apiKey ?? process.env.APP_CONNECTION_PROBE_API_KEY ?? "uc_app_connection_readiness_probe");
+  const endpoint = `${liveUrl}/api/oauth-init`;
+  const livePlatforms = unique(options.platforms?.length ? options.platforms : receipt.platforms);
+
+  for (const platform of livePlatforms) {
+    const platformResult = receipt.platform_results.find((result) => result.platform === platform);
+    if (!platformResult) continue;
+
+    try {
+      const response = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ platform, api_key: apiKey }),
+      });
+      const data = await response.json().catch(() => ({}));
+      const ok = Boolean(
+        response.ok
+        && data?.success === true
+        && typeof data?.client_id === "string"
+        && data.client_id.length > 0
+        && typeof data?.redirect_uri === "string"
+        && data.redirect_uri.length > 0
+        && data?.setup_pending !== true
+      );
+      const setupPending = data?.setup_pending === true;
+      addCheck(
+        platformResult.checks,
+        "live_oauth_init_ready",
+        ok,
+        setupPending
+          ? `Production OAuth init is still setup-pending; missing ${missingText(data)}.`
+          : "Production OAuth init returns a provider-ready login payload, not setup-pending.",
+        {
+          live_url: liveUrl,
+          http_status: response.status,
+          setup_pending: setupPending,
+          missing_fields: Array.isArray(data?.missing_fields) ? data.missing_fields : [],
+        }
+      );
+    } catch (error) {
+      addCheck(
+        platformResult.checks,
+        "live_oauth_init_ready",
+        false,
+        `Production OAuth init could not be checked: ${error instanceof Error ? error.message : String(error)}.`,
+        { live_url: liveUrl }
+      );
+    }
+  }
+
+  return refreshReceiptStatus(receipt);
 }
 
 export async function evaluateConnectionReadiness(options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const sources = await loadConnectionReadinessSources(cwd);
-  return evaluateConnectionReadinessSources(sources, options);
+  const receipt = evaluateConnectionReadinessSources(sources, options);
+  return addLiveConnectionReadinessChecks(receipt, options);
 }
 
 async function main() {
   const cwd = getArgValue("cwd", process.cwd());
   const platforms = getPlatformArgs();
+  const liveUrl = getArgValue("live-url", process.env.APP_CONNECTION_LIVE_URL ?? "");
+  const live = hasFlag("live") || Boolean(liveUrl);
   const receipt = await evaluateConnectionReadiness({
     cwd,
     platforms: platforms.length ? platforms : undefined,
+    liveUrl: live ? liveUrl : "",
   });
   console.log(JSON.stringify(receipt, null, 2));
   process.exitCode = receipt.status === "pass" ? 0 : 1;

--- a/scripts/check-app-connection-readiness.test.mjs
+++ b/scripts/check-app-connection-readiness.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  addLiveConnectionReadinessChecks,
   evaluateConnectionReadinessSources,
   loadConnectionReadinessSources,
 } from "./check-app-connection-readiness.mjs";
@@ -103,5 +104,52 @@ describe("app connection readiness", () => {
     assert.equal(receipt.status, "blocker");
     assert.match(actionText(receipt), /oauth_init_supported/);
     assert.match(actionText(receipt), /oauth_env_names_match_start_and_callback/);
+  });
+
+  it("blocks when production OAuth init is still setup-pending", async () => {
+    const sources = await loadConnectionReadinessSources(process.cwd());
+    const receipt = evaluateConnectionReadinessSources(sources, {
+      platforms: ["supabase"],
+      now: "2026-06-18T00:00:00.000Z",
+    });
+
+    await addLiveConnectionReadinessChecks(receipt, {
+      liveUrl: "https://unclick.world",
+      fetchImpl: async () => new Response(JSON.stringify({
+        setup_pending: true,
+        missing_fields: ["client_id", "client_secret"],
+      }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    });
+
+    assert.equal(receipt.status, "blocker");
+    assert.match(actionText(receipt), /supabase: live_oauth_init_ready/);
+    assert.match(actionText(receipt), /client_id,client_secret/);
+  });
+
+  it("passes the live OAuth init check when production returns a provider-ready payload", async () => {
+    const sources = await loadConnectionReadinessSources(process.cwd());
+    const receipt = evaluateConnectionReadinessSources(sources, {
+      platforms: ["supabase"],
+      now: "2026-06-18T00:00:00.000Z",
+    });
+
+    await addLiveConnectionReadinessChecks(receipt, {
+      liveUrl: "https://unclick.world",
+      fetchImpl: async () => new Response(JSON.stringify({
+        success: true,
+        client_id: "client-id",
+        redirect_uri: "https://unclick.world/api/oauth-callback",
+        state: "state",
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    });
+
+    assert.equal(receipt.status, "pass");
+    assert.equal(actionText(receipt), "");
   });
 });

--- a/scripts/pinballwake-xpass-gate-room.mjs
+++ b/scripts/pinballwake-xpass-gate-room.mjs
@@ -9,6 +9,7 @@ const CHECK_ORDER = [
   "flowpass",
   "securitypass",
   "rotatepass",
+  "connectorpass",
   "copypass",
   "fidelitypass",
   "seopass",
@@ -27,6 +28,7 @@ const CHECK_LABELS = {
   flowpass: "FlowPass",
   securitypass: "SecurityPass",
   rotatepass: "RotatePass",
+  connectorpass: "ConnectorPass",
   copypass: "CopyPass",
   fidelitypass: "FidelityPass",
   seopass: "SEOPass",
@@ -55,6 +57,7 @@ const PASS_PRODUCT_CHECKS = new Map([
   ["uxpass", "uxpass"],
   ["wakepass", "wakepass"],
   ["rotatepass", "rotatepass"],
+  ["connectorpass", "connectorpass"],
 ]);
 
 const ENTERPRISE_READINESS_TERMS = [
@@ -256,6 +259,7 @@ function addReason(map, check, reason) {
 }
 
 function addAppConnectionReasons(map, reason) {
+  addReason(map, "connectorpass", `app connector readiness proof: ${reason}`);
   addReason(map, "testpass", `app connection readiness needs deterministic proof: ${reason}`);
   addReason(map, "uxpass", `provider login and fallback UX surface: ${reason}`);
   addReason(map, "flowpass", `OAuth login journey surface: ${reason}`);

--- a/scripts/pinballwake-xpass-gate-room.test.mjs
+++ b/scripts/pinballwake-xpass-gate-room.test.mjs
@@ -59,6 +59,7 @@ describe("PinballWake XPass Gate Room", () => {
     assert.ok(selected.includes("flowpass"));
     assert.ok(selected.includes("securitypass"));
     assert.ok(selected.includes("rotatepass"));
+    assert.ok(selected.includes("connectorpass"));
     assert.ok(selected.includes("commonsensepass"));
     assert.ok(selected.includes("sloppass"));
   });


### PR DESCRIPTION
## Summary
- add ConnectorPass routing for OAuth/app connector/keychain readiness work
- extend app connection readiness checks with a live production OAuth init probe
- document the future connector checklist so dashboard, login, fallback, and tool-side visibility must agree

## Verification
- npm run test:app-connections
- node --test scripts/pinballwake-xpass-gate-room.test.mjs
- npx vitest run src/xpass-aggregated-verdict-tool.test.ts (from packages/mcp-server)
- node scripts/check-app-connection-readiness.mjs --platform=supabase --live-url=https://unclick.world
- npm run build --workspace=@unclick/mcp-server
- npm run brainmap:check