### PR TITLE
[codex] Retry Higgsfield MCP after token expiry

### DIFF
--- a/packages/mcp-server/src/higgsfield-tool.test.ts
+++ b/packages/mcp-server/src/higgsfield-tool.test.ts
@@ -223,4 +223,94 @@ describe("higgsfield connector resilience (L2)", () => {
     expect(result.provider).toBe("higgsfield_mcp");
     expect(result.tool).toBe("models_explore");
   });
+
+  it("refreshes and retries when Higgsfield reports token expiry inside a tool result", async () => {
+    process.env.UNCLICK_API_KEY = "uc_test";
+    process.env.UNCLICK_API_URL = "https://unclick.test";
+    let activeToken = "old-token";
+    let toolCallCount = 0;
+
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = String(init?.method ?? "GET").toUpperCase();
+      const headers = init?.headers as Record<string, string>;
+      const bodyText = String(init?.body ?? "");
+      const body = bodyText.startsWith("{") ? JSON.parse(bodyText) as Record<string, unknown> : {};
+
+      if (url === "https://unclick.test/api/credentials?platform=higgsfield") {
+        return jsonResponse({
+          credential_kind: "higgsfield_mcp_oauth",
+          access_token: "old-token",
+          refresh_token: "refresh-token",
+          client_id: "client-123",
+          expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          token_type: "Bearer",
+          mcp_url: "https://mcp.higgsfield.ai/mcp",
+        });
+      }
+
+      if (url === "https://mcp.higgsfield.ai/oauth2/token") {
+        activeToken = "fresh-token";
+        return jsonResponse({
+          access_token: "fresh-token",
+          refresh_token: "fresh-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        });
+      }
+
+      if (url === "https://unclick.test/api/credentials" && method === "POST") {
+        return jsonResponse({ success: true });
+      }
+
+      if (url === "https://mcp.higgsfield.ai/mcp" && method === "POST" && body.method === "initialize") {
+        expect(headers.Authorization).toBe(`Bearer ${activeToken}`);
+        return jsonResponse({ jsonrpc: "2.0", id: body.id, result: {} }, { headers: { "mcp-session-id": `session-${activeToken}` } });
+      }
+
+      if (url === "https://mcp.higgsfield.ai/mcp" && method === "POST" && body.method === "notifications/initialized") {
+        return acceptedResponse();
+      }
+
+      if (url === "https://mcp.higgsfield.ai/mcp" && method === "POST" && body.method === "tools/list") {
+        return jsonResponse({ jsonrpc: "2.0", id: body.id, result: { tools: [{ name: "generate_image" }] } });
+      }
+
+      if (url === "https://mcp.higgsfield.ai/mcp" && method === "POST" && body.method === "tools/call") {
+        toolCallCount += 1;
+        if (toolCallCount === 1) {
+          return jsonResponse({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              content: [{ type: "text", text: "Error starting generation: Invalid or expired token\nRequest ID: req-1" }],
+              structuredContent: { error: "Invalid or expired token", request_id: "req-1" },
+              isError: true,
+            },
+          });
+        }
+        expect(headers.Authorization).toBe("Bearer fresh-token");
+        return jsonResponse({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { structuredContent: { job_id: "job-2", status: "submitted" } },
+        });
+      }
+
+      throw new Error(`Unexpected fetch ${method} ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await higgsfield_generate_image({
+      prompt: "a 2k cat portrait",
+      model: "nano_banana_pro",
+      resolution: "2k",
+      aspect_ratio: "1:1",
+    }) as Record<string, unknown>;
+
+    expect(result.provider).toBe("higgsfield_mcp");
+    expect(result.tool).toBe("generate_image");
+    expect(toolCallCount).toBe(2);
+  });
 });

--- a/packages/mcp-server/src/higgsfield-tool.ts
+++ b/packages/mcp-server/src/higgsfield-tool.ts
@@ -369,6 +369,22 @@ async function mcpRequest(args: {
   };
 }
 
+function higgsfieldNativeAuthError(result: unknown): boolean {
+  if (!isRecord(result)) return false;
+  const fragments: string[] = [];
+  const structured = result.structuredContent;
+  if (isRecord(structured)) {
+    fragments.push(String(structured.error ?? ""));
+    fragments.push(String(structured.message ?? ""));
+  }
+  const content = Array.isArray(result.content) ? result.content : [];
+  for (const item of content) {
+    if (isRecord(item) && typeof item.text === "string") fragments.push(item.text);
+  }
+  const text = fragments.join(" ").toLowerCase();
+  return /invalid or expired token|expired token|invalid token|unauthori[sz]ed/.test(text);
+}
+
 async function createMcpSession(credentials: HiggsfieldMcpCredentials): Promise<{ credentials: HiggsfieldMcpCredentials; sessionId?: string }> {
   const initialized = await mcpRequest({
     credentials,
@@ -423,8 +439,9 @@ async function callNativeHiggsfieldTool(
   toolArgs: Record<string, unknown>,
 ): Promise<unknown> {
   let fresh = await ensureFreshMcpCredentials(credentials);
-  try {
-    const session = await createMcpSession(fresh);
+
+  const invoke = async (active: HiggsfieldMcpCredentials): Promise<unknown> => {
+    const session = await createMcpSession(active);
     const toolName = await chooseNativeTool(session, preferredNames);
     const called = await mcpRequest({
       credentials: session.credentials,
@@ -432,6 +449,9 @@ async function callNativeHiggsfieldTool(
       params: { name: toolName, arguments: { params: toolArgs } },
       sessionId: session.sessionId,
     });
+    if (higgsfieldNativeAuthError(called.result)) {
+      throw new HiggsfieldMcpAuthError("Higgsfield login expired. Reconnect Higgsfield from UnClick Apps.");
+    }
     return stampMeta({
       provider: "higgsfield_mcp",
       tool: toolName,
@@ -442,27 +462,14 @@ async function callNativeHiggsfieldTool(
       fetched_at: new Date().toISOString(),
       next_steps: ["This used the signed-in customer's Higgsfield account, plan, and credits."],
     });
+  };
+
+  try {
+    return await invoke(fresh);
   } catch (err) {
     if (!(err instanceof HiggsfieldMcpAuthError) || !fresh.refresh_token || !fresh.client_id) throw err;
     fresh = await refreshMcpCredentials(fresh);
-    const session = await createMcpSession(fresh);
-    const toolName = await chooseNativeTool(session, preferredNames);
-    const called = await mcpRequest({
-      credentials: session.credentials,
-      method: "tools/call",
-      params: { name: toolName, arguments: { params: toolArgs } },
-      sessionId: session.sessionId,
-    });
-    return stampMeta({
-      provider: "higgsfield_mcp",
-      tool: toolName,
-      arguments: toolArgs,
-      result: called.result,
-    }, {
-      source: "Higgsfield MCP",
-      fetched_at: new Date().toISOString(),
-      next_steps: ["This used the signed-in customer's Higgsfield account, plan, and credits."],
-    });
+    return invoke(fresh);
   }
 }
 


### PR DESCRIPTION
## What changed
- Detect Higgsfield native MCP auth failures that arrive inside a successful `tools/call` payload.
- Refresh the stored Higgsfield MCP login and retry the native call once.
- Add coverage for the exact live response shape: `Invalid or expired token` returned in `structuredContent` / text content.

## Why
The live cat-image smoke test reached Higgsfield's signed-in MCP account with `model=nano_banana_pro`, `resolution=2k`, and `aspect_ratio=1:1`, but Higgsfield returned a tool-level `Invalid or expired token` result. That should behave like an auth expiry and be refreshed automatically.

## Validation
- `npx vitest run src/higgsfield-tool.test.ts --reporter=dot` from `packages/mcp-server`
- `npm run build --workspace=@unclick/mcp-server`
- `npm test --workspace=@unclick/mcp-server`
