### PR TITLE
[codex] Compact MCP advertised tool surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ api/                            # Vercel serverless functions (REST API endpoint
 
 | File | Purpose |
 |------|---------|
-| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and hidden internal meta-tools |
+| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and catalog meta-tools |
 | `packages/mcp-server/src/tool-wiring.ts` | Maps tool names to API calls |
 | `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (canonical memory operation surface) |
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
@@ -88,7 +88,7 @@ npm run test --workspace=@unclick/mcp-server
 
 Current summary:
 
-- Hidden internal meta-tools: `unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call`
+- Catalog meta-tools: `unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call`
 - Direct memory tools: `load_memory`, `save_session`, `save_fact`, `search_memory`, `save_identity`
 - Old memory tool names still work as aliases: `get_startup_context`, `write_session_summary`, `add_fact`, `set_business_context`
 - Signals and Fishbowl coordination tools are visible first-party tools for worker operation
@@ -109,7 +109,7 @@ Read `docs/adding-a-connector.md` first for the full playbook.
 ## Style rules
 
 - No em dashes anywhere in code or content (use a regular dash or restructure the sentence)
-- Do not add one-off MCP registrations casually. Catalog and integration tools should normally flow through `tool-wiring.ts` and the hidden internal meta-tools. Add visible first-party tools only when agents need a direct workflow surface.
+- Do not add one-off MCP registrations casually. Catalog and integration tools should normally flow through `tool-wiring.ts` and the catalog meta-tools. Add visible first-party tools only when agents need a direct workflow surface.
 
 ## Operating rules for cloud-async coding agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ api/                            # Vercel serverless functions (REST API endpoint
 
 | File | Purpose |
 |------|---------|
-| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and hidden internal meta-tools |
+| `packages/mcp-server/src/server.ts` | MCP server entrypoint, registers the direct tool surface and catalog meta-tools |
 | `packages/mcp-server/src/tool-wiring.ts` | Maps tool names to API calls |
 | `packages/mcp-server/src/memory/handlers.ts` | Memory operation dispatcher (canonical memory operation surface) |
 | `packages/mcp-server/src/memory/db.ts` | Backend factory (local JSON or Supabase) |
@@ -62,14 +62,14 @@ npm run test --workspace=@unclick/mcp-server
 
 This is the canonical tool-surface summary for this repo.
 
-**Hidden internal meta-tools** let agents discover and call catalog endpoints without crowding the default MCP tool list:
+**Catalog meta-tools** let agents discover and call catalog endpoints without crowding the default MCP tool list:
 
 - `unclick_search` - find tools by keyword
 - `unclick_browse` - list tools, optionally by category
 - `unclick_tool_info` - get endpoint and parameter details for a specific tool
 - `unclick_call` - execute any endpoint with parameters
 
-These tools remain callable by name, but they are hidden from `ListTools` to keep the default surface clean.
+These tools are advertised in `ListTools`; the generated connector catalog stays behind them so clients do not carry every endpoint schema on every request.
 
 **Visible first-party tools** expose the workflows agents should use directly. They include:
 
@@ -107,4 +107,4 @@ Short version (each connector is built to L5):
 ## Style rules
 
 - No em dashes anywhere in code or content (use a regular dash or restructure the sentence)
-- Do not add one-off MCP registrations casually. Catalog and integration tools should normally flow through `tool-wiring.ts` and the hidden internal meta-tools. Add visible first-party tools only when agents need a direct workflow surface.
+- Do not add one-off MCP registrations casually. Catalog and integration tools should normally flow through `tool-wiring.ts` and the catalog meta-tools. Add visible first-party tools only when agents need a direct workflow surface.

--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ Gives your agent access to a growing catalog of tools across developer utilities
 
 ## Tool Surface
 
-UnClick exposes a small direct surface for daily agent workflows, plus hidden internal discovery tools for the full catalog.
+UnClick exposes a small direct surface for daily agent workflows, plus compact catalog meta-tools for the full generated endpoint catalog.
 
 | Tool group | Tools |
 |------------|-------|
 | Memory session protocol | `load_memory`, `save_fact`, `search_memory`, `save_identity`, `save_session` |
 | Signals and Boardroom coordination | `check_signals`, `read_messages`, `post_message`, `create_todo`, `list_todos`, `update_todo`, `complete_todo`, `create_idea`, `list_ideas`, `vote_on_idea`, `promote_idea_to_todo` |
-| Hidden internal catalog tools | `unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call` |
+| Catalog meta-tools | `unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call` |
 
-The agent starts with memory, uses direct Boardroom tools for coordination, and can still call the hidden catalog tools by name when it needs dynamic endpoint discovery.
+The agent starts with memory, uses direct Boardroom tools for coordination, and uses the catalog meta-tools when it needs dynamic endpoint discovery. Generated connector tools stay behind this layer instead of being advertised one by one in `tools/list`.
 
 ### Compatibility and advanced memory operations
 

--- a/api/mcp-public-pairing.test.ts
+++ b/api/mcp-public-pairing.test.ts
@@ -18,18 +18,14 @@ import {
 } from "./lib/public-mcp-pairing";
 
 describe("public MCP pairing door", () => {
-  it("advertises setup plus the normal catalog for unpaired clients", () => {
+  it("advertises only setup for unpaired clients", () => {
     expect(PUBLIC_PAIRING_TOOL.name).toBe("unclick_start_pairing");
     expect(PUBLIC_PAIRING_TOOL.description).toContain("not paired yet");
     expect(PUBLIC_PAIRING_TOOL.description).not.toContain("API key");
 
     const tools = publicToolsForUnpairedClient();
     const names = tools.map((tool) => tool.name);
-    expect(names[0]).toBe("unclick_start_pairing");
-    expect(names).toContain("load_memory");
-    expect(names).toContain("search_memory");
-    expect(new Set(names).size).toBe(names.length);
-    expect(tools.length).toBeGreaterThan(10);
+    expect(names).toEqual(["unclick_start_pairing"]);
   });
 
   it("builds a magic-link landing URL with a non-secret pair id", () => {

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -83,12 +83,7 @@ export const PUBLIC_PAIRING_TOOL = {
 };
 
 export function publicToolsForUnpairedClient() {
-  return [
-    PUBLIC_PAIRING_TOOL,
-    ...ADVERTISED_TOOLS_SAFE.filter(
-      (tool) => tool.name !== PUBLIC_PAIRING_TOOL.name,
-    ),
-  ];
+  return [PUBLIC_PAIRING_TOOL];
 }
 
 function singleRpc(body: unknown): Record<string, unknown> | null {

--- a/docs/adr/0001-mcp-first-agent-protocol.md
+++ b/docs/adr/0001-mcp-first-agent-protocol.md
@@ -10,7 +10,7 @@ Agent-to-tool communication has no dominant standard. OpenAI function calling, L
 
 ## Decision
 
-UnClick exposes every capability through MCP. The agent-facing surface is one marketplace search tool (`unclick_search`) plus five direct memory tools (`load_memory`, `save_session`, `save_fact`, `search_memory`, `save_identity`). The raw meta-tools (`unclick_browse`, `unclick_tool_info`, `unclick_call`) remain callable but are hidden from the default tool list for readability. Every other capability, including all 17 memory operations and 450+ wired endpoints, is reachable through `unclick_call` with an `endpoint_id`. No parallel REST-only protocol is maintained as a first-class agent surface. The website and admin shell exist for humans; MCP is the canonical surface for agents.
+UnClick exposes every capability through MCP. The agent-facing surface is the compact catalog meta-tool set (`unclick_search`, `unclick_browse`, `unclick_tool_info`, `unclick_call`) plus direct memory and coordination tools. Every generated connector capability, including all memory operations and 450+ wired endpoints, is reachable through `unclick_call` with an `endpoint_id`, but generated connector tools are not advertised one by one in `tools/list`. No parallel REST-only protocol is maintained as a first-class agent surface. The website and admin shell exist for humans; MCP is the canonical surface for agents.
 
 ## Consequences
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -85,7 +85,7 @@ Workers can call `commonsensepass_protocol` with no arguments to fetch the canon
 |---|---|
 | `unclick_search` | Search for tools by keyword. "I need to resize an image" returns the image tool with endpoints and schemas. |
 
-`unclick_browse`, `unclick_tool_info`, and `unclick_call` remain callable for backward compatibility but are hidden from the advertised tool list so end users are not shown internal machinery.
+`unclick_browse`, `unclick_tool_info`, and `unclick_call` are also advertised as compact catalog meta-tools. Generated connector tools stay behind this layer instead of being advertised one by one in `tools/list`.
 
 **Discovery flow for an agent:**
 1. `unclick_search` to find relevant tools

--- a/packages/mcp-server/src/__tests__/advertised-tools-schema.test.ts
+++ b/packages/mcp-server/src/__tests__/advertised-tools-schema.test.ts
@@ -17,21 +17,28 @@ describe("advertised tool schemas are Anthropic-API safe", () => {
     expect(offenders).toEqual([]);
   });
 
-  it("the known catalog offenders are cleaned but keep their properties", () => {
+  it("the generated catalog offenders are not advertised by default", () => {
     const names = ["legalpass_run", "legalpass_save_pack", "flowpass_register_pack", "sloppass_run"];
+    const advertisedNames = new Set(ADVERTISED_TOOLS_SAFE.map((t: AdvertisedTool) => t.name));
     for (const name of names) {
-      const tool = ADVERTISED_TOOLS_SAFE.find((t: AdvertisedTool) => t.name === name);
-      expect(tool, `${name} should be advertised`).toBeTruthy();
-      const schema = tool!.inputSchema as Record<string, unknown>;
-      expect(hasTopLevelCombinator(schema)).toBe(false);
-      expect(schema.properties, `${name} should keep its properties`).toBeTruthy();
+      expect(advertisedNames.has(name), `${name} should stay behind unclick_call`).toBe(false);
     }
   });
 
-  it("does not mutate the original schemas (runtime validation stays intact)", () => {
-    // At least one original still carries the top-level anyOf used by AJV.
-    const original = ADVERTISED_TOOLS.find((t: AdvertisedTool) => t.name === "sloppass_run");
-    expect(hasTopLevelCombinator(original?.inputSchema)).toBe(true);
+  it("cleans top-level combinators without mutating the original schema", () => {
+    const original = {
+      name: "needs-cleaning",
+      inputSchema: {
+        type: "object",
+        anyOf: [{ required: ["url"] }, { required: ["html"] }],
+        properties: { url: { type: "string" }, html: { type: "string" } },
+      },
+    };
+    const safe = advertiseToolSchema(original);
+
+    expect(hasTopLevelCombinator(safe.inputSchema)).toBe(false);
+    expect((safe.inputSchema as Record<string, unknown>).properties).toBeTruthy();
+    expect(hasTopLevelCombinator(original.inputSchema)).toBe(true);
   });
 
   it("preserves nested combinators inside properties", () => {

--- a/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
+++ b/packages/mcp-server/src/__tests__/tool-schema-validation.test.ts
@@ -273,17 +273,26 @@ describe("runtime tool schema validation", () => {
     }
   });
 
+  it("advertises catalog meta-tools to connected agents", () => {
+    const advertisedNames = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
+
+    expect(advertisedNames.has("unclick_search")).toBe(true);
+    expect(advertisedNames.has("unclick_tool_info")).toBe(true);
+    expect(advertisedNames.has("unclick_call")).toBe(true);
+  });
+
   it("advertises the guarded Boardroom release tool", () => {
     const advertisedNames = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
 
     expect(advertisedNames.has("release_claim")).toBe(true);
   });
 
-  it("advertises SecurityPass as a scope-gated receipt surface", () => {
+  it("keeps generated connector tools behind the catalog meta-tools", () => {
     const advertisedNames = new Set(ADVERTISED_TOOLS.map((tool) => tool.name));
 
-    expect(advertisedNames.has("securitypass_run")).toBe(true);
-    expect(advertisedNames.has("securitypass_status")).toBe(true);
-    expect(advertisedNames.has("securitypass_verify_scope")).toBe(true);
+    expect(advertisedNames.has("securitypass_run")).toBe(false);
+    expect(advertisedNames.has("reddit_vote")).toBe(false);
+    expect(advertisedNames.has("email_delete")).toBe(false);
+    expect(advertisedNames.has("wise_create_quote")).toBe(false);
   });
 });

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -240,8 +240,9 @@ function formatToolSummary(tool: ToolDef): string {
 
 // ─── MCP Tool definitions ───────────────────────────────────────────────────
 
-// Internal tools: still callable for backwards compatibility, but not advertised
-// to reduce noise in the tool list. Users who know the names can still invoke them.
+// Catalog meta-tools: the compact bridge from a small MCP tool list to the full
+// generated endpoint catalog. These stay advertised so agents can discover and
+// call scoped capabilities without loading every generated connector schema.
 const INTERNAL_TOOLS = [
   {
     name: "unclick_search",
@@ -1727,17 +1728,16 @@ for (const tool of AUTOPILOT_VISIBLE_TOOLS) {
   registerToolInputSchema(tool);
 }
 
-// DraftRoom needs friendly connected-agent tools, while the rest of the
-// internal meta layer stays hidden from tools/list.
+// DraftRoom needs friendly connected-agent tools.
 const EXPRESSROOM_VISIBLE_TOOLS = INTERNAL_TOOLS.filter((tool) =>
   (EXPRESSROOM_VISIBLE_TOOL_NAMES as readonly string[]).includes(tool.name),
 );
 
 export const ADVERTISED_TOOLS: readonly RuntimeToolSchema[] = [
   ...(VISIBLE_TOOLS as unknown as RuntimeToolSchema[]),
+  ...(INTERNAL_TOOLS as unknown as RuntimeToolSchema[]),
   ...EXPRESSROOM_VISIBLE_TOOLS,
   ...AUTOPILOT_VISIBLE_TOOLS,
-  ...(ADDITIONAL_TOOLS as unknown as RuntimeToolSchema[]),
 ];
 
 /** Combinators the Anthropic API rejects at the TOP level of a tool schema. */
@@ -1925,12 +1925,11 @@ export function createServer(): Server {
     }
   );
 
-  // LIST TOOLS: advertise the core memory tools, the friendly DraftRoom
-  // bridge tools, plus every product + marketplace tool registered in
-  // ADDITIONAL_TOOLS (TestPass, Crews, and third-party integrations from
-  // tool-wiring.ts). Internal meta tools (unclick_search, unclick_browse,
-  // unclick_tool_info, unclick_call) and the small DIRECT_TOOLS utility set
-  // remain callable for backwards compatibility but stay hidden from tools/list.
+  // LIST TOOLS: advertise the core memory, coordination, and catalog meta-tool
+  // surface only. The generated connector catalog in ADDITIONAL_TOOLS and the
+  // small DIRECT_TOOLS utility set remain callable for backwards compatibility,
+  // but they stay out of tools/list so every request does not carry thousands of
+  // unused third-party tool definitions.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     // Enforcement: hide tools belonging to apps this tenant turned off in the
     // admin Apps page. Fail-safe (empty set => no filtering).


### PR DESCRIPTION
## Summary
- stop unauthenticated public MCP discovery from returning the full catalog before pairing
- advertise only the compact core + catalog meta-tool surface by default
- keep generated connector tools callable behind `unclick_search` / `unclick_call`, but out of `tools/list`
- align docs and add regression coverage for dangerous/generated tools staying hidden from advertised discovery

## Proof
- Live pre-fix reproduction: public `https://unclick.world/api/mcp` `tools/list` returned 1,632 tools and included `reddit_vote` + `email_delete`.
- Local post-fix proof: advertised authenticated list is 42 tools, pre-auth public discovery is 1 pairing tool, and `reddit_vote`, `email_delete`, `wise_create_quote`, `telegram_manage_chat`, and `vault_action` are absent from the advertised list.

## Tests
- `npx vitest run api/mcp-public-pairing.test.ts`
- `cd packages/mcp-server && npx vitest run src/__tests__/advertised-tools-schema.test.ts src/__tests__/tool-schema-validation.test.ts`